### PR TITLE
feat: add clipboard read/write commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The project is in early development and considered experimental. Pull requests a
 - Platforms: iOS (simulator + physical device core automation) and Android (emulator + device).
 - Core commands: `open`, `back`, `home`, `app-switcher`, `press`, `long-press`, `focus`, `type`, `fill`, `scroll`, `scrollintoview`, `wait`, `alert`, `screenshot`, `close`, `reinstall`, `push`.
 - Inspection commands: `snapshot` (accessibility tree), `diff snapshot` (structural baseline diff), `appstate`, `apps`, `devices`.
+- Clipboard commands: `clipboard read`, `clipboard write <text>`.
 - App logs: `logs path` returns session log metadata; `logs start` / `logs stop` stream app output; `logs clear` truncates session app logs; `logs clear --restart` resets and restarts stream in one step; `logs doctor` checks readiness; `logs mark` writes timeline markers.
 - Device tooling: `adb` (Android), `simctl`/`devicectl` (iOS via Xcode).
 - Minimal dependencies; TypeScript executed directly on Node 22+ (no build step).
@@ -147,6 +148,7 @@ agent-device scrollintoview @e42
 - `alert`, `wait`, `screenshot`
 - `trace start`, `trace stop`
 - `logs path`, `logs start`, `logs stop`, `logs clear`, `logs clear --restart`, `logs doctor`, `logs mark` (session app log file for grep; iOS simulator + iOS device + Android)
+- `clipboard read`, `clipboard write <text>` (iOS simulator + Android)
 - `settings wifi|airplane|location on|off`
 - `settings appearance light|dark|toggle`
 - `settings faceid match|nonmatch|enroll|unenroll` (iOS simulator only)
@@ -332,6 +334,12 @@ App state:
 - `appstate` shows the foreground app/activity (Android).
 - On iOS, `appstate` returns the currently tracked session app (`source: session`) and requires an active session on the selected device.
 - `apps` includes default/system apps by default (use `--user-installed` to filter).
