### PR TITLE
feat(ios): add pinch gesture for zoom on iOS simulators

### DIFF
--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-device
-description: Automates mobile and simulator interactions for iOS and Android devices. Use when navigating apps, taking snapshots/screenshots, tapping, typing, scrolling, or extracting UI info on mobile devices or simulators.
+description: Automates mobile and simulator interactions for iOS and Android devices. Use when navigating apps, taking snapshots/screenshots, tapping, typing, scrolling, pinching, or extracting UI info on mobile devices or simulators.
 ---
 
 # Mobile Automation with agent-device
@@ -101,6 +101,8 @@ agent-device type "text"               # Type into focused field
 agent-device press 300 500             # Tap by coordinates
 agent-device long-press 300 500 800    # Long press (where supported)
 agent-device scroll down 0.5
+agent-device pinch 2.0              # Zoom in 2x (iOS simulator)
+agent-device pinch 0.5 200 400     # Zoom out at coordinates (iOS simulator)
 agent-device back
 agent-device home
 agent-device app-switcher
@@ -138,6 +140,7 @@ agent-device apps --platform android --user-installed
 
 ## Best practices
 
+- Pinch (`pinch <scale> [x y]`) is supported on iOS simulators only; scale > 1 zooms in, < 1 zooms out.
 - Always snapshot right before interactions; refs invalidate on UI changes.
 - Prefer `snapshot -i` to reduce output size.
 - On iOS, `xctest` is the default and does not require Accessibility permission.
@@ -151,7 +154,7 @@ agent-device apps --platform android --user-installed
 - [references/snapshot-refs.md](references/snapshot-refs.md)
 - [references/session-management.md](references/session-management.md)
 - [references/permissions.md](references/permissions.md)
-- [references/recording.md](references/recording.md)
+- [references/video-recording.md](references/video-recording.md)
 - [references/coordinate-system.md](references/coordinate-system.md)
 
 ## Missing features roadmap (high level)

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -223,6 +223,24 @@ export async function dispatchCommand(
       await interactor.scrollIntoView(text);
       return { text };
     }
+    case 'pinch': {
+      const scale = Number(positionals[0]);
+      const x = positionals[1] ? Number(positionals[1]) : undefined;
+      const y = positionals[2] ? Number(positionals[2]) : undefined;
+      if (Number.isNaN(scale) || scale <= 0) {
+        throw new AppError('INVALID_ARGS', 'pinch requires scale > 0');
+      }
+      if (device.platform === 'ios' && device.kind === 'simulator') {
+        await runIosRunnerCommand(
+          device,
+          { command: 'pinch', scale, x, y, appBundleId: context?.appBundleId },
+          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+        );
+      } else {
+        throw new AppError('UNSUPPORTED_OPERATION', 'pinch is only supported on iOS simulators');
+      }
+      return { scale, x, y };
+    }
     case 'screenshot': {
       const path = outPath ?? `./screenshot-${Date.now()}.png`;
       await interactor.screenshot(path);

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -20,6 +20,7 @@ export type RunnerCommand = {
     | 'home'
     | 'appSwitcher'
     | 'alert'
+    | 'pinch'
     | 'shutdown';
   appBundleId?: string;
   text?: string;
@@ -27,6 +28,7 @@ export type RunnerCommand = {
   x?: number;
   y?: number;
   direction?: 'up' | 'down' | 'left' | 'right';
+  scale?: number;
   interactiveOnly?: boolean;
   compact?: boolean;
   depth?: number;

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -34,6 +34,8 @@ agent-device type "text"
 agent-device press 300 500
 agent-device long-press 300 500 800
 agent-device scroll down 0.5
+agent-device pinch 2.0          # zoom in 2x
+agent-device pinch 0.5 200 400 # zoom out at coordinates
 ```
 
 ## Find (semantic)


### PR DESCRIPTION
- Add 'pinch' CLI command: pinch <scale> [x y] (scale > 1 zoom in, < 1 zoom out)
- Implement in dispatch, runner-client (RunnerCommand + scale param), Swift runner
- Use double-tap + drag workaround for map zoom (tap center, drag up/down) instead of XCUITest pinch(withScale:velocity:) which pans on map views
- Update commands.md and agent-device skill with pinch usage and best practices
- Fix skill reference: recording.md -> video-recording.md