### PR TITLE
fix: strip trailing OK from Android emulator names

### DIFF
--- a/src/platforms/android/__tests__/devices.test.ts
+++ b/src/platforms/android/__tests__/devices.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import {
   ensureAndroidEmulatorBooted,
   parseAndroidAvdList,
+  parseAndroidEmulatorAvdNameOutput,
   parseAndroidFeatureListForTv,
   parseAndroidTargetFromCharacteristics,
   resolveAndroidAvdName,
@@ -29,6 +30,12 @@ test('parseAndroidFeatureListForTv detects television and leanback features', ()
 test('parseAndroidAvdList drops empty lines', () => {
   const listed = parseAndroidAvdList('\nPixel_9_Pro_XL\n\nWear_OS\n');
   assert.deepEqual(listed, ['Pixel_9_Pro_XL', 'Wear_OS']);
+});
+
+test('parseAndroidEmulatorAvdNameOutput drops trailing adb protocol status', () => {
+  assert.equal(parseAndroidEmulatorAvdNameOutput('Pixel_9_Pro_XL\r\nOK\r\n'), 'Pixel_9_Pro_XL');
+  assert.equal(parseAndroidEmulatorAvdNameOutput('Pixel_9_Pro_XL\n'), 'Pixel_9_Pro_XL');
+  assert.equal(parseAndroidEmulatorAvdNameOutput('\r\nOK\r\n'), undefined);
 });
 
 test('resolveAndroidAvdName supports space vs underscore matching', () => {

--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -37,6 +37,18 @@ function normalizeAndroidName(value: string): string {
   return value.toLowerCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+export function parseAndroidEmulatorAvdNameOutput(rawOutput: string): string | undefined {
+  const lines = rawOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) return undefined;
+  if (lines.at(-1) === 'OK') {
+    lines.pop();
+  }
+  return lines.join('\n').trim() || undefined;
+}
+
 async function readAndroidBootProp(
   serial: string,
   timeoutMs = TIMEOUT_PROFILES.android_boot.operationMs,
@@ -71,8 +83,8 @@ async function resolveAndroidEmulatorAvdName(serial: string): Promise<string | u
     allowFailure: true,
     timeoutMs: ANDROID_EMULATOR_AVD_NAME_TIMEOUT_MS,
   });
-  const emuValue = emuResult.stdout.trim();
-  if (emuResult.exitCode === 0 && emuValue.length > 0) {
+  const emuValue = parseAndroidEmulatorAvdNameOutput(emuResult.stdout);
+  if (emuResult.exitCode === 0 && emuValue) {
     return emuValue;
   }
   return undefined;


### PR DESCRIPTION
## Summary

Strip the trailing `OK` status line from `adb emu avd name` output before using it as the Android emulator display name.
Add a regression test for the `Pixel_9_Pro_XL
OK` case.
Touched files: 2. Scope stayed within Android device discovery.

Note: `pnpm format` and `pnpm typecheck` could not run in this worktree because local dependencies are missing (`node_modules` is absent).

## Validation

- `pnpm test -- src/platforms/android/__tests__/devices.test.ts`