### PR TITLE
fix: harden Android non-ASCII text input path

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,13 @@ Android fill reliability:
 - `fill` now verifies the entered value on Android.
 - If value does not match, agent-device clears the field and retries once with slower typing.
 - This reduces IME-related character swaps on long strings (e.g. emails and IDs).
+- Some Android system images cannot inject non-ASCII text (for example Chinese or emoji) through shell input.
+- If this occurs, install an ADB keyboard IME from a trusted source, verify checksum/signature, and enable it only for test sessions:
+  - Trusted sources: https://github.com/senzhk/ADBKeyBoard or https://f-droid.org/packages/com.android.adbkeyboard/
+  - `adb -s <serial> install <path-to-adbkeyboard.apk>`
+  - `adb -s <serial> shell ime enable com.android.adbkeyboard/.AdbIME`
+  - `adb -s <serial> shell ime set com.android.adbkeyboard/.AdbIME`
+  - `adb -s <serial> shell ime list -s` (verify current/default IME)
 
 Settings helpers:
 - `settings wifi on|off`

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -111,6 +111,7 @@ agent-device batch --steps-file /tmp/batch-steps.json --json
 - Permission settings are app-scoped and require an active session app:
   `settings permission <grant|deny|reset> <camera|microphone|photos|contacts|notifications> [full|limited]`
 - `full|limited` mode applies only to iOS `photos`; other targets reject mode.
+- On Android, non-ASCII `fill/type` may require an ADB keyboard IME on some system images; only install IME APKs from trusted sources and verify checksum/signature.
 - If using `--save-script`, prefer explicit path syntax (`--save-script=flow.ad` or `./flow.ad`).
 
 ## Security and Trust Notes

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -66,6 +66,7 @@ agent-device pinch 0.5 200 400 # zoom out at coordinates (iOS simulator)
 
 `fill` clears then types. `type` does not clear.
 On Android, `fill` also verifies text and performs one clear-and-retry pass on mismatch.
+Some Android images cannot enter non-ASCII text over shell input; in that case use a trusted ADB keyboard IME and verify APK checksum/signature before install.
 `swipe` accepts an optional `durationMs` argument (default `250ms`, range `16..10000`).
 On iOS, swipe duration is clamped to a safe range (`16..60ms`) to avoid longpress side effects.
 `scrollintoview` accepts plain text or a snapshot ref (`@eN`); ref mode uses best-effort geometry-based scrolling without post-scroll verification. Run `snapshot` again before follow-up `@ref` commands.

--- a/website/docs/docs/known-limitations.md
+++ b/website/docs/docs/known-limitations.md
@@ -19,3 +19,22 @@ This is an Apple platform constraint that affects all XCUITest-based automation 
   echo "some text" | xcrun simctl pbcopy booted
   ```
 - **Test the dialog manually** — the "Allow Paste" UX cannot be exercised through XCUITest-based automation.
+
+## Android: non-ASCII text over `adb shell input text`
+
+Some Android system images fail to inject non-ASCII text (for example Chinese characters or emoji) through `adb shell input text`.
+
+**Workarounds:**
+
+- **Use an ADB keyboard IME for test runs**:
+  ```bash
+  adb -s <serial> install <path-to-adbkeyboard.apk>
+  adb -s <serial> shell ime enable com.android.adbkeyboard/.AdbIME
+  adb -s <serial> shell ime set com.android.adbkeyboard/.AdbIME
+  ```
+- **Use trusted APK sources only** (official project: https://github.com/senzhk/ADBKeyBoard or F-Droid: https://f-droid.org/packages/com.android.adbkeyboard/), and verify checksum/signature before installing.
+- **Revert to your normal IME after automation**:
+  ```bash
+  adb -s <serial> shell ime list -s
+  adb -s <serial> shell ime set <previous-ime-id>
+  ```


### PR DESCRIPTION
## Summary

Improve Android text input reliability for non-ASCII payloads and document safe fallback guidance.
- For non-ASCII text, try clipboard+paste injection first; keep `adb shell input text` for ASCII.
- If device shell cannot support non-ASCII input, return a clear normalized error instead of corrupting field content.
- Keep Unicode-safe chunking and align fill clear-count with code-point length.
- Add/adjust Android platform tests for unicode clipboard path, ASCII path, and unsupported-shell error path.
- Update docs/skill with safe IME workaround guidance and trusted-source + verification notes.
- Closes #116.

Touched files: 6.
Scope: Android text input path + related docs/skill only (did not expand beyond this module area).
Known gap: this emulator image does not expose clipboard shell command support (`cmd clipboard`), so non-ASCII requires an external IME workaround.

## Validation

- `pnpm typecheck`
- `pnpm test src/platforms/android/__tests__/index.test.ts`
- Live emulator checks:
  - `pnpm ad --session android --platform android fill @e2 很 --json`
  - `pnpm ad --session android --platform android fill @e2 ☝ --json`
