### PR TITLE
fix: prefer simulators/emulators over physical devices in auto-selection

### DIFF
--- a/src/utils/__tests__/device.test.ts
+++ b/src/utils/__tests__/device.test.ts
@@ -60,3 +60,45 @@ test('selectDevice returns a device when candidates are available', async () => 
   const result = await selectDevice([device], { platform: 'ios' });
   assert.equal(result.id, 'abc123');
 });
+
+test('selectDevice prefers simulator over physical device when no explicit device selector', async () => {
+  const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
+  const simulator: DeviceInfo = {
+    platform: 'ios',
+    id: 'sim-1',
+    name: 'iPhone 16',
+    kind: 'simulator',
+    booted: false,
+  };
+  const result = await selectDevice([physical, simulator], { platform: 'ios' });
+  assert.equal(result.id, 'sim-1');
+  assert.equal(result.kind, 'simulator');
+});
+
+test('selectDevice prefers booted simulator over physical device', async () => {
+  const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
+  const sim1: DeviceInfo = { platform: 'ios', id: 'sim-1', name: 'iPhone 16', kind: 'simulator', booted: true };
+  const sim2: DeviceInfo = { platform: 'ios', id: 'sim-2', name: 'iPhone 15', kind: 'simulator', booted: false };
+  const result = await selectDevice([physical, sim1, sim2], { platform: 'ios' });
+  assert.equal(result.id, 'sim-1');
+});
+
+test('selectDevice falls back to physical device when no simulators exist', async () => {
+  const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
+  const result = await selectDevice([physical], { platform: 'ios' });
+  assert.equal(result.id, 'phys-1');
+});
+
+test('selectDevice returns physical device when explicitly selected by deviceName', async () => {
+  const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
+  const simulator: DeviceInfo = { platform: 'ios', id: 'sim-1', name: 'iPhone 16', kind: 'simulator', booted: true };
+  const result = await selectDevice([physical, simulator], { platform: 'ios', deviceName: 'My iPhone' });
+  assert.equal(result.id, 'phys-1');
+});
+
+test('selectDevice returns physical device when explicitly selected by udid', async () => {
+  const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
+  const simulator: DeviceInfo = { platform: 'ios', id: 'sim-1', name: 'iPhone 16', kind: 'simulator', booted: true };
+  const result = await selectDevice([physical, simulator], { platform: 'ios', udid: 'phys-1' });
+  assert.equal(result.id, 'phys-1');
+});

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -92,6 +92,13 @@ export async function selectDevice(
     throw new AppError('DEVICE_NOT_FOUND', 'No devices found', { selector });
   }
 
+  // Prefer virtual devices (simulators/emulators) over physical devices unless
+  // a physical device was explicitly requested via --device/--udid/--serial.
+  const virtual = candidates.filter((d) => d.kind !== 'device');
+  if (virtual.length > 0) {
+    candidates = virtual;
+  }
+
   const booted = candidates.filter((d) => d.booted);
   if (booted.length === 1) return booted[0];
 


### PR DESCRIPTION
## Summary
- When no explicit device selector (`--udid`/`--device`/`--serial`) is provided, auto-selection now prefers simulators/emulators over physical devices
- Physical iOS devices always report `booted=true`, which caused the "prefer booted" tiebreaker to pick them over unbooted simulators — binding sessions to a connected iPhone instead of a simulator
- Physical devices are still selected when explicitly targeted or when no virtual devices are available

## Test plan
- [x] Added test: prefers simulator over physical device when no explicit selector
- [x] Added test: prefers booted simulator over physical device
- [x] Added test: falls back to physical device when no simulators exist
- [x] Added test: returns physical device when explicitly selected by `deviceName`
- [x] Added test: returns physical device when explicitly selected by `udid`
- [x] All 12 device selection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)