### PR TITLE
fix: resolve replay script path from caller cwd

### DIFF
--- a/src/__tests__/cli-diagnostics.test.ts
+++ b/src/__tests__/cli-diagnostics.test.ts
@@ -72,6 +72,7 @@ test('cli forwards --debug as verbose/debug metadata', async () => {
   assert.equal(result.calls.length, 1);
   assert.equal(result.calls[0]?.flags?.verbose, true);
   assert.equal(result.calls[0]?.meta?.debug, true);
+  assert.equal(result.calls[0]?.meta?.cwd, process.cwd());
   assert.equal(typeof result.calls[0]?.meta?.requestId, 'string');
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,6 +108,7 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
           meta: {
             requestId,
             debug: Boolean(flags.verbose),
+            cwd: process.cwd(),
           },
         });
       try {

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -56,6 +56,7 @@ export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<D
     meta: {
       requestId,
       debug,
+      cwd: req.meta?.cwd,
     },
   };
   emitDiagnostic({

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -21,6 +21,19 @@ function makeSession(name: string): SessionState {
   };
 }
 
+test('expandHome resolves tilde, relative-with-cwd, and absolute paths', () => {
+  const homePath = SessionStore.expandHome('~/flows/replay.ad');
+  assert.equal(homePath.startsWith(os.homedir()), true);
+  assert.equal(homePath.endsWith(path.join('flows', 'replay.ad')), true);
+
+  const relativePath = SessionStore.expandHome('workflows/replay.ad', '/tmp/agent-device-cwd');
+  assert.equal(relativePath, path.resolve('/tmp/agent-device-cwd', 'workflows/replay.ad'));
+
+  const absoluteInput = path.resolve('/tmp', 'agent-device-absolute.ad');
+  const absolutePath = SessionStore.expandHome(absoluteInput, '/tmp/ignored-cwd');
+  assert.equal(absolutePath, absoluteInput);
+});
+
 test('recordAction stores normalized action entries', () => {
   const store = new SessionStore(path.join(os.tmpdir(), 'agent-device-tests'));
   const session = makeSession('default');

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -544,7 +544,7 @@ export async function handleSessionCommands(params: {
       return { ok: false, error: { code: 'INVALID_ARGS', message: 'replay requires a path' } };
     }
     try {
-      const resolved = SessionStore.expandHome(filePath);
+      const resolved = SessionStore.expandHome(filePath, req.meta?.cwd);
       const script = fs.readFileSync(resolved, 'utf8');
       const firstNonWhitespace = script.trimStart()[0];
       if (firstNonWhitespace === '{' || firstNonWhitespace === '[') {

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -91,9 +91,12 @@ export class SessionStore {
     return path.join(this.sessionsDir, `${safeName}-${timestamp}.trace.log`);
   }
 
-  static expandHome(filePath: string): string {
+  static expandHome(filePath: string, cwd?: string): string {
     if (filePath.startsWith('~/')) {
       return path.join(os.homedir(), filePath.slice(2));
+    }
+    if (cwd && !path.isAbsolute(filePath)) {
+      return path.resolve(cwd, filePath);
     }
     return path.resolve(filePath);
   }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -12,6 +12,7 @@ export type DaemonRequest = {
   meta?: {
     requestId?: string;
     debug?: boolean;
+    cwd?: string;
   };
 };
 


### PR DESCRIPTION
## Summary

Fix replay path resolution so relative .ad script paths are resolved from the CLI caller's current working directory instead of daemon startup cwd.
Add regression tests for CLI metadata forwarding and SessionStore path expansion behavior.

## Validation

- pnpm typecheck
- pnpm test:unit
- pnpm test:smoke