### PR TITLE
docs: clarify commit and PR title prefixes for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ Minimal operating guide for AI coding agents in this repo.
 - Before opening PR: ensure no conflict markers/unmerged paths.
 - Commit messages and PR titles should use conventional prefixes such as `feat:`, `fix:`, `chore:`, `perf:`, `refactor:`, `docs:`, `test:`, `build:`, or `ci:` as appropriate.
 - Do not use bracketed automation prefixes such as `[codex]` or similar bot tags in commit messages or PR titles.
+- Open a ready-for-review PR by default. Use a draft PR only when the user explicitly asks for one or the work is intentionally incomplete.
 - Run required checks for touched scope from **Testing Matrix**.
 - PR body must be short and include:
   - `## Summary`


### PR DESCRIPTION
## Summary

Clarify agent guidance for commit messages and PR titles in `AGENTS.md`.
Document conventional prefixes like `feat:`, `fix:`, `chore:`, `perf:`, `refactor:`, `docs:`, `test:`, `build:`, and `ci:` and explicitly disallow bracketed bot-style prefixes such as `[codex]`.

## Validation

Docs-only change; no tests run.