### PR TITLE
feat: export artifact package resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "import": "./dist/src/index.js",
       "types": "./dist/src/index.d.ts"
     },
+    "./artifacts": {
+      "import": "./dist/src/artifacts.js",
+      "types": "./dist/src/artifacts.d.ts"
+    },
     "./metro": {
       "import": "./dist/src/metro.js",
       "types": "./dist/src/metro.d.ts"

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       },
       source: {
         entry: {
+          artifacts: 'src/artifacts.ts',
           index: 'src/index.ts',
           metro: 'src/metro.ts',
           'remote-config': 'src/remote-config.ts',

--- a/src/__tests__/artifacts-public.test.ts
+++ b/src/__tests__/artifacts-public.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+import { resolveAndroidArchivePackageName } from '../artifacts.ts';
+
+const resolver: (archivePath: string) => Promise<string | undefined> =
+  resolveAndroidArchivePackageName;
+
+test('package subpath exports android archive package resolver', () => {
+  assert.equal(typeof resolver, 'function');
+});

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -1,0 +1,1 @@
+export { resolveAndroidArchivePackageName } from './platforms/android/manifest.ts';


### PR DESCRIPTION
## Summary
- Worth it: yes. This exposes the existing APK package-name resolver so consumers can reuse the binary XML parser and existing `aapt` fallback instead of copying it.
- Add the `agent-device/artifacts` subpath and rslib entrypoint.
- Re-export `resolveAndroidArchivePackageName` from the new public artifact surface.
- Add focused public-entrypoint coverage.

Touched files: 4. Scope stayed within artifact export surface. Docs/skills were not updated because this is a library API export, not CLI behavior.

Closes #386

## Validation
- `pnpm install`
- `pnpm format`
- `pnpm check:quick`
- `pnpm check:tooling`
- `pnpm test -- src/__tests__/artifacts-public.test.ts`
- `node --input-type=module -e "import('./dist/src/artifacts.js').then(({ resolveAndroidArchivePackageName }) => { if (typeof resolveAndroidArchivePackageName !== 'function') throw new Error('missing export'); })"`

Known gaps: none.