### PR TITLE
Fix batch recording session state preservation

### DIFF
--- a/src/daemon/__tests__/request-router-lock-policy.test.ts
+++ b/src/daemon/__tests__/request-router-lock-policy.test.ts
@@ -154,3 +154,46 @@ test('direct daemon requests apply strip lock policy for existing sessions befor
   assert.equal(action?.flags.target, undefined);
   assert.equal(action?.flags.device, 'iPhone 16');
 });
+
+test('batch preserves tenant-scoped session names across nested requests', async () => {
+  const sessionStore = makeStore();
+  sessionStore.set('tenant-a:default', makeIosSession('tenant-a:default'));
+  const leaseRegistry = new LeaseRegistry();
+  const lease = leaseRegistry.allocateLease({
+    tenantId: 'tenant-a',
+    runId: 'run-1',
+  });
+  let dispatchCalls = 0;
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry,
+    trackDownloadableArtifact: () => 'artifact-id',
+    dispatchCommand: async () => {
+      dispatchCalls += 1;
+      return {};
+    },
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'default',
+    command: 'batch',
+    positionals: [],
+    flags: {
+      batchSteps: [{ command: 'home' }],
+    },
+    meta: {
+      tenantId: 'tenant-a',
+      runId: 'run-1',
+      leaseId: lease.leaseId,
+      sessionIsolation: 'tenant',
+    },
+  });
+
+  assert.equal(response.ok, true);
+  assert.equal(dispatchCalls, 1);
+  assert.equal(sessionStore.get('tenant-a:default')?.actions.at(-1)?.command, 'home');
+});

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -270,6 +270,41 @@ test('batch step forwards typed runtime payload', async () => {
   ]);
 });
 
+test('batch step pins nested requests to the resolved session', async () => {
+  const sessionStore = makeSessionStore();
+  const seenSessions: Array<{ session: string; flagSession: string | undefined }> = [];
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'batch',
+      positionals: [],
+      flags: {
+        batchSteps: [{ command: 'wait', positionals: ['100'] }],
+      },
+    },
+    sessionName: 'resolved-session',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: async (stepReq) => {
+      seenSessions.push({
+        session: stepReq.session,
+        flagSession: stepReq.flags?.session,
+      });
+      return { ok: true, data: {} };
+    },
+  });
+
+  assert.equal(response?.ok, true);
+  assert.deepEqual(seenSessions, [
+    {
+      session: 'resolved-session',
+      flagSession: 'resolved-session',
+    },
+  ]);
+});
+
 test('runtime set/show/clear manages session-scoped runtime hints before open', async () => {
   const sessionStore = makeSessionStore();
   const baseRequest = {

--- a/src/daemon/handlers/session-batch.ts
+++ b/src/daemon/handlers/session-batch.ts
@@ -113,12 +113,16 @@ async function runBatchStep(
     }
 > {
   const stepStartedAt = Date.now();
+  const stepFlags = buildBatchStepFlags(req.flags, step.flags);
+  if (stepFlags.session === undefined) {
+    stepFlags.session = sessionName;
+  }
   const response = await invoke({
     token: req.token,
     session: sessionName,
     command: step.command,
     positionals: step.positionals,
-    flags: buildBatchStepFlags(req.flags, step.flags),
+    flags: stepFlags,
     runtime: step.runtime as DaemonRequest['runtime'],
     meta: req.meta,
   });

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -86,9 +86,20 @@ function scopeRequestSession(req: DaemonRequest): DaemonRequest {
       'session isolation mode tenant requires --tenant (or meta.tenantId).',
     );
   }
+  const requestedSession = req.session || 'default';
+  if (requestedSession.startsWith(`${tenant}:`)) {
+    return {
+      ...req,
+      meta: {
+        ...req.meta,
+        tenantId: tenant,
+        sessionIsolation: isolation,
+      },
+    };
+  }
   return {
     ...req,
-    session: `${tenant}:${req.session || 'default'}`,
+    session: `${tenant}:${requestedSession}`,
     meta: {
       ...req.meta,
       tenantId: tenant,


### PR DESCRIPTION
## Summary

Preserve batch session state across nested commands so `record start -> actions -> record stop` stays on the same in-memory session.
Fix nested tenant session scoping so batch and other nested invoke paths do not double-prefix already scoped session names.
Add router- and handler-level regressions for both paths.

## Validation

`node --test src/daemon/handlers/__tests__/session.test.ts`
`node --test src/daemon/__tests__/request-router-lock-policy.test.ts`

Focused validation only. Full `pnpm format`, `pnpm typecheck`, and broad `pnpm test:*` runs are blocked in this worktree because local dependencies are missing (`node_modules`, including `prettier`, `tsc`, and `pngjs`).
