### PR TITLE
fix: prevent rslib publish chunk collisions

### DIFF
--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -29,27 +29,6 @@ export default defineConfig({
           contracts: 'src/contracts.ts',
           selectors: 'src/selectors.ts',
           finders: 'src/finders.ts',
-        },
-        tsconfigPath: 'tsconfig.lib.json',
-      },
-      output: {
-        distPath: {
-          root: path.join('dist', 'src'),
-        },
-        minify: true,
-      },
-    },
-    {
-      format: 'esm',
-      syntax: 'esnext',
-      dts: false,
-      shims: {
-        esm: {
-          __filename: true,
-        },
-      },
-      source: {
-        entry: {
           bin: 'src/bin.ts',
           'metro-companion': 'src/metro-companion.ts',
           daemon: 'src/daemon.ts',


### PR DESCRIPTION
## Summary

Collapse the two Rslib ESM builds into a single build so published artifacts share one chunk namespace.

This fixes the `agent-device@0.12.7` global install/runtime failure caused by both Rslib compilations emitting numeric chunks such as `dist/src/818.js` into the same directory. Touched files: 1. Scope stayed within build tooling.

## Validation

- `pnpm check:tooling`
- `pnpm exec oxfmt --check rslib.config.ts`
- `node bin/agent-device.mjs --help`
- `node dist/src/bin.js --version`
- `node --input-type=module -e "await import('./dist/src/index.js'); await import('./dist/src/commands/index.js'); await import('./dist/src/metro.js'); console.log('imports ok')"`
- `npm pack --ignore-scripts` and installed the tarball into a temporary prefix, then ran installed `agent-device --help`

Known gap: the already-published `0.12.7` tarball is immutable; this fix needs a new patch release.