### PR TITLE
fix: add screenshot max-size flag

### DIFF
--- a/skills/agent-device/references/verification.md
+++ b/skills/agent-device/references/verification.md
@@ -46,7 +46,10 @@ agent-device diff snapshot -i
 
 Use `screenshot` when the proof needs a rendered image instead of a structural tree.
 
+- Add `--max-size 1024` when a full-resolution screenshot is too large for an agent, model, or chat attachment.
 - Add `--overlay-refs` when you want the saved PNG to show fresh `@eN` refs burned into the screenshot.
+- Combine them as `screenshot /tmp/proof.png --max-size 1024 --overlay-refs` when you need a smaller visual proof that still includes tappable refs.
+- Avoid very small `--max-size` values when text, icons, or labels need to remain readable.
 
 ## Visual regression with diff screenshot
 

--- a/src/__tests__/cli-client-commands.test.ts
+++ b/src/__tests__/cli-client-commands.test.ts
@@ -200,6 +200,7 @@ test('screenshot forwards --overlay-refs to the client capture API', async () =>
     | {
         path?: string;
         overlayRefs?: boolean;
+        maxSize?: number;
       }
     | undefined;
   const client = createStubClient({
@@ -223,6 +224,7 @@ test('screenshot forwards --overlay-refs to the client capture API', async () =>
       help: false,
       version: false,
       overlayRefs: true,
+      screenshotMaxSize: 1024,
     },
     client,
   });
@@ -231,6 +233,7 @@ test('screenshot forwards --overlay-refs to the client capture API', async () =>
   assert.deepEqual(observed, {
     path: '/tmp/screenshot.png',
     overlayRefs: true,
+    maxSize: 1024,
   });
 });
 

--- a/src/__tests__/runtime-public.test.ts
+++ b/src/__tests__/runtime-public.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { PNG } from 'pngjs';
 import { test } from 'vitest';
 import {
   createAgentDevice,
@@ -165,6 +166,35 @@ test('runtime screenshot command reserves output and calls backend primitive', a
   assert.deepEqual(result, {
     path: '/tmp/screen.png',
     message: 'Saved screenshot: /tmp/screen.png',
+  });
+});
+
+test('runtime screenshot command downscales screenshots to max size', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runtime-screenshot-resize-'));
+  const outPath = path.join(root, 'screen.png');
+  const device = createAgentDevice({
+    backend: {
+      ...backend,
+      captureScreenshot: async (_context, targetPath) => {
+        fs.writeFileSync(targetPath, PNG.sync.write(new PNG({ width: 20, height: 10 })));
+      },
+    },
+    artifacts,
+    sessions,
+    policy: localCommandPolicy(),
+  });
+
+  const result = await device.capture.screenshot({
+    out: { kind: 'path', path: outPath },
+    maxSize: 8,
+  });
+
+  const resized = PNG.sync.read(fs.readFileSync(outPath));
+  assert.equal(resized.width, 8);
+  assert.equal(resized.height, 4);
+  assert.deepEqual(result, {
+    path: outPath,
+    message: `Saved screenshot: ${outPath}`,
   });
 });
 

