### PR TITLE
fix: harden iOS runner resilience and cancellation

### DIFF
--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -77,6 +77,7 @@ export async function dispatchCommand(
   positionals: string[],
   outPath?: string,
   context?: {
+    requestId?: string;
     appBundleId?: string;
     activity?: string;
     verbose?: boolean;
@@ -97,6 +98,7 @@ export async function dispatchCommand(
   },
 ): Promise<Record<string, unknown> | void> {
   const runnerCtx: RunnerContext = {
+    requestId: context?.requestId,
     appBundleId: context?.appBundleId,
     verbose: context?.verbose,
     logPath: context?.logPath,
@@ -182,7 +184,12 @@ export async function dispatchCommand(
             doubleTap,
             appBundleId: context?.appBundleId,
           },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { x, y, count, intervalMs, holdMs, jitterPx, doubleTap, timingMode: 'runner-series' };
       }
@@ -235,7 +242,12 @@ export async function dispatchCommand(
             pattern,
             appBundleId: context?.appBundleId,
           },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return {
           x1,
@@ -332,7 +344,12 @@ export async function dispatchCommand(
       await runIosRunnerCommand(
         device,
         { command: 'pinch', scale, x, y, appBundleId: context?.appBundleId },
-        { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+        {
+          verbose: context?.verbose,
+          logPath: context?.logPath,
+          traceLogPath: context?.traceLogPath,
+          requestId: context?.requestId,
+        },
       );
       return { scale, x, y };
     }
@@ -348,7 +365,12 @@ export async function dispatchCommand(
         await runIosRunnerCommand(
           device,
           { command: 'back', appBundleId: context?.appBundleId },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { action: 'back' };
       }
@@ -360,7 +382,12 @@ export async function dispatchCommand(
         await runIosRunnerCommand(
           device,
           { command: 'home', appBundleId: context?.appBundleId },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { action: 'home' };
       }
@@ -372,7 +399,12 @@ export async function dispatchCommand(
         await runIosRunnerCommand(
           device,
           { command: 'appSwitcher', appBundleId: context?.appBundleId },
-          { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+          {
+            verbose: context?.verbose,
+            logPath: context?.logPath,
+            traceLogPath: context?.traceLogPath,
+            requestId: context?.requestId,
+          },
         );
         return { action: 'app-switcher' };
       }
@@ -413,7 +445,12 @@ export async function dispatchCommand(
                 scope: context?.snapshotScope,
                 raw: context?.snapshotRaw,
               },
-              { verbose: context?.verbose, logPath: context?.logPath, traceLogPath: context?.traceLogPath },
+              {
+                verbose: context?.verbose,
+                logPath: context?.logPath,
+                traceLogPath: context?.traceLogPath,
+                requestId: context?.requestId,
+              },
             ),
           {
             backend: 'xctest',

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { AppError } from './utils/errors.ts';
 import type { DaemonRequest as SharedDaemonRequest, DaemonResponse as SharedDaemonResponse } from './daemon/types.ts';
-import { runCmdDetached } from './utils/exec.ts';
+import { runCmdDetached, runCmdSync } from './utils/exec.ts';
 import { findProjectRoot, readVersion } from './utils/version.ts';
 import { createRequestId, emitDiagnostic, withDiagnosticTimer } from './utils/diagnostics.ts';
 import {
@@ -41,6 +41,11 @@ const REQUEST_TIMEOUT_MS = resolveDaemonRequestTimeoutMs();
 const DAEMON_STARTUP_TIMEOUT_MS = 5000;
 const DAEMON_TAKEOVER_TERM_TIMEOUT_MS = 3000;
 const DAEMON_TAKEOVER_KILL_TIMEOUT_MS = 1000;
+const IOS_RUNNER_XCODEBUILD_KILL_PATTERNS = [
+  'xcodebuild .*AgentDeviceRunnerUITests/RunnerTests/testCommand',
+  'xcodebuild .*AgentDeviceRunner\\.env\\.session-',
+  'xcodebuild build-for-testing .*ios-runner/AgentDeviceRunner/AgentDeviceRunner\\.xcodeproj',
+];
 
 export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> {
   const requestId = req.meta?.requestId ?? createRequestId();
@@ -242,6 +247,8 @@ async function sendRequest(info: DaemonInfo, req: DaemonRequest): Promise<Daemon
     });
     const timeout = setTimeout(() => {
       socket.destroy();
+      const cleanup = cleanupTimedOutIosRunnerBuilds();
+      const daemonReset = resetDaemonAfterTimeout(info);
       emitDiagnostic({
         level: 'error',
         phase: 'daemon_request_timeout',
@@ -249,13 +256,17 @@ async function sendRequest(info: DaemonInfo, req: DaemonRequest): Promise<Daemon
           timeoutMs: REQUEST_TIMEOUT_MS,
           requestId: req.meta?.requestId,
           command: req.command,
+          timedOutRunnerPidsTerminated: cleanup.terminated,
+          timedOutRunnerCleanupError: cleanup.error,
+          daemonPidReset: info.pid,
+          daemonPidForceKilled: daemonReset.forcedKill,
         },
       });
       reject(
         new AppError('COMMAND_FAILED', 'Daemon request timed out', {
           timeoutMs: REQUEST_TIMEOUT_MS,
           requestId: req.meta?.requestId,
-          hint: 'Retry with --debug and check daemon diagnostics logs.',
+          hint: 'Retry with --debug and check daemon diagnostics logs. Timed-out iOS runner xcodebuild processes were terminated when detected.',
         }),
       );
     }, REQUEST_TIMEOUT_MS);
@@ -305,6 +316,42 @@ async function sendRequest(info: DaemonInfo, req: DaemonRequest): Promise<Daemon
       );
     });
   });
+}
+
+function cleanupTimedOutIosRunnerBuilds(): { terminated: number; error?: string } {
+  let terminated = 0;
+  try {
+    for (const pattern of IOS_RUNNER_XCODEBUILD_KILL_PATTERNS) {
+      const result = runCmdSync('pkill', ['-f', pattern], { allowFailure: true });
+      if (result.exitCode === 0) terminated += 1;
+    }
+    return { terminated };
+  } catch (error) {
+    return {
+      terminated,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function resetDaemonAfterTimeout(info: DaemonInfo): { forcedKill: boolean } {
+  let forcedKill = false;
+  try {
+    if (isAgentDeviceDaemonProcess(info.pid, info.processStartTime)) {
+      process.kill(info.pid, 'SIGKILL');
+      forcedKill = true;
+    }
+  } catch {
+    void stopProcessForTakeover(info.pid, {
+      termTimeoutMs: DAEMON_TAKEOVER_TERM_TIMEOUT_MS,
+      killTimeoutMs: DAEMON_TAKEOVER_KILL_TIMEOUT_MS,
+      expectedStartTime: info.processStartTime,
+    });
+  } finally {
+    removeDaemonInfo();
+    removeDaemonLock();
+  }
+  return { forcedKill };
 }
 
 export function resolveDaemonRequestTimeoutMs(raw: string | undefined = process.env.AGENT_DEVICE_DAEMON_TIMEOUT_MS): number {

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -1,6 +1,8 @@
 import type { CommandFlags } from '../core/dispatch.ts';
+import { getDiagnosticsMeta } from '../utils/diagnostics.ts';
 
 export type DaemonCommandContext = {
+  requestId?: string;
   appBundleId?: string;
   activity?: string;
   verbose?: boolean;
@@ -25,8 +27,11 @@ export function contextFromFlags(
   flags: CommandFlags | undefined,
   appBundleId?: string,
   traceLogPath?: string,
+  requestId?: string,
 ): DaemonCommandContext {
+  const effectiveRequestId = requestId ?? getDiagnosticsMeta().requestId;
   return {
+    requestId: effectiveRequestId,
     appBundleId,
     activity: flags?.activity,
     verbose: flags?.verbose,

--- a/src/daemon/handlers/snapshot.ts
+++ b/src/daemon/handlers/snapshot.ts
@@ -234,7 +234,12 @@ export async function handleSnapshotCommands(params: {
           const result = (await runIosRunnerCommand(
             device,
             { command: 'findText', text, appBundleId: session?.appBundleId },
-            { verbose: req.flags?.verbose, logPath, traceLogPath: session?.trace?.outPath },
+            {
+              verbose: req.flags?.verbose,
+              logPath,
+              traceLogPath: session?.trace?.outPath,
+              requestId: req.meta?.requestId,
+            },
           )) as { found?: boolean };
           if (result?.found) {
             recordIfSession(sessionStore, session, req, { text, waitedMs: Date.now() - start });
@@ -277,7 +282,12 @@ export async function handleSnapshotCommands(params: {
             const data = await runIosRunnerCommand(
               device,
               { command: 'alert', action: 'get', appBundleId: session?.appBundleId },
-              { verbose: req.flags?.verbose, logPath, traceLogPath: session?.trace?.outPath },
+              {
+                verbose: req.flags?.verbose,
+                logPath,
+                traceLogPath: session?.trace?.outPath,
+                requestId: req.meta?.requestId,
+              },
             );
             recordIfSession(sessionStore, session, req, data as Record<string, unknown>);
             return { ok: true, data };
@@ -296,7 +306,12 @@ export async function handleSnapshotCommands(params: {
             action === 'accept' || action === 'dismiss' ? (action as 'accept' | 'dismiss') : 'get',
           appBundleId: session?.appBundleId,
         },
-        { verbose: req.flags?.verbose, logPath, traceLogPath: session?.trace?.outPath },
+        {
+          verbose: req.flags?.verbose,
+          logPath,
+          traceLogPath: session?.trace?.outPath,
+          requestId: req.meta?.requestId,
+        },
       );
       recordIfSession(sessionStore, session, req, data as Record<string, unknown>);
       return { ok: true, data };

--- a/src/daemon/request-cancel.ts
+++ b/src/daemon/request-cancel.ts
@@ -1,0 +1,16 @@
+const canceledRequestIds = new Set<string>();
+
+export function markRequestCanceled(requestId: string | undefined): void {
+  if (!requestId) return;
+  canceledRequestIds.add(requestId);
+}
+
+export function clearRequestCanceled(requestId: string | undefined): void {
+  if (!requestId) return;
+  canceledRequestIds.delete(requestId);
+}
+
+export function isRequestCanceled(requestId: string | undefined): boolean {
+  if (!requestId) return false;
+  return canceledRequestIds.has(requestId);
+}

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -15,11 +15,13 @@ export type ExecOptions = {
   binaryStdout?: boolean;
   stdin?: string | Buffer;
   timeoutMs?: number;
+  detached?: boolean;
 };
 
 export type ExecStreamOptions = ExecOptions & {
   onStdoutChunk?: (chunk: string) => void;
   onStderrChunk?: (chunk: string) => void;
+  onSpawn?: (child: ReturnType<typeof spawn>) => void;
 };
 
 export type ExecBackgroundResult = {
@@ -37,6 +39,7 @@ export async function runCmd(
       cwd: options.cwd,
       env: options.env,
       stdio: ['pipe', 'pipe', 'pipe'],
+      detached: options.detached,
     });
 
     let stdout = '';
@@ -199,7 +202,9 @@ export async function runCmdStreaming(
       cwd: options.cwd,
       env: options.env,
       stdio: ['pipe', 'pipe', 'pipe'],
+      detached: options.detached,
     });
+    options.onSpawn?.(child);
 
     let stdout = '';
     let stderr = '';
@@ -269,6 +274,7 @@ export function runCmdBackground(
     cwd: options.cwd,
     env: options.env,
     stdio: ['ignore', 'pipe', 'pipe'],
+    detached: options.detached,
   });
 
   let stdout = '';

--- a/src/utils/interactors.ts
+++ b/src/utils/interactors.ts
@@ -21,8 +21,10 @@ import {
   screenshotIos,
 } from '../platforms/ios/index.ts';
 import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
+import { isRequestCanceled } from '../daemon/request-cancel.ts';
 
 export type RunnerContext = {
+  requestId?: string;
   appBundleId?: string;
   verbose?: boolean;
   logPath?: string;
@@ -85,7 +87,16 @@ type IoRunnerOverrides = Pick<
 >;
 
 function iosRunnerOverrides(device: DeviceInfo, ctx: RunnerContext): IoRunnerOverrides {
-  const runnerOpts = { verbose: ctx.verbose, logPath: ctx.logPath, traceLogPath: ctx.traceLogPath };
+  const runnerOpts = {
+    verbose: ctx.verbose,
+    logPath: ctx.logPath,
+    traceLogPath: ctx.traceLogPath,
+    requestId: ctx.requestId,
+  };
+  const throwIfCanceled = () => {
+    if (!isRequestCanceled(ctx.requestId)) return;
+    throw new AppError('COMMAND_FAILED', 'request canceled');
+  };
 
   return {
     tap: async (x, y) => {
@@ -154,20 +165,34 @@ function iosRunnerOverrides(device: DeviceInfo, ctx: RunnerContext): IoRunnerOve
       );
     },
     scrollIntoView: async (text) => {
-      const maxAttempts = 8;
-      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      // Check once, then scroll in bursts to avoid slow find->swipe->find cadence on heavy screens.
+      const initial = (await runIosRunnerCommand(
+        device,
+        { command: 'findText', text, appBundleId: ctx.appBundleId },
+        runnerOpts,
+      )) as { found?: boolean };
+      if (initial?.found) return { attempts: 1 };
+
+      const maxBursts = 12;
+      const swipesPerBurst = 4;
+      for (let burst = 0; burst < maxBursts; burst += 1) {
+        for (let i = 0; i < swipesPerBurst; i += 1) {
+          throwIfCanceled();
+          await runIosRunnerCommand(
+            device,
+            { command: 'swipe', direction: 'up', appBundleId: ctx.appBundleId },
+            runnerOpts,
+          );
+          // Small settle keeps gesture chain stable without long visible pauses.
+          await new Promise((resolve) => setTimeout(resolve, 80));
+        }
+        throwIfCanceled();
         const found = (await runIosRunnerCommand(
           device,
           { command: 'findText', text, appBundleId: ctx.appBundleId },
           runnerOpts,
         )) as { found?: boolean };
-        if (found?.found) return { attempts: attempt + 1 };
-        await runIosRunnerCommand(
-          device,
-          { command: 'swipe', direction: 'up', appBundleId: ctx.appBundleId },
-          runnerOpts,
-        );
-        await new Promise((resolve) => setTimeout(resolve, 300));
+        if (found?.found) return { attempts: burst + 2 };
       }
       throw new AppError('COMMAND_FAILED', `scrollintoview could not find text: ${text}`);
     },


### PR DESCRIPTION
## Summary

Harden iOS runner lifecycle and cancellation behavior for flaky/long-running XCTest sessions.
- tighten runner retry policy to read-only commands and transient failure signatures
- harden Springboard modal probing against stale XCUI element exceptions
- improve daemon/client interrupt and timeout teardown so detached xcodebuild trees are aborted reliably
- propagate request cancellation through runner command paths to prevent stale in-flight loops after disconnect/timeout

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:smoke`
- `pnpm build:xcuitest`
