### PR TITLE
test: lock find click JSON response to exact deterministic key set

### DIFF
--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -7,7 +7,7 @@ import { parseFindArgs, handleFindCommands } from '../find.ts';
 import { AppError } from '../../../utils/errors.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { SessionState } from '../../types.ts';
-import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import type { DaemonRequest } from '../../types.ts';
 
 function makeSessionStore(): SessionStore {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-find-handler-'));
@@ -173,12 +173,54 @@ test('handleFindCommands click returns deterministic matched-target metadata', a
   assert.equal(data.x, 100, 'x must be derived from the matched node rect center');
   assert.equal(data.y, 50, 'y must be derived from the matched node rect center');
 
-  // Non-deterministic platform data must not leak through
-  assert.equal(data.platformSpecificRef, undefined, 'platform runner data must not appear in response');
+  // Strict key set — no platform-specific fields may leak through
+  assert.deepEqual(Object.keys(data).sort(), ['locator', 'query', 'ref', 'x', 'y']);
 
   // invoke was called with the resolved ref
   assert.equal(invokeCalls.length, 1);
   assert.equal(invokeCalls[0].positionals?.[0], '@e1');
+});
+
+test('handleFindCommands click response contains exactly the deterministic key set (fallback: no rect on resolved node)', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeSession(sessionName));
+
+  // Parent is hittable but has no rect — resolving through it loses coordinates.
+  // Child has a rect (satisfies requireRect) but is not hittable, so findNearestHittableAncestor
+  // walks up to the parent, which has no rect → fallback path: x/y are absent from response.
+  const hittableParentNoRect = { index: 0, type: 'View', hittable: true, depth: 0 };
+  const nonHittableChildWithRect = {
+    index: 1,
+    type: 'StaticText',
+    label: 'Increment',
+    hittable: false,
+    rect: { x: 50, y: 0, width: 100, height: 100 },
+    depth: 1,
+    parentIndex: 0,
+  };
+
+  const response = await handleFindCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'find',
+      positionals: ['Increment', 'click'],
+      flags: {},
+    },
+    sessionName,
+    logPath: '/tmp/test.log',
+    sessionStore,
+    invoke: async () => ({ ok: true, data: { platformSpecificRef: 'XCUIElementTypeView' } }),
+    dispatch: async (_device, command) => {
+      if (command === 'snapshot') return { nodes: [hittableParentNoRect, nonHittableChildWithRect] };
+      return {};
+    },
+  });
+
+  assert.ok(response?.ok);
+  const data = response!.data as Record<string, unknown>;
+  assert.deepEqual(Object.keys(data).sort(), ['locator', 'query', 'ref']);
 });
 
 test('handleFindCommands click with explicit label locator returns locator in metadata', async () => {
@@ -206,6 +248,7 @@ test('handleFindCommands click with explicit label locator returns locator in me
 
   assert.ok(response?.ok);
   const data = response!.data as Record<string, unknown>;
+  assert.deepEqual(Object.keys(data).sort(), ['locator', 'query', 'ref', 'x', 'y']);
   assert.equal(data.locator, 'label');
   assert.equal(data.query, 'Increment');
 });


### PR DESCRIPTION
## Summary
- Add strict key-set assertions (`deepEqual` on sorted `Object.keys`) to all `find click` handler tests so they fail if any key is added, removed, or renamed in the success payload
- Add a new test covering the fallback coordinate path where the resolved hittable ancestor lacks a `rect` (response must contain exactly `ref`, `locator`, `query` — no `x`/`y`)
- Strengthen the existing "explicit label locator" test with the same strict key-set check
- Remove unused `DaemonResponse` import

## Test plan
- [x] `pnpm test:unit` passes (541/541)
- [x] Tests fail if any key is added/removed/renamed in `find click` success payload
- [x] No platform-specific fields leak into response

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)