### PR TITLE
feat: export runtime transport helper

### DIFF
--- a/src/__tests__/metro-public.test.ts
+++ b/src/__tests__/metro-public.test.ts
@@ -21,6 +21,7 @@ import {
   buildIosRuntimeHints,
   ensureMetroTunnel,
   prepareRemoteMetro,
+  resolveRuntimeTransport,
   stopMetroTunnel,
 } from '../metro.ts';
 
@@ -110,5 +111,16 @@ test('public metro helpers expose stable Node-facing wrappers', async () => {
   assert.equal(
     buildAndroidRuntimeHints('https://public.example.test').bundleUrl,
     'https://public.example.test/index.bundle?platform=android&dev=true&minify=false',
+  );
+  assert.deepEqual(
+    resolveRuntimeTransport({
+      platform: 'ios',
+      bundleUrl: 'https://10.0.0.10:8082/index.bundle?platform=ios',
+    }),
+    {
+      host: '10.0.0.10',
+      port: 8082,
+      scheme: 'https',
+    },
   );
 });

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -1,12 +1,19 @@
 import type { SessionRuntimeHints } from './contracts.ts';
 import { buildMetroRuntimeHints, prepareMetroRuntime } from './client-metro.ts';
 import { ensureMetroCompanion, stopMetroCompanion } from './client-metro-companion.ts';
+import { resolveRuntimeTransportHints } from './daemon/runtime-hints.ts';
 export { buildBundleUrl, normalizeBaseUrl } from './utils/url.ts';
 
 type EnvSource = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
 /** Re-export of {@link SessionRuntimeHints} under the Metro-specific alias used by public API consumers. */
 export type MetroRuntimeHints = SessionRuntimeHints;
+
+export function resolveRuntimeTransport(
+  runtime: SessionRuntimeHints | undefined,
+): { host: string; port: number; scheme: 'http' | 'https' } | undefined {
+  return resolveRuntimeTransportHints(runtime);
+}
 
 export type MetroBridgeResult = {
   enabled: boolean;


### PR DESCRIPTION
## Summary
- Worth it: yes. This exposes the existing runtime transport parser so consumers can derive Metro transport hints without duplicating URL parsing.
- Add `resolveRuntimeTransport` to the public `agent-device/metro` entrypoint as a thin wrapper over existing behavior.
- Add focused public Metro coverage for bundle URL parsing.

Touched files: 2. Scope stayed within Metro public helper export surface. Docs/skills were not updated because this is a library API export, not CLI behavior.

Closes #389

## Validation
- `pnpm install`
- `pnpm format`
- `pnpm check:quick`
- `pnpm typecheck`

Known gaps: none.