### PR TITLE
fix: fallback iOS/tvOS screenshot when devicectl screenshot is unavailable

### DIFF
--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -14,6 +14,7 @@ import {
   setIosSetting,
   writeIosClipboardText,
 } from '../index.ts';
+import { shouldFallbackToRunnerForIosScreenshot } from '../apps.ts';
 import type { DeviceInfo } from '../../../utils/device.ts';
 import { AppError } from '../../../utils/errors.ts';
 
@@ -112,6 +113,20 @@ test('openIosApp custom scheme deep links on iOS devices require app bundle cont
       return true;
     },
   );
+});
+
+test('shouldFallbackToRunnerForIosScreenshot detects removed devicectl subcommand output', () => {
+  const error = new AppError('COMMAND_FAILED', 'Failed to capture iOS screenshot', {
+    stderr: "error: Unknown option '--device'",
+  });
+  assert.equal(shouldFallbackToRunnerForIosScreenshot(error), true);
+});
+
+test('shouldFallbackToRunnerForIosScreenshot ignores unrelated command failures', () => {
+  const error = new AppError('COMMAND_FAILED', 'Failed to capture iOS screenshot', {
+    stderr: 'error: device is busy connecting',
+  });
+  assert.equal(shouldFallbackToRunnerForIosScreenshot(error), false);
 });
 
 test('openIosApp web URL on iOS device without app falls back to Safari', async () => {

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -24,6 +24,7 @@ type RunnerCommand = {
     | 'swipe'
     | 'findText'
     | 'snapshot'
+    | 'screenshot'
     | 'back'
     | 'home'
     | 'appSwitcher'
@@ -654,7 +655,7 @@ export function isRetryableRunnerError(err: unknown): boolean {
 }
 
 function isReadOnlyRunnerCommand(command: RunnerCommand['command']): boolean {
-  return command === 'snapshot' || command === 'findText' || command === 'alert';
+  return command === 'snapshot' || command === 'screenshot' || command === 'findText' || command === 'alert';
 }
 
 function assertRunnerRequestActive(requestId: string | undefined): void {


### PR DESCRIPTION
## Summary

Fallback Apple device screenshots to the runner path when xcrun devicectl device screenshot is unavailable (Xcode 26.x), while preserving existing simulator behavior.
Added a targeted detection path for unsupported devicectl screenshot invocations and runner support for a new read-only screenshot command.

Fixes https://github.com/callstackincubator/agent-device/issues/129

## Validation

pnpm typecheck
pnpm test:unit
pnpm test:smoke
pnpm build:xcuitest