### PR TITLE
feat: add Android keyboard status and dismiss command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The project is in early development and considered experimental. Pull requests a
 - Core commands: `open`, `back`, `home`, `app-switcher`, `press`, `long-press`, `focus`, `type`, `fill`, `scroll`, `scrollintoview`, `wait`, `alert`, `screenshot`, `close`, `reinstall`, `push`, `trigger-app-event`.
 - Inspection commands: `snapshot` (accessibility tree), `diff snapshot` (structural baseline diff), `appstate`, `apps`, `devices`.
 - Clipboard commands: `clipboard read`, `clipboard write <text>`.
+- Keyboard commands: `keyboard status|get|dismiss` (Android).
 - Performance command: `perf` (alias: `metrics`) returns a metrics JSON blob for the active session; startup timing is currently sampled.
 - App logs and traffic inspection: `logs path` returns session log metadata; `logs start` / `logs stop` stream app output; `logs clear` truncates session app logs; `logs clear --restart` resets and restarts stream in one step; `logs doctor` checks readiness; `logs mark` writes timeline markers; `network dump` parses recent HTTP(s) entries from session logs.
 - Device tooling: `adb` (Android), `simctl`/`devicectl` (iOS via Xcode).
@@ -152,6 +153,7 @@ agent-device scrollintoview @e42
 - `trace start`, `trace stop`
 - `logs path`, `logs start`, `logs stop`, `logs clear`, `logs clear --restart`, `logs doctor`, `logs mark` (session app log file for grep; iOS simulator + iOS device + Android)
 - `clipboard read`, `clipboard write <text>` (iOS simulator + Android)
+- `keyboard [status|get|dismiss]` (Android emulator/device)
 - `network dump [limit] [summary|headers|body|all]`, `network log ...` (best-effort HTTP(s) parsing from session app log)
 - `settings wifi|airplane|location on|off`
 - `settings appearance light|dark|toggle`
@@ -417,6 +419,12 @@ Clipboard:
 - `clipboard write <text>` sets clipboard text (`clipboard write ""` clears it).
 - Supported on Android emulator/device and iOS simulator.
 - iOS physical devices currently return `UNSUPPORTED_OPERATION` for clipboard commands.
+
+Keyboard:
+- `keyboard status` (or `keyboard get`) reports Android keyboard visibility and best-effort input type classification (`text`, `number`, `email`, `phone`, `password`, `datetime`).
+- `keyboard dismiss` issues Android back keyevent only when keyboard is visible, then verifies hidden state.
+- Works with an active session device or explicit selectors (`--platform`, `--device`, `--udid`, `--serial`).
+- Supported on Android emulator/device.
 
 ## Debug
 

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -138,6 +138,8 @@ agent-device is visible 'id="anchor"'
 agent-device appstate
 agent-device clipboard read
 agent-device clipboard write "token"
+agent-device keyboard status
+agent-device keyboard dismiss
 agent-device perf --json
 agent-device network dump [limit] [summary|headers|body|all]
 agent-device push <bundle|package> <payload.json|inline-json>
@@ -169,6 +171,7 @@ agent-device batch --steps-file /tmp/batch-steps.json --json
 - Use `fill` for clear-then-type semantics; use `type` for focused append typing.
 - iOS `appstate` is session-scoped; Android `appstate` is live foreground state.
 - Clipboard helpers: `clipboard read` / `clipboard write <text>` are supported on Android and iOS simulators; iOS physical devices are not supported yet.
+- Android keyboard helpers: `keyboard status|get|dismiss` report keyboard visibility/type and dismiss via keyevent when visible.
 - `network dump` is best-effort and parses HTTP(s) entries from the session app log file.
 - Biometric settings: iOS simulator supports `settings faceid|touchid <match|nonmatch|enroll|unenroll>`; Android supports `settings fingerprint <match|nonmatch>` where runtime tooling is available.
 - For AndroidTV/tvOS selection, always pair `--target` with `--platform` (`ios`, `android`, or `apple` alias); target-only selection is invalid.

--- a/src/core/__tests__/capabilities.test.ts
+++ b/src/core/__tests__/capabilities.test.ts
@@ -56,6 +56,12 @@ test('simulator-only iOS commands with Android support reject iOS devices', () =
   }
 });
 
