### PR TITLE
fix: avoid hanging http server unit test

### DIFF
--- a/src/daemon/artifact-registry.ts
+++ b/src/daemon/artifact-registry.ts
@@ -24,6 +24,7 @@ export function trackDownloadableArtifact(params: {
   const timer = setTimeout(() => {
     cleanupDownloadableArtifact(artifactId);
   }, ARTIFACT_CLEANUP_TIMEOUT_MS);
+  timer.unref();
   pendingArtifacts.set(artifactId, {
     artifactPath: params.artifactPath,
     tenantId: params.tenantId,


### PR DESCRIPTION
## Summary

Unref the downloadable artifact cleanup timer so pending artifact expiry does not keep the Node test process alive.
Smoke-suite smoke-daemon-http still has a separate existing pending-promise failure and is not addressed here.

## Validation

node --test src/daemon/__tests__/http-server.test.ts
timeout 15s pnpm test:smoke (shows separate existing failure in test/integration/smoke-daemon-http.test.ts)
pnpm typecheck (blocked locally because node_modules is missing and tsc is unavailable)