### PR TITLE
fix: tolerate android emulator avd probe timeouts

### DIFF
--- a/src/platforms/android/__tests__/devices.test.ts
+++ b/src/platforms/android/__tests__/devices.test.ts
@@ -243,6 +243,25 @@ test('resolveAndroidEmulatorAvdName ignores probe timeouts and keeps probing', a
   );
 });
 
+test('resolveAndroidEmulatorAvdName rethrows non-timeout probe failures', async () => {
+  const failure = new AppError('COMMAND_FAILED', 'adb exited with code 1', {
+    stderr: 'device offline',
+    exitCode: 1,
+    processExitError: true,
+  });
+  let callCount = 0;
+  const runAdb = async (): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+    callCount += 1;
+    throw failure;
+  };
+
+  await assert.rejects(
+    async () => await resolveAndroidEmulatorAvdName('emulator-5554', runAdb),
+    (error) => error === failure,
+  );
+  assert.equal(callCount, 1);
+});
+
 test('listAndroidDevices falls back to model when emulator avd name is unavailable', async () => {
   await withMockedAndroidTools(
     async ({ emulatorBootedPath }) => {

--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -82,12 +82,16 @@ async function runBestEffortAndroidEmulatorNameProbe(
     });
   } catch (error) {
     const appError = asAppError(error);
-    // Friendly-name lookup is optional during discovery, so timeouts should not hide a reachable device.
-    if (appError.code === 'COMMAND_FAILED') {
+    // Friendly-name lookup is optional during discovery, but only probe timeouts should fall back.
+    if (isAndroidEmulatorNameProbeTimeout(appError)) {
       return undefined;
     }
     throw error;
   }
+}
+
+function isAndroidEmulatorNameProbeTimeout(error: AppError): boolean {
+  return error.code === 'COMMAND_FAILED' && typeof error.details?.timeoutMs === 'number';
 }
 
 export async function resolveAndroidEmulatorAvdName(


### PR DESCRIPTION
## Summary

Make Android emulator AVD-name discovery best-effort so `devices --platform android` and downstream target resolution still succeed when friendly-name probes hang or time out.
Add regression coverage for probe timeout handling and fallback to model-based naming.

Touched files: 2.
Scope did not expand beyond the Android discovery module and its unit tests.

## Validation

- `node --test src/platforms/android/__tests__/devices.test.ts`
- `node --test src/platforms/android/__tests__/*.test.ts`
