### PR TITLE
chore: remove dead node/ts code paths

### DIFF
--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -2,7 +2,7 @@ import { AppError } from '../utils/errors.ts';
 import type { BatchStep, CommandFlags } from './dispatch.ts';
 
 export const DEFAULT_BATCH_MAX_STEPS = 100;
-export const BATCH_BLOCKED_COMMANDS = new Set(['batch', 'replay']);
+const BATCH_BLOCKED_COMMANDS = new Set(['batch', 'replay']);
 
 export type NormalizedBatchStep = {
   command: string;

--- a/src/daemon/is-predicates.ts
+++ b/src/daemon/is-predicates.ts
@@ -2,7 +2,7 @@ import type { SnapshotState } from '../utils/snapshot.ts';
 import { extractNodeText } from './snapshot-processing.ts';
 import { isNodeEditable, isNodeVisible } from './selectors.ts';
 
-export type IsPredicate = 'visible' | 'hidden' | 'exists' | 'editable' | 'selected' | 'text';
+type IsPredicate = 'visible' | 'hidden' | 'exists' | 'editable' | 'selected' | 'text';
 
 export function isSupportedPredicate(input: string): input is IsPredicate {
   return ['visible', 'hidden', 'exists', 'editable', 'selected', 'text'].includes(input);

--- a/src/daemon/scroll-planner.ts
+++ b/src/daemon/scroll-planner.ts
@@ -1,6 +1,6 @@
 import { centerOfRect, type RawSnapshotNode, type Rect } from '../utils/snapshot.ts';
 
-export type ScrollIntoViewPlan = {
+type ScrollIntoViewPlan = {
   x: number;
   startY: number;
   endY: number;

--- a/src/daemon/selectors.ts
+++ b/src/daemon/selectors.ts
@@ -21,7 +21,7 @@ type SelectorTerm = {
   value: string | boolean;
 };
 
-export type Selector = {
+type Selector = {
   raw: string;
   terms: SelectorTerm[];
 };
@@ -31,12 +31,12 @@ export type SelectorChain = {
   selectors: Selector[];
 };
 
-export type SelectorDiagnostics = {
+type SelectorDiagnostics = {
   selector: string;
   matches: number;
 };
 
-export type SelectorResolution = {
+type SelectorResolution = {
   node: SnapshotNode;
   selector: Selector;
   selectorIndex: number;
@@ -233,7 +233,7 @@ export function isNodeEditable(node: SnapshotNode, platform: 'ios' | 'android'):
 
 export function buildSelectorChainForNode(
   node: SnapshotNode,
-  platform: 'ios' | 'android',
+  _platform: 'ios' | 'android',
   options: { action?: 'click' | 'fill' | 'get' } = {},
 ): string[] {
   const chain: string[] = [];

--- a/src/daemon/snapshot-diff.ts
+++ b/src/daemon/snapshot-diff.ts
@@ -1,23 +1,23 @@
 import type { SnapshotNode } from '../utils/snapshot.ts';
 import { buildSnapshotDisplayLines, displayLabel, formatRole, formatSnapshotLine } from '../utils/snapshot-lines.ts';
 
-export type SnapshotDiffLine = {
+type SnapshotDiffLine = {
   kind: 'added' | 'removed' | 'unchanged';
   text: string;
 };
 
-export type SnapshotDiffSummary = {
+type SnapshotDiffSummary = {
   additions: number;
   removals: number;
   unchanged: number;
 };
 
-export type SnapshotDiffResult = {
+type SnapshotDiffResult = {
   summary: SnapshotDiffSummary;
   lines: SnapshotDiffLine[];
 };
 
-export type SnapshotDiffOptions = {
+type SnapshotDiffOptions = {
   flatten?: boolean;
 };
 
@@ -26,7 +26,7 @@ type SnapshotComparableLine = {
   comparable: string;
 };
 
-export function snapshotNodeToComparableLine(node: SnapshotNode, depthOverride?: number): string {
+function snapshotNodeToComparableLine(node: SnapshotNode, depthOverride?: number): string {
   const role = formatRole(node.type ?? 'Element');
   const textPart = displayLabel(node, role);
   const enabledPart = node.enabled === false ? 'disabled' : 'enabled';

--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -76,7 +76,7 @@ export async function listAndroidDevices(): Promise<DeviceInfo[]> {
   return devices;
 }
 
-export async function isAndroidBooted(serial: string): Promise<boolean> {
+async function isAndroidBooted(serial: string): Promise<boolean> {
   try {
     const result = await readAndroidBootProp(serial);
     return result.stdout.trim() === '1';

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -16,7 +16,7 @@ function adbArgs(device: DeviceInfo, args: string[]): string[] {
   return ['-s', device.id, ...args];
 }
 
-export async function resolveAndroidApp(
+async function resolveAndroidApp(
   device: DeviceInfo,
   app: string,
 ): Promise<{ type: 'intent' | 'package'; value: string }> {
@@ -320,7 +320,7 @@ export async function closeAndroidApp(device: DeviceInfo, app: string): Promise<
   await runCmd('adb', adbArgs(device, ['shell', 'am', 'force-stop', resolved.value]));
 }
 
-export async function uninstallAndroidApp(
+async function uninstallAndroidApp(
   device: DeviceInfo,
   app: string,
 ): Promise<{ package: string }> {
@@ -342,7 +342,7 @@ export async function uninstallAndroidApp(
   return { package: resolved.value };
 }
 
-export async function installAndroidApp(device: DeviceInfo, appPath: string): Promise<void> {
+async function installAndroidApp(device: DeviceInfo, appPath: string): Promise<void> {
   await runCmd('adb', adbArgs(device, ['install', appPath]));
 }
 

--- a/src/platforms/boot-diagnostics.ts
+++ b/src/platforms/boot-diagnostics.ts
@@ -1,6 +1,6 @@
 import { asAppError } from '../utils/errors.ts';
 
-export type BootFailureReason =
+type BootFailureReason =
   | 'IOS_BOOT_TIMEOUT'
   | 'IOS_RUNNER_CONNECT_TIMEOUT'
   | 'IOS_TOOL_MISSING'

--- a/src/platforms/ios/config.ts
+++ b/src/platforms/ios/config.ts
@@ -1,4 +1,4 @@
-import { isEnvTruthy, TIMEOUT_PROFILES } from '../../utils/retry.ts';
+import { TIMEOUT_PROFILES } from '../../utils/retry.ts';
 import { resolveTimeoutMs } from '../../utils/timeouts.ts';
 
 export const IOS_BOOT_TIMEOUT_MS = resolveTimeoutMs(
@@ -24,5 +24,3 @@ export const IOS_DEVICECTL_TIMEOUT_MS = resolveTimeoutMs(
   20_000,
   1_000,
 );
-
-export const RETRY_LOGS_ENABLED = isEnvTruthy(process.env.AGENT_DEVICE_RETRY_LOGS);

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -13,7 +13,7 @@ import { bootFailureHint, classifyBootFailure } from '../boot-diagnostics.ts';
 import { resolveTimeoutMs, resolveTimeoutSeconds } from '../../utils/timeouts.ts';
 import { isRequestCanceled } from '../../daemon/request-cancel.ts';
 
-export type RunnerCommand = {
+type RunnerCommand = {
   command:
     | 'tap'
     | 'tapSeries'
@@ -58,7 +58,7 @@ export type RunnerCommand = {
   clearFirst?: boolean;
 };
 
-export type RunnerSession = {
+type RunnerSession = {
   device: DeviceInfo;
   deviceId: string;
   port: number;
@@ -115,18 +115,6 @@ const RUNNER_DESTINATION_TIMEOUT_SECONDS = resolveTimeoutSeconds(
 const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 const RUNNER_DERIVED_ROOT = path.join(os.homedir(), '.agent-device', 'ios-runner');
-
-export type RunnerSnapshotNode = {
-  index: number;
-  type?: string;
-  label?: string;
-  value?: string;
-  identifier?: string;
-  rect?: { x: number; y: number; width: number; height: number };
-  enabled?: boolean;
-  hittable?: boolean;
-  depth?: number;
-};
 
 export async function runIosRunnerCommand(
   device: DeviceInfo,

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -11,7 +11,7 @@ import {
   type FlagKey,
 } from './command-schema.ts';
 
-export type ParsedArgs = {
+type ParsedArgs = {
   command: string | null;
   positionals: string[];
   flags: CliFlags;

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -40,7 +40,7 @@ export type CliFlags = {
 };
 
 export type FlagKey = keyof CliFlags;
-export type FlagType = 'boolean' | 'int' | 'enum' | 'string' | 'booleanOrString';
+type FlagType = 'boolean' | 'int' | 'enum' | 'string' | 'booleanOrString';
 
 export type FlagDefinition = {
   key: FlagKey;
@@ -54,7 +54,7 @@ export type FlagDefinition = {
   usageDescription?: string;
 };
 
-export type CommandSchema = {
+type CommandSchema = {
   description: string;
   positionalArgs: readonly string[];
   allowsExtraPositionals?: boolean;
@@ -80,7 +80,7 @@ const SELECTOR_SNAPSHOT_FLAGS = [
 
 const FIND_SNAPSHOT_FLAGS = ['snapshotDepth', 'snapshotRaw'] as const satisfies readonly FlagKey[];
 
-export const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
+const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
   {
     key: 'platform',
     names: ['--platform'],
@@ -354,7 +354,7 @@ export const GLOBAL_FLAG_KEYS = new Set<FlagKey>([
   'noRecord',
 ]);
 
-export const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
+const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
   boot: {
     description: 'Ensure target device/simulator is booted and ready',
     positionalArgs: [],

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -2,8 +2,8 @@ import { AppError } from './errors.ts';
 import { isInteractive } from './interactive.ts';
 import { isCancel, select } from '@clack/prompts';
 
-export type Platform = 'ios' | 'android';
-export type DeviceKind = 'simulator' | 'emulator' | 'device';
+type Platform = 'ios' | 'android';
+type DeviceKind = 'simulator' | 'emulator' | 'device';
 
 export type DeviceInfo = {
   platform: Platform;
@@ -13,7 +13,7 @@ export type DeviceInfo = {
   booted?: boolean;
 };
 
-export type DeviceSelector = {
+type DeviceSelector = {
   platform?: Platform;
   deviceName?: string;
   udid?: string;

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -4,9 +4,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-export type DiagnosticLevel = 'info' | 'warn' | 'error' | 'debug';
+type DiagnosticLevel = 'info' | 'warn' | 'error' | 'debug';
 
-export type DiagnosticEvent = {
+type DiagnosticEvent = {
   ts: string;
   level: DiagnosticLevel;
   phase: string;
@@ -17,7 +17,7 @@ export type DiagnosticEvent = {
   data?: Record<string, unknown>;
 };
 
-export type DiagnosticsScopeOptions = {
+type DiagnosticsScopeOptions = {
   session?: string;
   requestId?: string;
   command?: string;
@@ -40,7 +40,7 @@ export function createRequestId(): string {
   return crypto.randomBytes(8).toString('hex');
 }
 
-export function createDiagnosticId(): string {
+function createDiagnosticId(): string {
   return `${Date.now().toString(36)}-${crypto.randomBytes(4).toString('hex')}`;
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,6 @@
 import { redactDiagnosticData } from './diagnostics.ts';
 
-export type ErrorCode =
+type ErrorCode =
   | 'INVALID_ARGS'
   | 'DEVICE_NOT_FOUND'
   | 'TOOL_MISSING'
@@ -12,7 +12,7 @@ export type ErrorCode =
   | 'UNAUTHORIZED'
   | 'UNKNOWN';
 
-export type AppErrorDetails = Record<string, unknown> & {
+type AppErrorDetails = Record<string, unknown> & {
   hint?: string;
   diagnosticId?: string;
   logPath?: string;

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -8,7 +8,7 @@ export type ExecResult = {
   stdoutBuffer?: Buffer;
 };
 
-export type ExecOptions = {
+type ExecOptions = {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   allowFailure?: boolean;
@@ -18,7 +18,7 @@ export type ExecOptions = {
   detached?: boolean;
 };
 
-export type ExecStreamOptions = ExecOptions & {
+type ExecStreamOptions = ExecOptions & {
   onStdoutChunk?: (chunk: string) => void;
   onStderrChunk?: (chunk: string) => void;
   onSpawn?: (child: ReturnType<typeof spawn>) => void;
@@ -318,16 +318,6 @@ export function runCmdBackground(
   });
 
   return { child, wait };
-}
-
-export function whichCmdSync(cmd: string): boolean {
-  try {
-    const { shell, args } = resolveWhichArgs(cmd);
-    const result = runCmdSync(shell, args, { allowFailure: true });
-    return result.exitCode === 0 && result.stdout.trim().length > 0;
-  } catch {
-    return false;
-  }
 }
 
 function resolveWhichArgs(cmd: string): { shell: string; args: string[] } {

--- a/src/utils/finders.ts
+++ b/src/utils/finders.ts
@@ -2,11 +2,11 @@ import type { SnapshotNode } from './snapshot.ts';
 
 export type FindLocator = 'any' | 'text' | 'label' | 'value' | 'role' | 'id';
 
-export type FindMatchOptions = {
+type FindMatchOptions = {
   requireRect?: boolean;
 };
 
-export type FindBestMatches = {
+type FindBestMatches = {
   matches: SnapshotNode[];
   score: number;
 };

--- a/src/utils/interactors.ts
+++ b/src/utils/interactors.ts
@@ -31,7 +31,7 @@ export type RunnerContext = {
   traceLogPath?: string;
 };
 
-export type Interactor = {
+type Interactor = {
   open(app: string, options?: { activity?: string; appBundleId?: string; url?: string }): Promise<void>;
   openDevice(): Promise<void>;
   close(app: string): Promise<void>;

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -2,7 +2,7 @@ import { AppError, normalizeError, type NormalizedError } from './errors.ts';
 import { buildSnapshotDisplayLines, formatSnapshotLine } from './snapshot-lines.ts';
 import type { SnapshotNode } from './snapshot.ts';
 
-export type JsonResult =
+type JsonResult =
   | { success: true; data?: Record<string, unknown> }
   | {
     success: false;

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -9,7 +9,7 @@ type RetryOptions = {
   shouldRetry?: (error: unknown, attempt: number) => boolean;
 };
 
-export type RetryPolicy = {
+type RetryPolicy = {
   maxAttempts: number;
   baseDelayMs: number;
   maxDelayMs: number;
@@ -17,19 +17,19 @@ export type RetryPolicy = {
   shouldRetry?: (error: unknown, attempt: number) => boolean;
 };
 
-export type RetryAttemptContext = {
+type RetryAttemptContext = {
   attempt: number;
   maxAttempts: number;
   deadline?: Deadline;
 };
 
-export type TimeoutProfile = {
+type TimeoutProfile = {
   startupMs: number;
   operationMs: number;
   totalMs: number;
 };
 
-export type RetryTelemetryEvent = {
+type RetryTelemetryEvent = {
   phase?: string;
   event: 'attempt_failed' | 'retry_scheduled' | 'succeeded' | 'exhausted';
   attempt: number;

--- a/src/utils/snapshot-lines.ts
+++ b/src/utils/snapshot-lines.ts
@@ -1,6 +1,6 @@
 import type { SnapshotNode } from './snapshot.ts';
 
-export type SnapshotDisplayLine = {
+type SnapshotDisplayLine = {
   node: SnapshotNode;
   depth: number;
   type: string;


### PR DESCRIPTION
## Summary

Prune dead internal Node/TS code paths and reduce unnecessary module export surface without changing CLI behavior.
- remove unused helper/value declarations and internal-only exports
- make unused type aliases/interfaces module-private
- drop an unused iOS retry config constant and a stale runner type declaration
- keep runtime behavior unchanged and preserve existing command flows

## Validation

- pnpm exec tsc -p tsconfig.json --noUnusedLocals --noUnusedParameters
- pnpm typecheck
- pnpm test:unit
- pnpm test:smoke