### PR TITLE
fix: speed up and simplify scrollintoview @ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ Pinch:
 Swipe timing:
 - `swipe` accepts optional `durationMs` (default `250`, range `16..10000`).
 - Android uses requested swipe duration directly.
-- iOS uses a safe normalized duration to avoid longpress side effects.
-- `scrollintoview` accepts either plain text or a snapshot ref (`@eN`); ref mode uses geometry-based scrolling.
+- iOS clamps swipe duration to a safe range (`16..60ms`) to avoid longpress side effects.
+- `scrollintoview` accepts either plain text or a snapshot ref (`@eN`); ref mode uses best-effort geometry-based scrolling without post-scroll verification. Run `snapshot` again before follow-up `@ref` commands.
 
 ## Skills
 Install the automation skills listed in [SKILL.md](skills/agent-device/SKILL.md).

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -219,7 +219,7 @@ export async function dispatchCommand(
 
       const requestedDurationMs = positionals[4] ? Number(positionals[4]) : 250;
       const durationMs = requireIntInRange(requestedDurationMs, 'durationMs', 16, 10_000);
-      const effectiveDurationMs = device.platform === 'ios' ? 60 : durationMs;
+      const effectiveDurationMs = device.platform === 'ios' ? clampIosSwipeDuration(durationMs) : durationMs;
       const count = requireIntInRange(context?.count ?? 1, 'count', 1, 200);
       const pauseMs = requireIntInRange(context?.pauseMs ?? 0, 'pause-ms', 0, 10_000);
       const pattern = context?.pattern ?? 'one-way';
@@ -509,6 +509,11 @@ function requireIntInRange(value: number, name: string, min: number, max: number
     throw new AppError('INVALID_ARGS', `${name} must be an integer between ${min} and ${max}`);
   }
   return value;
+}
+
+function clampIosSwipeDuration(durationMs: number): number {
+  // Keep iOS swipes stable while allowing explicit fast durations for scroll-heavy flows.
+  return Math.min(60, Math.max(16, Math.round(durationMs)));
 }
 
 export function shouldUseIosTapSeries(

--- a/src/daemon/__tests__/scroll-planner.test.ts
+++ b/src/daemon/__tests__/scroll-planner.test.ts
@@ -36,6 +36,9 @@ test('buildScrollIntoViewPlan computes downward content scroll when target is be
   assert.ok(plan);
   assert.equal(plan?.direction, 'down');
   assert.ok((plan?.count ?? 0) > 1);
+  assert.equal(plan?.x, 80);
+  assert.equal(plan?.startY, 726);
+  assert.equal(plan?.endY, 118);
 });
 
 test('buildScrollIntoViewPlan returns null when already in safe viewport band', () => {
@@ -44,4 +47,12 @@ test('buildScrollIntoViewPlan returns null when already in safe viewport band', 
   const plan = buildScrollIntoViewPlan(targetRect, viewportRect);
   assert.equal(plan, null);
   assert.equal(isRectWithinSafeViewportBand(targetRect, viewportRect), true);
+});
+
+test('buildScrollIntoViewPlan keeps swipe lane inside viewport when target center is out of bounds', () => {
+  const targetRect = { x: 1000, y: 2100, width: 120, height: 40 };
+  const viewportRect = { x: 0, y: 0, width: 390, height: 844 };
+  const plan = buildScrollIntoViewPlan(targetRect, viewportRect);
+  assert.ok(plan);
+  assert.equal(plan?.x, 351);
 });

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -214,7 +214,6 @@ test('scrollintoview @ref dispatches geometry-based swipe series', async () => {
     positionals: string[];
     context: Record<string, unknown> | undefined;
   }> = [];
-  let snapshotCallCount = 0;
   const response = await handleInteractionCommands({
     req: {
       token: 't',
@@ -227,16 +226,6 @@ test('scrollintoview @ref dispatches geometry-based swipe series', async () => {
     sessionStore,
     contextFromFlags,
     dispatch: async (_device, command, positionals, _out, context) => {
-      if (command === 'snapshot') {
-        snapshotCallCount += 1;
-        return {
-          nodes: [
-            { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 } },
-            { index: 1, type: 'XCUIElementTypeStaticText', label: 'Far item', rect: { x: 20, y: 320, width: 120, height: 40 } },
-          ],
-          backend: 'xctest',
-        };
-      }
       dispatchCalls.push({ command, positionals, context: context as Record<string, unknown> | undefined });
       return { ok: true };
     },
@@ -244,7 +233,6 @@ test('scrollintoview @ref dispatches geometry-based swipe series', async () => {
 
   assert.ok(response);
   assert.equal(response.ok, true);
-  assert.equal(snapshotCallCount, 1);
   assert.equal(dispatchCalls.length, 1);
   assert.equal(dispatchCalls[0]?.command, 'swipe');
   assert.equal(dispatchCalls[0]?.positionals.length, 5);
@@ -259,8 +247,6 @@ test('scrollintoview @ref dispatches geometry-based swipe series', async () => {
   assert.equal(stored?.actions[0]?.command, 'scrollintoview');
   const result = (stored?.actions[0]?.result ?? {}) as Record<string, unknown>;
   assert.equal(result.ref, 'e2');
-  assert.equal(result.strategy, 'ref-geometry');
-  assert.equal(result.verified, true);
 });
 
 test('scrollintoview @ref returns immediately when target is already in viewport safe band', async () => {
@@ -313,7 +299,7 @@ test('scrollintoview @ref returns immediately when target is already in viewport
   }
 });
 
-test('scrollintoview @ref fails if target remains outside viewport after scroll', async () => {
+test('scrollintoview @ref does not run post-scroll verification snapshot', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'default';
   const session = makeSession(sessionName);
@@ -335,6 +321,7 @@ test('scrollintoview @ref fails if target remains outside viewport after scroll'
     backend: 'xctest',
   };
   sessionStore.set(sessionName, session);
+  let snapshotCallCount = 0;
 
   const response = await handleInteractionCommands({
     req: {
@@ -349,6 +336,7 @@ test('scrollintoview @ref fails if target remains outside viewport after scroll'
     contextFromFlags,
     dispatch: async (_device, command) => {
       if (command === 'snapshot') {
+        snapshotCallCount += 1;
         return {
           nodes: [
             { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 } },
@@ -362,9 +350,6 @@ test('scrollintoview @ref fails if target remains outside viewport after scroll'
   });
 
   assert.ok(response);
-  assert.equal(response.ok, false);
-  if (!response.ok) {
-    assert.equal(response.error?.code, 'COMMAND_FAILED');
-    assert.match(response.error?.message ?? '', /outside viewport/i);
-  }
+  assert.equal(response.ok, true);
+  assert.equal(snapshotCallCount, 0);
 });

--- a/src/daemon/scroll-planner.ts
+++ b/src/daemon/scroll-planner.ts
@@ -38,22 +38,27 @@ export function resolveViewportRect(nodes: RawSnapshotNode[], targetRect: Rect):
 
 export function buildScrollIntoViewPlan(targetRect: Rect, viewportRect: Rect): ScrollIntoViewPlan | null {
   const viewportHeight = Math.max(1, viewportRect.height);
+  const viewportWidth = Math.max(1, viewportRect.width);
   const viewportTop = viewportRect.y;
   const viewportBottom = viewportRect.y + viewportHeight;
+  const viewportLeft = viewportRect.x;
+  const viewportRight = viewportRect.x + viewportWidth;
   const safeTop = viewportTop + viewportHeight * 0.25;
   const safeBottom = viewportBottom - viewportHeight * 0.25;
+  const lanePaddingPx = Math.max(8, viewportWidth * 0.1);
   const targetCenterY = targetRect.y + targetRect.height / 2;
+  const targetCenterX = targetRect.x + targetRect.width / 2;
 
   if (targetCenterY >= safeTop && targetCenterY <= safeBottom) {
     return null;
   }
 
-  const x = Math.round(viewportRect.x + viewportRect.width / 2);
-  const dragUpStartY = Math.round(viewportTop + viewportHeight * 0.78);
-  const dragUpEndY = Math.round(viewportTop + viewportHeight * 0.22);
+  const x = Math.round(clamp(targetCenterX, viewportLeft + lanePaddingPx, viewportRight - lanePaddingPx));
+  const dragUpStartY = Math.round(viewportTop + viewportHeight * 0.86);
+  const dragUpEndY = Math.round(viewportTop + viewportHeight * 0.14);
   const dragDownStartY = dragUpEndY;
   const dragDownEndY = dragUpStartY;
-  const swipeStepPx = Math.max(1, Math.abs(dragUpStartY - dragUpEndY) * 0.9);
+  const swipeStepPx = Math.max(1, Math.abs(dragUpStartY - dragUpEndY));
 
   if (targetCenterY > safeBottom) {
     const delta = targetCenterY - safeBottom;
@@ -110,4 +115,8 @@ function pickLargestRect(rects: Rect[]): Rect | null {
 
 function clampInt(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -67,8 +67,8 @@ agent-device pinch 0.5 200 400 # zoom out at coordinates (iOS simulator)
 `fill` clears then types. `type` does not clear.
 On Android, `fill` also verifies text and performs one clear-and-retry pass on mismatch.
 `swipe` accepts an optional `durationMs` argument (default `250ms`, range `16..10000`).
-On iOS, swipe timing uses a safe normalized duration to avoid longpress side effects.
-`scrollintoview` accepts plain text or a snapshot ref (`@eN`); ref mode uses geometry-based scrolling.
+On iOS, swipe duration is clamped to a safe range (`16..60ms`) to avoid longpress side effects.
+`scrollintoview` accepts plain text or a snapshot ref (`@eN`); ref mode uses best-effort geometry-based scrolling without post-scroll verification. Run `snapshot` again before follow-up `@ref` commands.
 `longpress` is supported on iOS and Android.
 `pinch` is iOS simulator-only.
 


### PR DESCRIPTION
## Summary

Improve scrollintoview @ref execution speed and reliability while simplifying post-scroll behavior.
- Increase geometry swipe effectiveness (lane follows target X and larger swipe span).
- Speed up iOS ref-scroll swipes by honoring fast safe durations.
- Reduce iOS scroll gesture idle-wait delays without affecting tap/click cadence.
- Remove post-scroll verification for @ref mode (best-effort scroll, then resnapshot workflow).
- Trim unused strategy payload fields from scrollintoview results.
- Update docs for iOS swipe duration clamping and ref-scroll best-effort behavior.

## Validation

- pnpm typecheck
- pnpm test:unit
- pnpm test:smoke
- pnpm build:xcuitest