+test('keyboard command is Android-only', () => {
+  assert.equal(isCommandSupportedOnDevice('keyboard', iosSimulator), false, 'keyboard on iOS sim');
+  assert.equal(isCommandSupportedOnDevice('keyboard', iosDevice), false, 'keyboard on iOS device');
+  assert.equal(isCommandSupportedOnDevice('keyboard', androidDevice), true, 'keyboard on Android');
+});
+
 test('swipe supports iOS simulator, iOS device, and Android', () => {
   assert.equal(isCommandSupportedOnDevice('swipe', iosSimulator), true, 'swipe on iOS sim');
   assert.equal(isCommandSupportedOnDevice('swipe', iosDevice), true, 'swipe on iOS device');
@@ -127,6 +133,7 @@ test('tvOS follows iOS capability matrix by device kind', () => {
   for (const cmd of ['pinch', 'push', 'settings', 'alert']) {
     assert.equal(isCommandSupportedOnDevice(cmd, tvOsSimulator), true, `${cmd} on tvOS simulator`);
   }
+  assert.equal(isCommandSupportedOnDevice('keyboard', tvOsSimulator), false, 'keyboard on tvOS simulator');
 });
 
 test('unknown commands default to supported', () => {

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -22,6 +22,7 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
   boot: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   click: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   clipboard: { ios: { simulator: true }, android: { emulator: true, device: true, unknown: true } },
+  keyboard: { ios: {}, android: { emulator: true, device: true, unknown: true } },
   close: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   fill: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },
   diff: { ios: { simulator: true, device: true }, android: { emulator: true, device: true, unknown: true } },

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -806,6 +806,20 @@ export async function handleSessionCommands(params: {
     });
   }
 
+  if (command === 'keyboard') {
+    return await runSessionOrSelectorDispatch({
+      req,
+      sessionName,
+      logPath,
+      sessionStore,
+      ensureReady,
+      resolveDevice,
+      dispatch,
+      command: 'keyboard',
+      positionals: req.positionals ?? [],
+    });
+  }
+
   if (command === 'perf') {
     const session = sessionStore.get(sessionName);
     if (!session) {

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -20,11 +20,32 @@ const ALIASES: Record<string, { type: 'intent' | 'package'; value: string }> = {
 const ANDROID_LAUNCHER_CATEGORY = 'android.intent.category.LAUNCHER';
 const ANDROID_LEANBACK_CATEGORY = 'android.intent.category.LEANBACK_LAUNCHER';
 const ANDROID_DEFAULT_CATEGORY = 'android.intent.category.DEFAULT';
+const ANDROID_INPUT_TYPE_CLASS_MASK = 0x0000000f;
+const ANDROID_INPUT_TYPE_CLASS_TEXT = 0x00000001;
+const ANDROID_INPUT_TYPE_CLASS_NUMBER = 0x00000002;
+const ANDROID_INPUT_TYPE_CLASS_PHONE = 0x00000003;
+const ANDROID_INPUT_TYPE_CLASS_DATETIME = 0x00000004;
+const ANDROID_INPUT_TYPE_VARIATION_MASK = 0x00000ff0;
+const ANDROID_TEXT_VARIATION_EMAIL_ADDRESS = 0x00000020;
+const ANDROID_TEXT_VARIATION_WEB_EMAIL_ADDRESS = 0x000000d0;
+const ANDROID_TEXT_VARIATION_PASSWORD = 0x00000080;
+const ANDROID_TEXT_VARIATION_WEB_PASSWORD = 0x000000e0;
+const ANDROID_TEXT_VARIATION_VISIBLE_PASSWORD = 0x00000090;
+const ANDROID_KEYBOARD_DISMISS_MAX_ATTEMPTS = 2;
+const ANDROID_KEYBOARD_DISMISS_RETRY_DELAY_MS = 120;
 
 type AndroidBroadcastPayload = {
   action?: string;
   receiver?: string;
   extras?: Record<string, unknown>;
+};
+
+type AndroidKeyboardType = 'text' | 'number' | 'email' | 'phone' | 'password' | 'datetime' | 'unknown';
+
+export type AndroidKeyboardState = {
+  visible: boolean;
+  inputType?: string;
+  type?: AndroidKeyboardType;
 };
 
 function adbArgs(device: DeviceInfo, args: string[]): string[] {
@@ -183,6 +204,116 @@ export async function getAndroidAppState(
   ]);
   if (activityFocus) return activityFocus;
   return {};
+}
+
+export async function getAndroidKeyboardState(
+  device: DeviceInfo,
+): Promise<AndroidKeyboardState> {
+  const result = await runCmd('adb', adbArgs(device, ['shell', 'dumpsys', 'input_method']), {
+    allowFailure: true,
+  });
+  if (result.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', 'Failed to query Android keyboard state', {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    });
+  }
+  return parseAndroidKeyboardState(result.stdout);
+}
+
+export async function dismissAndroidKeyboard(device: DeviceInfo): Promise<{
+  attempts: number;
+  wasVisible: boolean;
+  dismissed: boolean;
+  visible: boolean;
+  inputType?: string;
+  type?: AndroidKeyboardType;
+}> {
+  const initialState = await getAndroidKeyboardState(device);
+  let state = initialState;
+  let attempts = 0;
+
+  while (state.visible && attempts < ANDROID_KEYBOARD_DISMISS_MAX_ATTEMPTS) {
+    await backAndroid(device);
+    attempts += 1;
+    await sleep(ANDROID_KEYBOARD_DISMISS_RETRY_DELAY_MS);
+    state = await getAndroidKeyboardState(device);
+  }
+
+  return {
+    attempts,
+    wasVisible: initialState.visible,
+    dismissed: initialState.visible && !state.visible,
+    visible: state.visible,
+    inputType: state.inputType,
+    type: state.type,
+  };
+}
+
+function parseAndroidKeyboardState(stdout: string): AndroidKeyboardState {
+  const visibility = parseAndroidKeyboardVisibility(stdout);
+  let visible = visibility ?? false;
+  if (visibility === null) {
+    const imeWindowVisibility = stdout.match(/\bmImeWindowVis=0x([0-9a-fA-F]+)\b/);
+    if (imeWindowVisibility?.[1]) {
+      const flags = Number.parseInt(imeWindowVisibility[1], 16);
+      if (!Number.isNaN(flags)) {
+        visible = (flags & 0x1) !== 0;
+      }
+    }
+  }
+
+  const inputTypeMatches = Array.from(stdout.matchAll(/\binputType=0x([0-9a-fA-F]+)\b/gi));
+  const lastInputType = inputTypeMatches.length > 0
+    ? inputTypeMatches[inputTypeMatches.length - 1]?.[1]
+    : undefined;
+  const inputType = lastInputType ? `0x${lastInputType.toLowerCase()}` : undefined;
+
+  return {
+    visible,
+    inputType,
+    type: inputType ? classifyAndroidKeyboardType(inputType) : undefined,
+  };
+}
+
+function parseAndroidKeyboardVisibility(stdout: string): boolean | null {
+  const latestByKey = new Map<string, boolean>();
+  const pattern = /\b(mInputShown|mIsInputViewShown|isInputViewShown)=([a-zA-Z]+)\b/g;
+  for (const match of stdout.matchAll(pattern)) {
+    const key = match[1];
+    const value = match[2]?.toLowerCase();
+    if (!key || (value !== 'true' && value !== 'false')) continue;
+    latestByKey.set(key, value === 'true');
+  }
+  if (latestByKey.size === 0) return null;
+  for (const visible of latestByKey.values()) {
+    if (visible) return true;
+  }
+  return false;
+}
+
+function classifyAndroidKeyboardType(inputType: string): AndroidKeyboardType {
+  const parsed = Number.parseInt(inputType.replace(/^0x/i, ''), 16);
+  if (Number.isNaN(parsed)) return 'unknown';
+  const inputClass = parsed & ANDROID_INPUT_TYPE_CLASS_MASK;
+  if (inputClass === ANDROID_INPUT_TYPE_CLASS_NUMBER) return 'number';
+  if (inputClass === ANDROID_INPUT_TYPE_CLASS_PHONE) return 'phone';
+  if (inputClass === ANDROID_INPUT_TYPE_CLASS_DATETIME) return 'datetime';
+  if (inputClass !== ANDROID_INPUT_TYPE_CLASS_TEXT) return 'unknown';
+
+  const variation = parsed & ANDROID_INPUT_TYPE_VARIATION_MASK;
+  if (variation === ANDROID_TEXT_VARIATION_EMAIL_ADDRESS || variation === ANDROID_TEXT_VARIATION_WEB_EMAIL_ADDRESS) {
+    return 'email';
+  }
+  if (
+    variation === ANDROID_TEXT_VARIATION_PASSWORD ||
+    variation === ANDROID_TEXT_VARIATION_WEB_PASSWORD ||
+    variation === ANDROID_TEXT_VARIATION_VISIBLE_PASSWORD
+  ) {
+    return 'password';
+  }
+  return 'text';
 }
 
 async function readAndroidFocus(

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -79,6 +79,16 @@ test('parseArgs accepts clipboard subcommands', () => {
   assert.deepEqual(write.positionals, ['write', 'otp', '123456']);
 });
 
+test('parseArgs accepts keyboard subcommands', () => {
+  const status = parseArgs(['keyboard', 'status'], { strictFlags: true });
+  assert.equal(status.command, 'keyboard');
+  assert.deepEqual(status.positionals, ['status']);
+
+  const dismiss = parseArgs(['keyboard', 'dismiss'], { strictFlags: true });
+  assert.equal(dismiss.command, 'keyboard');
+  assert.deepEqual(dismiss.positionals, ['dismiss']);
+});
+
 test('parseArgs recognizes --debug alias for verbose mode', () => {
   const parsed = parseArgs(['open', 'settings', '--debug']);
   assert.equal(parsed.command, 'open');
@@ -309,6 +319,7 @@ test('usage includes --relaunch flag', () => {
   assert.match(usage(), /network dump/);
   assert.match(usage(), /--save-script \[path\]/);
   assert.match(usage(), /clipboard read \| clipboard write <text>/);
+  assert.match(usage(), /keyboard \[status\|get\|dismiss\]/);
   assert.match(usage(), /trigger-app-event <event> \[payloadJson\]/);
   assert.match(usage(), /pinch <scale> \[x\] \[y\]/);
   assert.match(usage(), /--state-dir <path>/);
@@ -474,6 +485,13 @@ test('clipboard command usage is documented', () => {
   if (help === null) throw new Error('Expected command help text');
   assert.match(help, /clipboard read \| clipboard write <text>/);
   assert.match(help, /Read or write device clipboard text/);
+});
+
+test('keyboard command usage is documented', () => {
+  const help = usageForCommand('keyboard');
+  if (help === null) throw new Error('Expected command help text');
+  assert.match(help, /keyboard \[status\|get\|dismiss\]/);
+  assert.match(help, /Inspect Android keyboard visibility\/type or dismiss it/);
 });
 
 test('settings usage documents canonical faceid states', () => {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -528,6 +528,12 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowsExtraPositionals: true,
     allowedFlags: [],
   },
+  keyboard: {
+    usageOverride: 'keyboard [status|get|dismiss]',
+    description: 'Inspect Android keyboard visibility/type or dismiss it',
+    positionalArgs: ['action?'],
+    allowedFlags: [],
+  },
   perf: {
     description: 'Show session performance metrics (startup timing)',
     positionalArgs: [],

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -258,6 +258,19 @@ agent-device clipboard write ""   # clear clipboard
 - Supported on Android emulator/device and iOS simulator.
 - iOS physical devices currently return `UNSUPPORTED_OPERATION` for clipboard commands.
 
+## Keyboard (Android)
+
+```bash
+agent-device keyboard status
+agent-device keyboard get
+agent-device keyboard dismiss
+```
+
+- `keyboard status` (or `keyboard get`) returns keyboard visibility and best-effort input type classification.
+- `keyboard dismiss` dismisses keyboard with Android back keyevent only when the keyboard is visible, then confirms hidden state.
+- Works with active sessions and explicit selectors (`--platform`, `--device`, `--udid`, `--serial`).
+- Supported on Android emulator/device.
+
 ## Performance metrics
 
 ```bash

--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -30,7 +30,7 @@ For exploratory QA and bug-hunting workflows, see `skills/dogfood/SKILL.md` in t
   - Physical devices use runner screenshot capture (`XCUIScreen.main.screenshot()` frames) stitched into MP4, so FPS is best-effort (not guaranteed 60 even with `--fps 60`).
   - Physical-device recording requires an active app session context (`open <app>` first).
   - Physical-device recording defaults to uncapped (max available) FPS and supports `--fps` caps.
-- Android supports the same core interaction set, plus `push` notification simulation and `clipboard read/write` via adb shell commands.
+- Android supports the same core interaction set, plus `push` notification simulation, `clipboard read/write`, and `keyboard status|get|dismiss` via adb shell commands.
 - App-event triggers are available on iOS and Android through app-defined deep-link hooks (`trigger-app-event`), using active session context or explicit device selectors.
 
 ## Architecture (high level)


### PR DESCRIPTION
## Summary

Add a new keyboard command for Android so flows can detect and dismiss the soft keyboard without dropping to raw ADB (issue #102 + comment use case).
- Adds keyboard status|get|dismiss
- Wires command through daemon session/selector flow (active session or explicit target selectors)
- Implements Android backend via dumpsys input_method parsing + best-effort input type classification and reliable dismiss
- Adds unit coverage for capabilities, args/help, session handling, and Android backend behavior
- Updates README, docs, and skill references for the new command

Touched files: 13.
Scope expansion beyond initial command family: No functional scope expansion beyond the new keyboard command path; remaining edits are command registration, tests, and docs.

## Validation

- pnpm typecheck
- pnpm test:unit
- pnpm test:smoke
