### PR TITLE
fix: allow swipe on iOS physical devices

### DIFF
--- a/src/core/__tests__/capabilities.test.ts
+++ b/src/core/__tests__/capabilities.test.ts
@@ -33,11 +33,17 @@ test('iOS simulator-only commands reject iOS devices and Android', () => {
 });
 
 test('simulator-only iOS commands with Android support reject iOS devices', () => {
-  for (const cmd of ['record', 'settings', 'swipe']) {
+  for (const cmd of ['record', 'settings']) {
     assert.equal(isCommandSupportedOnDevice(cmd, iosSimulator), true, `${cmd} on iOS sim`);
     assert.equal(isCommandSupportedOnDevice(cmd, iosDevice), false, `${cmd} on iOS device`);
     assert.equal(isCommandSupportedOnDevice(cmd, androidDevice), true, `${cmd} on Android`);
   }
+});
+
+test('swipe supports iOS simulator, iOS device, and Android', () => {
+  assert.equal(isCommandSupportedOnDevice('swipe', iosSimulator), true, 'swipe on iOS sim');
+  assert.equal(isCommandSupportedOnDevice('swipe', iosDevice), true, 'swipe on iOS device');
+  assert.equal(isCommandSupportedOnDevice('swipe', androidDevice), true, 'swipe on Android');
 });
 
 test('reinstall supports iOS simulator, iOS device, and Android', () => {

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -36,7 +36,7 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
   screenshot: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   scroll: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   scrollintoview: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
-  swipe: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
+  swipe: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   settings: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
   snapshot: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   type: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },


### PR DESCRIPTION
## Summary

Enable `swipe` for iOS physical devices by updating capability matrix gating.
Adjust capability unit tests to keep simulator-only coverage for `record`/`settings` and add explicit cross-platform `swipe` support assertions.

## Validation

- pnpm typecheck
- node --test src/core/__tests__/capabilities.test.ts
- pnpm test:unit
- pnpm test:smoke
