### PR TITLE
build: publish iOS simulator runner release assets

### DIFF
--- a/.github/workflows/release-ios-runner.yml
+++ b/.github/workflows/release-ios-runner.yml
@@ -1,0 +1,71 @@
+name: Release iOS Runner
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  publish-ios-simulator-runner:
+    name: Publish iOS Simulator Runner
+    runs-on: macos-26
+    timeout-minutes: 90
+    env:
+      AGENT_DEVICE_XCUITEST_PLATFORM: ios
+      AGENT_DEVICE_XCUITEST_DESTINATION: generic/platform=iOS Simulator
+      AGENT_DEVICE_IOS_CLEAN_DERIVED: "1"
+      AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH: ${{ runner.temp }}/ios-runner-derived
+      RELEASE_ASSET_DIR: ${{ runner.temp }}/release-assets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "22"
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION="$(node -p "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version")"
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+          if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Release tag $TAG_NAME does not match package.json version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+          echo "tag=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Build iOS simulator runner
+        run: sh ./scripts/build-xcuitest-apple.sh
+        shell: bash
+
+      - name: Package iOS simulator runner
+        id: package
+        run: |
+          set -euo pipefail
+          mkdir -p "${RELEASE_ASSET_DIR}"
+          sh ./scripts/package-ios-simulator-runner.sh \
+            "${{ steps.meta.outputs.version }}" \
+            "${{ steps.meta.outputs.tag }}" \
+            "${RELEASE_ASSET_DIR}"
+        shell: bash
+
+      - name: Upload runner assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "${{ steps.meta.outputs.tag }}" \
+            "${{ steps.package.outputs.archive_path }}" \
+            "${{ steps.package.outputs.checksum_path }}" \
+            "${{ steps.package.outputs.manifest_path }}" \
+            --clobber
+        shell: bash

--- a/scripts/package-ios-simulator-runner.sh
+++ b/scripts/package-ios-simulator-runner.sh
@@ -13,7 +13,7 @@ OUTPUT_DIR="$3"
 DERIVED_PATH="${AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH:-$HOME/.agent-device/ios-runner/derived}"
 PRODUCTS_DIR="$DERIVED_PATH/Build/Products"
 EXPECTED_RUNNER_BUNDLE_ID="${AGENT_DEVICE_IOS_RUNNER_RELEASE_BUNDLE_ID:-com.callstack.agentdevice.runner.uitests.xctrunner}"
-ARCHIVE_BASENAME="agent-device-ios-runner-$VERSION.app.zip"
+ARCHIVE_BASENAME="agent-device-ios-runner-$VERSION.app.tar.gz"
 CHECKSUM_BASENAME="$ARCHIVE_BASENAME.sha256"
 MANIFEST_BASENAME="agent-device-ios-runner-$VERSION.manifest.json"
 GITHUB_SERVER="${GITHUB_SERVER_URL:-https://github.com}"
@@ -74,7 +74,7 @@ ditto "$RUNNER_APP_PATH" "$STAGED_APP_PATH"
 rm -f "$ARCHIVE_PATH"
 (
   cd "$STAGE_DIR"
-  COPYFILE_DISABLE=1 zip -qry "$ARCHIVE_PATH" "$(basename "$STAGED_APP_PATH")"
+  COPYFILE_DISABLE=1 tar -czf "$ARCHIVE_PATH" "$(basename "$STAGED_APP_PATH")"
 )
 
 SHA256="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')"
@@ -101,7 +101,7 @@ fi
   printf '  "bundle_id": "%s",\n' "$RUNNER_BUNDLE_ID"
   printf '  "bundle_name": "%s",\n' "$APP_NAME"
   printf '  "platform_target": "iphonesimulator",\n'
-  printf '  "archive_format": "zip"\n'
+  printf '  "archive_format": "tar.gz"\n'
   printf '}\n'
 } > "$MANIFEST_PATH"
 

