### PR TITLE
chore: add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "description": "Unified control plane for physical and virtual devices via an agent-driven CLI.",
   "license": "MIT",
   "author": "Callstack",
+  "homepage": "https://agent-device.dev/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/callstackincubator/agent-device.git"
+  },
+  "bugs": {
+    "url": "https://github.com/callstackincubator/agent-device/issues"
+  },
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

Add npm package metadata for the project homepage, canonical GitHub repository, and issue tracker.

Touched files: 1 (`package.json`). Scope stayed within package metadata.

## Validation

- `pnpm check:tooling`
