### PR TITLE
fix: strip pre-PNG garbage from Android screenshots on multi-display devices

### DIFF
--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -7,7 +7,10 @@ import { screenshotAndroid } from '../index.ts';
 import type { DeviceInfo } from '../../../utils/device.ts';
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-const FAKE_PNG = Buffer.concat([PNG_SIGNATURE, Buffer.from('fake-png-body')]);
+const VALID_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+b9xkAAAAASUVORK5CYII=',
+  'base64',
+);
 
 async function withMockedAdb(
   tempPrefix: string,
@@ -49,20 +52,31 @@ test('screenshotAndroid writes a valid PNG when output is clean', async () => {
     const outPath = path.join(tmpDir, 'out.png');
     await screenshotAndroid(device, outPath);
     const written = await fs.readFile(outPath);
-    assert.deepEqual(written, FAKE_PNG);
-  }, FAKE_PNG);
+    assert.deepEqual(written, VALID_PNG);
+  }, VALID_PNG);
 });
 
 test('screenshotAndroid strips warning text before PNG signature', async () => {
   const warning =
     '[Warning] Multiple displays were found, but no display id was specified! Defaulting to the first display found.';
-  const payload = Buffer.concat([Buffer.from(warning), FAKE_PNG]);
+  const payload = Buffer.concat([Buffer.from(warning), VALID_PNG]);
 
   await withMockedAdb('screenshot-warning-', catPayload, async ({ device, tmpDir }) => {
     const outPath = path.join(tmpDir, 'out.png');
     await screenshotAndroid(device, outPath);
     const written = await fs.readFile(outPath);
-    assert.deepEqual(written, FAKE_PNG);
+    assert.deepEqual(written, VALID_PNG);
+  }, payload);
+});
+
+test('screenshotAndroid strips trailing garbage after PNG payload', async () => {
+  const payload = Buffer.concat([VALID_PNG, Buffer.from('\ntrailing-warning\n')]);
+
+  await withMockedAdb('screenshot-trailing-', catPayload, async ({ device, tmpDir }) => {
+    const outPath = path.join(tmpDir, 'out.png');
+    await screenshotAndroid(device, outPath);
+    const written = await fs.readFile(outPath);
+    assert.deepEqual(written, VALID_PNG);
   }, payload);
 });
 
@@ -75,4 +89,15 @@ test('screenshotAndroid throws when output contains no PNG signature', async () 
       message: 'Screenshot data does not contain a valid PNG header',
     });
   });
+});
+
+test('screenshotAndroid throws when PNG payload is truncated', async () => {
+  const payload = VALID_PNG.subarray(0, VALID_PNG.length - 3);
+
+  await withMockedAdb('screenshot-truncated-', catPayload, async ({ device, tmpDir }) => {
+    const outPath = path.join(tmpDir, 'out.png');
+    await assert.rejects(() => screenshotAndroid(device, outPath), {
+      message: 'Screenshot data does not contain a complete PNG payload',
+    });
+  }, payload);
 });

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -35,7 +35,11 @@ export async function screenshotAndroid(device: DeviceInfo, outPath: string): Pr
   if (pngOffset < 0) {
     throw new AppError('COMMAND_FAILED', 'Screenshot data does not contain a valid PNG header');
   }
-  await fs.writeFile(outPath, result.stdoutBuffer.subarray(pngOffset));
+  const pngEndOffset = findPngEndOffset(result.stdoutBuffer, pngOffset);
+  if (!pngEndOffset) {
+    throw new AppError('COMMAND_FAILED', 'Screenshot data does not contain a complete PNG payload');
+  }
+  await fs.writeFile(outPath, result.stdoutBuffer.subarray(pngOffset, pngEndOffset));
 }
 
 export async function dumpUiHierarchy(device: DeviceInfo): Promise<string> {
@@ -91,6 +95,20 @@ function extractUiDumpXml(stdout: string, stderr: string): string | null {
   if (end < 0 || end < hierarchyStart) return null;
   const xml = text.slice(hierarchyStart, end + '</hierarchy>'.length).trim();
   return xml.length > 0 ? xml : null;
+}
+
+function findPngEndOffset(buffer: Buffer, pngStartOffset: number): number | null {
+  let offset = pngStartOffset + PNG_SIGNATURE.length;
+  while (offset + 8 <= buffer.length) {
+    const chunkLength = buffer.readUInt32BE(offset);
+    const chunkTypeOffset = offset + 4;
+    const chunkType = buffer.toString('ascii', chunkTypeOffset, chunkTypeOffset + 4);
+    const chunkEnd = offset + 12 + chunkLength; // len(4) + type(4) + data + crc(4)
+    if (chunkEnd > buffer.length) return null;
+    if (chunkType === 'IEND') return chunkEnd;
+    offset = chunkEnd;
+  }
+  return null;
 }
 
 function isRetryableAdbError(err: unknown): boolean {


### PR DESCRIPTION
## Summary
- On Android emulators with multiple displays (e.g. Galaxy Z Fold), `adb exec-out screencap -p` can write warning text to stdout before PNG bytes, producing corrupt screenshot files.
- The screenshot path now finds the PNG signature and strips any leading bytes before it.
- It now also parses PNG chunks and writes only through `IEND`, so trailing stdout garbage is stripped as well.
- If no PNG signature is found, or the PNG payload is truncated, the command now fails with a clear error instead of writing invalid data.

Fixes #184 

## Validation
- `pnpm typecheck`
- `node --test src/platforms/android/__tests__/snapshot.test.ts`
- Added/updated tests:
  - clean PNG output is written correctly
  - warning text before PNG signature is stripped
  - trailing garbage after PNG payload is stripped
  - missing PNG signature throws descriptive error
  - truncated PNG payload throws descriptive error
- Manual (not run yet): boot Galaxy Z Fold emulator (dual display), run `agent-device screenshot`, verify valid PNG output
