### PR TITLE
fix: address P0 safety issues from codebase review

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -143,6 +143,12 @@ async function start(): Promise<void> {
     process.stderr.write(`Daemon error: ${appErr.message}\n`);
     void shutdown();
   });
+  process.on('unhandledRejection', (reason) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    const appErr = err instanceof AppError ? err : asAppError(err);
+    process.stderr.write(`Daemon error: ${appErr.message}\n`);
+    void shutdown();
+  });
 }
 
 void start();

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -306,11 +306,11 @@ export async function getFreePort(): Promise<number> {
     const server = net.createServer();
     server.listen(0, '127.0.0.1', () => {
       const address = server.address();
-      server.close();
       if (typeof address === 'object' && address?.port) {
-        resolve(address.port);
+        const port = address.port;
+        server.close(() => resolve(port));
       } else {
-        reject(new AppError('COMMAND_FAILED', 'Failed to allocate port'));
+        server.close(() => reject(new AppError('COMMAND_FAILED', 'Failed to allocate port')));
       }
     });
     server.on('error', reject);
@@ -323,8 +323,8 @@ export function logChunk(
   traceLogPath?: string,
   verbose?: boolean,
 ): void {
-  if (logPath) fs.appendFileSync(logPath, chunk);
-  if (traceLogPath) fs.appendFileSync(traceLogPath, chunk);
+  if (logPath) fs.appendFile(logPath, chunk, () => {});
+  if (traceLogPath) fs.appendFile(traceLogPath, chunk, () => {});
   if (verbose) {
     process.stderr.write(chunk);
   }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -216,6 +216,14 @@ export async function runCmdStreaming(
     let stdout = '';
     let stderr = '';
     let stdoutBuffer: Buffer | undefined = options.binaryStdout ? Buffer.alloc(0) : undefined;
+    let didTimeout = false;
+    const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
+    const timeoutHandle = timeoutMs
+      ? setTimeout(() => {
+          didTimeout = true;
+          child.kill('SIGKILL');
+        }, timeoutMs)
+      : null;
 
     if (!options.binaryStdout) child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -245,6 +253,7 @@ export async function runCmdStreaming(
     });
 
     child.on('error', (err) => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
       const code = (err as NodeJS.ErrnoException).code;
       if (code === 'ENOENT') {
         reject(new AppError('TOOL_MISSING', `${cmd} not found in PATH`, { cmd }, err));
@@ -254,7 +263,21 @@ export async function runCmdStreaming(
     });
 
     child.on('close', (code) => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
       const exitCode = code ?? 1;
+      if (didTimeout && timeoutMs) {
+        reject(
+          new AppError('COMMAND_FAILED', `${cmd} timed out after ${timeoutMs}ms`, {
+            cmd,
+            args,
+            stdout,
+            stderr,
+            exitCode,
+            timeoutMs,
+          }),
+        );
+        return;
+      }
       if (exitCode !== 0 && !options.allowFailure) {
         reject(
           new AppError('COMMAND_FAILED', `${cmd} exited with code ${exitCode}`, {


### PR DESCRIPTION
## Summary

- **P0-1: Missing `unhandledRejection` handler in daemon** — Added `process.on('unhandledRejection', ...)` in `src/daemon.ts` matching the existing `uncaughtException` handler style to prevent silent crashes from unhandled promise rejections.
- **P0-2: `runCmdStreaming` has no timeout handling** — Added `setTimeout` + `SIGKILL` timeout pattern to `runCmdStreaming()` in `src/utils/exec.ts`, matching the existing `runCmd()` implementation. Timeout is cleared in both `error` and `close` handlers.
- **P0-3: Port allocation race in `getFreePort()`** — Moved `resolve()`/`reject()` calls inside the `server.close()` callback in `src/platforms/ios/runner-transport.ts` so the port is only returned after the OS releases it.
- **P0-4: Synchronous file I/O in hot path** — Replaced `fs.appendFileSync()` with `fs.appendFile()` (fire-and-forget) in `logChunk()` in `src/platforms/ios/runner-transport.ts` to stop blocking the event loop.

## Test plan

- [ ] Verify daemon gracefully shuts down on unhandled promise rejection
- [ ] Verify `runCmdStreaming` respects `timeoutMs` option and kills the child process
- [ ] Verify `getFreePort()` returns usable ports without EADDRINUSE races
- [ ] Verify log output still appears correctly with async writes
- [ ] Run `npx tsc --noEmit` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)