### PR TITLE
fix: increase Android emulator AVD name resolution timeout

### DIFF
--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -10,7 +10,7 @@ const EMULATOR_SERIAL_PREFIX = 'emulator-';
 const ANDROID_BOOT_POLL_MS = 1000;
 const ANDROID_EMULATOR_BOOT_POLL_MS = 1000;
 const ANDROID_EMULATOR_BOOT_TIMEOUT_MS = 120_000;
-const ANDROID_EMULATOR_AVD_NAME_TIMEOUT_MS = 1_500;
+const ANDROID_EMULATOR_AVD_NAME_TIMEOUT_MS = 10_000;
 const ANDROID_TV_FEATURES = [
   'android.software.leanback',
   'android.software.leanback_only',


### PR DESCRIPTION
## Summary
- Increases `ANDROID_EMULATOR_AVD_NAME_TIMEOUT_MS` from 1.5s to 10s, matching the general `android_boot.operationMs` budget
- The previous 1.5s per-command timeout was too aggressive for emulators over remote adb daemon transport, causing `open --relaunch` to fail during device discovery in `resolveAndroidEmulatorAvdName`

## Test plan
- [ ] Run `agent-device open <apk> --relaunch --platform android` against an emulator over remote adb transport
- [ ] Verify AVD name resolution no longer times out on slow connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)