### PR TITLE
refactor: simplify daemon transport resolution

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -12,7 +12,10 @@ import type {
 import { runCmdDetached, runCmdSync } from './utils/exec.ts';
 import { findProjectRoot, readVersion } from './utils/version.ts';
 import { createRequestId, emitDiagnostic, withDiagnosticTimer } from './utils/diagnostics.ts';
-import { isAgentDeviceDaemonProcess, stopProcessForTakeover } from './utils/process-identity.ts';
+import {
+  isAgentDeviceDaemonProcess,
+  stopProcessForTakeover,
+} from './utils/process-identity.ts';
 import {
   resolveDaemonPaths,
   resolveDaemonServerMode,
@@ -115,18 +118,12 @@ export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<D
       tenantId: req.meta?.tenantId ?? req.flags?.tenant,
       runId: req.meta?.runId ?? req.flags?.runId,
       leaseId: req.meta?.leaseId ?? req.flags?.leaseId,
-      sessionIsolation: req.meta?.sessionIsolation ?? req.flags?.sessionIsolation,
+    sessionIsolation: req.meta?.sessionIsolation ?? req.flags?.sessionIsolation,
       lockPolicy: req.meta?.lockPolicy,
       lockPlatform: req.meta?.lockPlatform,
-      ...(preparedRemoteRequest.uploadedArtifactId
-        ? { uploadedArtifactId: preparedRemoteRequest.uploadedArtifactId }
-        : {}),
-      ...(preparedRemoteRequest.clientArtifactPaths
-        ? { clientArtifactPaths: preparedRemoteRequest.clientArtifactPaths }
-        : {}),
-      ...(preparedRemoteRequest.installSource
-        ? { installSource: preparedRemoteRequest.installSource }
-        : {}),
+      ...(preparedRemoteRequest.uploadedArtifactId ? { uploadedArtifactId: preparedRemoteRequest.uploadedArtifactId } : {}),
+      ...(preparedRemoteRequest.clientArtifactPaths ? { clientArtifactPaths: preparedRemoteRequest.clientArtifactPaths } : {}),
+      ...(preparedRemoteRequest.installSource ? { installSource: preparedRemoteRequest.installSource } : {}),
     },
   };
   emitDiagnostic({
@@ -165,7 +162,9 @@ export async function openApp(options: OpenAppOptions = {}): Promise<DaemonRespo
     meta,
   } = options;
 
-  const positionals = app ? (url ? [app, url] : [app]) : url ? [url] : [];
+  const positionals = app
+    ? (url ? [app, url] : [app])
+    : (url ? [url] : []);
 
   return await sendToDaemon({
     session,
@@ -228,9 +227,9 @@ async function prepareRemoteRequest(
   }
 
   if (
-    !isRemoteDaemon(info) ||
-    (req.command !== 'install' && req.command !== 'reinstall') ||
-    positionals.length < 2
+    !isRemoteDaemon(info)
+    || (req.command !== 'install' && req.command !== 'reinstall')
+    || positionals.length < 2
   ) {
     return {
       positionals,
@@ -375,15 +374,14 @@ function resolveClientArtifactOutputPath(
   const requested = req.positionals?.[positionalIndex] ?? req.flags?.out;
   const fallbackName = `${field === 'path' ? 'screenshot' : 'recording'}-${Date.now()}${fallbackExtension}`;
   const rawPath = requested && requested.trim().length > 0 ? requested : fallbackName;
-  return path.isAbsolute(rawPath) ? rawPath : path.resolve(req.meta?.cwd ?? process.cwd(), rawPath);
+  return path.isAbsolute(rawPath)
+    ? rawPath
+    : path.resolve(req.meta?.cwd ?? process.cwd(), rawPath);
 }
 
 function buildRemoteTempArtifactPath(prefix: string, extension: string): string {
   const safeExtension = extension.startsWith('.') ? extension : `.${extension}`;
-  return path.posix.join(
-    '/tmp',
-    `agent-device-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${safeExtension}`,
-  );
+  return path.posix.join('/tmp', `agent-device-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${safeExtension}`);
 }
 
 function resolveClientSettings(req: Omit<DaemonRequest, 'token'>): DaemonClientSettings {
@@ -402,9 +400,9 @@ function resolveClientSettings(req: Omit<DaemonRequest, 'token'>): DaemonClientS
     );
   }
   const rawServerMode =
-    req.flags?.daemonServerMode ??
-    process.env.AGENT_DEVICE_DAEMON_SERVER_MODE ??
-    (rawTransport === 'dual' ? 'dual' : undefined);
+    req.flags?.daemonServerMode
+    ?? process.env.AGENT_DEVICE_DAEMON_SERVER_MODE
+    ?? (rawTransport === 'dual' ? 'dual' : undefined);
   const serverMode = resolveDaemonServerMode(rawServerMode);
   return {
     paths: resolveDaemonPaths(stateDir),
@@ -434,22 +432,22 @@ async function ensureDaemon(settings: DaemonClientSettings): Promise<DaemonInfo>
   const existing = readDaemonInfo(settings.paths.infoPath);
   const localVersion = readVersion();
   const localCodeSignature = resolveLocalDaemonCodeSignature();
-  const existingReachable = existing
-    ? await canConnect(existing, settings.transportPreference)
-    : false;
+  const existingReachable = existing ? await canConnect(existing, settings.transportPreference) : false;
   if (
-    existing &&
-    existing.version === localVersion &&
-    existing.codeSignature === localCodeSignature &&
-    existingReachable
+    existing
+    && existing.version === localVersion
+    && existing.codeSignature === localCodeSignature
+    && existingReachable
   ) {
     return existing;
   }
   if (
-    existing &&
-    (existing.version !== localVersion ||
-      existing.codeSignature !== localCodeSignature ||
-      !existingReachable)
+    existing
+    && (
+      existing.version !== localVersion
+      || existing.codeSignature !== localCodeSignature
+      || !existingReachable
+    )
   ) {
     await stopDaemonProcessForTakeover(existing);
     removeDaemonInfo(settings.paths.infoPath);
@@ -492,10 +490,7 @@ async function ensureDaemon(settings: DaemonClientSettings): Promise<DaemonInfo>
   });
 }
 
-async function waitForDaemonInfo(
-  timeoutMs: number,
-  settings: DaemonClientSettings,
-): Promise<DaemonInfo | null> {
+async function waitForDaemonInfo(timeoutMs: number, settings: DaemonClientSettings): Promise<DaemonInfo | null> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const info = readDaemonInfo(settings.paths.infoPath);
@@ -539,47 +534,44 @@ async function stopDaemonProcessForTakeover(info: DaemonInfo): Promise<void> {
 }
 
 function readDaemonInfo(infoPath: string): DaemonInfo | null {
-  return readDaemonMetadata(infoPath, (data) => {
-    if (!data || typeof data !== 'object') return null;
-    const parsed = data as Partial<DaemonInfo>;
-    const token = typeof parsed.token === 'string' && parsed.token.length > 0 ? parsed.token : null;
-    if (!token) return null;
-    const hasSocket = Number.isInteger(parsed.port) && Number(parsed.port) > 0;
-    const hasHttp = Number.isInteger(parsed.httpPort) && Number(parsed.httpPort) > 0;
-    if (!hasSocket && !hasHttp) return null;
-    const hasPid = Number.isInteger(parsed.pid) && Number(parsed.pid) > 0;
-    const pid = hasPid ? Number(parsed.pid) : 0;
-    return {
-      ...parsed,
-      token,
-      port: hasSocket ? Number(parsed.port) : undefined,
-      httpPort: hasHttp ? Number(parsed.httpPort) : undefined,
-      pid,
-    };
-  });
+  const data = readJsonFile(infoPath);
+  if (!data || typeof data !== 'object') return null;
+  const parsed = data as Partial<DaemonInfo>;
+  const token = typeof parsed.token === 'string' && parsed.token.length > 0 ? parsed.token : null;
+  if (!token) return null;
+  const hasSocket = Number.isInteger(parsed.port) && Number(parsed.port) > 0;
+  const hasHttp = Number.isInteger(parsed.httpPort) && Number(parsed.httpPort) > 0;
+  if (!hasSocket && !hasHttp) return null;
+  const transport = parsed.transport;
+  const version = typeof parsed.version === 'string' ? parsed.version : undefined;
+  const codeSignature = typeof parsed.codeSignature === 'string' ? parsed.codeSignature : undefined;
+  const processStartTime = typeof parsed.processStartTime === 'string' ? parsed.processStartTime : undefined;
+  const hasPid = Number.isInteger(parsed.pid) && Number(parsed.pid) > 0;
+  return {
+    token,
+    port: hasSocket ? Number(parsed.port) : undefined,
+    httpPort: hasHttp ? Number(parsed.httpPort) : undefined,
+    transport: transport === 'socket' || transport === 'http' || transport === 'dual' ? transport : undefined,
+    pid: hasPid ? Number(parsed.pid) : 0,
+    version,
+    codeSignature,
+    processStartTime,
+  };
 }
 
 function readDaemonLockInfo(lockPath: string): DaemonLockInfo | null {
-  return readDaemonMetadata(lockPath, (data) => {
-    if (!data || typeof data !== 'object') return null;
-    const parsed = data as Partial<DaemonLockInfo>;
-    const hasPid = Number.isInteger(parsed.pid) && Number(parsed.pid) > 0;
-    const pid = hasPid ? Number(parsed.pid) : null;
-    if (pid === null) {
-      return null;
-    }
-    return {
-      pid,
-      processStartTime: parsed.processStartTime,
-      startedAt: parsed.startedAt,
-    };
-  });
-}
-
-function readDaemonMetadata<T>(filePath: string, parse: (data: unknown) => T | null): T | null {
-  const data = readJsonFile(filePath);
-  if (data === null) return null;
-  return parse(data);
+  const data = readJsonFile(lockPath);
+  if (!data || typeof data !== 'object') return null;
+  const parsed = data as Partial<DaemonLockInfo>;
+  const hasPid = Number.isInteger(parsed.pid) && Number(parsed.pid) > 0;
+  if (!hasPid) {
+    return null;
+  }
+  return {
+    pid: Number(parsed.pid),
+    processStartTime: typeof parsed.processStartTime === 'string' ? parsed.processStartTime : undefined,
+    startedAt: typeof parsed.startedAt === 'number' ? parsed.startedAt : undefined,
+  };
 }
 
 function removeDaemonInfo(infoPath: string): void {
@@ -628,10 +620,7 @@ function removeFileIfExists(filePath: string): void {
   }
 }
 
-async function canConnect(
-  info: DaemonInfo,
-  preference: DaemonTransportPreference,
-): Promise<boolean> {
+async function canConnect(info: DaemonInfo, preference: DaemonTransportPreference): Promise<boolean> {
   const transport = chooseTransport(info, preference);
   if (transport === 'http') {
     return await canConnectHttp(info);
@@ -661,9 +650,7 @@ function canConnectHttp(info: DaemonInfo): Promise<boolean> {
   if (!endpoint) return Promise.resolve(false);
   const url = new URL(endpoint);
   const transport = url.protocol === 'https:' ? https : http;
-  const timeoutMs = info.baseUrl
-    ? REMOTE_DAEMON_HEALTHCHECK_TIMEOUT_MS
-    : LOCAL_DAEMON_HEALTHCHECK_TIMEOUT_MS;
+  const timeoutMs = info.baseUrl ? REMOTE_DAEMON_HEALTHCHECK_TIMEOUT_MS : LOCAL_DAEMON_HEALTHCHECK_TIMEOUT_MS;
   return new Promise((resolve) => {
     const req = transport.request(
       {
@@ -732,10 +719,7 @@ function resolveLocalDaemonCodeSignature(): string {
   return computeDaemonCodeSignature(entryPath, launchSpec.root);
 }
 
-export function computeDaemonCodeSignature(
-  entryPath: string,
-  root: string = findProjectRoot(),
-): string {
+export function computeDaemonCodeSignature(entryPath: string, root: string = findProjectRoot()): string {
   try {
     const stat = fs.statSync(entryPath);
     const relativePath = path.relative(root, entryPath) || entryPath;
@@ -757,10 +741,7 @@ async function sendRequest(
   return await sendSocketRequest(info, req);
 }
 
-function chooseTransport(
-  info: DaemonInfo,
-  preference: DaemonTransportPreference,
-): ResolvedDaemonTransport {
+function chooseTransport(info: DaemonInfo, preference: DaemonTransportPreference): ResolvedDaemonTransport {
   if (info.baseUrl) {
     // Defensive guard: resolveClientSettings rejects this earlier for normal CLI flow.
     if (preference === 'socket') {
@@ -773,29 +754,23 @@ function chooseTransport(
   if (preference === 'http' || preference === 'socket') {
     return requireDaemonTransport(info, preference);
   }
-  const autoOrder: ResolvedDaemonTransport[] =
-    info.transport === 'socket' || info.transport === 'dual'
-      ? ['socket', 'http']
-      : ['http', 'socket'];
+  const autoOrder: ResolvedDaemonTransport[] = info.transport === 'socket' || info.transport === 'dual'
+    ? ['socket', 'http']
+    : ['http', 'socket'];
   const available = autoOrder.find((transport) => hasDaemonTransport(info, transport));
   if (available) return available;
   throw new AppError('COMMAND_FAILED', 'Daemon metadata has no reachable transport');
 }
 
 function hasDaemonTransport(info: DaemonInfo, transport: ResolvedDaemonTransport): boolean {
-  return transport === 'http' ? Boolean(info.baseUrl || info.httpPort) : Boolean(info.port);
+  return transport === 'http' ? Boolean(info.httpPort) : Boolean(info.port);
 }
 
-function requireDaemonTransport(
-  info: DaemonInfo,
-  transport: ResolvedDaemonTransport,
-): ResolvedDaemonTransport {
+function requireDaemonTransport(info: DaemonInfo, transport: ResolvedDaemonTransport): ResolvedDaemonTransport {
   if (hasDaemonTransport(info, transport)) return transport;
   throw new AppError(
     'COMMAND_FAILED',
-    transport === 'http'
-      ? 'Daemon HTTP endpoint is unavailable'
-      : 'Daemon socket endpoint is unavailable',
+    transport === 'http' ? 'Daemon HTTP endpoint is unavailable' : 'Daemon socket endpoint is unavailable',
   );
 }
 
@@ -809,10 +784,7 @@ async function sendSocketRequest(info: DaemonInfo, req: DaemonRequest): Promise<
     const timeout = setTimeout(() => {
       socket.destroy();
       const cleanup = cleanupTimedOutIosRunnerBuilds();
-      const daemonReset = resetDaemonAfterTimeout(
-        info,
-        resolveDaemonPaths(req.flags?.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR),
-      );
+      const daemonReset = resetDaemonAfterTimeout(info, resolveDaemonPaths(req.flags?.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR));
       emitDiagnostic({
         level: 'error',
         phase: 'daemon_request_timeout',
@@ -850,17 +822,10 @@ async function sendSocketRequest(info: DaemonInfo, req: DaemonRequest): Promise<
         resolve(response);
       } catch (err) {
         clearTimeout(timeout);
-        reject(
-          new AppError(
-            'COMMAND_FAILED',
-            'Invalid daemon response',
-            {
-              requestId: req.meta?.requestId,
-              line,
-            },
-            err instanceof Error ? err : undefined,
-          ),
-        );
+        reject(new AppError('COMMAND_FAILED', 'Invalid daemon response', {
+          requestId: req.meta?.requestId,
+          line,
+        }, err instanceof Error ? err : undefined));
       }
     });
 
@@ -912,9 +877,7 @@ async function sendHttpRequest(info: DaemonInfo, req: DaemonRequest): Promise<Da
   }
 
   return await new Promise((resolve, reject) => {
-    const statePaths = resolveDaemonPaths(
-      req.flags?.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR,
-    );
+    const statePaths = resolveDaemonPaths(req.flags?.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR);
     const transport = rpcUrl.protocol === 'https:' ? https : http;
     const request = transport.request(
       {
@@ -950,8 +913,7 @@ async function sendHttpRequest(info: DaemonInfo, req: DaemonRequest): Promise<Da
                   {
                     ...(typeof data.details === 'object' && data.details ? data.details : {}),
                     hint: typeof data.hint === 'string' ? data.hint : undefined,
-                    diagnosticId:
-                      typeof data.diagnosticId === 'string' ? data.diagnosticId : undefined,
+                    diagnosticId: typeof data.diagnosticId === 'string' ? data.diagnosticId : undefined,
                     logPath: typeof data.logPath === 'string' ? data.logPath : undefined,
                     requestId: req.meta?.requestId,
                   },
@@ -968,22 +930,19 @@ async function sendHttpRequest(info: DaemonInfo, req: DaemonRequest): Promise<Da
               return;
             }
             if (info.baseUrl && parsed.result.ok) {
-              void materializeRemoteArtifacts(info, req, parsed.result).then(resolve).catch(reject);
+              void materializeRemoteArtifacts(info, req, parsed.result)
+                .then(resolve)
+                .catch(reject);
               return;
             }
             resolve(parsed.result);
           } catch (err) {
             clearTimeout(timeout);
             reject(
-              new AppError(
-                'COMMAND_FAILED',
-                'Invalid daemon response',
-                {
-                  requestId: req.meta?.requestId,
-                  line: body,
-                },
-                err instanceof Error ? err : undefined,
-              ),
+              new AppError('COMMAND_FAILED', 'Invalid daemon response', {
+                requestId: req.meta?.requestId,
+                line: body,
+              }, err instanceof Error ? err : undefined),
             );
           }
         });
@@ -1097,14 +1056,9 @@ function resolveRemoteDaemonBaseUrl(raw: string | undefined): string | undefined
   try {
     parsed = new URL(raw);
   } catch (error) {
-    throw new AppError(
-      'INVALID_ARGS',
-      'Invalid daemon base URL',
-      {
-        daemonBaseUrl: raw,
-      },
-      error instanceof Error ? error : undefined,
-    );
+    throw new AppError('INVALID_ARGS', 'Invalid daemon base URL', {
+      daemonBaseUrl: raw,
+    }, error instanceof Error ? error : undefined);
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new AppError('INVALID_ARGS', 'Daemon base URL must use http or https', {
@@ -1157,7 +1111,10 @@ async function materializeRemoteArtifacts(
   return { ok: true, data: nextData };
 }
 
-function resolveMaterializedArtifactPath(artifact: DaemonArtifact, req: DaemonRequest): string {
+function resolveMaterializedArtifactPath(
+  artifact: DaemonArtifact,
+  req: DaemonRequest,
+): string {
   if (artifact.localPath && artifact.localPath.trim().length > 0) {
     return artifact.localPath;
   }
@@ -1198,9 +1155,9 @@ export async function downloadRemoteArtifact(params: {
         path: artifactUrl.pathname + artifactUrl.search,
         headers: params.token
           ? {
-              authorization: `Bearer ${params.token}`,
-              'x-agent-device-token': params.token,
-            }
+            authorization: `Bearer ${params.token}`,
+            'x-agent-device-token': params.token,
+          }
           : undefined,
       },
       (res) => {
@@ -1244,13 +1201,11 @@ export async function downloadRemoteArtifact(params: {
       },
     );
     const timeoutHandle = setTimeout(() => {
-      request.destroy(
-        new AppError('COMMAND_FAILED', 'Remote artifact download timed out', {
-          artifactId: params.artifactId,
-          requestId: params.requestId,
-          timeoutMs,
-        }),
-      );
+      request.destroy(new AppError('COMMAND_FAILED', 'Remote artifact download timed out', {
+        artifactId: params.artifactId,
+        requestId: params.requestId,
+        timeoutMs,
+      }));
     }, timeoutMs);
     request.on('error', (error) => {
       if (error instanceof AppError) {
@@ -1258,25 +1213,18 @@ export async function downloadRemoteArtifact(params: {
         return;
       }
       settle(
-        new AppError(
-          'COMMAND_FAILED',
-          'Failed to download remote artifact',
-          {
-            artifactId: params.artifactId,
-            requestId: params.requestId,
-            timeoutMs,
-          },
-          error instanceof Error ? error : undefined,
-        ),
+        new AppError('COMMAND_FAILED', 'Failed to download remote artifact', {
+          artifactId: params.artifactId,
+          requestId: params.requestId,
+          timeoutMs,
+        }, error instanceof Error ? error : undefined),
       );
     });
     request.end();
   });
 }
 
-export function resolveDaemonRequestTimeoutMs(
-  raw: string | undefined = process.env.AGENT_DEVICE_DAEMON_TIMEOUT_MS,
-): number {
+export function resolveDaemonRequestTimeoutMs(raw: string | undefined = process.env.AGENT_DEVICE_DAEMON_TIMEOUT_MS): number {
   if (!raw) return 90000;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed)) return 90000;
@@ -1303,9 +1251,7 @@ export function resolveDaemonStartupAttempts(
 
 export function resolveDaemonStartupHint(
   state: { hasInfo: boolean; hasLock: boolean },
-  paths: Pick<DaemonPaths, 'infoPath' | 'lockPath'> = resolveDaemonPaths(
-    process.env.AGENT_DEVICE_STATE_DIR,
-  ),
+  paths: Pick<DaemonPaths, 'infoPath' | 'lockPath'> = resolveDaemonPaths(process.env.AGENT_DEVICE_STATE_DIR),
 ): string {
   if (state.hasLock && !state.hasInfo) {
     return `Detected ${paths.lockPath} without ${paths.infoPath}. If no agent-device daemon process is running, delete ${paths.lockPath} and retry.`;


### PR DESCRIPTION
## Summary

Simplify daemon client transport selection by centralizing availability checks and preferred transport resolution.
Tighten local daemon metadata parsing to return only the expected daemon info/lock fields instead of passing through arbitrary JSON keys.
Touched files: 1. Scope now stays within `daemon-client.ts`.

Known gaps/follow-ups: I dropped the session runtime-hint refactor from this PR because the review correctly called out worse type-safety and unnecessary abstraction for that part.

## Validation

pnpm install --frozen-lockfile
pnpm typecheck
pnpm test:unit
pnpm test:smoke