### PR TITLE
fix: detect persistent iOS simulator launch failures early

### DIFF
--- a/src/platforms/ios/__tests__/launch-diagnostics.test.ts
+++ b/src/platforms/ios/__tests__/launch-diagnostics.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isSimulatorLaunchFBSError,
+  classifyLaunchFailure,
+  launchFailureHint,
+} from '../launch-diagnostics.ts';
+import { AppError } from '../../../utils/errors.ts';
+
+test('isSimulatorLaunchFBSError identifies FBS code=4 errors', () => {
+  const error = new AppError('COMMAND_FAILED', 'xcrun exited with code 4', {
+    exitCode: 4,
+    stderr:
+      'An error was encountered processing the command (domain=FBSOpenApplicationServiceErrorDomain, code=4):\nThe request to open "com.example.app" failed.',
+  });
+  assert.equal(isSimulatorLaunchFBSError(error), true);
+});
+
+test('isSimulatorLaunchFBSError rejects non-AppError', () => {
+  assert.equal(isSimulatorLaunchFBSError(new Error('something')), false);
+});
+
+test('isSimulatorLaunchFBSError rejects wrong error code', () => {
+  const error = new AppError('INVALID_ARGS', 'bad args', {
+    exitCode: 4,
+    stderr: 'FBSOpenApplicationServiceErrorDomain the request to open',
+  });
+  assert.equal(isSimulatorLaunchFBSError(error), false);
+});
+
+test('isSimulatorLaunchFBSError rejects wrong exit code', () => {
+  const error = new AppError('COMMAND_FAILED', 'xcrun exited with code 1', {
+    exitCode: 1,
+    stderr: 'FBSOpenApplicationServiceErrorDomain the request to open',
+  });
+  assert.equal(isSimulatorLaunchFBSError(error), false);
+});
+
+test('isSimulatorLaunchFBSError rejects unrelated stderr', () => {
+  const error = new AppError('COMMAND_FAILED', 'xcrun exited with code 4', {
+    exitCode: 4,
+    stderr: 'some other error message',
+  });
+  assert.equal(isSimulatorLaunchFBSError(error), false);
+});
+
+test('classifyLaunchFailure returns APP_NOT_INSTALLED when not installed', () => {
+  assert.equal(classifyLaunchFailure({ installed: false }), 'APP_NOT_INSTALLED');
+});
+
+test('classifyLaunchFailure returns ARCH_MISMATCH when not simulator compatible', () => {
+  assert.equal(
+    classifyLaunchFailure({ installed: true, simulatorCompatible: false }),
+    'ARCH_MISMATCH',
+  );
+});
+
+test('classifyLaunchFailure returns PERSISTENT_LAUNCH_FAIL when compatible', () => {
+  assert.equal(
+    classifyLaunchFailure({ installed: true, simulatorCompatible: true }),
+    'PERSISTENT_LAUNCH_FAIL',
+  );
+});
+
+test('classifyLaunchFailure returns PERSISTENT_LAUNCH_FAIL when compatibility unknown', () => {
+  assert.equal(
+    classifyLaunchFailure({ installed: true }),
+    'PERSISTENT_LAUNCH_FAIL',
+  );
+});
+
+test('launchFailureHint returns actionable string for ARCH_MISMATCH', () => {
+  const hint = launchFailureHint('ARCH_MISMATCH');
+  assert.ok(hint.length > 0);
+  assert.ok(hint.includes('simulator'));
+});
+
+test('launchFailureHint returns actionable string for APP_NOT_INSTALLED', () => {
+  const hint = launchFailureHint('APP_NOT_INSTALLED');
+  assert.ok(hint.length > 0);
+  assert.ok(hint.includes('install'));
+});
+
+test('launchFailureHint returns actionable string for PERSISTENT_LAUNCH_FAIL', () => {
+  const hint = launchFailureHint('PERSISTENT_LAUNCH_FAIL');
+  assert.ok(hint.length > 0);
+  assert.ok(hint.includes('crash logs') || hint.includes('reinstalling'));
+});
+
+test('launchFailureHint returns actionable string for UNKNOWN', () => {
+  const hint = launchFailureHint('UNKNOWN');
+  assert.ok(hint.length > 0);
+});

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -22,6 +22,12 @@ import {
   runIosDevicectl,
   type IosAppInfo,
 } from './devicectl.ts';
