### PR TITLE
docs: add missing command reference entries

### DIFF
--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -131,7 +131,10 @@ agent-device alert dismiss
 ```
 
 - `wait` accepts a millisecond duration, `text <value>`, a snapshot ref (`@eN`), or a selector.
-- `wait <selector> [timeoutMs]` and `wait @ref [timeoutMs]` poll until the target appears or the timeout expires.
+- `wait <selector> [timeoutMs]` polls until the selector resolves or the timeout expires.
+- `wait @ref [timeoutMs]` requires an existing session snapshot from a prior `snapshot` command.
+- `wait @ref` resolves the ref to its label/text from that stored snapshot, then polls for that text; it does not track the original node identity.
+- Because `wait @ref` is text-based after resolution, duplicate labels can match a different element than the original ref target.
 - `wait` shares the selector/snapshot resolution flow used by `click`, `fill`, `get`, and `is`.
 - `alert` inspects or handles system alerts on iOS simulator targets.
 - `alert` without an action is equivalent to `alert get`.


### PR DESCRIPTION
## Summary

Expand the commands reference page to explicitly document missing CLI entries, including wait/alert, assertions, tracing, runtime hints, device discovery, and session inspection.
Fix the assertions section to use selector-only `is` examples and explicitly note that snapshot refs are not supported.
Touched files: 1 (`website/docs/docs/commands.md`). Scope stayed within docs only.

## Validation

Docs-only change; tests not run.
