### PR TITLE
chore: clean up unused exports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,8 +5,14 @@
     "node": true,
     "es6": true
   },
+  "categories": {
+    "correctness": "error"
+  },
   "rules": {
-    "eslint/no-unused-vars": "error",
+    "eslint/no-unused-vars": [
+      "error",
+      { "fix": { "imports": "safe-fix", "variables": "suggestion" } }
+    ],
     "eslint/prefer-const": "error",
     "eslint/no-useless-escape": "error",
     "eslint/no-empty": ["error", { "allowEmptyCatch": true }],

--- a/src/__tests__/test-utils/session-factories.ts
+++ b/src/__tests__/test-utils/session-factories.ts
@@ -1,10 +1,7 @@
 import type { SessionState } from '../../daemon/types.ts';
 import { IOS_SIMULATOR, ANDROID_EMULATOR, MACOS_DEVICE } from './device-fixtures.ts';
 
-export function makeSession(
-  name: string,
-  overrides?: Partial<SessionState>,
-): SessionState {
+export function makeSession(name: string, overrides?: Partial<SessionState>): SessionState {
   return {
     name,
     device: IOS_SIMULATOR,
@@ -14,23 +11,14 @@ export function makeSession(
   };
 }
 
-export function makeIosSession(
-  name: string,
-  overrides?: Partial<SessionState>,
-): SessionState {
+export function makeIosSession(name: string, overrides?: Partial<SessionState>): SessionState {
   return makeSession(name, { device: IOS_SIMULATOR, ...overrides });
 }
 
-export function makeAndroidSession(
-  name: string,
-  overrides?: Partial<SessionState>,
-): SessionState {
+export function makeAndroidSession(name: string, overrides?: Partial<SessionState>): SessionState {
   return makeSession(name, { device: ANDROID_EMULATOR, ...overrides });
 }
 
-export function makeMacOsSession(
-  name: string,
-  overrides?: Partial<SessionState>,
-): SessionState {
+export function makeMacOsSession(name: string, overrides?: Partial<SessionState>): SessionState {
   return makeSession(name, { device: MACOS_DEVICE, ...overrides });
 }

--- a/src/core/__tests__/dispatch-push.test.ts
+++ b/src/core/__tests__/dispatch-push.test.ts
@@ -59,7 +59,10 @@ test('dispatch push prefers existing brace-prefixed payload file over inline par
   process.env.AGENT_DEVICE_TEST_ARGS_FILE = argsLogPath;
 
   try {
-    const result = await dispatchCommand(ANDROID_EMULATOR, 'push', ['com.example.app', payloadPath]);
+    const result = await dispatchCommand(ANDROID_EMULATOR, 'push', [
+      'com.example.app',
+      payloadPath,
+    ]);
     assert.deepEqual(result, {
       platform: 'android',
       package: 'com.example.app',

--- a/src/core/__tests__/dispatch-trigger-app-event.test.ts
+++ b/src/core/__tests__/dispatch-trigger-app-event.test.ts
@@ -44,7 +44,10 @@ test('trigger-app-event validates payload JSON', async () => {
   try {
     await assert.rejects(
       () =>
-        dispatchCommand(ANDROID_EMULATOR, 'trigger-app-event', ['screenshot_taken', '{invalid-json']),
+        dispatchCommand(ANDROID_EMULATOR, 'trigger-app-event', [
+          'screenshot_taken',
+          '{invalid-json',
+        ]),
       (error: unknown) => {
         assert.equal(error instanceof AppError, true);
         assert.equal((error as AppError).code, 'INVALID_ARGS');
@@ -126,7 +129,9 @@ test('trigger-app-event prefers platform-specific template over global template'
   process.env.AGENT_DEVICE_ANDROID_APP_EVENT_URL_TEMPLATE = 'myapp://android?name={event}';
 
   try {
-    const result = await dispatchCommand(ANDROID_EMULATOR, 'trigger-app-event', ['screenshot_taken']);
+    const result = await dispatchCommand(ANDROID_EMULATOR, 'trigger-app-event', [
+      'screenshot_taken',
+    ]);
     assert.equal(result?.eventUrl, 'myapp://android?name=screenshot_taken');
   } finally {
     process.env.PATH = previousPath;

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -82,7 +82,13 @@ export async function resolveAppleDevice(
   throw new AppError('DEVICE_NOT_FOUND', 'No devices found', { selector });
 }
 
-export const resolveIosDevice = resolveAppleDevice;
+export async function resolveIosDevice(
+  devices: DeviceInfo[],
+  selector: AppleDeviceSelector,
+  context: { simulatorSetPath?: string },
+): Promise<DeviceInfo> {
+  return await resolveAppleDevice(devices, selector, context);
+}
 
 export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<DeviceInfo> {
   const normalizedPlatform = normalizePlatformSelector(flags.platform);

--- a/src/daemon/__tests__/request-router-android-modal.test.ts
+++ b/src/daemon/__tests__/request-router-android-modal.test.ts
@@ -61,7 +61,6 @@ vi.mock('../../utils/exec.ts', () => ({
   }),
 }));
 
-
 function makeAndroidSession(name: string): SessionState {
   return {
     name,

--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -435,17 +435,6 @@ export async function ensureAndroidEmulatorBooted(params: {
   };
 }
 
-export async function ensureAndroidEmulatorHeadlessBooted(params: {
-  avdName: string;
-  serial?: string;
-  timeoutMs?: number;
-}): Promise<DeviceInfo> {
-  return await ensureAndroidEmulatorBooted({
-    ...params,
-    headless: true,
-  });
-}
-
 export async function waitForAndroidBoot(serial: string, timeoutMs = 60000): Promise<void> {
   const timeoutBudget = timeoutMs;
   const deadline = Deadline.fromTimeoutMs(timeoutBudget);

--- a/src/platforms/ios/devices.ts
+++ b/src/platforms/ios/devices.ts
@@ -371,5 +371,3 @@ export async function listAppleDevices(
   devices = mergeAppleDevices(devices, devicectlDevices);
   return mergeAppleDevices(devices, xctraceDevices);
 }
-
-export const listIosDevices = listAppleDevices;

--- a/src/platforms/linux/screenshot.ts
+++ b/src/platforms/linux/screenshot.ts
@@ -19,9 +19,6 @@ const screenshotResolver = createLinuxToolResolver<ScreenshotTool>({
     'scrot, import (ImageMagick), or gnome-screenshot is required for screenshots on X11. Install via your package manager.',
 });
 
-/** Reset cached tool (for testing). */
-export const resetScreenshotToolCache = screenshotResolver.resetCache;
-
 /**
  * Capture a screenshot of the Linux desktop.
  *

--- a/src/utils/cli-config.ts
+++ b/src/utils/cli-config.ts
@@ -26,28 +26,6 @@ export function resolveConfigBackedFlagDefaults(options: {
   return mergeDefinedFlags(defaults, readEnvFlagDefaults(env, options.command));
 }
 
-export function readEnvFlagDefaultsForKeys(
-  env: EnvMap,
-  keys: readonly FlagKey[],
-): Partial<CliFlags> {
-  const flags: Partial<CliFlags> = {};
-  for (const key of keys) {
-    const spec = getOptionSpec(key);
-    if (!spec) continue;
-    const envValue = spec.env.names
-      .map((name) => ({ name, value: env[name] }))
-      .find((entry) => typeof entry.value === 'string' && entry.value.trim().length > 0);
-    if (!envValue) continue;
-    (flags as Record<string, unknown>)[key] = parseOptionValueFromSource(
-      spec,
-      envValue.value as string,
-      `environment variable ${envValue.name}`,
-      envValue.name,
-    );
-  }
-  return flags;
-}
-
 function resolveConfigPaths(
   cwd: string,
   explicitCliConfigPath: string | undefined,

--- a/src/utils/cli-option-schema.ts
+++ b/src/utils/cli-option-schema.ts
@@ -39,10 +39,6 @@ const LEGACY_ENV_VAR_NAMES: Partial<Record<FlagKey, string[]>> = {
 const optionSpecs = buildOptionSpecs();
 const optionSpecByKey = new Map(optionSpecs.map((spec) => [spec.key, spec]));
 
-export function getOptionSpecs(): readonly OptionSpec[] {
-  return optionSpecs;
-}
-
 export function getOptionSpec(key: FlagKey): OptionSpec | undefined {
   return optionSpecByKey.get(key);
 }

--- a/src/utils/timeouts.ts
+++ b/src/utils/timeouts.ts
@@ -6,4 +6,10 @@ export function resolveTimeoutMs(raw: string | undefined, fallback: number, min:
 }
 
 /** Alias for `resolveTimeoutMs` — semantically marks the caller expects seconds. */
-export const resolveTimeoutSeconds = resolveTimeoutMs;
+export function resolveTimeoutSeconds(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+): number {
+  return resolveTimeoutMs(raw, fallback, min);
+}


### PR DESCRIPTION
## Summary

Clean up unused internal exports reported during pruning work.

- Remove unused helper exports and duplicate alias exports without changing behavior.
- Configure Oxlint's `no-unused-vars` rule to safely fix unused imports and emit correctness rules as errors.
- Include formatter-only test updates from `pnpm format`.

Touched-file count: 12. Scope stayed within tooling and unused export cleanup.

## Validation

- `pnpm format`
- `pnpm check:quick`
- `pnpm dlx knip --reporter compact`
- `pnpm check:tooling`
- `pnpm check:unit`