### PR TITLE
fix: carry remote-config run id for install-from-source

### DIFF
--- a/src/__tests__/cli-config.test.ts
+++ b/src/__tests__/cli-config.test.ts
@@ -27,6 +27,7 @@ async function runCliCapture(
   options?: {
     cwd?: string;
     env?: Record<string, string | undefined>;
+    sendToDaemon?: (req: Omit<DaemonRequest, 'token'>) => Promise<DaemonResponse>;
   },
 ): Promise<RunResult> {
   let stdout = '';
@@ -61,10 +62,12 @@ async function runCliCapture(
     return true;
   }) as typeof process.stderr.write;
 
-  const sendToDaemon = async (req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> => {
-    calls.push(req);
-    return { ok: true, data: {} };
-  };
+  const sendToDaemon =
+    options?.sendToDaemon ??
+    (async (req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> => {
+      calls.push(req);
+      return { ok: true, data: {} };
+    });
 
   try {
     await runCli(argv, { sendToDaemon });
@@ -280,74 +283,36 @@ test('install-from-source forwards remote-config run id with explicit lease bind
     'utf8',
   );
 
-  let stdout = '';
-  let stderr = '';
-  let code: number | null = null;
   const calls: Array<Omit<DaemonRequest, 'token'>> = [];
-
-  const originalExit = process.exit;
-  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-  const originalStderrWrite = process.stderr.write.bind(process.stderr);
-  const originalCwd = process.cwd();
-  const previousEnv = new Map<string, string | undefined>();
-
-  process.chdir(project);
-  previousEnv.set('HOME', process.env.HOME);
-  process.env.HOME = home;
-
-  (process as any).exit = ((nextCode?: number) => {
-    throw new ExitSignal(nextCode ?? 0);
-  }) as typeof process.exit;
-  (process.stdout as any).write = ((chunk: unknown) => {
-    stdout += String(chunk);
-    return true;
-  }) as typeof process.stdout.write;
-  (process.stderr as any).write = ((chunk: unknown) => {
-    stderr += String(chunk);
-    return true;
-  }) as typeof process.stderr.write;
-
-  const sendToDaemon = async (req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> => {
-    calls.push(req);
-    return {
-      ok: true,
-      data: {
-        launchTarget: 'com.example.demo',
-        packageName: 'com.example.demo',
+  const result = await runCliCapture(
+    [
+      'install-from-source',
+      'https://example.com/app.apk',
+      '--remote-config',
+      remoteConfig,
+      '--lease-id',
+      'lease-demo-001',
+      '--json',
+    ],
+    {
+      cwd: project,
+      env: { HOME: home },
+      sendToDaemon: async (req) => {
+        calls.push(req);
+        return {
+          ok: true,
+          data: {
+            launchTarget: 'com.example.demo',
+            packageName: 'com.example.demo',
+          },
+        };
       },
-    };
-  };
+    },
+  );
 
-  try {
-    await runCli(
-      [
-        'install-from-source',
-        'https://example.com/app.apk',
-        '--remote-config',
-        remoteConfig,
-        '--lease-id',
-        'lease-demo-001',
-        '--json',
-      ],
-      { sendToDaemon },
-    );
-  } catch (error) {
-    if (error instanceof ExitSignal) code = error.code;
-    else throw error;
-  } finally {
-    process.exit = originalExit;
-    process.stdout.write = originalStdoutWrite;
-    process.stderr.write = originalStderrWrite;
-    process.chdir(originalCwd);
-    for (const [key, value] of previousEnv.entries()) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
-    }
-  }
-
-  assert.equal(code, null);
-  assert.equal(stderr, '');
-  const payload = JSON.parse(stdout);
+  assert.equal(result.code, null);
+  assert.equal(result.stderr, '');
+  const payload = JSON.parse(result.stdout);
   assert.equal(payload.success, true);
   assert.equal(payload.data.launchTarget, 'com.example.demo');
   assert.equal(calls.length, 1);

--- a/src/__tests__/cli-config.test.ts
+++ b/src/__tests__/cli-config.test.ts
@@ -265,6 +265,103 @@ test('remote config defaults override generic config and env for remote workflow
   fs.rmSync(root, { recursive: true, force: true });
 });
 
+test('install-from-source forwards remote-config run id with explicit lease binding', async () => {
+  const { root, home, project } = makeTempWorkspace();
+  const remoteConfig = path.join(project, 'agent-device.remote.json');
+  fs.writeFileSync(
+    remoteConfig,
+    JSON.stringify({
+      daemonBaseUrl: 'http://remote-mac.example.test:9124/agent-device',
+      tenant: 'micha-pierzcha-a',
+      sessionIsolation: 'tenant',
+      runId: 'demo-run-001',
+      platform: 'android',
+    }),
+    'utf8',
+  );
+
+  let stdout = '';
+  let stderr = '';
+  let code: number | null = null;
+  const calls: Array<Omit<DaemonRequest, 'token'>> = [];
+
+  const originalExit = process.exit;
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalCwd = process.cwd();
+  const previousEnv = new Map<string, string | undefined>();
+
+  process.chdir(project);
+  previousEnv.set('HOME', process.env.HOME);
+  process.env.HOME = home;
+
+  (process as any).exit = ((nextCode?: number) => {
+    throw new ExitSignal(nextCode ?? 0);
+  }) as typeof process.exit;
+  (process.stdout as any).write = ((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  (process.stderr as any).write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  const sendToDaemon = async (req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> => {
+    calls.push(req);
+    return {
+      ok: true,
+      data: {
+        launchTarget: 'com.example.demo',
+        packageName: 'com.example.demo',
+      },
+    };
+  };
+
+  try {
+    await runCli(
+      [
+        'install-from-source',
+        'https://example.com/app.apk',
+        '--remote-config',
+        remoteConfig,
+        '--lease-id',
+        'lease-demo-001',
+        '--json',
+      ],
+      { sendToDaemon },
+    );
+  } catch (error) {
+    if (error instanceof ExitSignal) code = error.code;
+    else throw error;
+  } finally {
+    process.exit = originalExit;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.chdir(originalCwd);
+    for (const [key, value] of previousEnv.entries()) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+
+  assert.equal(code, null);
+  assert.equal(stderr, '');
+  const payload = JSON.parse(stdout);
+  assert.equal(payload.success, true);
+  assert.equal(payload.data.launchTarget, 'com.example.demo');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.meta?.tenantId, 'micha-pierzcha-a');
+  assert.equal(calls[0]?.meta?.runId, 'demo-run-001');
+  assert.equal(calls[0]?.meta?.leaseId, 'lease-demo-001');
+  assert.equal(calls[0]?.flags?.tenant, 'micha-pierzcha-a');
+  assert.equal(calls[0]?.flags?.runId, 'demo-run-001');
+  assert.equal(calls[0]?.flags?.leaseId, 'lease-demo-001');
+  assert.deepEqual(calls[0]?.positionals, []);
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
 test('missing explicit remote config path returns parse error before daemon dispatch', async () => {
   const { root, home, project } = makeTempWorkspace();
 

--- a/src/utils/remote-config.ts
+++ b/src/utils/remote-config.ts
@@ -1,8 +1,19 @@
 import type { CliFlags } from './command-schema.ts';
-import { REMOTE_OPEN_PROFILE_KEYS, type RemoteConfigProfile } from '../remote-config-schema.ts';
+import {
+  REMOTE_CONFIG_FIELD_SPECS,
+  REMOTE_OPEN_PROFILE_KEYS,
+  type RemoteConfigProfile,
+} from '../remote-config-schema.ts';
 import { resolveRemoteConfigProfile } from '../remote-config-core.ts';
 
-// This subset is intentional: only the flags used by remote-config-backed CLI defaults belong here.
+// Remote config can supply defaults for any supported CLI flag that exists in the profile schema.
+// Command validation later strips unsupported defaults for the active command.
+const REMOTE_CONFIG_DEFAULT_FLAG_KEYS = REMOTE_CONFIG_FIELD_SPECS.map(
+  (spec) => spec.key,
+) as readonly (keyof RemoteConfigProfile)[];
+
+// This subset is still intentional: open preserves extra remote-config defaults after command
+// parsing so it can prepare remote Metro without exposing every Metro flag as an open CLI option.
 export const REMOTE_OPEN_FLAG_KEYS = [
   'remoteConfig',
   ...REMOTE_OPEN_PROFILE_KEYS,
@@ -10,7 +21,7 @@ export const REMOTE_OPEN_FLAG_KEYS = [
 
 function profileToCliFlags(profile: RemoteConfigProfile): Partial<CliFlags> {
   const flags: Partial<CliFlags> = {};
-  for (const key of REMOTE_OPEN_PROFILE_KEYS) {
+  for (const key of REMOTE_CONFIG_DEFAULT_FLAG_KEYS) {
     const value = profile[key];
     if (value !== undefined) {
       (flags as Record<string, unknown>)[key] = value;


### PR DESCRIPTION
## Summary

Carry `runId` from `--remote-config` into `install-from-source` by hydrating CLI defaults from the full remote-config schema instead of the open-only subset.
Add a CLI regression test covering `install-from-source --remote-config ... --lease-id ...` so tenant-scoped lease flows keep the profile `runId` without requiring explicit `--run-id`.
Touched files: 2. Scope stayed within CLI remote-config parsing and CLI config test coverage.

## Validation

- `pnpm install`
- `pnpm exec oxfmt --write src/__tests__/cli-config.test.ts`
- `pnpm test -- src/__tests__/cli-config.test.ts`
- `pnpm check:quick`
