### PR TITLE
refactor(cli): add --version and -V flags to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Notes:
 - If XCTest returns 0 nodes (e.g., foreground app changed), agent-device falls back to AX when available.
 
 Flags:
+- `--version, -V` print version and exit
 - `--platform ios|android`
 - `--device <name>`
 - `--udid <udid>` (iOS)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { parseArgs, usage } from './utils/args.ts';
 import { asAppError, AppError } from './utils/errors.ts';
 import { formatSnapshotText, printHumanError, printJson } from './utils/output.ts';
+import { readVersion } from './utils/version.ts';
 import { pathToFileURL } from 'node:url';
 import { sendToDaemon } from './daemon-client.ts';
 import fs from 'node:fs';
@@ -9,6 +10,11 @@ import path from 'node:path';
 
 export async function runCli(argv: string[]): Promise<void> {
   const parsed = parseArgs(argv);
+
+  if (parsed.flags.version) {
+    process.stdout.write(`${readVersion()}\n`);
+    process.exit(0);
+  }
 
   if (parsed.flags.help || !parsed.command) {
     process.stdout.write(`${usage()}\n`);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,10 +3,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import { fileURLToPath } from 'node:url';
 import { dispatchCommand, type CommandFlags } from './core/dispatch.ts';
 import { isCommandSupportedOnDevice } from './core/capabilities.ts';
 import { asAppError, AppError } from './utils/errors.ts';
+import { readVersion } from './utils/version.ts';
 import { stopIosRunnerSession } from './platforms/ios/runner-client.ts';
 import type { DaemonRequest, DaemonResponse } from './daemon/types.ts';
 import { SessionStore } from './daemon/session-store.ts';
@@ -203,26 +203,3 @@ function start(): void {
 }
 
 start();
-
-function readVersion(): string {
-  try {
-    const root = findProjectRoot();
-    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as {
-      version?: string;
-    };
-    return pkg.version ?? '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
-}
-
-function findProjectRoot(): string {
-  const start = path.dirname(fileURLToPath(import.meta.url));
-  let current = start;
-  for (let i = 0; i < 6; i += 1) {
-    const pkgPath = path.join(current, 'package.json');
-    if (fs.existsSync(pkgPath)) return current;
-    current = path.dirname(current);
-  }
-  return start;
-}

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -25,11 +25,12 @@ export type ParsedArgs = {
     noRecord?: boolean;
     replayUpdate?: boolean;
     help: boolean;
+    version: boolean;
   };
 };
 
 export function parseArgs(argv: string[]): ParsedArgs {
-  const flags: ParsedArgs['flags'] = { json: false, help: false };
+  const flags: ParsedArgs['flags'] = { json: false, help: false, version: false };
   const positionals: string[] = [];
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -40,6 +41,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     if (arg === '--help' || arg === '-h') {
       flags.help = true;
+      continue;
+    }
+    if (arg === '--version' || arg === '-V') {
+      flags.version = true;
       continue;
     }
     if (arg === '--verbose' || arg === '-v') {
@@ -229,5 +234,6 @@ Flags:
   --update, -u                               Replay: update selectors and rewrite replay file in place
   --user-installed                           Apps: list user-installed packages (Android only)
   --all                                      Apps: list all packages (Android only)
+  --version, -V                              Print version and exit
 `;
 }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function readVersion(): string {
+  try {
+    const root = findProjectRoot();
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as {
+      version?: string;
+    };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+export function findProjectRoot(): string {
+  const start = path.dirname(fileURLToPath(import.meta.url));
+  let current = start;
+  for (let i = 0; i < 6; i += 1) {
+    const pkgPath = path.join(current, 'package.json');
+    if (fs.existsSync(pkgPath)) return current;
+    current = path.dirname(current);
+  }
+  return start;
+}

--- a/test/integration/smoke-cli.test.ts
+++ b/test/integration/smoke-cli.test.ts
@@ -17,6 +17,18 @@ test('cli --help returns usage', () => {
   assert.match(result.stdout, /agent-device/i);
 });
 
+test('cli --version prints semver and exits 0', () => {
+  const result = runCli(['--version']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^\d+\.\d+\.\d+/i);
+});
+
+test('cli -V prints semver and exits 0', () => {
+  const result = runCli(['-V']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^\d+\.\d+\.\d+/i);
+});
+
 test('cli without command prints usage and exits 1', () => {
   const result = runCli([]);
   assert.equal(result.status, 1, result.stderr);


### PR DESCRIPTION
## Summary

This PR adds CLI version flags (`--version`, `-V`) and makes version lookup consistent across source and dist execution paths.

### What changed

- Added `--version` / `-V` parsing and help/README docs.
- Introduced shared helper `src/utils/version.ts` for:
   - `readVersion()`
   - `findProjectRoot()`
- Reused the helper in `cli`, `daemon`, and `daemon-client` to remove duplicated logic.
- Added smoke coverage for both `--version` and `-V`.

## Usage

```bash
$ agent-device --version
0.3.0

$ agent-device -V
0.3.0
```

Closes #43