+
+Clipboard:
+- `clipboard read` returns current clipboard text.
+- `clipboard write <text>` sets clipboard text (`clipboard write ""` clears it).
+- Supported on Android emulator/device and iOS simulator.
+- iOS physical devices currently return `UNSUPPORTED_OPERATION` for clipboard commands.
 
 ## Debug
 

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -86,6 +86,8 @@ agent-device is visible 'id="anchor"'
 
 ```bash
 agent-device appstate
+agent-device clipboard read
+agent-device clipboard write "token"
 agent-device push <bundle|package> <payload.json|inline-json>
 agent-device get text @e1
 agent-device screenshot out.png
@@ -108,6 +110,7 @@ agent-device batch --steps-file /tmp/batch-steps.json --json
 - Use refs for discovery, selectors for replay/assertions.
 - Use `fill` for clear-then-type semantics; use `type` for focused append typing.
 - iOS `appstate` is session-scoped; Android `appstate` is live foreground state.
+- Clipboard helpers: `clipboard read` / `clipboard write <text>` are supported on Android and iOS simulators; iOS physical devices are not supported yet.
 - iOS settings helpers are simulator-only; use `appearance light|dark|toggle` and faceid `match|nonmatch|enroll|unenroll`.
 - `push` simulates notification delivery:
   - iOS simulator uses APNs-style payload JSON.

--- a/src/__tests__/cli-clipboard.test.ts
+++ b/src/__tests__/cli-clipboard.test.ts
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runCli } from '../cli.ts';
+import type { DaemonRequest, DaemonResponse } from '../daemon-client.ts';
+
+class ExitSignal extends Error {
+  public readonly code: number;
+
+  constructor(code: number) {
+    super(`EXIT_${code}`);
+    this.code = code;
+  }
+}
+
+type RunResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  calls: Omit<DaemonRequest, 'token'>[];
+};
+
+async function runCliCapture(
+  argv: string[],
+  responder: (req: Omit<DaemonRequest, 'token'>) => Promise<DaemonResponse>,
+): Promise<RunResult> {
+  let stdout = '';
+  let stderr = '';
+  let code: number | null = null;
+  const calls: Array<Omit<DaemonRequest, 'token'>> = [];
+
+  const originalExit = process.exit;
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  (process as any).exit = ((nextCode?: number) => {
+    throw new ExitSignal(nextCode ?? 0);
+  }) as typeof process.exit;
+  (process.stdout as any).write = ((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  (process.stderr as any).write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  const sendToDaemon = async (req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> => {
+    calls.push(req);
+    return await responder(req);
+  };
+
+  try {
+    await runCli(argv, { sendToDaemon });
+  } catch (error) {
+    if (error instanceof ExitSignal) code = error.code;
+    else throw error;
+  } finally {
+    process.exit = originalExit;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  return { code, stdout, stderr, calls };
+}
+
+test('clipboard read prints clipboard text', async () => {
+  const result = await runCliCapture(['clipboard', 'read'], async () => ({
+    ok: true,
+    data: { action: 'read', text: 'otp-123456' },
+  }));
+
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.command, 'clipboard');
+  assert.deepEqual(result.calls[0]?.positionals, ['read']);
+  assert.equal(result.stdout, 'otp-123456\n');
+  assert.equal(result.stderr, '');
+});
+
+test('clipboard write prints update confirmation', async () => {
+  const result = await runCliCapture(['clipboard', 'write', 'hello'], async () => ({
+    ok: true,
+    data: { action: 'write', textLength: 5 },
+  }));
+
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.command, 'clipboard');
+  assert.deepEqual(result.calls[0]?.positionals, ['write', 'hello']);
+  assert.equal(result.stdout, 'Clipboard updated\n');
+  assert.equal(result.stderr, '');
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -290,6 +290,21 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
         if (logTailStopper) logTailStopper();
         return;
       }
+      if (command === 'clipboard') {
+        const data = response.data as Record<string, unknown> | undefined;
+        const action = (positionals[0] ?? (typeof data?.action === 'string' ? data.action : '')).toLowerCase();
+        if (action === 'read') {
+          const text = typeof data?.text === 'string' ? data.text : '';
+          process.stdout.write(`${text}\n`);
+          if (logTailStopper) logTailStopper();
+          return;
+        }
+        if (action === 'write') {
+          process.stdout.write('Clipboard updated\n');
+          if (logTailStopper) logTailStopper();
+          return;
+        }
+      }
       if (command === 'click' || command === 'press') {
         const ref = (response.data as any)?.ref ?? '';
         const x = (response.data as any)?.x;

--- a/src/core/__tests__/capabilities.test.ts
+++ b/src/core/__tests__/capabilities.test.ts
@@ -33,7 +33,7 @@ test('iOS simulator-only commands reject iOS devices and Android', () => {
 });
 
 test('simulator-only iOS commands with Android support reject iOS devices', () => {
-  for (const cmd of ['settings', 'push']) {
+  for (const cmd of ['settings', 'push', 'clipboard']) {
     assert.equal(isCommandSupportedOnDevice(cmd, iosSimulator), true, `${cmd} on iOS sim`);
     assert.equal(isCommandSupportedOnDevice(cmd, iosDevice), false, `${cmd} on iOS device`);
     assert.equal(isCommandSupportedOnDevice(cmd, androidDevice), true, `${cmd} on Android`);

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -21,6 +21,7 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
   back: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   boot: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   click: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
+  clipboard: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
   close: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   fill: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   diff: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -227,6 +227,36 @@ export async function screenshotIos(device: DeviceInfo, outPath: string): Promis
   });
 }
 
+export async function readIosClipboardText(device: DeviceInfo): Promise<string> {
+  ensureSimulator(device, 'clipboard');
+  await ensureBootedSimulator(device);
+  const result = await runCmd('xcrun', ['simctl', 'pbpaste', device.id], { allowFailure: true });
+  if (result.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', 'Failed to read iOS simulator clipboard', {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    });
+  }
+  return result.stdout.replace(/\r\n/g, '\n').replace(/\n$/, '');
+}
+
+export async function writeIosClipboardText(device: DeviceInfo, text: string): Promise<void> {
+  ensureSimulator(device, 'clipboard');
+  await ensureBootedSimulator(device);
+  const result = await runCmd('xcrun', ['simctl', 'pbcopy', device.id], {
+    allowFailure: true,
+    stdin: text,
+  });
+  if (result.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', 'Failed to write iOS simulator clipboard', {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    });
+  }
+}
+
 export async function pushIosNotification(
   device: DeviceInfo,
   bundleId: string,

--- a/src/platforms/ios/index.ts
+++ b/src/platforms/ios/index.ts
@@ -6,11 +6,13 @@ export {
   openIosApp,
   openIosDevice,
   pushIosNotification,
+  readIosClipboardText,
   reinstallIosApp,
   resolveIosApp,
   screenshotIos,
   setIosSetting,
   uninstallIosApp,
+  writeIosClipboardText,
 } from './apps.ts';
 
 export { ensureBootedSimulator } from './simulator.ts';

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -25,6 +25,16 @@ test('parseArgs accepts push with payload file', () => {
   assert.deepEqual(parsed.positionals, ['com.example.app', './payload.json']);
 });
 
+test('parseArgs accepts clipboard subcommands', () => {
+  const read = parseArgs(['clipboard', 'read'], { strictFlags: true });
+  assert.equal(read.command, 'clipboard');
+  assert.deepEqual(read.positionals, ['read']);
+
+  const write = parseArgs(['clipboard', 'write', 'otp', '123456'], { strictFlags: true });
+  assert.equal(write.command, 'clipboard');
+  assert.deepEqual(write.positionals, ['write', 'otp', '123456']);
+});
+
 test('parseArgs recognizes --debug alias for verbose mode', () => {
   const parsed = parseArgs(['open', 'settings', '--debug']);
   assert.equal(parsed.command, 'open');
@@ -204,6 +214,7 @@ test('usage includes --relaunch flag', () => {
   assert.match(usage(), /--restart/);
   assert.match(usage(), /--fps <n>/);
   assert.match(usage(), /--save-script \[path\]/);
+  assert.match(usage(), /clipboard read \| clipboard write <text>/);
   assert.match(usage(), /pinch <scale> \[x\] \[y\]/);
   assert.doesNotMatch(usage(), /--metadata/);
 });
@@ -354,6 +365,13 @@ test('command usage shows no command flags when unsupported', () => {
   assert.match(help, /Show foreground app\/activity/);
   assert.doesNotMatch(help, /Command flags:/);
   assert.match(help, /Global flags:/);
+});
+
+test('clipboard command usage is documented', () => {
+  const help = usageForCommand('clipboard');
+  if (help === null) throw new Error('Expected command help text');
+  assert.match(help, /clipboard read \| clipboard write <text>/);
+  assert.match(help, /Read or write device clipboard text/);
 });
 
 test('settings usage documents canonical faceid states', () => {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -419,6 +419,13 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowedFlags: [],
     skipCapabilityCheck: true,
   },
+  clipboard: {
+    usageOverride: 'clipboard read | clipboard write <text>',
+    description: 'Read or write device clipboard text',
+    positionalArgs: ['read|write', 'text?'],
+    allowsExtraPositionals: true,
+    allowedFlags: [],
+  },
   back: {
     description: 'Navigate back (where supported)',
     positionalArgs: [],

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -181,6 +181,20 @@ agent-device apps --platform android --all
 - iOS `appstate` is session-scoped and reports the app tracked by the active session on the target device.
 - `apps` includes default/system apps by default (use `--user-installed` to filter).
 
+## Clipboard
+
+```bash
+agent-device clipboard read
+agent-device clipboard write "https://example.com"
+agent-device clipboard write ""   # clear clipboard
+```
+
+- `clipboard read` returns clipboard text for the selected target.
+- `clipboard write <text>` updates clipboard text on the selected target.
+- Works with an active session device or explicit selectors (`--platform`, `--device`, `--udid`, `--serial`).
+- Supported on Android emulator/device and iOS simulator.
+- iOS physical devices currently return `UNSUPPORTED_OPERATION` for clipboard commands.
+
 ## Media and logs
 
 ```bash

