### PR TITLE
feat: add Face ID simulator controls to settings command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ agent-device swipe 540 1500 540 500 120 --count 8 --pause-ms 30 --pattern ping-p
 - `alert`, `wait`, `screenshot`
 - `trace start`, `trace stop`
 - `settings wifi|airplane|location on|off`
-- `settings faceid match|nonmatch|enroll|unenroll` (aliases: `validate|unvalidate`, iOS simulator only)
+- `settings faceid match|nonmatch|enroll|unenroll` (iOS simulator only)
 - `appstate`, `apps`, `devices`, `session list`
 
 ## iOS Snapshots

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -99,7 +99,8 @@ agent-device settings faceid unenroll
 Note: iOS wifi/airplane toggles status bar indicators, not actual network state.
 Airplane off clears status bar overrides.
 iOS settings helpers are simulator-only.
-Face ID aliases: `validate` = `match`, `unvalidate` = `nonmatch`.
+Use `match`/`nonmatch` as the canonical command values.
+Think of them as validate/invalidate outcomes when describing intent.
 
 ### App state
 

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -91,7 +91,7 @@ test('settings rejects unsupported iOS physical devices', async () => {
   }
 });
 
-test('settings validates faceid aliases in usage hint', async () => {
+test('settings usage hint documents canonical faceid states', async () => {
   const sessionStore = makeSessionStore();
   const response = await handleSnapshotCommands({
     req: {
@@ -110,6 +110,7 @@ test('settings validates faceid aliases in usage hint', async () => {
   assert.equal(response?.ok, false);
   if (response && !response.ok) {
     assert.equal(response.error.code, 'INVALID_ARGS');
-    assert.match(response.error.message, /validate\|unvalidate/);
+    assert.match(response.error.message, /match\|nonmatch\|enroll\|unenroll/);
+    assert.doesNotMatch(response.error.message, /validate\|unvalidate/);
   }
 });

--- a/src/daemon/handlers/snapshot.ts
+++ b/src/daemon/handlers/snapshot.ts
@@ -312,7 +312,7 @@ export async function handleSnapshotCommands(params: {
         error: {
           code: 'INVALID_ARGS',
           message:
-            'settings requires <wifi|airplane|location> <on|off> or faceid <match|nonmatch|enroll|unenroll|validate|unvalidate>',
+            'settings requires <wifi|airplane|location> <on|off> or faceid <match|nonmatch|enroll|unenroll>',
         },
       };
     }

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -460,7 +460,7 @@ test('listIosApps applies user-installed filter on simulator', async () => {
   }
 });
 
-test('setIosSetting faceid validate uses simctl biometric match', async () => {
+test('setIosSetting faceid match uses simctl biometric match', async () => {
   await withMockedXcrun(
     'agent-device-ios-faceid-match-test-',
     `#!/bin/sh
@@ -486,7 +486,7 @@ exit 1
         kind: 'simulator',
         booted: true,
       };
-      await setIosSetting(device, 'faceid', 'validate');
+      await setIosSetting(device, 'faceid', 'match');
       const lines = (await fs.readFile(argsLogPath, 'utf8'))
         .trim()
         .split('\n')

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -339,15 +339,13 @@ type FaceIdAction = 'match' | 'nonmatch' | 'enroll' | 'unenroll';
 
 function parseFaceIdAction(state: string): FaceIdAction {
   const normalized = state.trim().toLowerCase();
-  if (normalized === 'match' || normalized === 'validate') return 'match';
-  if (normalized === 'nonmatch' || normalized === 'nomatch' || normalized === 'unvalidate') {
-    return 'nonmatch';
-  }
+  if (normalized === 'match') return 'match';
+  if (normalized === 'nonmatch') return 'nonmatch';
   if (normalized === 'enroll') return 'enroll';
   if (normalized === 'unenroll') return 'unenroll';
   throw new AppError(
     'INVALID_ARGS',
-    `Invalid faceid state: ${state}. Use match|nonmatch|enroll|unenroll (aliases: validate|unvalidate).`,
+    `Invalid faceid state: ${state}. Use match|nonmatch|enroll|unenroll.`,
   );
 }
 

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -282,8 +282,9 @@ test('command usage shows no command flags when unsupported', () => {
   assert.match(help, /Global flags:/);
 });
 
-test('settings usage documents faceid aliases', () => {
+test('settings usage documents canonical faceid states', () => {
   const help = usageForCommand('settings');
   if (help === null) throw new Error('Expected command help text');
-  assert.match(help, /match\|nonmatch\|enroll\|unenroll\|validate\|unvalidate/);
+  assert.match(help, /match\|nonmatch\|enroll\|unenroll/);
+  assert.doesNotMatch(help, /validate\|unvalidate/);
 });

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -525,7 +525,7 @@ export const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
   },
   settings: {
     usageOverride:
-      'settings <wifi|airplane|location|faceid> <on|off|match|nonmatch|enroll|unenroll|validate|unvalidate>',
+      'settings <wifi|airplane|location|faceid> <on|off|match|nonmatch|enroll|unenroll>',
     description: 'Toggle OS settings (simulators), including Face ID on iOS simulators',
     positionalArgs: ['setting', 'state'],
     allowedFlags: [],

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -129,7 +129,8 @@ agent-device settings faceid unenroll
 ```
 
 - iOS `settings` support is simulator-only.
-- Face ID controls are iOS simulator-only and support aliases: `validate` = `match`, `unvalidate` = `nonmatch`.
+- Face ID controls are iOS simulator-only.
+- Use `match`/`nonmatch` to simulate valid/invalid Face ID outcomes.
 
 ## App state and app lists
 


### PR DESCRIPTION
## Summary

Add iOS simulator Face ID controls to the existing settings command (match, nonmatch, enroll, unenroll) with validate/unvalidate aliases.
Align command help and runtime validation text so accepted values are documented consistently.
Add unit tests for Face ID command execution/fallback and usage/help regressions, plus docs/skill updates.

Fixes #74 

## Validation

- pnpm typecheck
- pnpm test:unit
- pnpm test:smoke