### PR TITLE
fix: remove interactive device prompt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,6 @@
     "trailingComma": "all",
     "printWidth": 100
   },
-  "dependencies": {
-    "@clack/prompts": "^1.0.0"
-  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@rslib/core": "0.19.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@clack/prompts':
-        specifier: ^1.0.0
-        version: 1.0.0
     devDependencies:
       '@rslib/core':
         specifier: 0.19.4
@@ -105,12 +101,6 @@ packages:
       '@rspress/core': ^2.0.0
       react: ^19.2.3
       react-dom: ^19.2.3
-
-  '@clack/core@1.0.0':
-    resolution: {integrity: sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==}
-
-  '@clack/prompts@1.0.0':
-    resolution: {integrity: sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -1057,9 +1047,6 @@ packages:
   shiki@3.22.0:
     resolution: {integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==}
 
-  sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
@@ -1231,17 +1218,6 @@ snapshots:
       '@rspress/core': 2.0.2(@module-federation/runtime-tools@0.22.0)(@types/react@19.2.13)(core-js@3.47.0)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-
-  '@clack/core@1.0.0':
-    dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.0.0':
-    dependencies:
-      '@clack/core': 1.0.0
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -2622,8 +2598,6 @@ snapshots:
       '@shikijs/types': 3.22.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
-
-  sisteransi@1.0.5: {}
 
   source-map@0.7.6: {}
 

--- a/src/core/__tests__/dispatch-resolve.test.ts
+++ b/src/core/__tests__/dispatch-resolve.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { resolveIosDevice } from '../dispatch-resolve.ts';
-import { selectDevice, type DeviceInfo } from '../../utils/device.ts';
+import { resolveDevice, type DeviceInfo } from '../../utils/device.ts';
 import { AppError } from '../../utils/errors.ts';
 
 const physical: DeviceInfo = {
@@ -36,7 +36,7 @@ function makeDeps(fallbackSimulator: DeviceInfo | null = null) {
   let findBootableCalled = false;
   return {
     deps: {
-      selectDevice,
+      resolveDevice,
       findBootableSimulator: async () => {
         findBootableCalled = true;
         return fallbackSimulator;
@@ -104,7 +104,7 @@ test('resolveIosDevice throws DEVICE_NOT_FOUND when empty list and no fallback s
   assert.equal(err.code, 'DEVICE_NOT_FOUND');
 });
 
-test('resolveIosDevice rethrows DEVICE_NOT_FOUND from selectDevice when explicit selector used', async () => {
+test('resolveIosDevice rethrows DEVICE_NOT_FOUND from resolveDevice when explicit selector used', async () => {
   const { deps } = makeDeps(simulator);
   const err = await resolveIosDevice(
     [],

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../utils/errors.ts';
-import { normalizePlatformSelector, selectDevice, type DeviceInfo } from '../utils/device.ts';
+import { normalizePlatformSelector, resolveDevice, type DeviceInfo } from '../utils/device.ts';
 import { listAndroidDevices } from '../platforms/android/devices.ts';
 import { ensureAdb } from '../platforms/android/index.ts';
 import { findBootableIosSimulator, listIosDevices } from '../platforms/ios/devices.ts';
@@ -22,7 +22,7 @@ type IosDeviceSelector = {
 };
 
 type ResolveIosDeviceDeps = {
-  selectDevice: typeof selectDevice;
+  resolveDevice: typeof resolveDevice;
   findBootableSimulator: typeof findBootableIosSimulator;
 };
 
@@ -43,9 +43,9 @@ export async function resolveIosDevice(
 
   let selected: DeviceInfo | undefined;
   try {
-    selected = await deps.selectDevice(devices, selector, context);
+    selected = await deps.resolveDevice(devices, selector, context);
   } catch (err) {
-    // When selectDevice throws DEVICE_NOT_FOUND and no explicit device
+    // When resolveDevice throws DEVICE_NOT_FOUND and no explicit device
     // selector was used, attempt the simulator fallback before giving up.
     if (hasExplicitSelector || !(err instanceof AppError) || err.code !== 'DEVICE_NOT_FOUND') {
       throw err;
@@ -92,7 +92,7 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
       if (selector.platform === 'android') {
         await ensureAdb();
         const devices = await listAndroidDevices({ serialAllowlist: androidSerialAllowlist });
-        return await selectDevice(devices, selector);
+        return await resolveDevice(devices, selector);
       }
 
       if (selector.platform === 'ios') {
@@ -101,7 +101,7 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
           devices,
           selector as IosDeviceSelector,
           { simulatorSetPath: iosSimulatorSetPath },
-          { selectDevice, findBootableSimulator: findBootableIosSimulator },
+          { resolveDevice, findBootableSimulator: findBootableIosSimulator },
         );
       }
 
@@ -116,7 +116,7 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
       } catch {
         // ignore
       }
-      return await selectDevice(devices, selector, { simulatorSetPath: iosSimulatorSetPath });
+      return await resolveDevice(devices, selector, { simulatorSetPath: iosSimulatorSetPath });
     },
     {
       platform: normalizedPlatform,

--- a/src/utils/__tests__/device.test.ts
+++ b/src/utils/__tests__/device.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizePlatformSelector, resolveApplePlatformName, selectDevice } from '../device.ts';
+import { normalizePlatformSelector, resolveApplePlatformName, resolveDevice } from '../device.ts';
 import type { DeviceInfo } from '../device.ts';
 import { AppError } from '../errors.ts';
 
@@ -17,9 +17,9 @@ test('resolveApplePlatformName resolves tv targets to tvOS', () => {
   assert.equal(resolveApplePlatformName(undefined), 'iOS');
 });
 
-test('selectDevice throws DEVICE_NOT_FOUND with scoped set guidance when simulatorSetPath is set and no devices found', async () => {
+test('resolveDevice throws DEVICE_NOT_FOUND with scoped set guidance when simulatorSetPath is set and no devices found', async () => {
   const setPath = '/path/to/sessions/abc/Simulators';
-  const err = await selectDevice([], { platform: 'ios' }, { simulatorSetPath: setPath }).catch((e) => e);
+  const err = await resolveDevice([], { platform: 'ios' }, { simulatorSetPath: setPath }).catch((e) => e);
   assert.ok(err instanceof AppError);
   assert.equal(err.code, 'DEVICE_NOT_FOUND');
   assert.match(err.message, /scoped simulator set/);
@@ -29,39 +29,39 @@ test('selectDevice throws DEVICE_NOT_FOUND with scoped set guidance when simulat
   assert.match(err.details.hint as string, /create/);
 });
 
-test('selectDevice throws generic DEVICE_NOT_FOUND when no simulatorSetPath and no devices found', async () => {
-  const err = await selectDevice([], { platform: 'ios' }).catch((e) => e);
+test('resolveDevice throws generic DEVICE_NOT_FOUND when no simulatorSetPath and no devices found', async () => {
+  const err = await resolveDevice([], { platform: 'ios' }).catch((e) => e);
   assert.ok(err instanceof AppError);
   assert.equal(err.code, 'DEVICE_NOT_FOUND');
   assert.equal(err.message, 'No devices found');
   assert.equal(err.details?.simulatorSetPath, undefined);
 });
 
-test('selectDevice does not apply scoped set guidance for non-iOS platform with simulatorSetPath', async () => {
+test('resolveDevice does not apply scoped set guidance for non-iOS platform with simulatorSetPath', async () => {
   const setPath = '/path/to/sessions/abc/Simulators';
-  const err = await selectDevice([], { platform: 'android' }, { simulatorSetPath: setPath }).catch((e) => e);
+  const err = await resolveDevice([], { platform: 'android' }, { simulatorSetPath: setPath }).catch((e) => e);
   assert.ok(err instanceof AppError);
   assert.equal(err.code, 'DEVICE_NOT_FOUND');
   assert.equal(err.message, 'No devices found');
   assert.equal(err.details?.simulatorSetPath, undefined);
 });
 
-test('selectDevice applies scoped set guidance when no platform selector specified and simulatorSetPath is set', async () => {
+test('resolveDevice applies scoped set guidance when no platform selector specified and simulatorSetPath is set', async () => {
   const setPath = '/path/to/sessions/abc/Simulators';
-  const err = await selectDevice([], {}, { simulatorSetPath: setPath }).catch((e) => e);
+  const err = await resolveDevice([], {}, { simulatorSetPath: setPath }).catch((e) => e);
   assert.ok(err instanceof AppError);
   assert.equal(err.code, 'DEVICE_NOT_FOUND');
   assert.match(err.message, /scoped simulator set/);
   assert.equal(err.details?.simulatorSetPath, setPath);
 });
 
-test('selectDevice returns a device when candidates are available', async () => {
+test('resolveDevice returns a device when candidates are available', async () => {
   const device: DeviceInfo = { platform: 'ios', id: 'abc123', name: 'iPhone 16', kind: 'simulator', booted: true };
-  const result = await selectDevice([device], { platform: 'ios' });
+  const result = await resolveDevice([device], { platform: 'ios' });
   assert.equal(result.id, 'abc123');
 });
 
-test('selectDevice prefers simulator over physical device when no explicit device selector', async () => {
+test('resolveDevice prefers simulator over physical device when no explicit device selector', async () => {
   const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
   const simulator: DeviceInfo = {
     platform: 'ios',
@@ -70,43 +70,42 @@ test('selectDevice prefers simulator over physical device when no explicit devic
     kind: 'simulator',
     booted: false,
   };
-  const result = await selectDevice([physical, simulator], { platform: 'ios' });
+  const result = await resolveDevice([physical, simulator], { platform: 'ios' });
   assert.equal(result.id, 'sim-1');
   assert.equal(result.kind, 'simulator');
 });
 
-test('selectDevice prefers booted simulator over physical device', async () => {
+test('resolveDevice prefers booted simulator over physical device', async () => {
   const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
   const sim1: DeviceInfo = { platform: 'ios', id: 'sim-1', name: 'iPhone 16', kind: 'simulator', booted: true };
   const sim2: DeviceInfo = { platform: 'ios', id: 'sim-2', name: 'iPhone 15', kind: 'simulator', booted: false };
-  const result = await selectDevice([physical, sim1, sim2], { platform: 'ios' });
+  const result = await resolveDevice([physical, sim1, sim2], { platform: 'ios' });
   assert.equal(result.id, 'sim-1');
 });
 
-test('selectDevice falls back to physical device when no simulators exist', async () => {
+test('resolveDevice falls back to physical device when no simulators exist', async () => {
   const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
-  const result = await selectDevice([physical], { platform: 'ios' });
+  const result = await resolveDevice([physical], { platform: 'ios' });
   assert.equal(result.id, 'phys-1');
 });
 
-test('selectDevice returns physical device when explicitly selected by deviceName', async () => {
+test('resolveDevice returns physical device when explicitly selected by deviceName', async () => {
   const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
   const simulator: DeviceInfo = { platform: 'ios', id: 'sim-1', name: 'iPhone 16', kind: 'simulator', booted: true };
-  const result = await selectDevice([physical, simulator], { platform: 'ios', deviceName: 'My iPhone' });
+  const result = await resolveDevice([physical, simulator], { platform: 'ios', deviceName: 'My iPhone' });
   assert.equal(result.id, 'phys-1');
 });
 
-test('selectDevice returns physical device when explicitly selected by udid', async () => {
+test('resolveDevice returns physical device when explicitly selected by udid', async () => {
   const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
   const simulator: DeviceInfo = { platform: 'ios', id: 'sim-1', name: 'iPhone 16', kind: 'simulator', booted: true };
-  const result = await selectDevice([physical, simulator], { platform: 'ios', udid: 'phys-1' });
+  const result = await resolveDevice([physical, simulator], { platform: 'ios', udid: 'phys-1' });
   assert.equal(result.id, 'phys-1');
 });
 
-test('selectDevice returns physical device when it is the only candidate (no simulators in list)', async () => {
+test('resolveDevice returns physical device when it is the only candidate (no simulators in list)', async () => {
   const physical: DeviceInfo = { platform: 'ios', id: 'phys-1', name: 'My iPhone', kind: 'device', booted: true };
-  const result = await selectDevice([physical], { platform: 'ios' });
+  const result = await resolveDevice([physical], { platform: 'ios' });
   assert.equal(result.id, 'phys-1');
   assert.equal(result.kind, 'device');
 });
-

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,6 +1,4 @@
 import { AppError } from './errors.ts';
-import { isInteractive } from './interactive.ts';
-import { isCancel, select } from '@clack/prompts';
 
 export type Platform = 'ios' | 'android';
 export type PlatformSelector = Platform | 'apple';
@@ -40,7 +38,7 @@ export function resolveApplePlatformName(target: DeviceTarget | undefined): 'iOS
   return target === 'tv' ? 'tvOS' : 'iOS';
 }
 
-export async function selectDevice(
+export async function resolveDevice(
   devices: DeviceInfo[],
   selector: DeviceSelector,
   context: DeviceSelectionContext = {},
@@ -102,22 +100,7 @@ export async function selectDevice(
   const booted = candidates.filter((d) => d.booted);
   if (booted.length === 1) return booted[0];
 
-  if (isInteractive()) {
-    const choice = await select({
-      message: 'Multiple devices available. Choose a device to continue:',
-      options: (booted.length > 0 ? booted : candidates).map((device) => ({
-        label: `${device.name} (${device.platform}${device.kind ? `, ${device.kind}` : ''}${device.booted ? ', booted' : ''})`,
-        value: device.id,
-      })),
-    });
-    if (isCancel(choice)) {
-      throw new AppError('INVALID_ARGS', 'Device selection cancelled');
-    }
-    if (choice) {
-      const match = candidates.find((d) => d.id === choice);
-      if (match) return match;
-    }
-  }
-
+  // When multiple candidates remain equally valid, preserve discovery order from
+  // the underlying platform tools rather than introducing another tie-breaker here.
   return booted[0] ?? candidates[0];
 }

--- a/src/utils/interactive.ts
+++ b/src/utils/interactive.ts
@@ -1,4 +1,0 @@
-export function isInteractive(): boolean {
-  if (process.env.CI) return false;
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
-}


### PR DESCRIPTION
## Summary

Remove the `@clack/prompts` dependency and the unused interactive device picker path.
Rename `selectDevice` to `resolveDevice` and document that remaining tie-breaks preserve platform discovery order.
Touched files: 7. Scope stayed within device resolution and related tests.

## Validation

pnpm typecheck
pnpm test:unit
pnpm test:smoke