### PR TITLE
fix: quote sh -c script in adb shell to prevent argument splitting

### DIFF
--- a/src/daemon/__tests__/runtime-hints.test.ts
+++ b/src/daemon/__tests__/runtime-hints.test.ts
@@ -208,7 +208,7 @@ test('applyRuntimeHintsToApp writes React Native Android dev prefs', async () =>
     const stdinPayload = await fs.readFile(stdinFilePath, 'utf8');
     assert.match(loggedArgs, /shell run-as com\.example\.demo cat shared_prefs\/ReactNativeDevPrefs\.xml/);
     assert.match(loggedArgs, /shell run-as com\.example\.demo sh -c/);
-    assert.equal(script, 'mkdir -p shared_prefs && cat > shared_prefs/ReactNativeDevPrefs.xml');
+    assert.equal(script, "'mkdir -p shared_prefs && cat > shared_prefs/ReactNativeDevPrefs.xml'");
     assert.match(stdinPayload, /<string name="keep">value<\/string>/);
     assert.match(stdinPayload, /<string name="debug_http_host">10\.0\.0\.10:8082<\/string>/);
     assert.match(stdinPayload, /<boolean name="dev_server_https" value="true" \/>/);

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -150,7 +150,7 @@ async function writeAndroidDevPrefs(device: DeviceInfo, packageName: string, xml
   }
 
   const script = `mkdir -p shared_prefs && cat > ${ANDROID_DEV_PREFS_PATH}`;
-  const writeArgs = adbArgs(device, ['shell', 'run-as', packageName, 'sh', '-c', script]);
+  const writeArgs = adbArgs(device, ['shell', 'run-as', packageName, 'sh', '-c', `'${script}'`]);
   try {
     await runCmd('adb', writeArgs, { stdin: xml.trimEnd() });
   } catch (error) {


### PR DESCRIPTION
## Summary
- `adb shell` concatenates all arguments into a single string for the remote device shell. The `&&` in the `mkdir -p shared_prefs && cat > ...` script was being interpreted as a command separator, causing `sh -c mkdir` to run `mkdir` with no arguments (`mkdir: Needs 1 argument`).
- Wrapping the script in single quotes ensures the remote shell passes the entire command as one argument to `sh -c`.

## Test plan
- [x] Existing `runtime-hints.test.ts` tests pass (8/8)
- [ ] Verify on Android emulator: `adb shell run-as <pkg> sh -c 'mkdir -p shared_prefs && cat > shared_prefs/ReactNativeDevPrefs.xml'` correctly creates the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)