### PR TITLE
[codex] remove duplicate publish build hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "build:all": "pnpm build:node && pnpm build:xcuitest",
     "ad": "node bin/agent-device.mjs",
     "format": "prettier --write src test skills",
-    "prepublishOnly": "pnpm build:all",
     "prepack": "pnpm build:all",
     "typecheck": "tsc -p tsconfig.json",
     "test": "node --test && vitest run",


### PR DESCRIPTION
## Summary

Remove the redundant `prepublishOnly` hook from `package.json` so `npm publish` only runs `build:all` once via `prepack`.

## Validation

Not run (package.json lifecycle change only)
