### PR TITLE
fix: avoid iOS fill runner tree scan

### DIFF
--- a/src/platforms/ios/interactions.ts
+++ b/src/platforms/ios/interactions.ts
@@ -170,8 +170,6 @@ export function iosRunnerOverrides(
           device,
           {
             command: 'type',
-            x,
-            y,
             text,
             clearFirst: true,
             delayMs,

--- a/src/utils/__tests__/interactors.test.ts
+++ b/src/utils/__tests__/interactors.test.ts
@@ -110,7 +110,7 @@ test('ios scroll reports planned pixels without recomputing from runner coordina
   assert.equal(pixels, 120);
 });
 
-test('ios fill preserves target coordinates for the follow-up type command', async () => {
+test('ios fill clears the focused field after tapping the target coordinates', async () => {
   const commands: RunnerCommand[] = [];
   mockRunIosRunnerCommand.mockImplementation(async (_device, command) => {
     commands.push(command);
@@ -124,8 +124,6 @@ test('ios fill preserves target coordinates for the follow-up type command', asy
     { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.app' },
     {
       command: 'type',
-      x: 120,
-      y: 240,
       text: 'hunter2',
       clearFirst: true,
       delayMs: undefined,


### PR DESCRIPTION
## Summary

Avoid the iOS `fill` timeout path by not forwarding coordinates into the follow-up runner `type` command after the target field has already been tapped and focused.
The previous flow caused the runner to rescan the entire accessibility tree to resolve a text input at the provided point before clearing, which matched the long `Any (Element at index N)` crawl seen in the Calendar repro and eventually triggered the daemon timeout and runner restart.

## Validation

- `pnpm build`
- `pnpm format`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm test:smoke`
- `node bin/agent-device.mjs --session fill-fix open --platform ios Calendar`
- `node bin/agent-device.mjs --session fill-fix fill @e59 "my calendar event title"`
- `node bin/agent-device.mjs --session fill-fix snapshot -i -s @e59`
