### PR TITLE
fix: preserve script argument whitespace

### DIFF
--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -367,3 +367,47 @@ test('writeSessionLog escapes device labels with quotes and backslashes', () => 
     /context platform=ios device="QA \\"Lab\\" \\\\ Shelf" kind=simulator theme=unknown/,
   );
 });
+
+test('writeSessionLog preserves significant whitespace and empty string arguments', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-whitespace-'));
+  const store = new SessionStore(root);
+  const session = makeSession('default');
+  store.recordAction(session, {
+    command: 'open',
+    positionals: ['Settings'],
+    flags: { platform: 'ios', saveScript: true },
+    runtime: {
+      platform: 'ios',
+      metroHost: ' host\t',
+      launchUrl: 'myapp://dev ',
+    },
+    result: {},
+  });
+  store.recordAction(session, {
+    command: 'type',
+    positionals: ['  leading\ttrailing  '],
+    flags: { platform: 'ios' },
+    result: {},
+  });
+  store.recordAction(session, {
+    command: 'fill',
+    positionals: ['@e5', ''],
+    flags: { platform: 'ios' },
+    result: { refLabel: 'Search field' },
+  });
+  store.recordAction(session, {
+    command: 'screenshot',
+    positionals: [' ./screens/final.png '],
+    flags: { platform: 'ios' },
+    result: {},
+  });
+
+  store.writeSessionLog(session);
+  const scriptFile = fs.readdirSync(root).find((file) => file.endsWith('.ad'));
+  assert.ok(scriptFile);
+  const script = fs.readFileSync(path.join(root, scriptFile!), 'utf8');
+  assert.match(script, /type "  leading\\ttrailing  "/);
+  assert.match(script, /fill @e5 "Search field" ""/);
+  assert.match(script, /screenshot " \.\/screens\/final\.png "/);
+  assert.match(script, /--metro-host " host\\t" --launch-url "myapp:\/\/dev "/);
+});

--- a/src/daemon/handlers/__tests__/session-replay-script.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-script.test.ts
@@ -145,6 +145,67 @@ test('writeReplayScript escapes device labels with quotes and backslashes', () =
   );
 });
 
+test('writeReplayScript preserves significant whitespace and empty string arguments', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-script-whitespace-'));
+  const replayPath = path.join(root, 'flow.ad');
+  const actions: SessionAction[] = [
+    {
+      ts: Date.now(),
+      command: 'type',
+      positionals: ['  leading\ttrailing  '],
+      flags: {},
+    },
+    {
+      ts: Date.now(),
+      command: 'fill',
+      positionals: ['@e2', ''],
+      flags: {},
+    },
+    {
+      ts: Date.now(),
+      command: 'screenshot',
+      positionals: [' ./screens/final.png '],
+      flags: {},
+    },
+    {
+      ts: Date.now(),
+      command: 'screenshot',
+      positionals: ['foo\\nbar.png'],
+      flags: {},
+    },
+    {
+      ts: Date.now(),
+      command: 'open',
+      positionals: ['Demo'],
+      runtime: {
+        platform: 'android',
+        metroHost: ' host\t',
+        launchUrl: 'myapp://dev ',
+      },
+      flags: {},
+    },
+  ];
+
+  writeReplayScript(replayPath, actions, makeSession());
+  const script = fs.readFileSync(replayPath, 'utf8');
+
+  assert.match(script, /type "  leading\\ttrailing  "/);
+  assert.match(script, /fill @e2 ""/);
+  assert.match(script, /screenshot " \.\/screens\/final\.png "/);
+  assert.match(script, /screenshot "foo\\\\nbar\.png"/);
+  assert.match(script, /--metro-host " host\\t" --launch-url "myapp:\/\/dev "/);
+  const parsed = parseReplayScript(script);
+  assert.deepEqual(parsed[0]?.positionals, ['  leading\ttrailing  ']);
+  assert.deepEqual(parsed[1]?.positionals, ['@e2', '']);
+  assert.deepEqual(parsed[2]?.positionals, [' ./screens/final.png ']);
+  assert.deepEqual(parsed[3]?.positionals, ['foo\\nbar.png']);
+  assert.deepEqual(parsed[4]?.runtime, {
+    platform: 'android',
+    metroHost: ' host\t',
+    launchUrl: 'myapp://dev ',
+  });
+});
+
 test('readReplayScriptMetadata extracts platform from context header', () => {
   const metadata = readReplayScriptMetadata(
     '# comment\n\ncontext platform=android device="Pixel 9 Pro"\nopen "Demo"\n',

--- a/src/daemon/script-utils.ts
+++ b/src/daemon/script-utils.ts
@@ -1,6 +1,7 @@
 import type { SessionAction } from './types.ts';
 
 const NUMERIC_ARG_RE = /^-?\d+(\.\d+)?$/;
+const BARE_SCRIPT_TOKEN_RE = /^[^\s"\\]+$/;
 
 const CLICK_LIKE_NUMERIC_FLAG_MAP = new Map<string, 'count' | 'intervalMs' | 'holdMs' | 'jitterPx'>(
   [
@@ -27,10 +28,7 @@ function isTypingCommand(command: string): command is 'type' | 'fill' {
 }
 
 export function formatScriptArg(value: string): string {
-  const trimmed = value.trim();
-  if (trimmed.startsWith('@')) return trimmed;
-  if (NUMERIC_ARG_RE.test(trimmed)) return trimmed;
-  return JSON.stringify(trimmed);
+  return formatScriptToken(value, isStructuralScriptToken);
 }
 
 // Use for literal values such as device labels where leading/trailing whitespace must survive round-trips.
@@ -40,8 +38,19 @@ export function formatScriptStringLiteral(value: string): string {
 
 // Preserve readable CLI-ish script output for ordinary tokens while still quoting whitespace.
 export function formatScriptArgQuoteIfNeeded(value: string): string {
-  const trimmed = value.trim();
-  return /\s/.test(trimmed) ? JSON.stringify(trimmed) : trimmed;
+  return formatScriptToken(value, isBareScriptToken);
+}
+
+function formatScriptToken(value: string, canStayBare: (value: string) => boolean): string {
+  return canStayBare(value) ? value : formatScriptStringLiteral(value);
+}
+
+function isStructuralScriptToken(value: string): boolean {
+  return (isBareScriptToken(value) && value.startsWith('@')) || NUMERIC_ARG_RE.test(value);
+}
+
+function isBareScriptToken(value: string): boolean {
+  return BARE_SCRIPT_TOKEN_RE.test(value);
 }
 
 export function formatScriptActionSummary(action: SessionAction): string {

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -304,7 +304,8 @@ function formatActionLine(action: SessionAction): string {
       if (typeof refLabel === 'string' && refLabel.trim().length > 0) {
         parts.push(formatScriptArg(refLabel));
       }
-      if (text) {
+      // Preserve explicit empty-string fill arguments.
+      if (action.positionals.length > 1) {
         parts.push(formatScriptArg(text));
       }
       appendScriptSeriesFlags(parts, action);


### PR DESCRIPTION
## Summary

Preserve significant whitespace in replay and session script argument serialization by avoiding implicit trimming and using JSON string literals for non-bare tokens.
Keep empty `fill @ref ""` values in session script output and add regression coverage for leading spaces, trailing spaces, tabs, empty-string arguments, and runtime hint values.

Touched-file count: 4. Scope stayed within replay/session script serialization.

## Validation

pnpm exec vitest run src/daemon/handlers/__tests__/session-replay-script.test.ts src/daemon/__tests__/session-store.test.ts
pnpm format
pnpm check:quick
pnpm check:unit