### PR TITLE
fix: skill should work, even if the npm package is not installed

### DIFF
--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -18,6 +18,12 @@ agent-device fill @e5 "test"
 agent-device close
 ```
 
+If not installed, run:
+
+```bash
+npx -y agent-device
+```
+
 ## Core workflow
 
 1. Open app or just boot device: `open [app]`


### PR DESCRIPTION
Added npx instructions for agent-device skill.