### PR TITLE
fix: serve artifact downloads at /upload/{id} to fix proxy 404

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -915,7 +915,7 @@ function buildDaemonHttpUrl(baseUrl: string, route: 'health' | 'rpc'): string {
 
 function buildDaemonArtifactUrl(baseUrl: string, artifactId: string): string {
   const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-  return new URL(`artifacts/${encodeURIComponent(artifactId)}`, normalizedBase).toString();
+  return new URL(`upload/${encodeURIComponent(artifactId)}`, normalizedBase).toString();
 }
 
 async function materializeRemoteArtifacts(

--- a/src/daemon/__tests__/http-server.test.ts
+++ b/src/daemon/__tests__/http-server.test.ts
@@ -193,7 +193,7 @@ test('HTTP artifact download streams registered files', async (t) => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  const response = await callGet(port, `/artifacts/${artifactId}`, {
+  const response = await callGet(port, `/upload/${artifactId}`, {
     authorization: 'Bearer test-token',
   });
   assert.equal(response.statusCode, 200);
@@ -232,7 +232,7 @@ test('HTTP artifact download rejects requests without the daemon token', async (
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  const response = await callGet(port, `/artifacts/${artifactId}`);
+  const response = await callGet(port, `/upload/${artifactId}`);
   assert.equal(response.statusCode, 401);
   assert.match(response.body, /Invalid token/);
 });

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -260,7 +260,7 @@ export async function createDaemonHttpServer(options: {
       return;
     }
 
-    if (req.method === 'GET' && req.url?.startsWith('/artifacts/')) {
+    if (req.method === 'GET' && req.url?.startsWith('/upload/')) {
       void handleArtifactDownload(req, res, authHook, token);
       return;
     }
@@ -442,7 +442,7 @@ async function handleArtifactDownload(
   authHook: HttpAuthHook | null,
   expectedToken?: string,
 ): Promise<void> {
-  const artifactId = req.url?.slice('/artifacts/'.length) ?? '';
+  const artifactId = req.url?.slice('/upload/'.length) ?? '';
   if (!artifactId) {
     res.statusCode = 400;
     res.end('Missing artifact id');

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -487,7 +487,7 @@ test('sendToDaemon downloads remote artifacts and rewrites local paths', async (
             callback?.();
             return;
           }
-          if (this.options.method === 'GET' && String(this.options.path).includes('/artifacts/')) {
+          if (this.options.method === 'GET' && String(this.options.path).includes('/upload/')) {
             res.end(Buffer.from('png-binary'));
             callback?.();
             return;
@@ -544,7 +544,7 @@ test('sendToDaemon downloads remote artifacts and rewrites local paths', async (
     });
 
     assert.equal(response.ok, true);
-    assert.deepEqual(seenPaths, ['/agent-device/health', '/agent-device/rpc', '/agent-device/artifacts/artifact-123']);
+    assert.deepEqual(seenPaths, ['/agent-device/health', '/agent-device/rpc', '/agent-device/upload/artifact-123']);
     assert.match(String((rpcRequest as any)?.params?.positionals?.[0]), /^\/tmp\/agent-device-screenshot-/);
     assert.equal(
       (rpcRequest as any)?.params?.meta?.clientArtifactPaths?.path,
@@ -573,7 +573,7 @@ test('downloadRemoteArtifact times out stalled artifact responses and removes pa
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-remote-artifact-timeout-'));
   const destinationPath = path.join(tempRoot, 'artifacts', 'screen.png');
   const server = http.createServer((req, _res) => {
-    if (req.url?.includes('/artifacts/')) {
+    if (req.url?.includes('/upload/')) {
       return;
     }
   });


### PR DESCRIPTION
## Summary
- Artifact downloads via `GET /artifacts/{id}` returned 404 when the daemon was behind a proxy (sandbox → proxy → daemon), because proxies only forward known paths (`/rpc`, `/health`, `/upload`)
- Moved the download endpoint to `GET /upload/{id}` so it shares the already-forwarded `/upload` path (POST for uploads, GET for downloads)

## Test plan
- [x] HTTP server tests pass (artifact download + auth rejection)
- [x] Daemon client tests pass (remote artifact download + timeout)
- [ ] Verify screenshot artifact download works through proxy in sandbox → proxy → daemon setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)