### PR TITLE
refactor: flatten session open flow

### DIFF
--- a/src/daemon/handlers/session-open-prepare.ts
+++ b/src/daemon/handlers/session-open-prepare.ts
@@ -31,6 +31,10 @@ type OpenCommandDetails = {
   runtime: SessionRuntimeHints | undefined;
 };
 
+export type PreparedOpenCommandDetailsResult =
+  | { type: 'response'; response: DaemonResponse }
+  | { type: 'details'; details: OpenCommandDetails };
+
 export function invalidOpenArgs(message: string): DaemonResponse {
   return {
     ok: false,
@@ -119,7 +123,7 @@ export async function prepareOpenCommandDetails(params: {
   ) => Promise<string | undefined>;
   clearRuntimeHints?: typeof clearRuntimeHintsFromApp;
   existingSession?: SessionState;
-}): Promise<DaemonResponse | OpenCommandDetails> {
+}): Promise<PreparedOpenCommandDetailsResult> {
   const {
     req,
     sessionName,
@@ -147,7 +151,10 @@ export async function prepareOpenCommandDetails(params: {
     device,
   });
   if (!runtimeResult.ok) {
-    return runtimeResult.response;
+    return {
+      type: 'response',
+      response: runtimeResult.response,
+    };
   }
 
   if (existingSession && clearRuntimeHints) {
@@ -162,9 +169,12 @@ export async function prepareOpenCommandDetails(params: {
   }
 
   return {
-    appBundleId,
-    appName,
-    runtime: runtimeResult.data.runtime,
+    type: 'details',
+    details: {
+      appBundleId,
+      appName,
+      runtime: runtimeResult.data.runtime,
+    },
   };
 }
 

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -281,8 +281,8 @@ export async function handleOpenCommand(params: {
       clearRuntimeHints,
       existingSession: session,
     });
-    if ('ok' in details) {
-      return details;
+    if (details.type === 'response') {
+      return details.response;
     }
 
     return await completeOpenCommand({
@@ -301,9 +301,9 @@ export async function handleOpenCommand(params: {
         : openTarget
           ? [openTarget]
           : [],
-      appBundleId: details.appBundleId,
-      appName: details.appName,
-      runtime: details.runtime,
+      appBundleId: details.details.appBundleId,
+      appName: details.details.appName,
+      runtime: details.details.runtime,
       surface: surfaceResult,
       existingSession: session,
     });
@@ -364,8 +364,8 @@ export async function handleOpenCommand(params: {
     ensureReady,
     resolveAndroidPackageForOpen: resolveAndroidPackageForOpenFn,
   });
-  if ('ok' in details) {
-    return details;
+  if (details.type === 'response') {
+    return details.response;
   }
 
   return await completeOpenCommand({
@@ -380,9 +380,9 @@ export async function handleOpenCommand(params: {
     settleSimulator,
     openTarget,
     openPositionals: req.positionals ?? [],
-    appBundleId: details.appBundleId,
-    appName: details.appName,
-    runtime: details.runtime,
+    appBundleId: details.details.appBundleId,
+    appName: details.details.appName,
+    runtime: details.details.runtime,
     surface: surfaceResult,
   });
 }


### PR DESCRIPTION
## Summary

Flatten the session `open` flow by moving the control flow back into `session-open.ts` and reducing `session-open-prepare.ts` to small helper functions.

This removes the old prepared-command abstraction, keeps validation to a single pass per path, and uses an explicit discriminated result when preparing open details so the handler does not rely on fragile shape checks.

## Validation

- `pnpm format`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:smoke`
