### PR TITLE
Tighten touch interaction reliability

### DIFF
--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -301,6 +301,53 @@ test('press coordinates without recording skips Android screen-size lookup', asy
   assert.equal(screenSizeReads, 0);
 });
 
+test('press coordinates during recording still dispatches when Android screen-size lookup fails', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-direct-press-screen-size-failure';
+  const session = makeAndroidSession(sessionName);
+  session.recording = {
+    platform: 'android',
+    outPath: '/tmp/demo.mp4',
+    remotePath: '/sdcard/demo.mp4',
+    remotePid: '1234',
+    startedAt: Date.now() - 1_000,
+    showTouches: true,
+    gestureEvents: [],
+  };
+  session.snapshot = undefined;
+  sessionStore.set(sessionName, session);
+
+  let dispatchCalls = 0;
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'press',
+      positionals: ['300', '2300'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+    dispatch: async () => {
+      dispatchCalls += 1;
+      return { x: 300, y: 2300 };
+    },
+    readAndroidScreenSize: async () => {
+      throw new Error('adb unavailable');
+    },
+  });
+
+  assert.equal(response?.ok, true);
+  assert.equal(dispatchCalls, 1);
+  const event = sessionStore.get(sessionName)?.recording?.gestureEvents[0];
+  assert.equal(event?.kind, 'tap');
+  assert.equal(event?.x, 300);
+  assert.equal(event?.y, 2300);
+  assert.equal(event?.referenceWidth, undefined);
+  assert.equal(event?.referenceHeight, undefined);
+});
+
 test('press @ref preserves native timing in recorded result and touch visualization', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'default';

--- a/src/daemon/handlers/interaction-common.ts
+++ b/src/daemon/handlers/interaction-common.ts
@@ -46,10 +46,15 @@ export async function dispatchRecordedTouchInteraction(params: {
   interactionCommand: string;
   interactionPositionals: string[];
   outPath: string | undefined;
-  buildPayloads: (data: Record<string, unknown> | undefined) => {
-    result: Record<string, unknown>;
-    responseData?: Record<string, unknown>;
-  };
+  buildPayloads: (data: Record<string, unknown> | undefined) =>
+    | {
+        result: Record<string, unknown>;
+        responseData?: Record<string, unknown>;
+      }
+    | Promise<{
+        result: Record<string, unknown>;
+        responseData?: Record<string, unknown>;
+      }>;
 }): Promise<DaemonResponse> {
   const {
     session,
@@ -73,7 +78,7 @@ export async function dispatchRecordedTouchInteraction(params: {
     positionals: interactionPositionals,
     outPath,
   });
-  const { result, responseData = result } = buildPayloads(interaction.data);
+  const { result, responseData = result } = await buildPayloads(interaction.data);
   return finalizeTouchInteraction({
     session,
     sessionStore,

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -16,7 +16,7 @@ import {
   resolveSelectorChain,
   splitSelectorFromArgs,
 } from '../selectors.ts';
-import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
+import { emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { getAndroidScreenSize } from '../../platforms/android/index.ts';
 import { getSnapshotReferenceFrame } from '../touch-reference-frame.ts';
 import {
@@ -122,15 +122,6 @@ export async function handleTouchInteractionCommands(params: {
     }
     const directCoordinates = parseCoordinateTarget(req.positionals ?? []);
     if (directCoordinates) {
-      const visualizationFrame = await resolveDirectTouchReferenceFrame({
-        session,
-        flags: req.flags,
-        sessionStore,
-        contextFromFlags,
-        captureSnapshotForSession,
-        dispatch,
-        readAndroidScreenSize,
-      });
       return dispatchRecordedTouchInteraction({
         session,
         sessionStore,
@@ -145,7 +136,16 @@ export async function handleTouchInteractionCommands(params: {
         interactionCommand: 'press',
         interactionPositionals: [String(directCoordinates.x), String(directCoordinates.y)],
         outPath: req.flags?.out,
-        buildPayloads: (data) => {
+        buildPayloads: async (data) => {
+          const visualizationFrame = await resolveDirectTouchReferenceFrameSafely({
+            session,
+            flags: req.flags,
+            sessionStore,
+            contextFromFlags,
+            captureSnapshotForSession,
+            dispatch,
+            readAndroidScreenSize,
+          });
           const result = buildTouchVisualizationResult({
             data,
             fallbackX: directCoordinates.x,
@@ -520,7 +520,7 @@ async function resolveDirectTouchReferenceFrame(params: {
   if (!session.recording) {
     return undefined;
   }
-  if (session.recording?.touchReferenceFrame) {
+  if (session.recording.touchReferenceFrame) {
     return session.recording.touchReferenceFrame;
   }
 
@@ -561,6 +561,30 @@ async function resolveDirectTouchReferenceFrame(params: {
     session.recording.touchReferenceFrame = referenceFrame;
   }
   return referenceFrame;
+}
+
+async function resolveDirectTouchReferenceFrameSafely(params: {
+  session: SessionState;
+  flags: CommandFlags | undefined;
+  sessionStore: SessionStore;
+  contextFromFlags: ContextFromFlags;
+  captureSnapshotForSession: CaptureSnapshotForSession;
+  dispatch: typeof dispatchCommand;
+  readAndroidScreenSize: typeof getAndroidScreenSize;
+}): Promise<{ referenceWidth: number; referenceHeight: number } | undefined> {
+  try {
+    return await resolveDirectTouchReferenceFrame(params);
+  } catch (error) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'touch_reference_frame_resolve_failed',
+      data: {
+        platform: params.session.device.platform,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    return undefined;
+  }
 }
 
 async function resolveRefTargetWithRectRefresh(params: {


### PR DESCRIPTION
## Summary

Tighten touch interaction reliability by sharing recorded touch post-processing, reusing stale `@ref` rect refresh for `fill`, and making direct-touch visualization metadata best effort after dispatch.
Reduce unnecessary direct-touch reference-frame work when no recording is active.

Closes #247.

Touched files: 3. Scope stayed within the interaction handler/test command family.

## Validation

pnpm typecheck
pnpm format
pnpm test:unit
pnpm test:smoke