### PR TITLE
fix: avoid focusing iOS simulator window

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -528,8 +528,9 @@ extension RunnerTests {
       needsPostSnapshotInteractionDelay = true
       return Response(ok: true, data: snapshotFast(app: activeApp, options: options))
     case .screenshot:
-      // If a target app bundle ID is provided, activate it first so the screenshot
-      // captures the target app rather than the AgentDeviceRunner itself.
+      let screenshot: XCUIScreenshot
+#if os(macOS)
+      // macOS keeps the app-targeted capture behavior for window-level screenshots.
       if let bundleId = command.appBundleId, !bundleId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         let targetApp = XCUIApplication(bundleIdentifier: bundleId)
         targetApp.activate()
@@ -537,8 +538,6 @@ extension RunnerTests {
         // Brief wait for the app transition animation to complete
         Thread.sleep(forTimeInterval: 0.5)
       }
-      let screenshot: XCUIScreenshot
-#if os(macOS)
       if command.fullscreen == true {
         screenshot = XCUIScreen.main.screenshot()
       } else if let bundleId = command.appBundleId, !bundleId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -32,7 +32,6 @@ import {
 import {
   ensureBootedSimulator,
   ensureSimulator,
-  focusIosSimulatorWindow,
   getSimulatorState,
 } from './simulator.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
@@ -119,7 +118,6 @@ export async function openIosApp(
     }
     if (device.kind === 'simulator') {
       await ensureBootedSimulator(device);
-      await focusIosSimulatorWindow();
       await runSimctl(device, ['openurl', device.id, explicitUrl]);
       return;
     }
@@ -139,7 +137,6 @@ export async function openIosApp(
   if (isDeepLinkTarget(deepLinkTarget)) {
     if (device.kind === 'simulator') {
       await ensureBootedSimulator(device);
-      await focusIosSimulatorWindow();
       await runSimctl(device, ['openurl', device.id, deepLinkTarget]);
       return;
     }
@@ -172,7 +169,6 @@ export async function openIosDevice(device: DeviceInfo): Promise<void> {
   if (state === 'Booted') return;
 
   await ensureBootedSimulator(device);
-  await focusIosSimulatorWindow();
 }
 
 export async function closeIosApp(device: DeviceInfo, app: string): Promise<void> {
@@ -857,7 +853,6 @@ function isIosBiometricCapabilityMissing(stdout: string, stderr: string): boolea
 
 async function launchIosSimulatorApp(device: DeviceInfo, bundleId: string): Promise<void> {
   await ensureBootedSimulator(device);
-  await focusIosSimulatorWindow();
 
   let consecutiveFBSFailures = 0;
   const MAX_CONSECUTIVE_FBS_FAILURES = 3;


### PR DESCRIPTION
## Summary

Avoid explicitly foregrounding Simulator.app before iOS simulator boot, launch, and deep-link commands.
Keep runner screenshots aligned with the current visible simulator screen instead of activating a target app first.

## Validation

- `pnpm build:xcuitest`
- `pnpm typecheck` (blocked: `tsc` not available because `node_modules` is missing)
