### PR TITLE
fix: promote press ref taps to hittable ancestors

### DIFF
--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -776,6 +776,65 @@ test('fill @ref preserves fallback coordinates for recording when platform resul
   assert.equal(event?.y, 40);
 });
 
+test('fill @ref keeps the original editable node when its parent is the hittable ancestor', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'default';
+  const session = makeSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'XCUIElementTypeCell',
+        label: 'Email row',
+        rect: { x: 20, y: 100, width: 320, height: 72 },
+        enabled: true,
+        hittable: true,
+      },
+      {
+        index: 1,
+        parentIndex: 0,
+        type: 'XCUIElementTypeTextField',
+        label: 'Email',
+        identifier: 'auth_email',
+        rect: { x: 44, y: 120, width: 200, height: 32 },
+        enabled: true,
+        hittable: false,
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'xctest',
+  };
+  sessionStore.set(sessionName, session);
+
+  const dispatchCalls: Array<{ command: string; positionals: string[] }> = [];
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'fill',
+      positionals: ['@e2', 'hello@example.com'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+    dispatch: async (_device, command, positionals) => {
+      dispatchCalls.push({ command, positionals });
+      return { filled: true };
+    },
+  });
+
+  assert.ok(response);
+  assert.equal(response.ok, true);
+  assert.equal(dispatchCalls.length, 1);
+  assert.equal(dispatchCalls[0]?.command, 'fill');
+  assert.deepEqual(dispatchCalls[0]?.positionals, ['144', '136', 'hello@example.com']);
+
+  const stored = sessionStore.get(sessionName);
+  const result = (stored?.actions[0]?.result ?? {}) as Record<string, unknown>;
+  assert.equal(result.ref, 'e2');
+});
+
 test('click --button secondary on @ref dispatches a secondary press on macOS and records click', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'default';

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -181,6 +181,7 @@ export async function handleTouchInteractionCommands(params: {
         session,
         refInput,
         fallbackLabel,
+        promoteToHittableAncestor: true,
         invalidRefMessage: `${commandLabel} requires a ref like @e2`,
         missingBoundsMessage: `Ref ${refInput} not found or has no bounds`,
         invalidBoundsMessage: `Ref ${refInput} not found or has invalid bounds`,
@@ -352,6 +353,7 @@ export async function handleTouchInteractionCommands(params: {
         session,
         refInput: req.positionals[0],
         fallbackLabel: labelCandidate,
+        promoteToHittableAncestor: false,
         invalidRefMessage: 'fill requires a ref like @e2',
         missingBoundsMessage: `Ref ${req.positionals[0]} not found or has no bounds`,
         invalidBoundsMessage: `Ref ${req.positionals[0]} not found or has invalid bounds`,
@@ -632,6 +634,7 @@ async function resolveRefTargetWithRectRefresh(params: {
   session: SessionState;
   refInput: string;
   fallbackLabel: string;
+  promoteToHittableAncestor: boolean;
   invalidRefMessage: string;
   missingBoundsMessage: string;
   invalidBoundsMessage: string;
@@ -657,6 +660,7 @@ async function resolveRefTargetWithRectRefresh(params: {
     session,
     refInput,
     fallbackLabel,
+    promoteToHittableAncestor,
     invalidRefMessage,
     missingBoundsMessage,
     invalidBoundsMessage,
@@ -678,10 +682,12 @@ async function resolveRefTargetWithRectRefresh(params: {
   if (!resolvedRefTarget.ok) return { ok: false, response: resolvedRefTarget.response };
 
   const { ref } = resolvedRefTarget.target;
-  let node = resolveActionableTouchNode(
-    resolvedRefTarget.target.snapshotNodes,
-    resolvedRefTarget.target.node,
-  );
+  let node = promoteToHittableAncestor
+    ? resolveActionableTouchNode(
+        resolvedRefTarget.target.snapshotNodes,
+        resolvedRefTarget.target.node,
+      )
+    : resolvedRefTarget.target.node;
   let snapshotNodes = resolvedRefTarget.target.snapshotNodes;
   let point = resolveRectCenter(node.rect);
 
@@ -697,17 +703,21 @@ async function resolveRefTargetWithRectRefresh(params: {
     const refNode = findNodeByRef(refreshed.nodes, ref);
     const fallbackNode =
       fallbackLabel.length > 0 ? findNodeByLabel(refreshed.nodes, fallbackLabel) : null;
-    const actionableRefNode = refNode ? resolveActionableTouchNode(refreshed.nodes, refNode) : null;
-    const actionableFallbackNode = fallbackNode
-      ? resolveActionableTouchNode(refreshed.nodes, fallbackNode)
-      : null;
-    const fallbackNodePoint = resolveRectCenter(actionableFallbackNode?.rect);
-    const refNodePoint = resolveRectCenter(actionableRefNode?.rect);
+    const resolvedRefNode =
+      refNode && promoteToHittableAncestor
+        ? resolveActionableTouchNode(refreshed.nodes, refNode)
+        : refNode;
+    const resolvedFallbackNode =
+      fallbackNode && promoteToHittableAncestor
+        ? resolveActionableTouchNode(refreshed.nodes, fallbackNode)
+        : fallbackNode;
+    const fallbackNodePoint = resolveRectCenter(resolvedFallbackNode?.rect);
+    const refNodePoint = resolveRectCenter(resolvedRefNode?.rect);
     const refreshedNode = refNodePoint
-      ? actionableRefNode
+      ? resolvedRefNode
       : fallbackNodePoint
-        ? actionableFallbackNode
-        : (actionableRefNode ?? actionableFallbackNode);
+        ? resolvedFallbackNode
+        : (resolvedRefNode ?? resolvedFallbackNode);
     const refreshedPoint = resolveRectCenter(refreshedNode?.rect);
     if (refreshedNode && refreshedPoint) {
       node = refreshedNode;


### PR DESCRIPTION
## Summary

Promote `press @ref` and selector-based press targets to the nearest hittable ancestor before computing tap coordinates, so iOS disabled RN row children still tap the actionable row container.
Keep `fill @ref` anchored to the original editable node, even when its parent is the hittable ancestor.
Add regression coverage for both cases.

Closes #276

Touched files: 2
Scope stayed within the interaction touch handler and its unit test.

## Validation

`pnpm format`
`pnpm typecheck`
`pnpm test:unit`
`pnpm test:smoke`
