### PR TITLE
fix: harden permission controls across iOS and Android

### DIFF
--- a/src/daemon/handlers/snapshot.ts
+++ b/src/daemon/handlers/snapshot.ts
@@ -395,7 +395,7 @@ export async function handleSnapshotCommands(params: {
         error: {
           code: 'INVALID_ARGS',
           message:
-            'settings requires <wifi|airplane|location> <on|off>, faceid <match|nonmatch|enroll|unenroll>, or permission <grant|deny|reset> <camera|microphone|photos|contacts|notifications> [full|limited]',
+            'settings requires <wifi|airplane|location> <on|off>, faceid <match|nonmatch|enroll|unenroll>, or permission <grant|deny|reset> <camera|microphone|photos|contacts|contacts-limited|notifications|calendar|location|location-always|media-library|motion|reminders|siri> [full|limited]',
         },
       };
     }

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -331,7 +331,7 @@ test('setAndroidSetting permission grant camera uses pm grant', async () => {
   );
 });
 
-test('setAndroidSetting permission deny notifications uses appops', async () => {
+test('setAndroidSetting permission deny notifications revokes runtime permission and appops', async () => {
   await withMockedAdb(
     'agent-device-android-permission-notifications-',
     '#!/bin/sh\nprintf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"\nprintf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"\nexit 0\n',
@@ -340,7 +340,31 @@ test('setAndroidSetting permission deny notifications uses appops', async () => 
         permissionTarget: 'notifications',
       });
       const logged = await fs.readFile(argsLogPath, 'utf8');
+      assert.match(logged, /shell\npm\nrevoke\ncom\.example\.app\nandroid\.permission\.POST_NOTIFICATIONS/);
       assert.match(logged, /shell\nappops\nset\ncom\.example\.app\nPOST_NOTIFICATION\ndeny/);
+    },
+  );
+});
+
+test('setAndroidSetting permission reset notifications clears permission flags for reprompt', async () => {
+  await withMockedAdb(
+    'agent-device-android-permission-notifications-reset-',
+    '#!/bin/sh\nprintf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"\nprintf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"\nexit 0\n',
+    async ({ argsLogPath, device }) => {
+      await setAndroidSetting(device, 'permission', 'reset', 'com.example.app', {
+        permissionTarget: 'notifications',
+      });
+      const logged = await fs.readFile(argsLogPath, 'utf8');
+      assert.match(logged, /shell\npm\nrevoke\ncom\.example\.app\nandroid\.permission\.POST_NOTIFICATIONS/);
+      assert.match(
+        logged,
+        /shell\npm\nclear-permission-flags\ncom\.example\.app\nandroid\.permission\.POST_NOTIFICATIONS\nuser-set/,
+      );
+      assert.match(
+        logged,
+        /shell\npm\nclear-permission-flags\ncom\.example\.app\nandroid\.permission\.POST_NOTIFICATIONS\nuser-fixed/,
+      );
+      assert.match(logged, /shell\nappops\nset\ncom\.example\.app\nPOST_NOTIFICATION\ndefault/);
     },
   );
 });
