### PR TITLE
fix: harden remote install-from-source transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ await client.sessions.close();
 await androidClient.sessions.close();
 ```
 
+`installFromSource` URL sources are intentionally limited:
+- Private and loopback hosts are blocked by default.
+- Archive-backed URL installs are only supported for trusted artifact services, currently GitHub Actions and EAS.
+- For other hosts, prefer `source: { kind: 'path', path: ... }` so the client downloads/uploads the artifact explicitly.
+
 The skill is also accessible on [ClawHub](https://clawhub.ai/okwasniewski/agent-device).
 For structured exploratory QA workflows, use the dogfood skill at [skills/dogfood/SKILL.md](skills/dogfood/SKILL.md).
 
@@ -613,6 +618,8 @@ Environment selectors:
 - `AGENT_DEVICE_DAEMON_TRANSPORT=auto|socket|http` client preference when connecting to daemon metadata.
 - `AGENT_DEVICE_HTTP_AUTH_HOOK=<module-path>` optional HTTP auth hook module path for JSON-RPC server mode.
 - `AGENT_DEVICE_HTTP_AUTH_EXPORT=<export-name>` optional export name from auth hook module (default: `default`).
+- `AGENT_DEVICE_SOURCE_DOWNLOAD_TIMEOUT_MS=<ms>` timeout for `installFromSource` URL downloads (default: `120000`).
+- `AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS=1` opt out of the default SSRF guard that blocks loopback/private-network artifact URLs for `installFromSource`.
 - `AGENT_DEVICE_MAX_SIMULATOR_LEASES=<n>` optional max concurrent simulator leases for HTTP lease allocation (default: unlimited).
 - `AGENT_DEVICE_LEASE_TTL_MS=<ms>` default lease TTL used by `agent_device.lease.allocate` and `agent_device.lease.heartbeat` (default: `60000`).
 - `AGENT_DEVICE_LEASE_MIN_TTL_MS=<ms>` minimum accepted lease TTL (default: `5000`).

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -109,6 +109,7 @@ export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<D
     flags: preparedRemoteRequest.flags,
     token: info.token,
     meta: {
+      ...(req.meta ?? {}),
       requestId,
       debug,
       cwd: req.meta?.cwd,
@@ -120,6 +121,7 @@ export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<D
       lockPlatform: req.meta?.lockPlatform,
       ...(preparedRemoteRequest.uploadedArtifactId ? { uploadedArtifactId: preparedRemoteRequest.uploadedArtifactId } : {}),
       ...(preparedRemoteRequest.clientArtifactPaths ? { clientArtifactPaths: preparedRemoteRequest.clientArtifactPaths } : {}),
+      ...(preparedRemoteRequest.installSource ? { installSource: preparedRemoteRequest.installSource } : {}),
     },
   };
   emitDiagnostic({
@@ -192,11 +194,13 @@ async function prepareRemoteRequest(
 ): Promise<{
   positionals: string[];
   flags?: DaemonRequest['flags'];
+  installSource?: NonNullable<DaemonRequest['meta']>['installSource'];
   uploadedArtifactId?: string;
   clientArtifactPaths?: Record<string, string>;
 }> {
   const positionals = [...(req.positionals ?? [])];
   let flags = req.flags ? { ...req.flags } : undefined;
+  let installSource = req.meta?.installSource;
   const clientArtifactPaths: Record<string, string> = {};
   let uploadedArtifactId: string | undefined;
 
@@ -212,6 +216,12 @@ async function prepareRemoteRequest(
       }
       clientArtifactPaths[remoteArtifact.field] = remoteArtifact.localPath;
     }
+
+    const remoteInstallSource = await prepareRemoteInstallSource(req, info);
+    if (remoteInstallSource) {
+      installSource = remoteInstallSource.installSource;
+      uploadedArtifactId = remoteInstallSource.uploadedArtifactId ?? uploadedArtifactId;
+    }
   }
 
   if (
@@ -222,6 +232,8 @@ async function prepareRemoteRequest(
     return {
       positionals,
       flags,
+      installSource,
+      uploadedArtifactId,
       ...(Object.keys(clientArtifactPaths).length > 0 ? { clientArtifactPaths } : {}),
     };
   }
@@ -255,8 +267,60 @@ async function prepareRemoteRequest(
   return {
     positionals,
     flags,
+    installSource,
     uploadedArtifactId,
     ...(Object.keys(clientArtifactPaths).length > 0 ? { clientArtifactPaths } : {}),
+  };
+}
+
+async function prepareRemoteInstallSource(
+  req: Omit<DaemonRequest, 'token'>,
+  info: DaemonInfo,
+): Promise<{
+  installSource: NonNullable<DaemonRequest['meta']>['installSource'];
+  uploadedArtifactId?: string;
+} | null> {
+  const source = req.meta?.installSource;
+  if (req.command !== 'install_source' || !source || source.kind !== 'path') {
+    return null;
+  }
+
+  const rawPath = source.path.trim();
+  if (!rawPath) {
+    return { installSource: source };
+  }
+  if (rawPath.startsWith('remote:')) {
+    return {
+      installSource: {
+        ...source,
+        path: rawPath.slice('remote:'.length),
+      },
+    };
+  }
+
+  const localPath = path.isAbsolute(rawPath)
+    ? rawPath
+    : path.resolve(req.meta?.cwd ?? process.cwd(), rawPath);
+  if (!fs.existsSync(localPath)) {
+    return {
+      installSource: {
+        ...source,
+        path: localPath,
+      },
+    };
+  }
+
+  const uploadedArtifactId = await uploadArtifact({
+    localPath,
+    baseUrl: info.baseUrl!,
+    token: info.token,
+  });
+  return {
+    installSource: {
+      ...source,
+      path: localPath,
+    },
+    uploadedArtifactId,
   };
 }
 

--- a/src/daemon/handlers/__tests__/install-source.test.ts
+++ b/src/daemon/handlers/__tests__/install-source.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveInstallSource } from '../../install-source-resolution.ts';
+import { trackUploadedArtifact } from '../../upload-registry.ts';
+import type { DaemonRequest } from '../../types.ts';
+
+function makeRequest(meta?: DaemonRequest['meta']): DaemonRequest {
+  return {
+    token: 't',
+    session: 'default',
+    command: 'install_source',
+    positionals: [],
+    flags: { platform: 'android' },
+    meta,
+  };
+}
+
+test('resolveInstallSource uses uploaded artifact path for uploaded path sources', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-install-source-upload-'));
+  const artifactPath = path.join(tempRoot, 'Sample.apk');
+  fs.writeFileSync(artifactPath, 'apk-binary');
+  const uploadedArtifactId = trackUploadedArtifact({ artifactPath, tempDir: tempRoot });
+
+  const resolved = resolveInstallSource(makeRequest({
+    uploadedArtifactId,
+    installSource: {
+      kind: 'path',
+      path: '/Users/dev/Downloads/Sample.apk',
+    },
+  }));
+
+  assert.equal(resolved.source.kind, 'path');
+  assert.equal(resolved.source.path, artifactPath);
+
+  resolved.cleanup();
+  assert.equal(fs.existsSync(tempRoot), false);
+});
+
+test('resolveInstallSource leaves URL sources unchanged even when upload metadata exists', () => {
+  const resolved = resolveInstallSource(makeRequest({
+    uploadedArtifactId: 'upload-123',
+    installSource: {
+      kind: 'url',
+      url: 'https://example.com/app.apk',
+      headers: {},
+    },
+  }));
+
+  assert.deepEqual(resolved.source, {
+    kind: 'url',
+    url: 'https://example.com/app.apk',
+    headers: {},
+  });
+  resolved.cleanup();
+});

--- a/src/daemon/handlers/install-source.ts
+++ b/src/daemon/handlers/install-source.ts
@@ -6,29 +6,13 @@ import {
   cleanupRetainedMaterializedPaths,
   retainMaterializedPaths,
 } from '../materialized-path-registry.ts';
+import { resolveInstallSource } from '../install-source-resolution.ts';
 import { SessionStore } from '../session-store.ts';
-import type { DaemonInstallSource, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { AppError, normalizeError } from '../../utils/errors.ts';
 
 function normalizePlatform(platform: CommandFlags['platform']): 'ios' | 'android' | undefined {
   return platform === 'ios' || platform === 'android' ? platform : undefined;
-}
-
-function requireInstallSource(req: DaemonRequest): DaemonInstallSource {
-  const source = req.meta?.installSource;
-  if (!source) {
-    throw new AppError('INVALID_ARGS', 'install_from_source requires a source payload');
-  }
-  if (source.kind === 'url') {
-    if (!source.url || source.url.trim().length === 0) {
-      throw new AppError('INVALID_ARGS', 'install_from_source url source requires a non-empty url');
-    }
-    return source;
-  }
-  if (!source.path || source.path.trim().length === 0) {
-    throw new AppError('INVALID_ARGS', 'install_from_source path source requires a non-empty path');
-  }
-  return source;
 }
 
 function resolveRetainMaterializedPaths(req: DaemonRequest): { enabled: boolean; ttlMs?: number } {
@@ -73,7 +57,7 @@ export async function handleInstallFromSourceCommand(params: {
   const { req, sessionName, sessionStore } = params;
   const session = sessionStore.get(sessionName);
   try {
-    const source = requireInstallSource(req);
+    const resolvedSource = resolveInstallSource(req);
     const retention = resolveRetainMaterializedPaths(req);
     const device = await resolveInstallDevice({
       session,
@@ -93,7 +77,7 @@ export async function handleInstallFromSourceCommand(params: {
     if (device.platform === 'ios') {
       const { installIosInstallablePath } = await import('../../platforms/ios/index.ts');
       const { prepareIosInstallArtifact } = await import('../../platforms/ios/install-artifact.ts');
-      const prepared = await prepareIosInstallArtifact(source, { signal: requestSignal });
+      const prepared = await prepareIosInstallArtifact(resolvedSource.source, { signal: requestSignal });
       let retained: Awaited<ReturnType<typeof retainMaterializedPaths>> | undefined;
       try {
         if (retention.enabled) {
@@ -136,12 +120,13 @@ export async function handleInstallFromSourceCommand(params: {
         throw error;
       } finally {
         await prepared.cleanup();
+        resolvedSource.cleanup();
       }
     }
 
     const { installAndroidInstallablePath } = await import('../../platforms/android/index.ts');
     const { prepareAndroidInstallArtifact } = await import('../../platforms/android/install-artifact.ts');
-    const prepared = await prepareAndroidInstallArtifact(source, { signal: requestSignal });
+    const prepared = await prepareAndroidInstallArtifact(resolvedSource.source, { signal: requestSignal });
     let retained: Awaited<ReturnType<typeof retainMaterializedPaths>> | undefined;
     try {
       if (retention.enabled) {
@@ -154,16 +139,14 @@ export async function handleInstallFromSourceCommand(params: {
         });
       }
       await installAndroidInstallablePath(device, prepared.installablePath);
-      if (!prepared.packageName) {
-        throw new AppError('COMMAND_FAILED', 'Installed Android package identity could not be resolved from the artifact');
-      }
       const { inferAndroidAppName } = await import('../../platforms/android/index.ts');
+      const appName = prepared.packageName ? inferAndroidAppName(prepared.packageName) : undefined;
       const result = {
         ...(retained?.archivePath ? { archivePath: retained.archivePath } : {}),
         ...(retained ? { installablePath: retained.installablePath } : {}),
-        packageName: prepared.packageName,
-        appName: inferAndroidAppName(prepared.packageName),
-        launchTarget: prepared.packageName,
+        ...(prepared.packageName ? { packageName: prepared.packageName } : {}),
+        ...(appName ? { appName } : {}),
+        ...(prepared.packageName ? { launchTarget: prepared.packageName } : {}),
         ...(retained ? {
           materializationId: retained.materializationId,
           materializationExpiresAt: retained.expiresAt,
@@ -185,6 +168,7 @@ export async function handleInstallFromSourceCommand(params: {
       throw error;
     } finally {
       await prepared.cleanup();
+      resolvedSource.cleanup();
     }
   } catch (error) {
     const normalized = normalizeError(error);

--- a/src/daemon/install-source-resolution.ts
+++ b/src/daemon/install-source-resolution.ts
@@ -1,0 +1,40 @@
+import { AppError } from '../utils/errors.ts';
+import { cleanupUploadedArtifact, prepareUploadedArtifact } from './upload-registry.ts';
+import type { DaemonInstallSource, DaemonRequest } from './types.ts';
+
+function requireInstallSource(req: DaemonRequest): DaemonInstallSource {
+  const source = req.meta?.installSource;
+  if (!source) {
+    throw new AppError('INVALID_ARGS', 'install_from_source requires a source payload');
+  }
+  if (source.kind === 'url') {
+    if (!source.url || source.url.trim().length === 0) {
+      throw new AppError('INVALID_ARGS', 'install_from_source url source requires a non-empty url');
+    }
+    return source;
+  }
+  if (!source.path || source.path.trim().length === 0) {
+    throw new AppError('INVALID_ARGS', 'install_from_source path source requires a non-empty path');
+  }
+  return source;
+}
+
+export function resolveInstallSource(req: DaemonRequest): {
+  source: DaemonInstallSource;
+  cleanup: () => void;
+} {
+  const source = requireInstallSource(req);
+  const uploadedArtifactId = req.meta?.uploadedArtifactId;
+  if (!uploadedArtifactId || source.kind !== 'path') {
+    return { source, cleanup: () => {} };
+  }
+  return {
+    source: {
+      kind: 'path',
+      path: prepareUploadedArtifact(uploadedArtifactId, req.meta?.tenantId),
+    },
+    cleanup: () => {
+      cleanupUploadedArtifact(uploadedArtifactId);
+    },
+  };
+}

--- a/src/platforms/__tests__/install-source.test.ts
+++ b/src/platforms/__tests__/install-source.test.ts
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  isTrustedInstallSourceUrl,
+  materializeInstallablePath,
+  validateDownloadSourceUrl,
+} from '../install-source.ts';
+import { prepareIosInstallArtifact } from '../ios/install-artifact.ts';
+
+test('validateDownloadSourceUrl rejects localhost and private literal addresses by default', async () => {
+  await assert.rejects(
+    async () => await validateDownloadSourceUrl(new URL('http://127.0.0.1/app.apk')),
+    /not allowed|private or loopback/i,
+  );
+  await assert.rejects(
+    async () => await validateDownloadSourceUrl(new URL('http://localhost/app.apk')),
+    /not allowed|private or loopback/i,
+  );
+  await assert.rejects(
+    async () => await validateDownloadSourceUrl(new URL('http://10.0.0.8/app.apk')),
+    /not allowed|private or loopback/i,
+  );
+});
+
+test('validateDownloadSourceUrl allows private URLs when explicitly enabled', async () => {
+  const previous = process.env.AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS;
+  process.env.AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS = '1';
+  try {
+    await validateDownloadSourceUrl(new URL('http://127.0.0.1/app.apk'));
+  } finally {
+    if (previous === undefined) delete process.env.AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS;
+    else process.env.AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS = previous;
+  }
+});
+
+test('validateDownloadSourceUrl rejects unsupported protocols', async () => {
+  await assert.rejects(
+    async () => await validateDownloadSourceUrl(new URL('ftp://example.com/app.apk')),
+    /Unsupported source URL protocol/i,
+  );
+});
+
+test('isTrustedInstallSourceUrl recognizes supported artifact services', () => {
+  assert.equal(isTrustedInstallSourceUrl('https://api.github.com/repos/acme/app/actions/artifacts/1/zip'), true);
+  assert.equal(isTrustedInstallSourceUrl('https://github.com/acme/app/actions/runs/123/artifacts/456'), true);
+  assert.equal(isTrustedInstallSourceUrl('https://github.com/acme/app/suites/789/artifacts/456'), true);
+  assert.equal(isTrustedInstallSourceUrl('https://expo.dev/accounts/acme/projects/app/builds/123'), true);
+  assert.equal(isTrustedInstallSourceUrl('https://download.expo.dev/artifacts/eas/build-123/app.apk'), true);
+  assert.equal(isTrustedInstallSourceUrl('https://example.com/app.zip'), false);
+  assert.equal(isTrustedInstallSourceUrl('https://github.com/acme/app/archive/refs/heads/main.zip'), false);
+  assert.equal(isTrustedInstallSourceUrl('https://expo.dev/pricing'), false);
+});
+
+test('materializeInstallablePath rejects archive extraction when disabled', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-device-install-source-archive-'));
+  const archivePath = path.join(tempRoot, 'bundle.zip');
+  await fs.writeFile(archivePath, 'placeholder');
+  try {
+    await assert.rejects(
+      async () => await materializeInstallablePath({
+        source: { kind: 'path', path: archivePath },
+        isInstallablePath: () => false,
+        installableLabel: 'Android installable (.apk or .aab)',
+        allowArchiveExtraction: false,
+      }),
+      /archive extraction is not allowed/i,
+    );
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('prepareIosInstallArtifact rejects untrusted URL sources', async () => {
+  await assert.rejects(
+    async () => await prepareIosInstallArtifact({
+      kind: 'url',
+      url: 'https://example.com/app.ipa',
+    }),
+    /only supported for trusted artifact services/i,
+  );
+});

--- a/src/platforms/android/install-artifact.ts
+++ b/src/platforms/android/install-artifact.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
-import { materializeInstallablePath, type MaterializeInstallSource } from '../install-source.ts';
+import {
+  isTrustedInstallSourceUrl,
+  materializeInstallablePath,
+  type MaterializeInstallSource,
+} from '../install-source.ts';
 import { resolveAndroidArchivePackageName } from './manifest.ts';
 
 export type PreparedAndroidInstallArtifact = {
@@ -13,14 +17,16 @@ export async function prepareAndroidInstallArtifact(
   source: MaterializeInstallSource,
   options?: { signal?: AbortSignal; resolveIdentity?: boolean },
 ): Promise<PreparedAndroidInstallArtifact> {
+  const trustedUrlSource = source.kind === 'url' && isTrustedInstallSourceUrl(source.url);
   const materialized = await materializeInstallablePath({
     source,
     isInstallablePath: (candidatePath, stat) =>
       stat.isFile() && isAndroidInstallablePath(candidatePath),
     installableLabel: 'Android installable (.apk or .aab)',
+    allowArchiveExtraction: source.kind !== 'url' || trustedUrlSource,
     signal: options?.signal,
   });
-  const identity = options?.resolveIdentity === false
+  const identity = options?.resolveIdentity === false || (source.kind === 'url' && !trustedUrlSource)
     ? {}
     : await inspectAndroidArtifactIdentity(materialized.installablePath);
   return {

--- a/src/platforms/install-source.ts
+++ b/src/platforms/install-source.ts
@@ -1,3 +1,5 @@
+import dns from 'node:dns/promises';
+import net from 'node:net';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -25,6 +27,7 @@ type MaterializeInstallableOptions = {
   source: MaterializeInstallSource;
   isInstallablePath: (candidatePath: string, stat: { isFile(): boolean; isDirectory(): boolean }) => boolean;
   installableLabel: string;
+  allowArchiveExtraction?: boolean;
   signal?: AbortSignal;
   downloadTimeoutMs?: number;
 };
@@ -42,6 +45,7 @@ const DEFAULT_SOURCE_DOWNLOAD_TIMEOUT_MS = resolveTimeoutMs(
   120_000,
   1_000,
 );
+const ALLOW_PRIVATE_SOURCE_URLS = ['1', 'true', 'yes', 'on'];
 
 export async function materializeInstallablePath(
   options: MaterializeInstallableOptions,
@@ -57,6 +61,7 @@ export async function materializeInstallablePath(
       archivePath: undefined,
       isInstallablePath: options.isInstallablePath,
       installableLabel: options.installableLabel,
+      allowArchiveExtraction: options.allowArchiveExtraction !== false,
       registerCleanup: (cleanup) => {
         cleanupTasks.push(cleanup);
       },
@@ -119,6 +124,7 @@ async function downloadToTempFile(
   } catch {
     throw new AppError('INVALID_ARGS', `Invalid source URL: ${url}`);
   }
+  await validateDownloadSourceUrl(parsedUrl);
   const requestSignal = options?.signal;
   if (requestSignal?.aborted) {
     throw new AppError('COMMAND_FAILED', 'request canceled', { reason: 'request_canceled' });
@@ -179,6 +185,61 @@ async function downloadToTempFile(
   }
 }
 
+export async function validateDownloadSourceUrl(parsedUrl: URL): Promise<void> {
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new AppError('INVALID_ARGS', `Unsupported source URL protocol: ${parsedUrl.protocol}`);
+  }
+  if (ALLOW_PRIVATE_SOURCE_URLS.includes((process.env.AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS ?? '').toLowerCase())) {
+    return;
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  if (isBlockedSourceHostname(hostname)) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Source URL host is not allowed: ${parsedUrl.hostname}`,
+      {
+        hint: 'Use a public artifact URL, or set AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS=1 for trusted private-network daemons.',
+      },
+    );
+  }
+
+  const resolved = await dns.lookup(parsedUrl.hostname, { all: true, verbatim: true }).catch(() => []);
+  if (resolved.some((entry) => isBlockedIpAddress(entry.address))) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Source URL host resolved to a private or loopback address: ${parsedUrl.hostname}`,
+      {
+        hint: 'Use a public artifact URL, or set AGENT_DEVICE_ALLOW_PRIVATE_SOURCE_URLS=1 for trusted private-network daemons.',
+      },
+    );
+  }
+}
+
+export function isTrustedInstallSourceUrl(sourceUrl: string | URL): boolean {
+  const parsed = sourceUrl instanceof URL ? sourceUrl : new URL(sourceUrl);
+  const hostname = parsed.hostname.toLowerCase();
+  if (!hostname) return false;
+  const pathname = parsed.pathname;
+  return isTrustedGithubActionsArtifactUrl(hostname, pathname)
+    || isTrustedEasArtifactUrl(hostname, pathname);
+}
+
+function isTrustedGithubActionsArtifactUrl(hostname: string, pathname: string): boolean {
+  if (hostname === 'api.github.com') {
+    return /^\/repos\/[^/]+\/[^/]+\/actions\/artifacts\/\d+\/zip$/i.test(pathname);
+  }
+  if (hostname !== 'github.com') return false;
+  return /^\/[^/]+\/[^/]+\/(?:actions\/runs\/\d+\/artifacts\/\d+|suites\/\d+\/artifacts\/\d+)$/i.test(pathname);
+}
+
+function isTrustedEasArtifactUrl(hostname: string, pathname: string): boolean {
+  if (hostname !== 'expo.dev' && !hostname.endsWith('.expo.dev')) {
+    return false;
+  }
+  return /^\/(?:artifacts\/eas\/|accounts\/[^/]+\/projects\/[^/]+\/builds\/)/i.test(pathname);
+}
+
 function resolveDownloadFileName(response: Response, parsedUrl: URL): string {
   const contentDisposition = response.headers.get('content-disposition');
   const filenameMatch = contentDisposition?.match(/filename\*?=(?:UTF-8'')?"?([^";]+)"?/i);
@@ -189,12 +250,47 @@ function resolveDownloadFileName(response: Response, parsedUrl: URL): string {
   return 'downloaded-artifact.bin';
 }
 
+function isBlockedSourceHostname(hostname: string): boolean {
+  if (!hostname) return true;
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) return true;
+  return isBlockedIpAddress(hostname);
+}
+
+function isBlockedIpAddress(address: string): boolean {
+  const family = net.isIP(address);
+  if (family === 4) return isBlockedIpv4(address);
+  if (family === 6) return isBlockedIpv6(address);
+  return false;
+}
+
+function isBlockedIpv4(address: string): boolean {
+  const octets = address.split('.').map((part) => Number.parseInt(part, 10));
+  if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  if (a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}
+
+function isBlockedIpv6(address: string): boolean {
+  const normalized = address.toLowerCase();
+  if (normalized === '::1') return true;
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+  if (normalized.startsWith('fe80:')) return true;
+  return false;
+}
+
 async function resolveInstallableCandidate(
   candidatePath: string,
   params: {
     archivePath: string | undefined;
     isInstallablePath: MaterializeInstallableOptions['isInstallablePath'];
     installableLabel: string;
+    allowArchiveExtraction: boolean;
     registerCleanup: (cleanup: () => Promise<void>) => void;
   },
 ): Promise<{ archivePath?: string; installablePath: string }> {
@@ -211,6 +307,13 @@ async function resolveInstallableCandidate(
   }
 
   if (stat.isFile() && isArchivePath(candidatePath)) {
+    if (!params.allowArchiveExtraction) {
+      throw new AppError(
+        'INVALID_ARGS',
+        `URL sources must point directly to a ${params.installableLabel}; archive extraction is not allowed`,
+        { path: candidatePath },
+      );
+    }
     const extracted = await extractArchive(candidatePath);
     params.registerCleanup(extracted.cleanup);
     return await resolveInstallableCandidate(extracted.outputPath, {
@@ -238,6 +341,13 @@ async function resolveInstallableCandidate(
     const archives = await collectMatchingPaths(candidatePath, (entryPath, entryStat) =>
       entryStat.isFile() && isArchivePath(entryPath));
     if (archives.length === 1) {
+      if (!params.allowArchiveExtraction) {
+        throw new AppError(
+          'INVALID_ARGS',
+          `URL sources must point directly to a ${params.installableLabel}; nested archives are not allowed`,
+          { path: archives[0] },
+        );
+      }
       const extracted = await extractArchive(archives[0]);
       params.registerCleanup(extracted.cleanup);
       return await resolveInstallableCandidate(extracted.outputPath, {

--- a/src/platforms/ios/install-artifact.ts
+++ b/src/platforms/ios/install-artifact.ts
@@ -4,7 +4,11 @@ import path from 'node:path';
 import { readInfoPlistString } from './plist.ts';
 import { AppError } from '../../utils/errors.ts';
 import { runCmd } from '../../utils/exec.ts';
-import { materializeInstallablePath, type MaterializeInstallSource } from '../install-source.ts';
+import {
+  isTrustedInstallSourceUrl,
+  materializeInstallablePath,
+  type MaterializeInstallSource,
+} from '../install-source.ts';
 
 type InstallIosArtifactOptions = {
   appIdentifierHint?: string;
@@ -30,12 +34,19 @@ export async function prepareIosInstallArtifact(
   source: MaterializeInstallSource,
   options?: InstallIosArtifactOptions,
 ): Promise<PreparedIosInstallArtifact> {
+  if (source.kind === 'url' && !isTrustedInstallSourceUrl(source.url)) {
+    throw new AppError(
+      'INVALID_ARGS',
+      'iOS install_from_source URL sources are only supported for trusted artifact services such as GitHub Actions and EAS. Use a path source for other hosts.',
+    );
+  }
   const materialized = await materializeInstallablePath({
     source,
     isInstallablePath: (candidatePath, stat) =>
       (stat.isDirectory() && candidatePath.toLowerCase().endsWith('.app'))
       || (stat.isFile() && candidatePath.toLowerCase().endsWith('.ipa')),
     installableLabel: 'iOS installable (.app or .ipa)',
+    allowArchiveExtraction: source.kind !== 'url' || isTrustedInstallSourceUrl(source.url),
     signal: options?.signal,
   });
 

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -520,6 +520,226 @@ test('sendToDaemon preserves explicit remote install paths without uploading', a
   }
 });
 
+test('sendToDaemon preserves install_source payload metadata for remote HTTP RPC', async () => {
+  const seenPaths: string[] = [];
+  let rpcRequest: Record<string, unknown> | null = null;
+  const originalHttpRequest = http.request;
+  (http as unknown as { request: typeof http.request }).request = ((options: any, callback: (res: any) => void) => {
+    const req = new EventEmitter() as EventEmitter & {
+      write: (chunk: string) => void;
+      end: () => void;
+      destroy: () => void;
+    };
+    let body = '';
+    req.write = (chunk: string) => {
+      body += chunk;
+    };
+    req.destroy = () => {
+      req.emit('close');
+    };
+    req.end = () => {
+      seenPaths.push(String(options.path ?? ''));
+      const res = new EventEmitter() as EventEmitter & {
+        statusCode?: number;
+        resume: () => void;
+        setEncoding: (_encoding: string) => void;
+      };
+      res.statusCode = 200;
+      res.resume = () => {};
+      res.setEncoding = () => {};
+      process.nextTick(() => {
+        callback(res);
+        if (options.method === 'GET') {
+          res.emit('end');
+          return;
+        }
+        rpcRequest = JSON.parse(body) as Record<string, unknown>;
+        res.emit('data', JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'req-install-source',
+          result: {
+            ok: true,
+            data: { source: 'remote-daemon' },
+          },
+        }));
+        res.emit('end');
+      });
+    };
+    return req as any;
+  }) as typeof http.request;
+
+  const previousBaseUrl = process.env.AGENT_DEVICE_DAEMON_BASE_URL;
+  process.env.AGENT_DEVICE_DAEMON_BASE_URL = 'http://remote-mac.example.test:7777/agent-device';
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'install_source',
+      positionals: [],
+      flags: { platform: 'android' },
+      meta: {
+        requestId: 'req-install-source',
+        installSource: {
+          kind: 'url',
+          url: 'https://example.com/app.apk',
+          headers: {},
+        },
+        retainMaterializedPaths: true,
+        materializedPathRetentionMs: 60_000,
+      },
+    });
+
+    assert.equal(response.ok, true);
+    assert.deepEqual(seenPaths, ['/agent-device/health', '/agent-device/rpc']);
+    assert.deepEqual((rpcRequest as any)?.params?.meta?.installSource, {
+      kind: 'url',
+      url: 'https://example.com/app.apk',
+      headers: {},
+    });
+    assert.equal((rpcRequest as any)?.params?.meta?.retainMaterializedPaths, true);
+    assert.equal((rpcRequest as any)?.params?.meta?.materializedPathRetentionMs, 60_000);
+  } finally {
+    (http as unknown as { request: typeof http.request }).request = originalHttpRequest;
+    if (previousBaseUrl === undefined) delete process.env.AGENT_DEVICE_DAEMON_BASE_URL;
+    else process.env.AGENT_DEVICE_DAEMON_BASE_URL = previousBaseUrl;
+  }
+});
+
+test('sendToDaemon uploads local install_source path artifacts for remote daemons', async () => {
+  const seenPaths: string[] = [];
+  let uploadBodySize = 0;
+  let uploadHeaders: Record<string, unknown> | undefined;
+  let rpcRequest: Record<string, unknown> | null = null;
+  const originalHttpRequest = http.request;
+
+  class MockRequest extends Writable {
+    private chunks: Buffer[] = [];
+    private readonly options: Record<string, unknown>;
+    private readonly callbackFn: (res: PassThrough & {
+      statusCode?: number;
+      resume?: () => void;
+      setEncoding: (_encoding: string) => void;
+    }) => void;
+
+    constructor(
+      options: Record<string, unknown>,
+      callbackFn: (res: PassThrough & {
+        statusCode?: number;
+        resume?: () => void;
+        setEncoding: (_encoding: string) => void;
+      }) => void,
+    ) {
+      super();
+      this.options = options;
+      this.callbackFn = callbackFn;
+    }
+
+    _write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+      this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      callback();
+    }
+
+    override end(chunk?: any, encoding?: any, callback?: any): this {
+      if (chunk) {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+        this.chunks.push(buffer);
+      }
+      const res = new PassThrough() as PassThrough & {
+        statusCode?: number;
+        resume?: () => void;
+        setEncoding: (_encoding: string) => void;
+      };
+      res.statusCode = 200;
+      res.resume = () => res as any;
+      res.setEncoding = () => res as any;
+      process.nextTick(() => {
+        this.callbackFn(res);
+        seenPaths.push(String(this.options.path ?? ''));
+        if (this.options.method === 'GET') {
+          res.emit('end');
+          callback?.();
+          return;
+        }
+        const body = Buffer.concat(this.chunks).toString('utf8');
+        if (String(this.options.path).endsWith('/upload')) {
+          uploadHeaders = this.options.headers as Record<string, unknown>;
+          uploadBodySize = Buffer.concat(this.chunks).byteLength;
+          res.emit('data', JSON.stringify({ ok: true, uploadId: 'upload-path-123' }));
+          res.emit('end');
+          callback?.();
+          return;
+        }
+
+        rpcRequest = JSON.parse(body) as Record<string, unknown>;
+        res.emit('data', JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'req-install-source-path',
+          result: {
+            ok: true,
+            data: { source: 'remote-daemon' },
+          },
+        }));
+        res.emit('end');
+        callback?.();
+      });
+      return this;
+    }
+
+    override destroy(error?: Error): this {
+      super.destroy(error);
+      return this;
+    }
+  }
+
+  (http as unknown as { request: typeof http.request }).request = ((options: any, callback: any) => {
+    return new MockRequest(options, callback) as any;
+  }) as typeof http.request;
+
+  const previousBaseUrl = process.env.AGENT_DEVICE_DAEMON_BASE_URL;
+  const previousAuthToken = process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN;
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-install-source-path-'));
+  const appPath = path.join(tempRoot, 'Sample.apk');
+  fs.writeFileSync(appPath, 'apk-binary');
+  process.env.AGENT_DEVICE_DAEMON_BASE_URL = 'http://remote-mac.example.test:7777/agent-device';
+  process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN = 'remote-secret';
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'install_source',
+      positionals: [],
+      flags: { platform: 'android' },
+      meta: {
+        requestId: 'req-install-source-path',
+        installSource: {
+          kind: 'path',
+          path: appPath,
+        },
+      },
+    });
+
+    assert.equal(response.ok, true);
+    assert.deepEqual(seenPaths, ['/agent-device/health', '/agent-device/upload', '/agent-device/rpc']);
+    assert.equal(uploadHeaders?.authorization, 'Bearer remote-secret');
+    assert.equal(uploadHeaders?.['x-agent-device-token'], 'remote-secret');
+    assert.equal(uploadHeaders?.['x-artifact-type'], 'file');
+    assert.equal(uploadHeaders?.['x-artifact-filename'], 'Sample.apk');
+    assert.ok(uploadBodySize > 0);
+    assert.equal((rpcRequest as any)?.params?.meta?.uploadedArtifactId, 'upload-path-123');
+    assert.deepEqual((rpcRequest as any)?.params?.meta?.installSource, {
+      kind: 'path',
+      path: appPath,
+    });
+  } finally {
+    (http as unknown as { request: typeof http.request }).request = originalHttpRequest;
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    if (previousBaseUrl === undefined) delete process.env.AGENT_DEVICE_DAEMON_BASE_URL;
+    else process.env.AGENT_DEVICE_DAEMON_BASE_URL = previousBaseUrl;
+    if (previousAuthToken === undefined) delete process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN;
+    else process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN = previousAuthToken;
+  }
+});
+
 test('sendToDaemon downloads remote artifacts and rewrites local paths', async () => {
   const seenPaths: string[] = [];
   let rpcRequest: Record<string, unknown> | null = null;


### PR DESCRIPTION
## Summary

Fix remote `installFromSource` compatibility and harden URL-based source handling.

This preserves `installSource` metadata over remote HTTP RPC, uploads local `source.path` artifacts for remote daemons, resolves uploaded path sources consistently on the daemon side, and blocks unsafe/private URL fetches while still allowing trusted artifact services such as GitHub Actions and EAS for URL-backed installs.

## Validation

pnpm install
pnpm typecheck
pnpm test:unit
pnpm test:smoke