### PR TITLE
docs: simplify README landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@
 
 If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this project applies the same broad idea to mobile apps and devices.
 
-## Demo
-
 <video src="https://github.com/user-attachments/assets/db81d164-c179-4e68-97fa-53f06e467211" controls muted playsinline></video>
-
-[Open the demo video directly](https://github.com/user-attachments/assets/db81d164-c179-4e68-97fa-53f06e467211).
 
 ## Project Goals
 


### PR DESCRIPTION
## Summary

Simplify the README into a lean project landing page.
Shift detailed usage guidance to the existing docs and skills links.
Touched files: 1 (`README.md`). Scope did not expand beyond the README.

## Validation

Not run (docs-only change).