### PR TITLE
fix: restore legacy iOS device discovery for pre-iOS 17 devices

### DIFF
--- a/src/platforms/ios/__tests__/devices.test.ts
+++ b/src/platforms/ios/__tests__/devices.test.ts
@@ -27,6 +27,8 @@ beforeEach(() => {
 
 async function withMockedPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
   const original = process.platform;
+  // Some Apple discovery paths are gated on process.platform at runtime, so
+  // these unit tests temporarily override it and always restore it in finally.
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
   try {
     return await fn();

--- a/src/platforms/ios/devices.ts
+++ b/src/platforms/ios/devices.ts
@@ -263,6 +263,9 @@ export function parseXctracePhysicalAppleDevices(output: string): DeviceInfo[] {
       name,
       kind: 'device',
       target,
+      // xctrace lists currently connected devices in the "Devices" section.
+      // The "Devices Offline" section is excluded above, so treating these as
+      // booted preserves the existing physical-device selection semantics.
       booted: true,
     });
   }
@@ -304,6 +307,8 @@ async function listApplePhysicalDevicesFromDevicectl(): Promise<DeviceInfo[]> {
     const jsonText = await fs.readFile(jsonPath, 'utf8');
     return mapDevicectlAppleDevices(JSON.parse(jsonText) as DevicectlListDevicesPayload);
   } catch {
+    // Ignore devicectl discovery failures so simulator and xctrace-based
+    // Apple discovery can still succeed.
     return [];
   } finally {
     if (jsonPath) {
@@ -318,6 +323,8 @@ async function listApplePhysicalDevicesFromXctrace(): Promise<DeviceInfo[]> {
     if (result.exitCode !== 0) return [];
     return parseXctracePhysicalAppleDevices(result.stdout);
   } catch {
+    // Ignore xctrace failures so modern CoreDevice discovery remains the
+    // source of truth when available.
     return [];
   }
 }
@@ -357,8 +364,13 @@ export async function listAppleDevices(
     return devices;
   }
 
-  devices = mergeAppleDevices(devices, await listApplePhysicalDevicesFromDevicectl());
-  return mergeAppleDevices(devices, await listApplePhysicalDevicesFromXctrace());
+  const [devicectlDevices, xctraceDevices] = await Promise.all([
+    listApplePhysicalDevicesFromDevicectl(),
+    listApplePhysicalDevicesFromXctrace(),
+  ]);
+
+  devices = mergeAppleDevices(devices, devicectlDevices);
+  return mergeAppleDevices(devices, xctraceDevices);
 }
 
 export const listIosDevices = listAppleDevices;


### PR DESCRIPTION
## Summary

Restore Apple device discovery for legacy physical iOS devices that `devicectl` cannot describe.
Add a supplemental `xctrace list devices` fallback during host-global Apple discovery, dedupe by device ID, and tighten the parser so only physical iPhone/iPad/iPod/Apple TV entries are accepted.
Add focused discovery tests for fallback coverage, dedupe, parser filtering, and simulator-set scoping.

Closes #331.

## Validation

- `pnpm format`
- `pnpm check:quick`
- `pnpm check:unit`