### PR TITLE
feat: export snapshot contracts

### DIFF
--- a/src/__tests__/client-public.test.ts
+++ b/src/__tests__/client-public.test.ts
@@ -5,6 +5,7 @@ import {
   type AgentDeviceClient,
   type CaptureScreenshotResult,
   type CaptureSnapshotResult,
+  centerOfRect,
   type Point,
   type Rect,
   type ScreenshotOverlayRef,
@@ -55,4 +56,5 @@ const overlay = {
 test('package root exports createAgentDeviceClient', () => {
   const client: AgentDeviceClient = createAgentDeviceClient();
   assert.equal(typeof client.capture.snapshot, 'function');
+  assert.deepEqual(centerOfRect(rect), { x: 3, y: 4 });
 });

--- a/src/__tests__/contracts-schema-public.test.ts
+++ b/src/__tests__/contracts-schema-public.test.ts
@@ -3,11 +3,23 @@ import assert from 'node:assert/strict';
 import {
   daemonCommandRequestSchema,
   daemonRuntimeSchema,
+  centerOfRect,
   jsonRpcRequestSchema,
   leaseAllocateSchema,
   leaseHeartbeatSchema,
   leaseReleaseSchema,
+  type Rect,
+  type SnapshotNode,
 } from '../contracts.ts';
+
+const rect = { x: 1, y: 2, width: 3, height: 4 } satisfies Rect;
+const node = {
+  index: 0,
+  ref: 'e1',
+  type: 'Button',
+  label: 'Continue',
+  rect,
+} satisfies SnapshotNode;
 
 test('public contract schemas validate daemon requests and lease payloads', () => {
   const runtime = daemonRuntimeSchema.parse({
@@ -54,6 +66,8 @@ test('public contract schemas validate daemon requests and lease payloads', () =
   assert.equal(release.tenant, 'acme');
   assert.equal(heartbeat.leaseId, 'lease-1');
   assert.equal(release.leaseId, 'lease-1');
+  assert.deepEqual(centerOfRect(rect), { x: 3, y: 4 });
+  assert.equal(node.ref, 'e1');
 });
 
 test('public contract schemas reject invalid payloads', () => {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -119,6 +119,9 @@ export type JsonRpcRequestEnvelope<TParams = unknown> = {
   params?: TParams;
 };
 
+export { centerOfRect } from './utils/snapshot.ts';
+export type { Rect, SnapshotNode } from './utils/snapshot.ts';
+
 type RuntimeSchema<T> = {
   parse(input: unknown): T;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { createAgentDeviceClient } from './client.ts';
 export { AppError } from './utils/errors.ts';
+export { centerOfRect } from './utils/snapshot.ts';
 
 export type {
   AgentDeviceClient,


### PR DESCRIPTION
## Summary
- Worth it: yes. This lets contracts-only consumers use canonical snapshot node types and center-point math without importing the full SDK surface.
- Re-export `SnapshotNode`, `Rect`, and `centerOfRect` from `agent-device/contracts`.
- Export `centerOfRect` from the package root to match existing snapshot type exports.
- Add public-entrypoint coverage for the new exports.

Touched files: 4. Scope stayed within snapshot contract export surface. Docs/skills were not updated because this is a library API export, not CLI behavior.

Closes #388

## Validation
- `pnpm format`
- `pnpm check:quick`

Known gaps: none.