+import {
+  isSimulatorLaunchFBSError,
+  probeSimulatorLaunchContext,
+  classifyLaunchFailure,
+  launchFailureHint,
+} from './launch-diagnostics.ts';
 import { ensureBootedSimulator, ensureSimulator, focusIosSimulatorWindow, getSimulatorState } from './simulator.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
 export {
@@ -856,56 +862,59 @@ function isIosBiometricCapabilityMissing(stdout: string, stderr: string): boolea
   );
 }
 
-function isTransientSimulatorLaunchFailure(error: unknown): boolean {
-  if (!(error instanceof AppError)) return false;
-  if (error.code !== 'COMMAND_FAILED') return false;
-
-  const details = (error.details ?? {}) as { exitCode?: number; stderr?: unknown };
-  if (details.exitCode !== 4) return false;
-  const stderr = String(details.stderr ?? '').toLowerCase();
-
-  return (
-    stderr.includes('fbsopenapplicationserviceerrordomain') &&
-    stderr.includes('the request to open')
-  );
-}
-
 async function launchIosSimulatorApp(device: DeviceInfo, bundleId: string): Promise<void> {
   await ensureBootedSimulator(device);
   await focusIosSimulatorWindow();
 
+  let consecutiveFBSFailures = 0;
+  const MAX_CONSECUTIVE_FBS_FAILURES = 3;
+
   const launchDeadline = Deadline.fromTimeoutMs(IOS_APP_LAUNCH_TIMEOUT_MS);
-  await retryWithPolicy(
-    async ({ deadline: attemptDeadline }) => {
-      if (attemptDeadline?.isExpired()) {
-        throw new AppError('COMMAND_FAILED', 'App launch deadline exceeded', {
-          timeoutMs: IOS_APP_LAUNCH_TIMEOUT_MS,
+  try {
+    await retryWithPolicy(
+      async ({ deadline: attemptDeadline }) => {
+        if (attemptDeadline?.isExpired()) {
+          throw new AppError('COMMAND_FAILED', 'App launch deadline exceeded', {
+            timeoutMs: IOS_APP_LAUNCH_TIMEOUT_MS,
+          });
+        }
+
+        const launchArgs = simctlArgs(device, ['launch', device.id, bundleId]);
+        const result = await runCmd('xcrun', launchArgs, {
+          allowFailure: true,
         });
-      }
+        if (result.exitCode === 0) return;
 
-      const launchArgs = simctlArgs(device, ['launch', device.id, bundleId]);
-      const result = await runCmd('xcrun', launchArgs, {
-        allowFailure: true,
-      });
-      if (result.exitCode === 0) return;
-
-      throw new AppError('COMMAND_FAILED', `xcrun exited with code ${result.exitCode}`, {
-        cmd: 'xcrun',
-        args: launchArgs,
-        stdout: result.stdout,
-        stderr: result.stderr,
-        exitCode: result.exitCode,
-      });
-    },
-    {
-      maxAttempts: 30,
-      baseDelayMs: 1_000,
-      maxDelayMs: 5_000,
-      jitter: 0.2,
-      shouldRetry: isTransientSimulatorLaunchFailure,
-    },
-    { deadline: launchDeadline },
-  );
+        throw new AppError('COMMAND_FAILED', `xcrun exited with code ${result.exitCode}`, {
+          cmd: 'xcrun',
+          args: launchArgs,
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+        });
+      },
+      {
+        maxAttempts: 10,
+        baseDelayMs: 1_000,
+        maxDelayMs: 5_000,
+        jitter: 0.2,
+        shouldRetry(error: unknown) {
+          if (!isSimulatorLaunchFBSError(error)) return false;
+          consecutiveFBSFailures += 1;
+          return consecutiveFBSFailures < MAX_CONSECUTIVE_FBS_FAILURES;
+        },
+      },
+      { deadline: launchDeadline },
+    );
+  } catch (error) {
+    if (isSimulatorLaunchFBSError(error)) {
+      const appError = error as AppError;
+      const probe = await probeSimulatorLaunchContext(device, bundleId);
+      const reason = classifyLaunchFailure(probe);
+      appError.details = { ...appError.details, hint: launchFailureHint(reason) };
+    }
+    throw error;
+  }
 }
 
 async function launchIosDeviceProcess(

--- a/src/platforms/ios/launch-diagnostics.ts
+++ b/src/platforms/ios/launch-diagnostics.ts
@@ -1,0 +1,96 @@
+import { AppError } from '../../utils/errors.ts';
+import { runCmd } from '../../utils/exec.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import { buildSimctlArgsForDevice } from './simctl.ts';
+
+export type LaunchFailureReason =
+  | 'ARCH_MISMATCH'
+  | 'APP_NOT_INSTALLED'
+  | 'PERSISTENT_LAUNCH_FAIL'
+  | 'UNKNOWN';
+
+type LaunchProbeResult = {
+  installed: boolean;
+  simulatorCompatible?: boolean;
+};
+
+export function isSimulatorLaunchFBSError(error: unknown): boolean {
+  if (!(error instanceof AppError)) return false;
+  if (error.code !== 'COMMAND_FAILED') return false;
+
+  const details = (error.details ?? {}) as { exitCode?: number; stderr?: unknown };
+  if (details.exitCode !== 4) return false;
+  const stderr = String(details.stderr ?? '').toLowerCase();
+
+  return (
+    stderr.includes('fbsopenapplicationserviceerrordomain') &&
+    stderr.includes('the request to open')
+  );
+}
+
+export async function probeSimulatorLaunchContext(
+  device: DeviceInfo,
+  bundleId: string,
+): Promise<LaunchProbeResult> {
+  const containerResult = await runCmd(
+    'xcrun',
+    buildSimctlArgsForDevice(device, ['get_app_container', device.id, bundleId]),
+    { allowFailure: true },
+  );
+
+  if (containerResult.exitCode !== 0) {
+    return { installed: false };
+  }
+
+  const containerPath = containerResult.stdout.trim();
+  if (!containerPath) {
+    return { installed: false };
+  }
+
+  // Read the Info.plist to find the executable name
+  const plistResult = await runCmd(
+    'plutil',
+    ['-extract', 'CFBundleExecutable', 'raw', '-o', '-', `${containerPath}/Info.plist`],
+    { allowFailure: true },
+  );
+
+  if (plistResult.exitCode !== 0 || !plistResult.stdout.trim()) {
+    return { installed: true };
+  }
+
+  const binaryName = plistResult.stdout.trim();
+  const binaryPath = `${containerPath}/${binaryName}`;
+
+  // Use otool to inspect LC_BUILD_VERSION for the platform marker.
+  // This is reliable on both Intel and Apple Silicon, where `file` output
+  // looks identical for device and simulator arm64 binaries.
+  const otoolResult = await runCmd('otool', ['-l', binaryPath], { allowFailure: true });
+  if (otoolResult.exitCode !== 0) {
+    return { installed: true };
+  }
+
+  const otoolOutput = otoolResult.stdout.toLowerCase();
+  const isSimulatorBinary =
+    otoolOutput.includes('iossimulator') || otoolOutput.includes('platform 7');
+
+  return { installed: true, simulatorCompatible: isSimulatorBinary };
+}
+
+export function classifyLaunchFailure(probe: LaunchProbeResult): LaunchFailureReason {
+  if (!probe.installed) return 'APP_NOT_INSTALLED';
+  if (probe.simulatorCompatible === false) return 'ARCH_MISMATCH';
+  return 'PERSISTENT_LAUNCH_FAIL';
+}
+
+export function launchFailureHint(reason: LaunchFailureReason): string {
+  switch (reason) {
+    case 'ARCH_MISMATCH':
+      return 'The app binary was not built for the simulator platform. Rebuild with a simulator destination or use a physical device.';
+    case 'APP_NOT_INSTALLED':
+      return 'The app bundle is not installed on this simulator. Run install before open.';
+    case 'PERSISTENT_LAUNCH_FAIL':
+      return 'The simulator repeatedly refused to launch the app. Inspect crash logs in Console.app or ~/Library/Logs/DiagnosticReports/ and consider reinstalling the app.';
+    default:
+      return 'The simulator failed to launch the app. Retry with --debug and inspect diagnostics log for details.';
+  }
+}


### PR DESCRIPTION
## Summary
- **Early bail-out on persistent FBS errors**: Tracks consecutive identical `FBSOpenApplicationServiceErrorDomain code=4` failures and stops retrying after 3, instead of burning 30 seconds on all 30 attempts
- **Root-cause probing on failure**: Checks whether the app is installed and inspects the binary's `LC_BUILD_VERSION` platform via `otool -l` to detect device-only binaries on simulator
- **Actionable error hints**: Surfaces specific guidance (architecture mismatch, app not installed, or generic persistent failure) following the `boot-diagnostics.ts` classifier+hint pattern

## Test plan
- [x] `node --test src/platforms/ios/__tests__/launch-diagnostics.test.ts` — 13 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: install a device-only .app on simulator, run `agent-device open` — should fail fast (~6s not 30s) with arch mismatch hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)