### PR TITLE
feat: improve logs debugging workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The project is in early development and considered experimental. Pull requests a
 - Platforms: iOS (simulator + physical device core automation) and Android (emulator + device).
 - Core commands: `open`, `back`, `home`, `app-switcher`, `press`, `long-press`, `focus`, `type`, `fill`, `scroll`, `scrollintoview`, `wait`, `alert`, `screenshot`, `close`, `reinstall`.
 - Inspection commands: `snapshot` (accessibility tree), `diff snapshot` (structural baseline diff), `appstate`, `apps`, `devices`.
-- App logs: `logs path` returns session log metadata; `logs start` / `logs stop` stream app output; `logs doctor` checks readiness; `logs mark` writes timeline markers.
+- App logs: `logs path` returns session log metadata; `logs start` / `logs stop` stream app output; `logs clear` truncates session app logs; `logs clear --restart` resets and restarts stream in one step; `logs doctor` checks readiness; `logs mark` writes timeline markers.
 - Device tooling: `adb` (Android), `simctl`/`devicectl` (iOS via Xcode).
 - Minimal dependencies; TypeScript executed directly on Node 22+ (no build step).
 
@@ -145,7 +145,7 @@ agent-device scrollintoview @e42
 - `press` (alias: `click`), `focus`, `type`, `fill`, `long-press`, `swipe`, `scroll`, `scrollintoview`, `pinch`, `is`
 - `alert`, `wait`, `screenshot`
 - `trace start`, `trace stop`
-- `logs path`, `logs start`, `logs stop`, `logs doctor`, `logs mark` (session app log file for grep; iOS simulator + iOS device + Android)
+- `logs path`, `logs start`, `logs stop`, `logs clear`, `logs clear --restart`, `logs doctor`, `logs mark` (session app log file for grep; iOS simulator + iOS device + Android)
 - `settings wifi|airplane|location on|off`
 - `settings faceid match|nonmatch|enroll|unenroll` (iOS simulator only)
 - `appstate`, `apps`, `devices`, `session list`
@@ -300,9 +300,11 @@ App state:
 
 ## Debug
 
-- **App logs (token-efficient):** With an active session, run `logs path` to get path + state metadata (e.g. `~/.agent-device/sessions/<session>/app.log`). Run `logs start` to stream app output to that file; use `logs stop` to stop. Run `logs doctor` for tool/runtime checks and `logs mark "step"` to insert timeline markers. Grep the file when you need to inspect errors (e.g. `grep -n "Error\|Exception" <path>`) instead of pulling full logs into context. Supported on iOS simulator, iOS physical device, and Android.
+- **App logs (token-efficient):** Logging is off by default in normal flows. Enable it on demand when debugging. With an active session, run `logs path` to get path + state metadata (e.g. `~/.agent-device/sessions/<session>/app.log`). Run `logs start` to stream app output to that file; use `logs stop` to stop. Run `logs clear` to truncate `app.log` (and remove rotated `app.log.N` files) before a new repro window. Run `logs doctor` for tool/runtime checks and `logs mark "step"` to insert timeline markers. Grep the file when you need to inspect errors (e.g. `grep -n "Error\|Exception" <path>`) instead of pulling full logs into context. Supported on iOS simulator, iOS physical device, and Android.
+- Use `logs clear --restart` when you want one command to stop an active stream, clear current logs, and immediately resume streaming.
 - `logs start` appends to `app.log` and rotates to `app.log.1` when the file exceeds 5 MB.
 - Android log streaming automatically rebinds to the app PID after process restarts.
+- Detailed playbook: `skills/agent-device/references/logs-and-debug.md`
 - iOS log capture relies on Unified Logging signals (for example `os_log`); plain stdout/stderr output may be limited depending on app/runtime.
 - Retention knobs: set `AGENT_DEVICE_APP_LOG_MAX_BYTES` and `AGENT_DEVICE_APP_LOG_MAX_FILES` to override rotation limits.
 - Optional write-time redaction patterns: set `AGENT_DEVICE_APP_LOG_REDACT_PATTERNS` to a comma-separated regex list.

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -112,15 +112,17 @@ Think of them as validate/invalidate outcomes when describing intent.
 ### Logs (token-efficient debugging)
 
 Use the detailed logs workflow reference:
-`skills/agent-device/references/logs.md`
+`skills/agent-device/references/logs-and-debug.md`
 
 Recommended minimum:
 
 ```bash
 agent-device logs doctor
-agent-device logs start
+agent-device logs clear --restart
 agent-device logs path
 ```
+
+Logging is off by default for normal flows. Turn it on only for debugging windows.
 
 ### App state
 

--- a/src/__tests__/cli-logs.test.ts
+++ b/src/__tests__/cli-logs.test.ts
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runCli } from '../cli.ts';
+import type { DaemonRequest, DaemonResponse } from '../daemon-client.ts';
+
+class ExitSignal extends Error {
+  public readonly code: number;
+
+  constructor(code: number) {
+    super(`EXIT_${code}`);
+    this.code = code;
+  }
+}
+
+type RunResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  calls: Omit<DaemonRequest, 'token'>[];
+};
+
+async function runCliCapture(
+  argv: string[],
+  responder: (req: Omit<DaemonRequest, 'token'>) => Promise<DaemonResponse>,
+): Promise<RunResult> {
+  let stdout = '';
+  let stderr = '';
+  let code: number | null = null;
+  const calls: Array<Omit<DaemonRequest, 'token'>> = [];
+
+  const originalExit = process.exit;
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  (process as any).exit = ((nextCode?: number) => {
+    throw new ExitSignal(nextCode ?? 0);
+  }) as typeof process.exit;
+  (process.stdout as any).write = ((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  (process.stderr as any).write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  const sendToDaemon = async (req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> => {
+    calls.push(req);
+    return await responder(req);
+  };
+
+  try {
+    await runCli(argv, { sendToDaemon });
+  } catch (error) {
+    if (error instanceof ExitSignal) code = error.code;
+    else throw error;
+  } finally {
+    process.exit = originalExit;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  return { code, stdout, stderr, calls };
+}
+
+test('logs clear prints action metadata and forwards --restart flag', async () => {
+  const result = await runCliCapture(['logs', 'clear', '--restart'], async () => ({
+    ok: true,
+    data: {
+      path: '/tmp/app.log',
+      cleared: true,
+      restarted: true,
+      removedRotatedFiles: 2,
+    },
+  }));
+
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.flags?.restart, true);
+  assert.match(result.stdout, /\/tmp\/app\.log/);
+  assert.match(result.stderr, /cleared=true/);
+  assert.match(result.stderr, /restarted=true/);
+  assert.match(result.stderr, /removedRotatedFiles=2/);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -249,6 +249,13 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
           const state = typeof data?.state === 'string' ? data.state : undefined;
           const backend = typeof data?.backend === 'string' ? data.backend : undefined;
           const sizeBytes = typeof data?.sizeBytes === 'number' ? data.sizeBytes : undefined;
+          const started = data?.started === true;
+          const stopped = data?.stopped === true;
+          const marked = data?.marked === true;
+          const cleared = data?.cleared === true;
+          const restarted = data?.restarted === true;
+          const removedRotatedFiles =
+            typeof data?.removedRotatedFiles === 'number' ? data.removedRotatedFiles : undefined;
           if (!flags.json && (active !== undefined || state || backend || sizeBytes !== undefined)) {
             const meta = [
               active !== undefined ? `active=${active}` : '',
@@ -257,6 +264,17 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
               sizeBytes !== undefined ? `sizeBytes=${sizeBytes}` : '',
             ].filter(Boolean).join(' ');
             if (meta) process.stderr.write(`${meta}\n`);
+          }
+          if (!flags.json && (started || stopped || marked || cleared || restarted || removedRotatedFiles !== undefined)) {
+            const actionMeta = [
+              started ? 'started=true' : '',
+              stopped ? 'stopped=true' : '',
+              marked ? 'marked=true' : '',
+              cleared ? 'cleared=true' : '',
+              restarted ? 'restarted=true' : '',
+              removedRotatedFiles !== undefined ? `removedRotatedFiles=${removedRotatedFiles}` : '',
+            ].filter(Boolean).join(' ');
+            if (actionMeta) process.stderr.write(`${actionMeta}\n`);
           }
           if (data?.hint && !flags.json) {
             process.stderr.write(`${data.hint}\n`);

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -12,6 +12,13 @@ test('parseArgs recognizes --relaunch', () => {
   assert.equal(parsed.flags.relaunch, true);
 });
 
+test('parseArgs recognizes logs clear --restart', () => {
+  const parsed = parseArgs(['logs', 'clear', '--restart'], { strictFlags: true });
+  assert.equal(parsed.command, 'logs');
+  assert.deepEqual(parsed.positionals, ['clear']);
+  assert.equal(parsed.flags.restart, true);
+});
+
 test('parseArgs recognizes --debug alias for verbose mode', () => {
   const parsed = parseArgs(['open', 'settings', '--debug']);
   assert.equal(parsed.command, 'open');
@@ -188,6 +195,7 @@ test('parseArgs rejects invalid swipe pattern', () => {
 
 test('usage includes --relaunch flag', () => {
   assert.match(usage(), /--relaunch/);
+  assert.match(usage(), /--restart/);
   assert.match(usage(), /--fps <n>/);
   assert.match(usage(), /--save-script \[path\]/);
   assert.match(usage(), /pinch <scale> \[x\] \[y\]/);

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -24,6 +24,7 @@ export type CliFlags = {
   activity?: string;
   saveScript?: boolean | string;
   relaunch?: boolean;
+  restart?: boolean;
   noRecord?: boolean;
   replayUpdate?: boolean;
   steps?: string;
@@ -234,6 +235,13 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--relaunch',
     usageDescription: 'open: terminate app process before launching it',
+  },
+  {
+    key: 'restart',
+    names: ['--restart'],
+    type: 'boolean',
+    usageLabel: '--restart',
+    usageDescription: 'logs clear: stop active stream, clear logs, then start streaming again',
   },
   {
     key: 'noRecord',
@@ -529,11 +537,11 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     skipCapabilityCheck: true,
   },
   logs: {
-    usageOverride: 'logs path | logs start | logs stop | logs doctor | logs mark [message...]',
+    usageOverride: 'logs path | logs start | logs stop | logs clear [--restart] | logs doctor | logs mark [message...]',
     description: 'Session app log info, start/stop streaming, diagnostics, and markers',
-    positionalArgs: ['path|start|stop|doctor|mark', 'message?'],
+    positionalArgs: ['path|start|stop|clear|doctor|mark', 'message?'],
     allowsExtraPositionals: true,
-    allowedFlags: [],
+    allowedFlags: ['restart'],
   },
   find: {
     usageOverride: 'find <locator|text> <action> [value]',

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -163,17 +163,20 @@ agent-device record start session.mp4 --fps 30  # Override iOS device runner FPS
 agent-device record stop                # Stop active recording
 ```
 
-**Session app logs (token-efficient debugging):** Logs are written to a file so agents can grep instead of loading full output into context.
+**Session app logs (token-efficient debugging):** Logging is off by default in normal flows. Enable it on demand for debugging. Logs are written to a file so agents can grep instead of loading full output into context.
 
 ```bash
 agent-device logs path                  # Print session log file path (e.g. ~/.agent-device/sessions/default/app.log)
 agent-device logs start                 # Start streaming app stdout/stderr to that file (requires open first)
 agent-device logs stop                  # Stop streaming
+agent-device logs clear                 # Truncate app.log + remove rotated app.log.N files (requires stopped stream)
+agent-device logs clear --restart       # Stop stream, clear log files, and start streaming again
 agent-device logs doctor                # Show logs backend/tool checks and readiness hints
 agent-device logs mark "before submit"  # Insert timeline marker into app.log
 ```
 
 - Supported on iOS simulator, iOS physical device, and Android.
+- Preferred debug entrypoint: `logs clear --restart` for clean-window repro loops.
 - `logs start` appends to `app.log` and rotates to `app.log.1` when the file exceeds 5 MB.
 - Android log streaming automatically rebinds to the app PID after process restarts.
 - iOS log capture relies on Unified Logging signals (for example `os_log`); plain stdout/stderr output may be limited depending on app/runtime.


### PR DESCRIPTION
## Summary

Improve logs debugging ergonomics and guidance.
- Add logs clear --restart flow to stop active stream, clear log files, and restart logging.
- Add stricter logs flag/action validation (--restart only with logs clear) and richer CLI action metadata output.
- Expand tests for args parsing, CLI logs output, and session handler restart/clear behavior.
- Rename logs skill reference to logs-and-debug.md and update docs/skills to clarify logging is off by default and debugging should be on-demand.

## Validation

- pnpm typecheck
- pnpm test:unit
- pnpm test:smoke