--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -22,13 +22,13 @@ If you know `agent-browser`, this is the mobile-native counterpart for iOS/Andro
 
 - iOS core runner commands: `snapshot`, `diff snapshot`, `wait`, `click`, `fill`, `get`, `is`, `find`, `press`, `long-press`, `focus`, `type`, `scroll`, `scrollintoview`, `back`, `home`, `app-switcher`, `open` (app), `close`, `screenshot`, `apps`, `appstate`, `reinstall`.
 - iOS `appstate` is session-scoped on the selected target device.
-- iOS simulator-only: `alert`, `pinch`, `settings`, `push`.
+- iOS simulator-only: `alert`, `pinch`, `settings`, `push`, `clipboard`.
 - iOS `record` supports simulators and physical devices.
   - Simulators use native `simctl io ... recordVideo`.
   - Physical devices use runner screenshot capture (`XCUIScreen.main.screenshot()` frames) stitched into MP4, so FPS is best-effort (not guaranteed 60 even with `--fps 60`).
   - Physical-device recording requires an active app session context (`open <app>` first).
   - Physical-device recording defaults to uncapped (max available) FPS and supports `--fps` caps.
-- Android supports the same core interaction set, plus `push` notification simulation via broadcast intents.
+- Android supports the same core interaction set, plus `push` notification simulation and `clipboard read/write` via adb shell commands.
 
 ## Architecture (high level)
 


### PR DESCRIPTION
## Summary

Add a new `clipboard` command family with `clipboard read` and `clipboard write <text>` across CLI, daemon routing, capabilities, and platform dispatch.
Implement platform backends using `simctl pbpaste/pbcopy` on iOS simulator and `adb shell cmd clipboard get/set text` on Android; iOS physical devices are intentionally unsupported for now.
Add coverage in CLI/session/platform tests and update docs + skill guidance for usage and platform limits.

Touched files: 18.
Scope: focused on one command family (`clipboard`) plus required platform adapters, tests, and docs.

Fixes #92 

## Validation

- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:smoke`
- `pnpm test:integration` (fails in existing environment-sensitive settings tests on iOS/Android; failures are unrelated to clipboard changes)