@@ -377,6 +401,28 @@ test('setAndroidSetting permission rejects mode argument', async () => {
       assert.equal(error instanceof AppError, true);
       assert.equal((error as AppError).code, 'INVALID_ARGS');
       assert.match((error as AppError).message, /mode is only supported for photos/i);
+      return true;
+    },
+  );
+});
+
+test('setAndroidSetting permission rejects iOS-only targets with Android-specific guidance', async () => {
+  const device: DeviceInfo = {
+    platform: 'android',
+    id: 'emulator-5554',
+    name: 'Pixel',
+    kind: 'emulator',
+    booted: true,
+  };
+  await assert.rejects(
+    () =>
+      setAndroidSetting(device, 'permission', 'grant', 'com.example.app', {
+        permissionTarget: 'calendar',
+      }),
+    (error: unknown) => {
+      assert.equal(error instanceof AppError, true);
+      assert.equal((error as AppError).code, 'INVALID_ARGS');
+      assert.match((error as AppError).message, /Unsupported permission target on Android/i);
       return true;
     },
   );

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -21,7 +21,7 @@ function adbArgs(device: DeviceInfo, args: string[]): string[] {
   return ['-s', device.id, ...args];
 }
 
-async function resolveAndroidApp(
+export async function resolveAndroidApp(
   device: DeviceInfo,
   app: string,
 ): Promise<{ type: 'intent' | 'package'; value: string }> {
@@ -589,9 +589,8 @@ export async function setAndroidSetting(
       }
       const action = parsePermissionAction(state);
       const target = parseAndroidPermissionTarget(options?.permissionTarget, options?.permissionMode);
-      if (target.kind === 'appops') {
-        const appOpsMode = action === 'grant' ? 'allow' : action === 'deny' ? 'deny' : 'default';
-        await runCmd('adb', adbArgs(device, ['shell', 'appops', 'set', appPackage, target.value, appOpsMode]));
+      if (target.kind === 'notifications') {
+        await setAndroidNotificationPermission(device, appPackage, action, target);
         return;
       }
       const pmAction = action === 'grant' ? 'grant' : 'revoke';
@@ -713,7 +712,7 @@ function parseAndroidPermissionTarget(
   permissionMode: string | undefined,
 ):
   | { kind: 'pm'; value: string; type: 'camera' | 'microphone' | 'photos' | 'contacts' }
-  | { kind: 'appops'; value: string } {
+  | { kind: 'notifications'; appOps: string; permission: string } {
   const normalized = parsePermissionTarget(permissionTarget);
   if (permissionMode?.trim()) {
     throw new AppError(
@@ -731,10 +730,16 @@ function parseAndroidPermissionTarget(
   if (normalized === 'contacts') {
     return { kind: 'pm', value: 'android.permission.READ_CONTACTS', type: 'contacts' };
   }
-  if (normalized === 'notifications') return { kind: 'appops', value: 'POST_NOTIFICATION' };
+  if (normalized === 'notifications') {
+    return {
+      kind: 'notifications',
+      appOps: 'POST_NOTIFICATION',
+      permission: 'android.permission.POST_NOTIFICATIONS',
+    };
+  }
   throw new AppError(
     'INVALID_ARGS',
-    `Unsupported permission target: ${permissionTarget}. Use camera|microphone|photos|contacts|notifications.`,
+    `Unsupported permission target on Android: ${permissionTarget}. Use camera|microphone|photos|contacts|notifications.`,
   );
 }
 
@@ -765,6 +770,41 @@ async function setAndroidPhotoPermission(
     sdkInt,
     attempts: failures,
   });
+}
+
+async function setAndroidNotificationPermission(
+  device: DeviceInfo,
+  appPackage: string,
+  action: 'grant' | 'deny' | 'reset',
+  target: { appOps: string; permission: string },
+): Promise<void> {
+  const appOpsMode = action === 'grant' ? 'allow' : action === 'deny' ? 'deny' : 'default';
+  if (action === 'grant') {
+    await runCmd(
+      'adb',
+      adbArgs(device, ['shell', 'pm', 'grant', appPackage, target.permission]),
+      { allowFailure: true },
+    );
+  } else {
+    await runCmd(
+      'adb',
+      adbArgs(device, ['shell', 'pm', 'revoke', appPackage, target.permission]),
+      { allowFailure: true },
+    );
+    if (action === 'reset') {
+      await runCmd(
+        'adb',
+        adbArgs(device, ['shell', 'pm', 'clear-permission-flags', appPackage, target.permission, 'user-set']),
+        { allowFailure: true },
+      );
+      await runCmd(
+        'adb',
+        adbArgs(device, ['shell', 'pm', 'clear-permission-flags', appPackage, target.permission, 'user-fixed']),
+        { allowFailure: true },
+      );
+    }
+  }
+  await runCmd('adb', adbArgs(device, ['shell', 'appops', 'set', appPackage, target.appOps, appOpsMode]));
 }
 
 async function getAndroidSdkInt(device: DeviceInfo): Promise<number | null> {

--- a/src/platforms/permission-utils.ts
+++ b/src/platforms/permission-utils.ts
@@ -1,7 +1,20 @@
 import { AppError } from '../utils/errors.ts';
 
 export type PermissionAction = 'grant' | 'deny' | 'reset';
-export type PermissionTarget = 'camera' | 'microphone' | 'photos' | 'contacts' | 'notifications';
+export type PermissionTarget =
+  | 'camera'
+  | 'microphone'
+  | 'photos'
+  | 'contacts'
+  | 'contacts-limited'
+  | 'notifications'
+  | 'calendar'
+  | 'location'
+  | 'location-always'
+  | 'media-library'
+  | 'motion'
+  | 'reminders'
+  | 'siri';
 export type PermissionSettingOptions = {
   permissionTarget?: string;
   permissionMode?: string;
@@ -11,7 +24,15 @@ export const PERMISSION_TARGETS: readonly PermissionTarget[] = [
   'microphone',
   'photos',
   'contacts',
+  'contacts-limited',
   'notifications',
+  'calendar',
+  'location',
+  'location-always',
+  'media-library',
+  'motion',
+  'reminders',
+  'siri',
 ];
 
 export function parsePermissionAction(action: string): PermissionAction {
@@ -29,7 +50,15 @@ export function parsePermissionTarget(value: string | undefined): PermissionTarg
     normalized === 'microphone' ||
     normalized === 'photos' ||
     normalized === 'contacts' ||
-    normalized === 'notifications'
+    normalized === 'contacts-limited' ||
+    normalized === 'notifications' ||
+    normalized === 'calendar' ||
+    normalized === 'location' ||
+    normalized === 'location-always' ||
+    normalized === 'media-library' ||
+    normalized === 'motion' ||
+    normalized === 'reminders' ||
+    normalized === 'siri'
   ) {
     return normalized;
   }

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -353,6 +353,6 @@ test('settings usage documents canonical faceid states', () => {
   const help = usageForCommand('settings');
   if (help === null) throw new Error('Expected command help text');
   assert.match(help, /match\|nonmatch\|enroll\|unenroll/);
-  assert.match(help, /camera\|microphone\|photos\|contacts\|notifications/);
+  assert.match(help, /camera\|microphone\|photos\|contacts\|contacts-limited\|notifications\|calendar\|location\|location-always\|media-library\|motion\|reminders\|siri/);
   assert.doesNotMatch(help, /validate\|unvalidate/);
 });

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -558,7 +558,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
   },
   settings: {
     usageOverride:
-      'settings <wifi|airplane|location> <on|off> | settings faceid <match|nonmatch|enroll|unenroll> | settings permission <grant|deny|reset> <camera|microphone|photos|contacts|notifications> [full|limited]',
+      'settings <wifi|airplane|location> <on|off> | settings faceid <match|nonmatch|enroll|unenroll> | settings permission <grant|deny|reset> <camera|microphone|photos|contacts|contacts-limited|notifications|calendar|location|location-always|media-library|motion|reminders|siri> [full|limited]',
     description: 'Toggle OS settings and app permissions (session app scope for permission actions)',
     positionalArgs: ['setting', 'state', 'target?', 'mode?'],
     allowedFlags: [],


### PR DESCRIPTION
## Summary

Harden permission controls and session/runtime handling across iOS + Android.

- Restart daemon when code signature changes to prevent stale daemon behavior.
- Improve Android session app resolution on `open` and preserve/clear package semantics correctly for intent/deeplink flows.
- Rework Android notifications permission behavior using `pm` + `appops` for `grant` / `deny` / `reset`.
- Expand permission target support to align with `simctl privacy` services and fail strictly on unsupported runtime services.
- Improve iOS notifications behavior with runtime-aware handling:
  - map unsupported `deny`/`grant` runtime behavior to clear `UNSUPPORTED_OPERATION`
  - add `reset notifications` fallback to `reset all` when runtime blocks direct reset
- Update command help/errors and tests for all changed behavior.

Touched files: 13.
Scope note: expanded beyond a single command module to include daemon client/runtime compatibility and both platform permission backends due cross-platform correctness requirements.

Known gaps/follow-ups:
- iOS simulator notifications `deny`/`grant` remains runtime/toolchain dependent and can be unsupported by `simctl privacy` on some runtimes; command now fails explicitly with guidance.

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:smoke`