--- a/src/cli/commands/screenshot.ts
+++ b/src/cli/commands/screenshot.ts
@@ -13,6 +13,7 @@ export const screenshotCommand: ClientCommandHandler = async ({ positionals, fla
   const result = await client.capture.screenshot({
     path: positionals[0] ?? flags.out,
     overlayRefs: flags.overlayRefs,
+    maxSize: flags.screenshotMaxSize,
     ...(flags.screenshotFullscreen !== undefined ? { fullscreen: flags.screenshotFullscreen } : {}),
   });
   const data = {

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -269,6 +269,7 @@ export function buildFlags(options: InternalRequestOptions): CommandFlags {
     snapshotScope: options.scope,
     snapshotRaw: options.raw,
     screenshotFullscreen: options.screenshotFullscreen,
+    screenshotMaxSize: options.screenshotMaxSize,
     overlayRefs: options.overlayRefs,
     appsFilter: options.appsFilter,
     out: options.out,

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -311,6 +311,7 @@ export type CaptureScreenshotOptions = AgentDeviceRequestOverrides & {
   path?: string;
   overlayRefs?: boolean;
   fullscreen?: boolean;
+  maxSize?: number;
   surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
 };
 
@@ -716,6 +717,7 @@ type CommandExecutionOptions = {
   scope?: string;
   raw?: boolean;
   screenshotFullscreen?: boolean;
+  screenshotMaxSize?: number;
   count?: number;
   fps?: number;
   quality?: RecordingQuality;

--- a/src/client.ts
+++ b/src/client.ts
@@ -309,6 +309,7 @@ export function createAgentDeviceClient(
         const data = await execute(CLIENT_COMMANDS.screenshot, options.path ? [options.path] : [], {
           ...options,
           screenshotFullscreen: options.fullscreen,
+          screenshotMaxSize: options.maxSize,
         });
         return {
           path: readRequiredString(data, 'path'),

--- a/src/commands/capture-screenshot.ts
+++ b/src/commands/capture-screenshot.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
+import { resizePngFileToMaxSize } from '../utils/png.ts';
 import type { ArtifactDescriptor } from '../io.ts';
 import type { RuntimeCommand, ScreenshotCommandOptions } from './runtime-types.ts';
 import { reserveCommandOutput } from './io-policy.ts';
@@ -41,6 +42,9 @@ export const screenshotCommand: RuntimeCommand<
         surface: options.surface,
       },
     );
+    if (options.maxSize !== undefined) {
+      await resizePngFileToMaxSize(reserved.path, options.maxSize);
+    }
     artifact = await reserved.publish();
   } catch (error) {
     await reserved.cleanup?.();

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -16,6 +16,7 @@ export type ScreenshotCommandOptions = CommandContext & {
   out?: FileOutputRef;
   fullscreen?: boolean;
   overlayRefs?: boolean;
+  maxSize?: number;
   appId?: string;
   appBundleId?: string;
   surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';

--- a/src/daemon/__tests__/context.test.ts
+++ b/src/daemon/__tests__/context.test.ts
@@ -15,7 +15,8 @@ test('contextFromFlags forwards scroll pixels from CLI flags', () => {
 });
 
 test('contextFromFlags forwards screenshot fullscreen from CLI flags', () => {
-  const flags: CommandFlags = { screenshotFullscreen: true };
+  const flags: CommandFlags = { screenshotFullscreen: true, screenshotMaxSize: 1024 };
   const context = contextFromFlags('/tmp/agent-device.log', flags);
   assert.equal(context.screenshotFullscreen, true);
+  assert.equal(context.screenshotMaxSize, 1024);
 });

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -178,7 +178,7 @@ test('writeSessionLog persists record --hide-touches flags in script output', ()
   assert.match(script, /record start "\.\/capture\.mp4" --fps 30 --quality 8 --hide-touches/);
 });
 
-test('writeSessionLog persists screenshot --fullscreen in script output', () => {
+test('writeSessionLog persists screenshot flags in script output', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-screenshot-'));
   const store = new SessionStore(root);
   const session = makeSession('default');
@@ -191,7 +191,7 @@ test('writeSessionLog persists screenshot --fullscreen in script output', () => 
   store.recordAction(session, {
     command: 'screenshot',
     positionals: ['./page.png'],
-    flags: { platform: 'ios', screenshotFullscreen: true },
+    flags: { platform: 'ios', screenshotFullscreen: true, screenshotMaxSize: 1024 },
     result: {},
   });
 
@@ -199,7 +199,7 @@ test('writeSessionLog persists screenshot --fullscreen in script output', () => 
   const scriptFile = fs.readdirSync(root).find((file) => file.endsWith('.ad'));
   assert.ok(scriptFile);
   const script = fs.readFileSync(path.join(root, scriptFile!), 'utf8');
-  assert.match(script, /screenshot "\.\/page\.png" --fullscreen/);
+  assert.match(script, /screenshot "\.\/page\.png" --fullscreen --max-size 1024/);
 });
 
 test('writeSessionLog persists inline open runtime hints in script output', () => {

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -16,6 +16,7 @@ export type DaemonCommandContext = {
   snapshotScope?: string;
   snapshotRaw?: boolean;
   screenshotFullscreen?: boolean;
+  screenshotMaxSize?: number;
   count?: number;
   intervalMs?: number;
   delayMs?: number;
@@ -51,6 +52,7 @@ export function contextFromFlags(
     snapshotScope: flags?.snapshotScope,
     snapshotRaw: flags?.snapshotRaw,
     screenshotFullscreen: flags?.screenshotFullscreen,
+    screenshotMaxSize: flags?.screenshotMaxSize,
     count: flags?.count,
     intervalMs: flags?.intervalMs,
     delayMs: flags?.delayMs,

--- a/src/daemon/handlers/__tests__/session-replay-script.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-script.test.ts
@@ -76,7 +76,7 @@ test('record replay script round-trips fps, quality, and hide-touches flags', ()
   assert.equal(parsed[0]?.flags.hideTouches, true);
 });
 
-test('screenshot replay script round-trips fullscreen flag', () => {
+test('screenshot replay script round-trips screenshot flags', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-script-screenshot-'));
   const replayPath = path.join(root, 'flow.ad');
   const actions: SessionAction[] = [
@@ -84,17 +84,18 @@ test('screenshot replay script round-trips fullscreen flag', () => {
       ts: Date.now(),
       command: 'screenshot',
       positionals: ['./page.png'],
-      flags: { screenshotFullscreen: true },
+      flags: { screenshotFullscreen: true, screenshotMaxSize: 1024 },
     },
   ];
 
   writeReplayScript(replayPath, actions, makeSession());
   const script = fs.readFileSync(replayPath, 'utf8');
-  assert.match(script, /screenshot "\.\/page\.png" --fullscreen/);
+  assert.match(script, /screenshot "\.\/page\.png" --fullscreen --max-size 1024/);
 
   const parsed = parseReplayScript(script);
   assert.deepEqual(parsed[0]?.positionals, ['./page.png']);
   assert.equal(parsed[0]?.flags.screenshotFullscreen, true);
+  assert.equal(parsed[0]?.flags.screenshotMaxSize, 1024);
 });
 
 test('type and fill replay scripts round-trip typing delay flags', () => {

--- a/src/daemon/handlers/session-replay-script.ts
+++ b/src/daemon/handlers/session-replay-script.ts
@@ -259,9 +259,20 @@ function parseReplayScriptLine(line: string): SessionAction | null {
 
   if (command === 'screenshot') {
     const positionals: string[] = [];
-    for (const token of args) {
+    for (let index = 0; index < args.length; index += 1) {
+      const token = args[index];
       if (token === '--fullscreen') {
         action.flags.screenshotFullscreen = true;
+        continue;
+      }
+      if (token === '--max-size') {
+        const value = args[index + 1];
+        const maxSize = value === undefined ? NaN : Number(value);
+        if (!Number.isInteger(maxSize) || maxSize < 1) {
+          throw new AppError('INVALID_ARGS', 'screenshot --max-size requires a positive integer');
+        }
+        action.flags.screenshotMaxSize = maxSize;
+        index += 1;
         continue;
       }
       positionals.push(token);
@@ -373,6 +384,9 @@ function formatReplayActionLine(action: SessionAction): string {
       parts.push(formatScriptArg(positional));
     }
     if (action.flags?.screenshotFullscreen) parts.push('--fullscreen');
+    if (typeof action.flags?.screenshotMaxSize === 'number') {
+      parts.push('--max-size', String(action.flags.screenshotMaxSize));
+    }
     return parts.join(' ');
   }
   for (const positional of action.positionals ?? []) {

--- a/src/daemon/screenshot-runtime.ts
+++ b/src/daemon/screenshot-runtime.ts
@@ -41,6 +41,7 @@ export async function dispatchScreenshotViaRuntime(params: {
     requestId: dispatchContext.requestId,
     appBundleId: session.appBundleId,
     fullscreen: dispatchContext.screenshotFullscreen,
+    maxSize: dispatchContext.screenshotMaxSize,
     surface: session.surface,
     ...(outPath ? { out: { kind: 'path', path: outPath } } : {}),
   });

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -231,6 +231,7 @@ const SANITIZED_FLAG_KEYS = [
   'snapshotScope',
   'snapshotRaw',
   'screenshotFullscreen',
+  'screenshotMaxSize',
   'relaunch',
   'saveScript',
   'noRecord',
@@ -343,6 +344,9 @@ function formatActionLine(action: SessionAction): string {
       parts.push(formatScriptArg(positional));
     }
     if (action.flags?.screenshotFullscreen) parts.push('--fullscreen');
+    if (typeof action.flags?.screenshotMaxSize === 'number') {
+      parts.push('--max-size', String(action.flags.screenshotMaxSize));
+    }
     return parts.join(' ');
   }
   if (action.command === 'open') {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -560,10 +560,13 @@ test('parseArgs recognizes record --hide-touches flag', () => {
 });
 
 test('parseArgs recognizes screenshot --fullscreen flag', () => {
-  const parsed = parseArgs(['screenshot', 'page.png', '--fullscreen'], { strictFlags: true });
+  const parsed = parseArgs(['screenshot', 'page.png', '--fullscreen', '--max-size', '1024'], {
+    strictFlags: true,
+  });
   assert.equal(parsed.command, 'screenshot');
   assert.deepEqual(parsed.positionals, ['page.png']);
   assert.equal(parsed.flags.screenshotFullscreen, true);
+  assert.equal(parsed.flags.screenshotMaxSize, 1024);
 });
 
 test('parseArgs rejects invalid record --fps range', () => {

--- a/src/utils/__tests__/png.test.ts
+++ b/src/utils/__tests__/png.test.ts
@@ -1,0 +1,97 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PNG } from 'pngjs';
+import { resizePngFileToMaxSize } from '../png.ts';
+
+test('resizePngFileToMaxSize downscales with area weighting', async () => {
+  const filePath = tmpPngPath('resize');
+  const png = new PNG({ width: 4, height: 2 });
+  setPngPixel(png, 0, 0, 0, 20, 30);
+  setPngPixel(png, 1, 0, 100, 20, 30);
+  setPngPixel(png, 0, 1, 100, 20, 30);
+  setPngPixel(png, 1, 1, 200, 20, 30);
+  setPngPixel(png, 2, 0, 20, 80, 140);
+  setPngPixel(png, 3, 0, 20, 80, 140);
+  setPngPixel(png, 2, 1, 20, 80, 140);
+  setPngPixel(png, 3, 1, 20, 80, 140);
+  writePng(filePath, png);
+
+  await resizePngFileToMaxSize(filePath, 2);
+
+  const resized = PNG.sync.read(fs.readFileSync(filePath));
+  assert.equal(resized.width, 2);
+  assert.equal(resized.height, 1);
+  assert.deepEqual(readPngPixel(resized, 0, 0), [100, 20, 30, 255]);
+  assert.deepEqual(readPngPixel(resized, 1, 0), [20, 80, 140, 255]);
+});
+
+test('resizePngFileToMaxSize leaves smaller images unchanged', async () => {
+  const filePath = tmpPngPath('unchanged');
+  const png = new PNG({ width: 4, height: 2 });
+  setPngPixel(png, 3, 1, 45, 90, 135);
+  writePng(filePath, png);
+
+  await resizePngFileToMaxSize(filePath, 8);
+
+  const unchanged = PNG.sync.read(fs.readFileSync(filePath));
+  assert.equal(unchanged.width, 4);
+  assert.equal(unchanged.height, 2);
+  assert.deepEqual(readPngPixel(unchanged, 3, 1), [45, 90, 135, 255]);
+});
+
+test('resizePngFileToMaxSize preserves source edges when downscaling', async () => {
+  const filePath = tmpPngPath('edges');
+  const png = new PNG({ width: 3, height: 1 });
+  setPngPixel(png, 0, 0, 0, 0, 0);
+  setPngPixel(png, 1, 0, 100, 0, 0);
+  setPngPixel(png, 2, 0, 250, 0, 0);
+  writePng(filePath, png);
+
+  await resizePngFileToMaxSize(filePath, 2);
+
+  const resized = PNG.sync.read(fs.readFileSync(filePath));
+  assert.equal(resized.width, 2);
+  assert.equal(resized.height, 1);
+  assert.deepEqual(readPngPixel(resized, 0, 0), [33, 0, 0, 255]);
+  assert.deepEqual(readPngPixel(resized, 1, 0), [200, 0, 0, 255]);
+});
+
+function tmpPngPath(prefix: string): string {
+  return path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), `agent-device-png-${prefix}-`)),
+    'image.png',
+  );
+}
+
+function writePng(filePath: string, png: PNG): void {
+  fs.writeFileSync(filePath, PNG.sync.write(png));
+}
+
+function setPngPixel(
+  png: PNG,
+  x: number,
+  y: number,
+  red: number,
+  green: number,
+  blue: number,
+  alpha = 255,
+): void {
+  const offset = (y * png.width + x) * 4;
+  png.data[offset] = red;
+  png.data[offset + 1] = green;
+  png.data[offset + 2] = blue;
+  png.data[offset + 3] = alpha;
+}
+
+function readPngPixel(png: PNG, x: number, y: number): number[] {
+  const offset = (y * png.width + x) * 4;
+  return [
+    png.data[offset] ?? 0,
+    png.data[offset + 1] ?? 0,
+    png.data[offset + 2] ?? 0,
+    png.data[offset + 3] ?? 0,
+  ];
+}

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -58,6 +58,7 @@ export type CliFlags = {
   networkInclude?: 'summary' | 'headers' | 'body' | 'all';
   overlayRefs?: boolean;
   screenshotFullscreen?: boolean;
+  screenshotMaxSize?: number;
   baseline?: string;
   threshold?: string;
   appsFilter?: 'user-installed' | 'all';
@@ -924,6 +925,14 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription: 'Screenshot: capture the full screen instead of the app window',
   },
   {
+    key: 'screenshotMaxSize',
+    names: ['--max-size'],
+    type: 'int',
+    min: 1,
+    usageLabel: '--max-size <px>',
+    usageDescription: 'Screenshot: downscale so the longest edge is at most <px>',
+  },
+  {
     key: 'baseline',
     names: ['--baseline', '-b'],
     type: 'string',
@@ -1297,9 +1306,9 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
   },
   screenshot: {
     helpDescription:
-      'Capture screenshot (macOS app sessions default to the app window; use --fullscreen for full desktop, or --overlay-refs to annotate the image with current refs)',
+      'Capture screenshot (macOS app sessions default to the app window; use --fullscreen for full desktop, --max-size to downscale, or --overlay-refs to annotate the image with current refs)',
     positionalArgs: ['path?'],
-    allowedFlags: ['out', 'overlayRefs', 'screenshotFullscreen'],
+    allowedFlags: ['out', 'overlayRefs', 'screenshotFullscreen', 'screenshotMaxSize'],
   },
   'trigger-app-event': {
     usageOverride: 'trigger-app-event <event> [payloadJson]',

--- a/src/utils/png.ts
+++ b/src/utils/png.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'node:fs';
 import { PNG } from 'pngjs';
 import { AppError } from './errors.ts';
 
@@ -10,4 +11,63 @@ export function decodePng(buffer: Buffer, label: string): PNG {
       reason: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+export async function resizePngFileToMaxSize(filePath: string, maxSize: number): Promise<void> {
+  if (!Number.isInteger(maxSize) || maxSize < 1) {
+    throw new AppError('INVALID_ARGS', 'Screenshot max size must be a positive integer');
+  }
+
+  const source = decodePng(await fs.readFile(filePath), 'screenshot');
+  const longestEdge = Math.max(source.width, source.height);
+
+  if (longestEdge <= maxSize) {
+    return;
+  }
+
+  const scale = maxSize / longestEdge;
+  const width = Math.max(1, Math.round(source.width * scale));
+  const height = Math.max(1, Math.round(source.height * scale));
+  const resized = resizePngBox(source, width, height);
+
+  await fs.writeFile(filePath, PNG.sync.write(resized));
+}
+
+function resizePngBox(source: PNG, width: number, height: number): PNG {
+  const output = new PNG({ width, height });
+  for (let y = 0; y < height; y += 1) {
+    const sourceTop = (y * source.height) / height;
+    const sourceBottom = ((y + 1) * source.height) / height;
+    for (let x = 0; x < width; x += 1) {
+      const sourceLeft = (x * source.width) / width;
+      const sourceRight = ((x + 1) * source.width) / width;
+
+      let red = 0;
+      let green = 0;
+      let blue = 0;
+      let alpha = 0;
+      let weight = 0;
+
+      for (let sourceY = Math.floor(sourceTop); sourceY < Math.ceil(sourceBottom); sourceY += 1) {
+        const yWeight = Math.min(sourceY + 1, sourceBottom) - Math.max(sourceY, sourceTop);
+        for (let sourceX = Math.floor(sourceLeft); sourceX < Math.ceil(sourceRight); sourceX += 1) {
+          const pixelWeight =
+            yWeight * (Math.min(sourceX + 1, sourceRight) - Math.max(sourceX, sourceLeft));
+          const sourceOffset = (sourceY * source.width + sourceX) * 4;
+          red += (source.data[sourceOffset] ?? 0) * pixelWeight;
+          green += (source.data[sourceOffset + 1] ?? 0) * pixelWeight;
+          blue += (source.data[sourceOffset + 2] ?? 0) * pixelWeight;
+          alpha += (source.data[sourceOffset + 3] ?? 0) * pixelWeight;
+          weight += pixelWeight;
+        }
+      }
+
+      const outputOffset = (y * output.width + x) * 4;
+      output.data[outputOffset] = Math.round(red / weight);
+      output.data[outputOffset + 1] = Math.round(green / weight);
+      output.data[outputOffset + 2] = Math.round(blue / weight);
+      output.data[outputOffset + 3] = Math.round(alpha / weight);
+    }
+  }
+  return output;
 }

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -119,6 +119,7 @@ const device = createAgentDevice({
 await device.capture.screenshot({
   session: 'default',
   out: { kind: 'path', path: './screen.png' },
+  maxSize: 1024,
 });
 
 await device.selectors.waitForText('Ready', { session: 'default', timeoutMs: 5_000 });

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -542,6 +542,7 @@ agent-device metrics --json
 ```bash
 agent-device screenshot                 # Auto filename
 agent-device screenshot page.png        # Explicit screenshot path
+agent-device screenshot page.png --max-size 1024  # Downscale longest edge for agent-friendly artifacts
 agent-device screenshot page.png --overlay-refs  # Draw current @eN refs and target rectangles onto the PNG
 agent-device screenshot textedit.png    # App-session window capture on macOS
 agent-device screenshot --fullscreen    # Force full-screen capture on macOS app sessions
@@ -557,7 +558,9 @@ agent-device record stop                # Stop active recording
 ```
 
 - Recordings always produce a video artifact. When touch visualization is enabled, they also produce a gesture telemetry sidecar that can be used for post-processing or inspection.
+- `screenshot --max-size <px>` preserves aspect ratio and only downscales when the saved PNG's longest edge is larger than the requested size.
 - `screenshot --overlay-refs` captures a fresh full snapshot and burns visible `@eN` refs plus their target rectangles into the saved PNG.
+- `screenshot --max-size <px> --overlay-refs` writes a smaller image and draws refs for that final image size; avoid very small max sizes when text, icons, or labels need to remain readable.
 - `diff screenshot` compares the current live screenshot to `--baseline`, or compares `--baseline` to an optional saved `current.png` path without requiring an active session, then prints ranked changed regions with screen-space rectangles, shape, size, density, average color, and luminance, and writes a diff PNG with a light grayscale current-screen context, red-tinted changed pixels, and outlined changed regions when `--out` is provided. JSON also includes normalized bounds.
 - If `tesseract` is installed, `diff screenshot` also adds best-effort OCR text deltas, movement clusters, and bbox size-change hints to the text and JSON output. OCR improves descriptions only; it does not change the pixel comparison or the diff PNG.
 - When OCR is available, `diff screenshot` also reports best-effort non-text visual deltas by masking OCR text boxes out of the diff and clustering remaining residuals. These are hints for icons, controls, and separators, not semantic icon recognition.


### PR DESCRIPTION
## Summary

Add `screenshot --max-size <px>` / `maxSize` support to downscale saved PNG screenshots by longest edge without new dependencies.

The resize runs in the runtime screenshot path before artifact publishing, preserves aspect ratio, only downscales, and round-trips through CLI/client/daemon replay scripts. Docs and the agent-device verification skill now mention the agent-friendly screenshot size option.

Closes #426 

## Validation

- `pnpm format`
- `pnpm test:unit -- src/__tests__/runtime-public.test.ts src/__tests__/cli-client-commands.test.ts src/utils/__tests__/args.test.ts src/daemon/__tests__/context.test.ts src/daemon/handlers/__tests__/session-replay-script.test.ts src/daemon/__tests__/session-store.test.ts`
- `pnpm check:quick`
- `pnpm check:unit`