--- a/scripts/package-ios-simulator-runner.sh
+++ b/scripts/package-ios-simulator-runner.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <version> <release-tag> <output-dir>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+RELEASE_TAG="$2"
+OUTPUT_DIR="$3"
+
+DERIVED_PATH="${AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH:-$HOME/.agent-device/ios-runner/derived}"
+PRODUCTS_DIR="$DERIVED_PATH/Build/Products"
+EXPECTED_RUNNER_BUNDLE_ID="${AGENT_DEVICE_IOS_RUNNER_RELEASE_BUNDLE_ID:-com.callstack.agentdevice.runner.uitests.xctrunner}"
+ARCHIVE_BASENAME="agent-device-ios-runner-$VERSION.app.zip"
+CHECKSUM_BASENAME="$ARCHIVE_BASENAME.sha256"
+MANIFEST_BASENAME="agent-device-ios-runner-$VERSION.manifest.json"
+GITHUB_SERVER="${GITHUB_SERVER_URL:-https://github.com}"
+REPOSITORY="${GITHUB_REPOSITORY:-}"
+
+if [ ! -d "$PRODUCTS_DIR" ]; then
+  echo "Runner build products not found at $PRODUCTS_DIR" >&2
+  exit 1
+fi
+
+read_plist_value() {
+  plist_path="$1"
+  key="$2"
+  /usr/libexec/PlistBuddy -c "Print :$key" "$plist_path" 2>/dev/null || true
+}
+
+write_github_output() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s\n' "$1" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+resolve_runner_app_path() {
+  find "$PRODUCTS_DIR" -type d -name '*.app' | sort | while IFS= read -r app_path; do
+    bundle_id="$(read_plist_value "$app_path/Info.plist" CFBundleIdentifier)"
+    if [ "$bundle_id" = "$EXPECTED_RUNNER_BUNDLE_ID" ]; then
+      printf '%s\n' "$app_path"
+      exit 0
+    fi
+  done
+}
+
+RUNNER_APP_PATH="$(resolve_runner_app_path)"
+if [ -z "$RUNNER_APP_PATH" ]; then
+  echo "Unable to locate simulator runner app with bundle id $EXPECTED_RUNNER_BUNDLE_ID under $PRODUCTS_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+STAGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agent-device-ios-runner.XXXXXX")"
+cleanup() {
+  rm -rf "$STAGE_DIR"
+}
+trap cleanup EXIT INT TERM
+
+STAGED_APP_PATH="$STAGE_DIR/agent-device-ios-runner-$VERSION.app"
+ARCHIVE_PATH="$OUTPUT_DIR/$ARCHIVE_BASENAME"
+CHECKSUM_PATH="$OUTPUT_DIR/$CHECKSUM_BASENAME"
+MANIFEST_PATH="$OUTPUT_DIR/$MANIFEST_BASENAME"
+RUNNER_BUNDLE_ID="$(read_plist_value "$RUNNER_APP_PATH/Info.plist" CFBundleIdentifier)"
+APP_NAME="$(read_plist_value "$RUNNER_APP_PATH/Info.plist" CFBundleName)"
+if [ -z "$APP_NAME" ]; then
+  APP_NAME="$(basename "$RUNNER_APP_PATH" .app)"
+fi
+
+ditto "$RUNNER_APP_PATH" "$STAGED_APP_PATH"
+rm -f "$ARCHIVE_PATH"
+(
+  cd "$STAGE_DIR"
+  COPYFILE_DISABLE=1 zip -qry "$ARCHIVE_PATH" "$(basename "$STAGED_APP_PATH")"
+)
+
+SHA256="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')"
+printf '%s  %s\n' "$SHA256" "$ARCHIVE_BASENAME" > "$CHECKSUM_PATH"
+
+if [ -n "$REPOSITORY" ]; then
+  ARCHIVE_URL="$GITHUB_SERVER/$REPOSITORY/releases/download/$RELEASE_TAG/$ARCHIVE_BASENAME"
+else
+  ARCHIVE_URL=""
+fi
+
+{
+  printf '{\n'
+  printf '  "version": "%s",\n' "$VERSION"
+  printf '  "release_tag": "%s",\n' "$RELEASE_TAG"
+  printf '  "asset_name": "%s",\n' "$ARCHIVE_BASENAME"
+  if [ -n "$ARCHIVE_URL" ]; then
+    printf '  "asset_url": "%s",\n' "$ARCHIVE_URL"
+  else
+    printf '  "asset_url": null,\n'
+  fi
+  printf '  "sha256": "%s",\n' "$SHA256"
+  printf '  "checksum_name": "%s",\n' "$CHECKSUM_BASENAME"
+  printf '  "bundle_id": "%s",\n' "$RUNNER_BUNDLE_ID"
+  printf '  "bundle_name": "%s",\n' "$APP_NAME"
+  printf '  "platform_target": "iphonesimulator",\n'
+  printf '  "archive_format": "zip"\n'
+  printf '}\n'
+} > "$MANIFEST_PATH"
+
+write_github_output "runner_app_path=$RUNNER_APP_PATH"
+write_github_output "archive_path=$ARCHIVE_PATH"
+write_github_output "checksum_path=$CHECKSUM_PATH"
+write_github_output "manifest_path=$MANIFEST_PATH"
+write_github_output "archive_name=$ARCHIVE_BASENAME"
+write_github_output "sha256=$SHA256"
+write_github_output "bundle_id=$RUNNER_BUNDLE_ID"
+
+printf 'archive=%s\n' "$ARCHIVE_PATH"
+printf 'checksum=%s\n' "$CHECKSUM_PATH"
+printf 'manifest=%s\n' "$MANIFEST_PATH"

--- a/scripts/package-ios-simulator-runner.sh
+++ b/scripts/package-ios-simulator-runner.sh
@@ -12,7 +12,7 @@ OUTPUT_DIR="$3"
 
 DERIVED_PATH="${AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH:-$HOME/.agent-device/ios-runner/derived}"
 PRODUCTS_DIR="$DERIVED_PATH/Build/Products"
