### PR TITLE
 test: add unit tests for dispatch-series helper functions

### DIFF
--- a/src/core/__tests__/dispatch-series.test.ts
+++ b/src/core/__tests__/dispatch-series.test.ts
@@ -163,14 +163,21 @@ test('runRepeatedSeries does not invoke operation when count is 0', async () => 
   assert.deepEqual(indices, []);
 });
 
-test('runRepeatedSeries pauses between operations but not after the last', async () => {
+test('runRepeatedSeries pauses between operations but not after the last', async (t) => {
+  const timeoutDelays: number[] = [];
+  t.mock.method(globalThis, 'setTimeout', (cb: () => void, ms: number) => {
+    timeoutDelays.push(ms);
+    cb();
+    return 0;
+  });
   const pauseMs = 50;
-  const start = Date.now();
-  await runRepeatedSeries(3, pauseMs, async () => {});
-  const elapsed = Date.now() - start;
+  const calls: number[] = [];
+  await runRepeatedSeries(3, pauseMs, async (i) => {
+    calls.push(i);
+  });
+  assert.deepEqual(calls, [0, 1, 2]);
   // 3 operations with pauses only between them = 2 pauses
-  assert.ok(elapsed >= pauseMs * 2 - 10, `elapsed ${elapsed}ms should be >= ${pauseMs * 2 - 10}ms`);
-  assert.ok(elapsed < pauseMs * 3 + 50, `elapsed ${elapsed}ms should be < ${pauseMs * 3 + 50}ms`);
+  assert.deepEqual(timeoutDelays, [pauseMs, pauseMs]);
 });
 
 test('runRepeatedSeries propagates operation error and stops iteration', async () => {


### PR DESCRIPTION
## Summary
- Add unit tests for all exported functions in `src/core/dispatch-series.ts`
- Cover `requireIntInRange`, `clampIosSwipeDuration`, `shouldUseIosTapSeries`, `shouldUseIosDragSeries`,
 `computeDeterministicJitter`, and `runRepeatedSeries`
- 29 tests total covering boundary values, error cases, and behavioral expectations

## Validation
- `pnpm node --test src/core/__tests__/dispatch-series.test.ts` → 29/29 pass

```
ℹ tests 29
ℹ suites 0
ℹ pass 29
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 234.259217
```

