### PR TITLE
[codex] Add replay retries to CI workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,7 +43,7 @@ jobs:
           arch: x86_64
           profile: pixel_7
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
-          script: node --experimental-strip-types src/bin.ts test test/integration/replays/android
+          script: node --experimental-strip-types src/bin.ts test test/integration/replays/android --retries 3
 
       - name: Upload Android artifacts
         if: always()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -101,13 +101,13 @@ jobs:
           xcrun simctl bootstatus "$UDID" -b
 
       - name: Run iOS simulator replay suite
-        run: node --experimental-strip-types src/bin.ts test test/integration/replays/ios/simulator
+        run: node --experimental-strip-types src/bin.ts test test/integration/replays/ios/simulator --retries 3
 
       - name: Run iOS physical device replay suite
         if: env.IOS_UDID != ''
         env:
           IOS_UDID: ${{ vars.IOS_UDID }}
-        run: node --experimental-strip-types src/bin.ts test test/integration/replays/ios/device --udid "$IOS_UDID"
+        run: node --experimental-strip-types src/bin.ts test test/integration/replays/ios/device --udid "$IOS_UDID" --retries 3
 
       - name: Upload iOS artifacts
         if: always()

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm build:macos-helper
 
       - name: Run macOS integration test
-        run: node --experimental-strip-types src/bin.ts test test/integration/replays/macos
+        run: node --experimental-strip-types src/bin.ts test test/integration/replays/macos --retries 3
 
       - name: Upload macOS artifacts
         if: always()


### PR DESCRIPTION
## Summary

Add `--retries 3` to the Android, iOS, and macOS replay-suite workflow steps so CI retries flaky replay runs without changing runtime defaults.
Keep the change scoped to GitHub Actions workflow configuration only.

## Validation

Not run locally (workflow YAML change only; no local GitHub Actions runner available).