### PR TITLE
fix: resolve screenshot path against caller cwd

### DIFF
--- a/src/daemon/__tests__/request-router-screenshot.test.ts
+++ b/src/daemon/__tests__/request-router-screenshot.test.ts
@@ -62,6 +62,8 @@ test('screenshot resolves relative positional path against request cwd', async (
   assert.ok(capturedPath, 'dispatch should have been called with a path');
   assert.equal(capturedPath, path.join(callerCwd, 'evidence/test.png'));
   assert.ok(path.isAbsolute(capturedPath), 'path passed to dispatch must be absolute');
+  const recordedAction = sessionStore.get('default')?.actions.at(-1);
+  assert.deepEqual(recordedAction?.positionals, [path.join(callerCwd, 'evidence/test.png')]);
 });
 
 test('screenshot keeps absolute positional path unchanged', async () => {
@@ -94,6 +96,8 @@ test('screenshot keeps absolute positional path unchanged', async () => {
   });
 
   assert.equal(capturedPath, absolutePath);
+  const recordedAction = sessionStore.get('default')?.actions.at(-1);
+  assert.deepEqual(recordedAction?.positionals, [absolutePath]);
 });
 
 test('screenshot resolves --out flag path against request cwd', async () => {
@@ -129,4 +133,6 @@ test('screenshot resolves --out flag path against request cwd', async () => {
   assert.ok(capturedOut, 'dispatch should have been called with out path');
   assert.equal(capturedOut, path.join(callerCwd, 'evidence/test.png'));
   assert.ok(path.isAbsolute(capturedOut), 'out path passed to dispatch must be absolute');
+  const recordedAction = sessionStore.get('default')?.actions.at(-1);
+  assert.equal(recordedAction?.flags.out, path.join(callerCwd, 'evidence/test.png'));
 });

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -308,13 +308,18 @@ export function createRequestHandler(deps: RequestRouterDeps): (req: DaemonReque
             command === 'screenshot' && outFlag
               ? SessionStore.expandHome(outFlag, scopedReq.meta?.cwd)
               : outFlag;
+          const recordedPositionals = command === 'screenshot' ? resolvedPositionals : positionals;
+          const recordedFlags =
+            command === 'screenshot' && resolvedOut
+              ? { ...(scopedReq.flags ?? {}), out: resolvedOut }
+              : (scopedReq.flags ?? {});
           const data = await dispatch(session.device, command, resolvedPositionals, resolvedOut, {
             ...contextFromFlags(logPath, scopedReq.flags, session.appBundleId, session.trace?.outPath),
           });
           sessionStore.recordAction(session, {
             command,
-            positionals: scopedReq.positionals ?? [],
-            flags: scopedReq.flags ?? {},
+            positionals: recordedPositionals,
+            flags: recordedFlags,
             result: data ?? {},
           });
           return finalize({ ok: true, data: data ?? {} });


### PR DESCRIPTION
Closes callstackincubator/agent-device#220

## Problem

The `agent-device` daemon is a long-running background process. Its working directory is fixed at the directory where it was first started. When a CLI invocation runs from a different directory, relative `screenshot` paths are resolved against the **daemon's cwd** instead of the **CLI's cwd**.

Example:

```sh
# Daemon started (and its cwd fixed) from /some/dir
cd /some/dir && agent-device session list

# CLI runs from a different directory
cd /workspace && agent-device --session s screenshot evidence/shot.png

# Result:   /some/dir/evidence/shot.png  ← wrong
# Expected: /workspace/evidence/shot.png ← correct
```

`replay` and `record` already resolve paths against `req.meta?.cwd` (the CLI's cwd) via `SessionStore.expandHome`. `screenshot` was missing the same treatment.

## Fix

Before calling `dispatchCommand`, resolve the `screenshot` positional path and `--out` flag against `req.meta?.cwd`, consistent with `replay` and `record`.

## Tests

Three new unit tests in `src/daemon/__tests__/request-router-screenshot.test.ts`:
- relative positional path resolved against `meta.cwd`
- absolute positional path left unchanged
- relative `--out` flag resolved against `meta.cwd`