### PR TITLE
fix: add MAIN/LAUNCHER flags to Android launcher activity resolver

### DIFF
--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   inferAndroidAppName,
+  isAmStartError,
   listAndroidApps,
   openAndroidApp,
   parseAndroidLaunchComponent,
@@ -137,6 +138,23 @@ test('parseAndroidLaunchComponent extracts final resolved component', () => {
 test('parseAndroidLaunchComponent returns null when no component is present', () => {
   const stdout = 'No activity found';
   assert.equal(parseAndroidLaunchComponent(stdout), null);
+});
+
+test('isAmStartError detects am start failure in stdout', () => {
+  assert.equal(
+    isAmStartError(
+      'Starting: Intent { ... }\nError: Activity not started, unable to resolve Intent { ... }',
+      '',
+    ),
+    true,
+  );
+});
+
+test('isAmStartError returns false for successful am start', () => {
+  assert.equal(
+    isAmStartError('Status: ok\nLaunchState: COLD\nActivity: com.example/.MainActivity', ''),
+    false,
+  );
 });
 
 test('inferAndroidAppName derives readable names from package ids', () => {
@@ -363,12 +381,13 @@ test('openAndroidApp fallback resolve-activity includes MAIN/LAUNCHER flags', as
       '  echo "package:com.microsoft.office.outlook"',
       '  exit 0',
       'fi',
-      '# First am start (with -p) fails to simulate multi-entry app issue',
+      '# First am start (with -p) outputs error but exits 0 (real Android behavior)',
       'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
       '  for arg in "$@"; do',
       '    if [ "$arg" = "-p" ]; then',
-      '      echo "Error: Activity not started" >&2',
-      '      exit 1',
+      '      echo "Starting: Intent { act=android.intent.action.MAIN cat=[android.intent.category.DEFAULT,android.intent.category.LAUNCHER] pkg=com.microsoft.office.outlook }"',
+      '      echo "Error: Activity not started, unable to resolve Intent { act=android.intent.action.MAIN cat=[android.intent.category.DEFAULT,android.intent.category.LAUNCHER] flg=0x10000000 pkg=com.microsoft.office.outlook }"',
+      '      exit 0',
       '    fi',
       '  done',
       '  echo "Status: ok"',

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -238,46 +238,51 @@ export async function openAndroidApp(
     );
     return;
   }
-  try {
-    await runCmd(
-      'adb',
-      adbArgs(device, [
-        'shell',
-        'am',
-        'start',
-        '-W',
-        '-a',
-        'android.intent.action.MAIN',
-        '-c',
-        'android.intent.category.DEFAULT',
-        '-c',
-        'android.intent.category.LAUNCHER',
-        '-p',
-        resolved.value,
-      ]),
-    );
+  const primaryResult = await runCmd(
+    'adb',
+    adbArgs(device, [
+      'shell',
+      'am',
+      'start',
+      '-W',
+      '-a',
+      'android.intent.action.MAIN',
+      '-c',
+      'android.intent.category.DEFAULT',
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '-p',
+      resolved.value,
+    ]),
+    { allowFailure: true },
+  );
+  if (primaryResult.exitCode === 0 && !isAmStartError(primaryResult.stdout, primaryResult.stderr)) {
     return;
-  } catch (initialError) {
-    const component = await resolveAndroidLaunchComponent(device, resolved.value);
-    if (!component) throw initialError;
-    await runCmd(
-      'adb',
-      adbArgs(device, [
-        'shell',
-        'am',
-        'start',
-        '-W',
-        '-a',
-        'android.intent.action.MAIN',
-        '-c',
-        'android.intent.category.DEFAULT',
-        '-c',
-        'android.intent.category.LAUNCHER',
-        '-n',
-        component,
-      ]),
-    );
   }
+  const component = await resolveAndroidLaunchComponent(device, resolved.value);
+  if (!component) {
+    throw new AppError('COMMAND_FAILED', `Failed to launch ${resolved.value}`, {
+      stdout: primaryResult.stdout,
+      stderr: primaryResult.stderr,
+    });
+  }
+  await runCmd(
+    'adb',
+    adbArgs(device, [
+      'shell',
+      'am',
+      'start',
+      '-W',
+      '-a',
+      'android.intent.action.MAIN',
+      '-c',
+      'android.intent.category.DEFAULT',
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '-n',
+      component,
+    ]),
+  );
 }
 
 async function resolveAndroidLaunchComponent(
@@ -302,6 +307,11 @@ async function resolveAndroidLaunchComponent(
   );
   if (result.exitCode !== 0) return null;
   return parseAndroidLaunchComponent(result.stdout);
+}
+
+export function isAmStartError(stdout: string, stderr: string): boolean {
+  const output = `${stdout}\n${stderr}`;
+  return /Error:.*(?:Activity not started|unable to resolve Intent)/i.test(output);
 }
 
 export function parseAndroidLaunchComponent(stdout: string): string | null {


### PR DESCRIPTION
## Summary

- Add `-a android.intent.action.MAIN -c android.intent.category.LAUNCHER` to the `resolve-activity` fallback command in `resolveAndroidLaunchComponent()`
- The resolver was missing these intent flags, causing it to resolve the wrong activity on multi-entry apps (e.g. Microsoft Outlook)
- **E2E testing uncovered a deeper issue**: `am start -W -p <package>` exits with code 0 even when it fails to resolve the activity, printing `Error: Activity not started, unable to resolve Intent` to stdout. The original `try/catch` never triggered the fallback because `runCmd` did not throw on exit code 0. Added `isAmStartError()` to detect this silent failure and correctly fall through to the component-based fallback.
- Add unit tests for resolver parsing, error detection, and launch command construction

## Changes

### Commit 1: Fix resolve-activity flags
`resolveAndroidLaunchComponent()` now passes `-a android.intent.action.MAIN -c android.intent.category.LAUNCHER` to `cmd package resolve-activity`, ensuring the correct launcher activity is resolved for multi-entry apps.

### Commit 2: Detect am start silent failures
- Replace `try/catch` with `allowFailure: true` + stdout/stderr inspection via `isAmStartError()`
- `am start -p` returning exit code 0 with `Error: Activity not started` in stdout now correctly triggers the component-based fallback
- Verified end-to-end on a physical Android device with Microsoft Outlook

## Test plan

- [x] `parseAndroidLaunchComponent` correctly parses multi-entry resolve output
- [x] `isAmStartError` detects `am start` failure messages in stdout
- [x] `isAmStartError` returns false for successful launches
- [x] Fallback `resolve-activity` command includes `-a MAIN -c LAUNCHER` flags
- [x] Default launch path still uses `-p <package>` (system-driven resolution)
- [x] E2E: `agent-device open "com.microsoft.office.outlook" --platform android` launches Outlook without `--activity` flag on physical device