### PR TITLE
ci: remove redundant Linux validation and fix unit hang

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,26 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    name: Typecheck & Unit Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup toolchain
-        uses: ./.github/actions/setup-node-pnpm
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Unit tests
-        run: pnpm test:unit
-
   smoke-linux:
     name: Smoke Tests
-    needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/test/scripts/metro-prepare-packaged-smoke.mjs
+++ b/test/scripts/metro-prepare-packaged-smoke.mjs
@@ -168,6 +168,11 @@ async function main() {
   const configDir = path.join(root, 'config');
   const packRoot = path.join(root, 'pack');
   const installRoot = path.join(root, 'install');
+  const bridgeScope = {
+    tenant: 'tenant-1',
+    runId: 'run-1',
+    leaseId: 'lease-1',
+  };
   fs.mkdirSync(projectRoot, { recursive: true });
   fs.mkdirSync(configDir, { recursive: true });
   fs.mkdirSync(packRoot, { recursive: true });
@@ -332,6 +337,7 @@ async function main() {
         metroPublicBaseUrl: 'https://public.example.test',
         metroProxyBaseUrl: `http://127.0.0.1:${hostPort}`,
         metroBearerToken: 'shared-token',
+        ...bridgeScope,
         metroPreparePort: metroPort,
         metroStartupTimeoutMs: 30_000,
         metroProbeTimeoutMs: 1_000,
@@ -405,11 +411,20 @@ async function main() {
     assert.equal(registerCalls > 0, true, 'expected companion registration request');
     assert.equal(bridgeCalls >= 2, true, 'expected bridge retry before success');
     assert.equal(bridgeSucceeded, true, 'expected bridge success after registration');
+    assert.equal(registerBody.tenantId, bridgeScope.tenant);
+    assert.equal(registerBody.runId, bridgeScope.runId);
+    assert.equal(registerBody.leaseId, bridgeScope.leaseId);
     assert.equal(registerBody.local_base_url, `http://127.0.0.1:${metroPort}`);
+    assert.equal(bridgeBodies[0]?.tenantId, bridgeScope.tenant);
+    assert.equal(bridgeBodies[0]?.runId, bridgeScope.runId);
+    assert.equal(bridgeBodies[0]?.leaseId, bridgeScope.leaseId);
     assert.equal(
       bridgeBodies[0]?.ios_runtime?.metro_bundle_url,
       'https://public.example.test/index.bundle?platform=ios&dev=true&minify=false',
     );
+    assert.equal(bridgeBodies.at(-1)?.tenantId, bridgeScope.tenant);
+    assert.equal(bridgeBodies.at(-1)?.runId, bridgeScope.runId);
+    assert.equal(bridgeBodies.at(-1)?.leaseId, bridgeScope.leaseId);
     assert.equal(
       bridgeBodies.at(-1)?.ios_runtime?.metro_bundle_url,
       'https://public.example.test/index.bundle?platform=ios&dev=true&minify=false',


### PR DESCRIPTION
## Summary

Remove the duplicate `Linux / Typecheck & Unit Tests` validate job from the Linux workflow so Linux smoke no longer depends on a duplicated typecheck/unit gate.

Add the required Metro bridge scope to the packaged Metro smoke config and assert that tenant/run/lease scope is sent to companion registration and bridge requests. This fixes the CI unit-suite hang after scoped Metro bridge calls started requiring that scope.

Touched-file count: 2. Scope expanded from Linux workflow cleanup to the packaged Metro smoke test because the CI unit timeout was still reproducing.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:tooling`
- `pnpm exec vitest run src/__tests__/cli-client-commands.test.ts --reporter=verbose`
- `pnpm exec vitest run src/__tests__/client-metro-packaged.test.ts --reporter=verbose`
- `pnpm format`
- `pnpm check:unit`
- GitHub Actions `CI / Unit Tests` passed on commit `3028da1b` in 1m7s: https://github.com/callstackincubator/agent-device/actions/runs/24450166229/job/71436764467