-EXPECTED_RUNNER_BUNDLE_ID="${AGENT_DEVICE_IOS_RUNNER_RELEASE_BUNDLE_ID:-com.callstack.agentdevice.runner.uitests.xctrunner}"
+EXPECTED_RUNNER_BUNDLE_ID="${AGENT_DEVICE_IOS_RUNNER_RELEASE_BUNDLE_ID:-}"
 ARCHIVE_BASENAME="agent-device-ios-runner-$VERSION.app.tar.gz"
 CHECKSUM_BASENAME="$ARCHIVE_BASENAME.sha256"
 MANIFEST_BASENAME="agent-device-ios-runner-$VERSION.manifest.json"
@@ -36,19 +36,36 @@ write_github_output() {
   fi
 }
 
-resolve_runner_app_path() {
-  find "$PRODUCTS_DIR" -type d -name '*.app' | sort | while IFS= read -r app_path; do
-    bundle_id="$(read_plist_value "$app_path/Info.plist" CFBundleIdentifier)"
-    if [ "$bundle_id" = "$EXPECTED_RUNNER_BUNDLE_ID" ]; then
-      printf '%s\n' "$app_path"
-      exit 0
-    fi
-  done
+resolve_runner_xctestrun_path() {
+  find "$PRODUCTS_DIR" -maxdepth 1 -name '*iphonesimulator*.xctestrun' | sort | head -n 1
 }
 
-RUNNER_APP_PATH="$(resolve_runner_app_path)"
-if [ -z "$RUNNER_APP_PATH" ]; then
-  echo "Unable to locate simulator runner app with bundle id $EXPECTED_RUNNER_BUNDLE_ID under $PRODUCTS_DIR" >&2
+resolve_xctestrun_runner_app_path() {
+  xctestrun_path="$1"
+  test_host_path="$(
+    read_plist_value "$xctestrun_path" \
+      'TestConfigurations:0:TestTargets:0:TestHostPath'
+  )"
+
+  case "$test_host_path" in
+    __TESTROOT__/*)
+      printf '%s\n' "$PRODUCTS_DIR/${test_host_path#__TESTROOT__/}"
+      ;;
+    *)
+      printf '%s\n' "$test_host_path"
+      ;;
+  esac
+}
+
+RUNNER_XCTESTRUN_PATH="$(resolve_runner_xctestrun_path)"
+if [ -z "$RUNNER_XCTESTRUN_PATH" ]; then
+  echo "Unable to locate iphonesimulator xctestrun under $PRODUCTS_DIR" >&2
+  exit 1
+fi
+
+RUNNER_APP_PATH="$(resolve_xctestrun_runner_app_path "$RUNNER_XCTESTRUN_PATH")"
+if [ ! -d "$RUNNER_APP_PATH" ]; then
+  echo "Unable to locate simulator runner app referenced by $RUNNER_XCTESTRUN_PATH" >&2
   exit 1
 fi
 
@@ -68,6 +85,10 @@ RUNNER_BUNDLE_ID="$(read_plist_value "$RUNNER_APP_PATH/Info.plist" CFBundleIdent
 APP_NAME="$(read_plist_value "$RUNNER_APP_PATH/Info.plist" CFBundleName)"
 if [ -z "$APP_NAME" ]; then
   APP_NAME="$(basename "$RUNNER_APP_PATH" .app)"
+fi
+if [ -n "$EXPECTED_RUNNER_BUNDLE_ID" ] && [ "$RUNNER_BUNDLE_ID" != "$EXPECTED_RUNNER_BUNDLE_ID" ]; then
+  echo "Runner bundle id $RUNNER_BUNDLE_ID did not match expected $EXPECTED_RUNNER_BUNDLE_ID" >&2
+  exit 1
 fi
 
 ditto "$RUNNER_APP_PATH" "$STAGED_APP_PATH"
@@ -106,6 +127,7 @@ fi
 } > "$MANIFEST_PATH"
 
 write_github_output "runner_app_path=$RUNNER_APP_PATH"
+write_github_output "xctestrun_path=$RUNNER_XCTESTRUN_PATH"
 write_github_output "archive_path=$ARCHIVE_PATH"
 write_github_output "checksum_path=$CHECKSUM_PATH"
 write_github_output "manifest_path=$MANIFEST_PATH"


### PR DESCRIPTION
## Summary

Add a release workflow that builds the iOS simulator runner and uploads predictable GitHub Release assets.
Package the built simulator `.xctrunner` app as `agent-device-ios-runner-<version>.app.tar.gz` with a matching SHA256 checksum and machine-readable manifest for cloud bootstrap flows.
Touched files: 2. Scope stayed within release tooling.

## Validation

- `sh -n scripts/package-ios-simulator-runner.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-ios-runner.yml'); puts 'workflow-ok'"`
- `AGENT_DEVICE_XCUITEST_PLATFORM=ios sh ./scripts/build-xcuitest-apple.sh`
- `./scripts/package-ios-simulator-runner.sh 0.12.5 v0.12.5 <tmpdir>`