### PR TITLE
fix: prevent APK file paths from being used as package names in adb run-as

### DIFF
--- a/src/daemon/__tests__/runtime-hints.test.ts
+++ b/src/daemon/__tests__/runtime-hints.test.ts
@@ -249,6 +249,40 @@ test('applyRuntimeHintsToApp distinguishes run-as denial from general write fail
   });
 });
 
+test('applyRuntimeHintsToApp uses generic probe hint when probe fails without run-as denial output', async () => {
+  await withMockedAdb(async ({ device }) => {
+    process.env.AGENT_DEVICE_TEST_RUN_AS_ID_EXIT_CODE = '1';
+    process.env.AGENT_DEVICE_TEST_RUN_AS_ID_STDERR = 'error: device not found';
+    try {
+      await assert.rejects(
+        applyRuntimeHintsToApp({
+          device,
+          appId: 'com.example.demo',
+          runtime: {
+            platform: 'android',
+            metroHost: '10.0.0.10',
+            metroPort: 8081,
+          },
+        }),
+        (error: unknown) => {
+          assert.ok(error instanceof AppError);
+          assert.equal(error.message, 'Failed to probe Android app sandbox for com.example.demo');
+          assert.equal(
+            error.details?.hint,
+            'adb shell run-as probe failed. Check adb connectivity and that the device is reachable. Inspect stderr/details for more information.',
+          );
+          assert.equal(error.details?.exitCode, 1);
+          assert.match(String(error.details?.stderr), /device not found/);
+          return true;
+        },
+      );
+    } finally {
+      delete process.env.AGENT_DEVICE_TEST_RUN_AS_ID_EXIT_CODE;
+      delete process.env.AGENT_DEVICE_TEST_RUN_AS_ID_STDERR;
+    }
+  });
+});
+
 test('applyRuntimeHintsToApp preserves write failures after a successful run-as probe', async () => {
   await withMockedAdb(async ({ device }) => {
     process.env.AGENT_DEVICE_TEST_RUN_AS_WRITE_EXIT_CODE = '1';

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -15,6 +15,8 @@ const ANDROID_RUN_AS_HINT =
   'React Native runtime hints require adb run-as access to the app sandbox. Verify the app is debuggable and the selected package/device are correct.';
 const ANDROID_WRITE_HINT =
   'adb run-as succeeded, but writing ReactNativeDevPrefs.xml failed. Inspect stderr/details for the failing shell command.';
+const ANDROID_PROBE_HINT =
+  'adb shell run-as probe failed. Check adb connectivity and that the device is reachable. Inspect stderr/details for more information.';
 const DEFAULT_ANDROID_PREFS_XML = [
   '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>',
   '<map>',
@@ -129,9 +131,12 @@ async function writeAndroidDevPrefs(device: DeviceInfo, packageName: string, xml
   const probeArgs = adbArgs(device, ['shell', 'run-as', packageName, 'id']);
   const probeResult = await runCmd('adb', probeArgs, { allowFailure: true });
   if (probeResult.exitCode !== 0) {
+    const runAsDenied = isAndroidRunAsDeniedOutput(probeResult.stdout, probeResult.stderr);
     throw new AppError(
       'COMMAND_FAILED',
-      `Failed to access Android app sandbox for ${packageName}`,
+      runAsDenied
+        ? `Failed to access Android app sandbox for ${packageName}`
+        : `Failed to probe Android app sandbox for ${packageName}`,
       {
         package: packageName,
         cmd: 'adb',
@@ -139,7 +144,7 @@ async function writeAndroidDevPrefs(device: DeviceInfo, packageName: string, xml
         stdout: probeResult.stdout,
         stderr: probeResult.stderr,
         exitCode: probeResult.exitCode,
-        hint: ANDROID_RUN_AS_HINT,
+        hint: runAsDenied ? ANDROID_RUN_AS_HINT : ANDROID_PROBE_HINT,
       },
     );
   }

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import {
   listAndroidApps,
   openAndroidApp,
   parseAndroidLaunchComponent,
+  resolveAndroidApp,
   pushAndroidNotification,
   readAndroidClipboardText,
   setAndroidSetting,
@@ -770,6 +771,32 @@ test('swipeAndroid invokes adb input swipe with duration', async () => {
     }
     await fs.rm(tmpDir, { recursive: true, force: true });
   }
+});
+
+test('resolveAndroidApp does not treat file paths as package names', async () => {
+  await withMockedAdb(
+    'agent-device-android-resolve-path-',
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "-s" ]; then shift; shift; fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
+      '  echo "package:com.example.demo"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    async ({ device }) => {
+      await assert.rejects(
+        resolveAndroidApp(device, '/path/to/app-debug.apk'),
+        (error: unknown) => {
+          assert.ok(error instanceof AppError);
+          assert.equal(error.code, 'APP_NOT_INSTALLED');
+          return true;
+        },
+      );
+    },
+  );
 });
 
 test('openAndroidApp default launch uses -p package flag', async () => {

--- a/src/platforms/android/app-lifecycle.ts
+++ b/src/platforms/android/app-lifecycle.ts
@@ -20,7 +20,7 @@ export async function resolveAndroidApp(
   app: string,
 ): Promise<{ type: 'intent' | 'package'; value: string }> {
   const trimmed = app.trim();
-  if (trimmed.includes('.')) return { type: 'package', value: trimmed };
+  if (trimmed.includes('.') && !trimmed.includes('/')) return { type: 'package', value: trimmed };
 
   const alias = ALIASES[trimmed.toLowerCase()];
   if (alias) return alias;


### PR DESCRIPTION
## Summary

- **Root cause**: `resolveAndroidApp` treated any input containing a `.` as a package name. APK file paths like `/path/to/app-debug.apk` matched this heuristic, causing the path to flow through as `appId` into `applyRuntimeHintsToApp`, which ran `adb shell run-as /path/to/app-debug.apk id` — always fails. Fixed by excluding inputs containing `/` (Android package names never have slashes).
- **Symptom**: The probe failure in `writeAndroidDevPrefs` was unconditionally diagnosed as "app not debuggable" without checking the actual output. Now uses `isAndroidRunAsDeniedOutput()` (same as the write phase) to differentiate run-as denial from connectivity/transport errors.

## Test plan

- [x] `resolveAndroidApp` rejects file paths as package names (new test)
- [x] Probe failure with non-run-as output uses generic hint (new test)
- [x] Existing runtime-hints tests pass (8/8)
- [x] Existing Android platform tests pass (63/63)
- [x] Existing session handler tests pass (77/77)

🤖 Generated with [Claude Code](https://claude.com/claude-code)