### PR TITLE
fix: improve android snapshot freshness

### DIFF
--- a/skills/agent-device/references/debugging.md
+++ b/skills/agent-device/references/debugging.md
@@ -111,7 +111,7 @@ agent-device alert accept
 - `snapshot` returns 0 nodes: the app may no longer be foregrounded or the UI is not stable yet. Re-open the app or retry when state settles.
 - Logs are empty: confirm you opened an app session before `logs clear --restart`.
 - Android logs look stale after relaunch: retry the repro window after the process rebinds.
-- Android accessibility snapshots can lag behind visible screen transitions. The next snapshot now retries briefly after navigation-sensitive actions, but if the tree still looks stale, use `screenshot` as visual truth, wait briefly, then re-run `snapshot -i`.
+- Android accessibility snapshots can lag behind visible screen transitions. The next snapshot retries suspicious trees for a short post-action deadline after navigation-sensitive actions, and `@ref` actions refresh while that window is active. If the tree still looks stale, use `screenshot` as visual truth, wait briefly, then re-run `snapshot -i`. For animation-heavy runs, try `settings animations off` and restore with `settings animations on`.
 - React Native dev warnings or errors keep reappearing: treat them as part of the app state, not as disposable chrome. Capture one clean repro and include them in the summary.
 - Permission prompts block the flow: wait for the alert and handle it explicitly.
 - If snapshots keep returning 0 nodes on an iOS simulator, restart Simulator and re-open the app.

--- a/skills/agent-device/references/exploration.md
+++ b/skills/agent-device/references/exploration.md
@@ -49,8 +49,9 @@ Open this file when the app or screen is already running and you need to discove
 **Android AX tree lag.** After submits, route changes, or composer transitions, the accessibility tree can lag behind the visible UI. If `snapshot -i` and `screenshot` disagree:
 
 1. Trust the screenshot as visual truth.
-2. Take one fresh `snapshot -i`. Android retries briefly after navigation-sensitive actions.
+2. Take one fresh `snapshot -i`. Android retries suspicious trees for a short post-action deadline after navigation-sensitive actions.
 3. If the tree still disagrees with the screenshot, wait briefly, then take one more fresh snapshot. Do not loop snapshots immediately.
+4. For animation-heavy Android runs, use `settings animations off` as an opt-in stabilizer and restore with `settings animations on` after the run.
 
 **React Native dev overlays.** In dev or debug builds, warning or error overlays can block taps, change focus, or hide the real UI. Check for them near app open and after major transitions.
 
@@ -222,7 +223,7 @@ Preferred mapping:
 Notes:
 
 - `wait text` is useful for synchronizing on text presence, but it is not the same as `is visible`.
-- After a nearby navigation or submit on Android, prefer `screenshot`, then `wait 500` or `wait 1000`, then one fresh `snapshot -i` if the accessibility tree seems stale.
+- After a nearby navigation or submit on Android, prefer `screenshot`, then one fresh `snapshot -i`; `@ref` interactions refresh while the Android freshness window is active.
 
 Anti-hallucination rules:
 

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -461,7 +461,10 @@ function readSettingsOptions(positionals: string[], flags: CliFlags): SettingsUp
   const setting = positionals[0];
   const state = positionals[1];
   if (
-    (setting === 'wifi' || setting === 'airplane' || setting === 'location') &&
+    (setting === 'wifi' ||
+      setting === 'airplane' ||
+      setting === 'location' ||
+      setting === 'animations') &&
     (state === 'on' || state === 'off')
   ) {
     return { ...base, setting, state };

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -690,6 +690,10 @@ export type SettingsUpdateOptions =
       state: 'on' | 'off';
     })
   | (ClientCommandBaseOptions & {
+      setting: 'animations';
+      state: 'on' | 'off';
+    })
+  | (ClientCommandBaseOptions & {
       setting: 'appearance';
       state: 'light' | 'dark' | 'toggle';
     })

--- a/src/core/settings-contract.ts
+++ b/src/core/settings-contract.ts
@@ -1,4 +1,5 @@
 export const SETTINGS_WIFI_USAGE = '<wifi|airplane|location> <on|off>';
+export const SETTINGS_ANIMATIONS_USAGE = 'animations <on|off>';
 export const SETTINGS_APPEARANCE_USAGE = 'appearance <light|dark|toggle>';
 export const SETTINGS_FACEID_USAGE = 'faceid <match|nonmatch|enroll|unenroll>';
 export const SETTINGS_TOUCHID_USAGE = 'touchid <match|nonmatch|enroll|unenroll>';
@@ -7,10 +8,11 @@ export const SETTINGS_PERMISSION_USAGE =
   'permission <grant|deny|reset> <camera|microphone|photos|contacts|contacts-limited|notifications|calendar|location|location-always|media-library|motion|reminders|siri> [full|limited]';
 export const SETTINGS_MACOS_PERMISSION_USAGE =
   'permission <grant|reset> <accessibility|screen-recording|input-monitoring>';
-export const SETTINGS_MACOS_SUPPORTED_MESSAGE = `macOS supports only settings ${SETTINGS_APPEARANCE_USAGE} and settings ${SETTINGS_MACOS_PERMISSION_USAGE}. wifi|airplane|location remain unsupported on macOS.`;
+export const SETTINGS_MACOS_SUPPORTED_MESSAGE = `macOS supports only settings ${SETTINGS_APPEARANCE_USAGE} and settings ${SETTINGS_MACOS_PERMISSION_USAGE}. wifi|airplane|location|animations remain unsupported on macOS.`;
 
 export const SETTINGS_USAGE_OVERRIDE = [
   `settings ${SETTINGS_WIFI_USAGE}`,
+  `settings ${SETTINGS_ANIMATIONS_USAGE}`,
   `settings ${SETTINGS_APPEARANCE_USAGE}`,
   `settings ${SETTINGS_FACEID_USAGE}`,
   `settings ${SETTINGS_TOUCHID_USAGE}`,
@@ -19,7 +21,7 @@ export const SETTINGS_USAGE_OVERRIDE = [
   `settings ${SETTINGS_MACOS_PERMISSION_USAGE}`,
 ].join(' | ');
 
-export const SETTINGS_INVALID_ARGS_MESSAGE = `settings requires ${SETTINGS_WIFI_USAGE}, ${SETTINGS_APPEARANCE_USAGE}, ${SETTINGS_FACEID_USAGE}, ${SETTINGS_TOUCHID_USAGE}, ${SETTINGS_FINGERPRINT_USAGE}, ${SETTINGS_PERMISSION_USAGE}, or ${SETTINGS_MACOS_PERMISSION_USAGE}`;
+export const SETTINGS_INVALID_ARGS_MESSAGE = `settings requires ${SETTINGS_WIFI_USAGE}, ${SETTINGS_ANIMATIONS_USAGE}, ${SETTINGS_APPEARANCE_USAGE}, ${SETTINGS_FACEID_USAGE}, ${SETTINGS_TOUCHID_USAGE}, ${SETTINGS_FINGERPRINT_USAGE}, ${SETTINGS_PERMISSION_USAGE}, or ${SETTINGS_MACOS_PERMISSION_USAGE}`;
 
 export function isMacOsSettingSupported(setting: string): boolean {
   const normalized = setting.trim().toLowerCase();

--- a/src/daemon/android-snapshot-freshness.ts
+++ b/src/daemon/android-snapshot-freshness.ts
@@ -9,10 +9,11 @@ export type { AndroidSnapshotFreshness } from './types.ts';
 // while avoiding unnecessary retries for steady-state interactions like typing.
 const ANDROID_FRESHNESS_WINDOW_MS = 2_500;
 
-// Progressive back-off delays between freshness retry attempts.  Two retries at
-// 250 ms + 400 ms cover the vast majority of Android transition latencies without
-// adding perceptible lag to the happy path.
-export const ANDROID_FRESHNESS_RETRY_DELAYS_MS = [250, 400] as const;
+// Retry suspicious snapshots until this post-action deadline expires.  The delay
+// sequence stays short in the happy path, while allowing one more capture for
+// slower Android route transitions.
+export const ANDROID_FRESHNESS_RETRY_DEADLINE_MS = 1_500;
+export const ANDROID_FRESHNESS_RETRY_DELAYS_MS = [250, 400, 600] as const;
 
 export type AndroidFreshnessCaptureMeta = {
   action: string;

--- a/src/daemon/android-snapshot-freshness.ts
+++ b/src/daemon/android-snapshot-freshness.ts
@@ -10,8 +10,8 @@ export type { AndroidSnapshotFreshness } from './types.ts';
 const ANDROID_FRESHNESS_WINDOW_MS = 2_500;
 
 // Retry suspicious snapshots until this post-action deadline expires.  The delay
-// sequence stays short in the happy path, while allowing one more capture for
-// slower Android route transitions.
+// sequence stays short in the happy path; the 600 ms tail retry is opportunistic
+// and may be skipped when slower devices spend the budget inside each capture.
 export const ANDROID_FRESHNESS_RETRY_DEADLINE_MS = 1_500;
 export const ANDROID_FRESHNESS_RETRY_DELAYS_MS = [250, 400, 600] as const;
 

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -847,6 +847,70 @@ test('press @ref refreshes stale stored refs and syncs the daemon session snapsh
   });
 });
 
+test('press @ref refreshes Android snapshot when freshness tracking is active', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-fresh-ref-refresh';
+  const session = makeAndroidSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'android.widget.Button',
+        label: 'Continue',
+        rect: { x: 0, y: 0, width: 40, height: 40 },
+        enabled: true,
+        hittable: true,
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'android',
+    comparisonSafe: true,
+  };
+  session.androidSnapshotFreshness = {
+    action: 'press',
+    markedAt: Date.now(),
+    baselineCount: 1,
+    routeComparable: false,
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockImplementation(async (_device, command, args) => {
+    if (command === 'snapshot') {
+      return {
+        nodes: [
+          {
+            index: 0,
+            type: 'android.widget.Button',
+            label: 'Continue',
+            rect: { x: 100, y: 200, width: 80, height: 40 },
+            enabled: true,
+            hittable: true,
+          },
+        ],
+        backend: 'android',
+      };
+    }
+    return { pressed: true, args };
+  });
+
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'press',
+      positionals: ['@e1', 'Continue'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['snapshot', 'press']);
+  expect(mockDispatch.mock.calls[1]?.[2]).toEqual(['140', '220']);
+});
+
 test('press @ref fails when Android tap escapes to launcher', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'android-escape';

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -913,6 +913,65 @@ test('press @ref refreshes Android snapshot when freshness tracking is active', 
   });
   expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['snapshot', 'press']);
   expect(mockDispatch.mock.calls[1]?.[2]).toEqual(['140', '220']);
+  expect(sessionStore.get(sessionName)?.androidSnapshotFreshness).toMatchObject({
+    action: 'press',
+    baselineCount: 1,
+    routeComparable: true,
+  });
+});
+
+test('press @ref falls back to cached Android ref when freshness refresh fails', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-fresh-ref-refresh-failure';
+  const session = makeAndroidSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'android.widget.Button',
+        label: 'Continue',
+        rect: { x: 10, y: 20, width: 100, height: 40 },
+        enabled: true,
+        hittable: true,
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'android',
+    comparisonSafe: true,
+  };
+  session.androidSnapshotFreshness = {
+    action: 'press',
+    markedAt: Date.now(),
+    baselineCount: 1,
+    routeComparable: true,
+  };
+  sessionStore.set(sessionName, session);
+
+  mockCaptureSnapshotForSession.mockRejectedValueOnce(new Error('uiautomator timeout'));
+  mockDispatch.mockResolvedValue({ pressed: true });
+
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'press',
+      positionals: ['@e1', 'Continue'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(mockCaptureSnapshotForSession).toHaveBeenCalledTimes(1);
+  expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['press']);
+  expect(mockDispatch.mock.calls[0]?.[2]).toEqual(['60', '40']);
+  expect(sessionStore.get(sessionName)?.androidSnapshotFreshness).toMatchObject({
+    action: 'press',
+    baselineCount: 1,
+    routeComparable: true,
+  });
 });
 
 test('press @ref fails when Android tap escapes to launcher', async () => {

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -58,7 +58,7 @@ async function emulateCaptureSnapshotForSession(
     appBundleId?: string,
     traceLogPath?: string,
   ) => Record<string, unknown>,
-  options: { interactiveOnly: boolean },
+  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
 ) {
   const effectiveFlags = {
     ...(flags ?? {}),
@@ -907,6 +907,10 @@ test('press @ref refreshes Android snapshot when freshness tracking is active', 
   });
 
   expect(response?.ok).toBe(true);
+  expect(mockCaptureSnapshotForSession.mock.calls[0]?.[4]).toEqual({
+    interactiveOnly: true,
+    androidFreshnessMode: 'ref-refresh',
+  });
   expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['snapshot', 'press']);
   expect(mockDispatch.mock.calls[1]?.[2]).toEqual(['140', '220']);
 });

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -326,11 +326,11 @@ test('snapshot warns when Android freshness retries still return the previous ro
   if (response?.ok) {
     expect(response.data?.warnings).toEqual([
       expect.stringContaining(
-        'Recent press was followed by a nearly identical snapshot after 2 automatic retries',
+        'Recent press was followed by a nearly identical snapshot after 3 automatic retries',
       ),
     ]);
   }
-  expect(mockDispatch).toHaveBeenCalledTimes(3);
+  expect(mockDispatch).toHaveBeenCalledTimes(4);
 });
 
 test('snapshot response includes normalized visibility metadata', async () => {
@@ -442,11 +442,11 @@ test('diff snapshot carries stale-tree warnings for recent Android presses', asy
   if (response?.ok) {
     expect(response.data?.warnings).toEqual([
       expect.stringContaining(
-        'Recent press was followed by a nearly identical snapshot after 2 automatic retries',
+        'Recent press was followed by a nearly identical snapshot after 3 automatic retries',
       ),
     ]);
   }
-  expect(mockDispatch).toHaveBeenCalledTimes(3);
+  expect(mockDispatch).toHaveBeenCalledTimes(4);
 });
 
 test('wait text on Android uses freshness-aware capture instead of one-shot snapshot polling', async () => {
@@ -659,7 +659,9 @@ test('settings on macOS rejects wifi before dispatch with explicit subset guidan
     expect(response.error.message).toMatch(
       /permission <grant\|reset> <accessibility\|screen-recording\|input-monitoring>/,
     );
-    expect(response.error.message).toMatch(/wifi\|airplane\|location remain unsupported on macOS/i);
+    expect(response.error.message).toMatch(
+      /wifi\|airplane\|location\|animations remain unsupported on macOS/i,
+    );
   }
 });
 

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -3,7 +3,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { handleSnapshotCommands } from '../snapshot.ts';
-import { buildSnapshotState, buildSnapshotVisibility } from '../snapshot-capture.ts';
+import {
+  buildSnapshotState,
+  buildSnapshotVisibility,
+  captureSnapshot,
+} from '../snapshot-capture.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { SessionState } from '../../types.ts';
 import { AppError } from '../../../utils/errors.ts';
@@ -447,6 +451,56 @@ test('diff snapshot carries stale-tree warnings for recent Android presses', asy
     ]);
   }
   expect(mockDispatch).toHaveBeenCalledTimes(4);
+});
+
+test('Android ref refresh mode does not retry narrow snapshots as sharp drops', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-ref-refresh-no-sharp-drop';
+  const session = makeSession(sessionName, androidDevice);
+  const baselineNodes = Array.from({ length: 50 }, (_, index) => ({
+    ref: `e${index + 1}`,
+    index,
+    depth: 0,
+    type: 'android.widget.TextView',
+    label: `Previous row ${index + 1}`,
+  }));
+  session.snapshot = {
+    nodes: baselineNodes,
+    createdAt: Date.now(),
+    backend: 'android',
+    comparisonSafe: true,
+  };
+  session.androidSnapshotFreshness = {
+    action: 'press',
+    markedAt: Date.now(),
+    baselineCount: baselineNodes.length,
+    baselineSignatures: buildSnapshotSignatures(baselineNodes),
+    routeComparable: true,
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockResolvedValue({
+    nodes: Array.from({ length: 8 }, (_, index) => ({
+      index,
+      depth: 0,
+      type: 'android.widget.TextView',
+    })),
+    truncated: false,
+    backend: 'android',
+    analysis: { rawNodeCount: 8, maxDepth: 1 },
+  });
+
+  const result = await captureSnapshot({
+    device: androidDevice,
+    session,
+    flags: { snapshotInteractiveOnly: true, snapshotCompact: true },
+    logPath: '/tmp/daemon.log',
+    androidFreshnessMode: 'ref-refresh',
+  });
+
+  expect(result.freshness).toBeUndefined();
+  expect(mockDispatch).toHaveBeenCalledTimes(1);
+  expect(session.androidSnapshotFreshness).toBeUndefined();
 });
 
 test('wait text on Android uses freshness-aware capture instead of one-shot snapshot polling', async () => {

--- a/src/daemon/handlers/interaction-common.ts
+++ b/src/daemon/handlers/interaction-common.ts
@@ -1,4 +1,5 @@
 import type { CommandFlags } from '../../core/dispatch.ts';
+import type { SnapshotState } from '../../utils/snapshot.ts';
 import type { DaemonCommandContext } from '../context.ts';
 import { recordTouchVisualizationEvent } from '../recording-gestures.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
@@ -73,6 +74,7 @@ export function finalizeTouchInteraction(params: {
   responseData: Record<string, unknown>;
   actionStartedAt: number;
   actionFinishedAt: number;
+  androidFreshnessBaseline?: SnapshotState | undefined;
 }): DaemonResponse {
   const {
     session,
@@ -84,6 +86,7 @@ export function finalizeTouchInteraction(params: {
     responseData,
     actionStartedAt,
     actionFinishedAt,
+    androidFreshnessBaseline,
   } = params;
   sessionStore.recordAction(session, {
     command,
@@ -92,7 +95,7 @@ export function finalizeTouchInteraction(params: {
     result,
   });
   if (isNavigationSensitiveAction(command)) {
-    markAndroidSnapshotFreshness(session, command);
+    markAndroidSnapshotFreshness(session, command, androidFreshnessBaseline ?? session.snapshot);
   }
   recordTouchVisualizationEvent(
     session,

--- a/src/daemon/handlers/interaction-snapshot.ts
+++ b/src/daemon/handlers/interaction-snapshot.ts
@@ -10,7 +10,7 @@ export type CaptureSnapshotForSession = (
   flags: CommandFlags | undefined,
   sessionStore: SessionStore,
   contextFromFlags: ContextFromFlags,
-  options: { interactiveOnly: boolean },
+  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
 ) => Promise<SnapshotState>;
 
 export async function captureSnapshotForSession(
@@ -18,7 +18,7 @@ export async function captureSnapshotForSession(
   flags: CommandFlags | undefined,
   sessionStore: SessionStore,
   contextFromFlags: ContextFromFlags,
-  options: { interactiveOnly: boolean },
+  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
 ): Promise<SnapshotState> {
   const effectiveFlags = {
     ...(flags ?? {}),
@@ -36,6 +36,7 @@ export async function captureSnapshotForSession(
     flags: effectiveFlags,
     outPath: effectiveFlags.out,
     logPath: dispatchContext.logPath ?? '',
+    androidFreshnessMode: options.androidFreshnessMode,
   });
   session.snapshot = snapshot;
   sessionStore.set(session.name, session);

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -263,7 +263,7 @@ async function refreshAndroidRefSnapshotIfFreshnessActive(
     params.req.flags,
     params.sessionStore,
     params.contextFromFlags,
-    { interactiveOnly: true },
+    { interactiveOnly: true, androidFreshnessMode: 'ref-refresh' },
   );
 }
 

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -6,7 +6,7 @@ import {
 } from '../../core/click-button.ts';
 import type { FillCommandResult, PressCommandResult } from '../../commands/index.ts';
 import { asAppError, normalizeError } from '../../utils/errors.ts';
-import type { DaemonResponse } from '../types.ts';
+import type { DaemonResponse, SessionState } from '../types.ts';
 import {
   buildTouchVisualizationResult,
   finalizeTouchInteraction,
@@ -32,6 +32,7 @@ import {
   parsePressTarget,
   stripAtPrefix,
 } from './interaction-touch-targets.ts';
+import { getActiveAndroidSnapshotFreshness } from '../android-snapshot-freshness.ts';
 
 export async function handleTouchInteractionCommands(
   params: InteractionHandlerParams & {
@@ -93,6 +94,7 @@ async function dispatchPressViaRuntime(
   if (parsedTarget.target.kind === 'ref') {
     const invalidRefFlagsResponse = params.refSnapshotFlagGuardResponse('press', req.flags);
     if (invalidRefFlagsResponse) return invalidRefFlagsResponse;
+    await refreshAndroidRefSnapshotIfFreshnessActive(params, session);
   }
 
   return await dispatchRuntimeInteraction(params, {
@@ -165,6 +167,7 @@ async function dispatchFillViaRuntime(
   if (parsedTarget.target.kind === 'ref') {
     const invalidRefFlagsResponse = params.refSnapshotFlagGuardResponse('fill', req.flags);
     if (invalidRefFlagsResponse) return invalidRefFlagsResponse;
+    await refreshAndroidRefSnapshotIfFreshnessActive(params, session);
   }
 
   return await dispatchRuntimeInteraction(params, {
@@ -246,6 +249,22 @@ async function dispatchRuntimeInteraction<TResult extends PressCommandResult | F
     if (isAndroidEscapeError(appError)) throw appError;
     return appErrorResponse(error);
   }
+}
+
+async function refreshAndroidRefSnapshotIfFreshnessActive(
+  params: InteractionHandlerParams & {
+    captureSnapshotForSession: CaptureSnapshotForSession;
+  },
+  session: SessionState,
+): Promise<void> {
+  if (!getActiveAndroidSnapshotFreshness(session)) return;
+  await params.captureSnapshotForSession(
+    session,
+    params.req.flags,
+    params.sessionStore,
+    params.contextFromFlags,
+    { interactiveOnly: true },
+  );
 }
 
 function appErrorResponse(error: unknown): DaemonResponse {

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -33,6 +33,7 @@ import {
   stripAtPrefix,
 } from './interaction-touch-targets.ts';
 import { getActiveAndroidSnapshotFreshness } from '../android-snapshot-freshness.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
 
 export async function handleTouchInteractionCommands(
   params: InteractionHandlerParams & {
@@ -91,13 +92,15 @@ async function dispatchPressViaRuntime(
 
   const parsedTarget = parsePressTarget(req.positionals ?? [], commandLabel);
   if (!parsedTarget.ok) return parsedTarget.response;
+  let androidFreshnessBaseline: SessionState['snapshot'];
   if (parsedTarget.target.kind === 'ref') {
     const invalidRefFlagsResponse = params.refSnapshotFlagGuardResponse('press', req.flags);
     if (invalidRefFlagsResponse) return invalidRefFlagsResponse;
-    await refreshAndroidRefSnapshotIfFreshnessActive(params, session);
+    androidFreshnessBaseline = await refreshAndroidRefSnapshotIfFreshnessActive(params, session);
   }
 
   return await dispatchRuntimeInteraction(params, {
+    androidFreshnessBaseline,
     run: async (runtime) => {
       const options = {
         session: sessionName,
@@ -215,6 +218,7 @@ async function dispatchRuntimeInteraction<TResult extends PressCommandResult | F
     captureSnapshotForSession: CaptureSnapshotForSession;
   },
   options: {
+    androidFreshnessBaseline?: SessionState['snapshot'];
     run(runtime: ReturnType<typeof createInteractionRuntime>): Promise<TResult>;
     afterRun?(result: TResult): Promise<void>;
     buildPayloads(
@@ -243,6 +247,7 @@ async function dispatchRuntimeInteraction<TResult extends PressCommandResult | F
       responseData,
       actionStartedAt,
       actionFinishedAt,
+      androidFreshnessBaseline: options.androidFreshnessBaseline,
     });
   } catch (error) {
     const appError = asAppError(error);
@@ -256,15 +261,29 @@ async function refreshAndroidRefSnapshotIfFreshnessActive(
     captureSnapshotForSession: CaptureSnapshotForSession;
   },
   session: SessionState,
-): Promise<void> {
-  if (!getActiveAndroidSnapshotFreshness(session)) return;
-  await params.captureSnapshotForSession(
-    session,
-    params.req.flags,
-    params.sessionStore,
-    params.contextFromFlags,
-    { interactiveOnly: true, androidFreshnessMode: 'ref-refresh' },
-  );
+): Promise<SessionState['snapshot']> {
+  if (!getActiveAndroidSnapshotFreshness(session)) return undefined;
+  const freshnessBaseline =
+    session.snapshot?.comparisonSafe === true ? session.snapshot : undefined;
+  try {
+    await params.captureSnapshotForSession(
+      session,
+      params.req.flags,
+      params.sessionStore,
+      params.contextFromFlags,
+      { interactiveOnly: true, androidFreshnessMode: 'ref-refresh' },
+    );
+  } catch (error) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'android_ref_snapshot_refresh_failed',
+      data: {
+        command: params.req.command,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+  return freshnessBaseline;
 }
 
 function appErrorResponse(error: unknown): DaemonResponse {

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -15,6 +15,7 @@ import { normalizeSnapshotTree } from '../../utils/snapshot-tree.ts';
 export { buildSnapshotVisibility } from '../../utils/snapshot-visibility.ts';
 import type { SessionState } from '../types.ts';
 import {
+  ANDROID_FRESHNESS_RETRY_DEADLINE_MS,
   ANDROID_FRESHNESS_RETRY_DELAYS_MS,
   clearAndroidSnapshotFreshness,
   getActiveAndroidSnapshotFreshness,
@@ -106,10 +107,13 @@ async function captureAndroidFreshnessAwareSnapshot(
   let latest = await captureSnapshotAttempt(params);
   let suspiciousReason = getAndroidFreshnessReason(latest, freshness, params.flags);
   let retryCount = 0;
+  const retryUntilMs = freshness.markedAt + ANDROID_FRESHNESS_RETRY_DEADLINE_MS;
 
   for (const delayMs of ANDROID_FRESHNESS_RETRY_DELAYS_MS) {
     if (!suspiciousReason) break;
-    await sleep(delayMs);
+    const remainingMs = retryUntilMs - Date.now();
+    if (remainingMs <= 0) break;
+    await sleep(Math.min(delayMs, remainingMs));
     latest = await captureSnapshotAttempt(params);
     retryCount += 1;
     suspiciousReason = getAndroidFreshnessReason(latest, freshness, params.flags);

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -35,6 +35,7 @@ type CaptureSnapshotParams = {
   outPath?: string;
   logPath: string;
   snapshotScope?: string;
+  androidFreshnessMode?: AndroidFreshnessMode;
 };
 
 type SnapshotData = {
@@ -45,6 +46,7 @@ type SnapshotData = {
 };
 
 type AndroidFreshnessReason = 'empty-interactive' | 'sharp-drop' | 'stuck-route';
+type AndroidFreshnessMode = 'default' | 'ref-refresh';
 
 export async function captureSnapshot(params: CaptureSnapshotParams): Promise<{
   snapshot: SnapshotState;
@@ -105,7 +107,7 @@ async function captureAndroidFreshnessAwareSnapshot(
   freshness?: AndroidFreshnessCaptureMeta;
 }> {
   let latest = await captureSnapshotAttempt(params);
-  let suspiciousReason = getAndroidFreshnessReason(latest, freshness, params.flags);
+  let suspiciousReason = getAndroidFreshnessReason(latest, freshness, params);
   let retryCount = 0;
   const retryUntilMs = freshness.markedAt + ANDROID_FRESHNESS_RETRY_DEADLINE_MS;
 
@@ -116,7 +118,7 @@ async function captureAndroidFreshnessAwareSnapshot(
     await sleep(Math.min(delayMs, remainingMs));
     latest = await captureSnapshotAttempt(params);
     retryCount += 1;
-    suspiciousReason = getAndroidFreshnessReason(latest, freshness, params.flags);
+    suspiciousReason = getAndroidFreshnessReason(latest, freshness, params);
   }
 
   if (!suspiciousReason) {
@@ -151,9 +153,9 @@ async function captureSnapshotAttempt(
 function getAndroidFreshnessReason(
   attempt: { data: SnapshotData; snapshot: SnapshotState },
   freshness: NonNullable<SessionState['androidSnapshotFreshness']>,
-  flags: CommandFlags | undefined,
+  params: Pick<CaptureSnapshotParams, 'flags' | 'androidFreshnessMode'>,
 ): AndroidFreshnessReason | null {
-  const interactiveOnly = flags?.snapshotInteractiveOnly === true;
+  const interactiveOnly = params.flags?.snapshotInteractiveOnly === true;
   const analysis = attempt.data.analysis;
 
   // When interactive-only filtering produces zero visible nodes from ≥12 raw nodes,
@@ -166,6 +168,10 @@ function getAndroidFreshnessReason(
     analysis.rawNodeCount >= 12
   ) {
     return 'empty-interactive';
+  }
+
+  if (params.androidFreshnessMode === 'ref-refresh') {
+    return null;
   }
 
   if (isLikelyStaleSnapshotDrop(freshness.baselineCount, attempt.snapshot.nodes.length)) {

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -1679,6 +1679,24 @@ test('setAndroidSetting permission grant camera uses pm grant', async () => {
   );
 });
 
+test('setAndroidSetting animations off disables global animation scales', async () => {
+  await withMockedAdb(
+    'agent-device-android-animations-',
+    '#!/bin/sh\nprintf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"\nprintf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"\nexit 0\n',
+    async ({ argsLogPath, device }) => {
+      const result = await setAndroidSetting(device, 'animations', 'off');
+      const logged = await fs.readFile(argsLogPath, 'utf8');
+      assert.match(logged, /shell\nsettings\nput\nglobal\nwindow_animation_scale\n0/);
+      assert.match(logged, /shell\nsettings\nput\nglobal\ntransition_animation_scale\n0/);
+      assert.match(logged, /shell\nsettings\nput\nglobal\nanimator_duration_scale\n0/);
+      assert.deepEqual(result, {
+        scale: '0',
+        keys: ['window_animation_scale', 'transition_animation_scale', 'animator_duration_scale'],
+      });
+    },
+  );
+});
+
 test('setAndroidSetting permission deny notifications revokes runtime permission and appops', async () => {
   await withMockedAdb(
     'agent-device-android-permission-notifications-',

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -183,6 +183,7 @@ test('dumpUiHierarchy returns streamed XML even when exec-out exits non-zero', a
 
   assert.equal(result, xml);
   assert.equal(mockRunCmd.mock.calls.length, 1);
+  assert.deepEqual(mockRunCmd.mock.calls[0]?.[2], { allowFailure: true, timeoutMs: 8000 });
 });
 
 test('dumpUiHierarchy reads fallback XML when dump exits non-zero', async () => {
@@ -224,7 +225,7 @@ test('dumpUiHierarchy reads fallback XML when dump exits non-zero', async () => 
   );
 
   assert.equal(result, xml);
-  assert.deepEqual(dumpCall?.[2], { allowFailure: true });
+  assert.deepEqual(dumpCall?.[2], { allowFailure: true, timeoutMs: 8000 });
   assert.equal(catCall?.[2], undefined);
 });
 
@@ -268,6 +269,28 @@ test('dumpUiHierarchy retries when fallback dump file is temporarily missing', a
       ([, args]) => args.includes('uiautomator') && args.includes('/sdcard/window_dump.xml'),
     ).length,
     2,
+  );
+});
+
+test('dumpUiHierarchy explains timeout on looping Android animations', async () => {
+  mockRunCmd.mockImplementation(async (_cmd, args) => {
+    if (args.includes('uiautomator')) {
+      throw new AppError('COMMAND_FAILED', 'adb timed out after 8000ms', {
+        cmd: 'adb',
+        args,
+        timeoutMs: 8000,
+      });
+    }
+    throw new Error(`unexpected args: ${args.join(' ')}`);
+  });
+
+  await assert.rejects(
+    dumpUiHierarchy(device),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.message.includes('Android UI hierarchy dump timed out') &&
+      typeof error.details?.hint === 'string' &&
+      error.details.hint.includes('settings animations off'),
   );
 });
 

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -294,6 +294,33 @@ test('dumpUiHierarchy explains timeout on looping Android animations', async () 
   );
 });
 
+test('dumpUiHierarchy does not attach animation hint to non-dump timeouts', async () => {
+  mockRunCmd.mockImplementation(async (_cmd, args) => {
+    if (args.includes('exec-out')) {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    }
+    if (args.includes('uiautomator')) {
+      return { exitCode: 0, stdout: 'UI hierarchy dumped to: /sdcard/window_dump.xml', stderr: '' };
+    }
+    if (args.includes('cat')) {
+      throw new AppError('COMMAND_FAILED', 'adb timed out after 8000ms', {
+        cmd: 'adb',
+        args,
+        timeoutMs: 8000,
+      });
+    }
+    throw new Error(`unexpected args: ${args.join(' ')}`);
+  });
+
+  await assert.rejects(
+    dumpUiHierarchy(device),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.message === 'adb timed out after 8000ms' &&
+      typeof error.details?.hint === 'undefined',
+  );
+});
+
 test('snapshotAndroid preserves hidden scroll content hints in interactive snapshots', async () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <hierarchy rotation="0">

--- a/src/platforms/android/settings.ts
+++ b/src/platforms/android/settings.ts
@@ -9,6 +9,12 @@ import {
 import { parseAppearanceAction } from '../appearance.ts';
 import { adbArgs } from './adb.ts';
 
+const ANDROID_ANIMATION_SCALE_SETTINGS = [
+  'window_animation_scale',
+  'transition_animation_scale',
+  'animator_duration_scale',
+] as const;
+
 export async function setAndroidSetting(
   device: DeviceInfo,
   setting: string,
@@ -57,6 +63,14 @@ export async function setAndroidSetting(
         adbArgs(device, ['shell', 'settings', 'put', 'secure', 'location_mode', mode]),
       );
       return;
+    }
+    case 'animations': {
+      const enabled = parseSettingState(state);
+      const scale = enabled ? '1' : '0';
+      for (const key of ANDROID_ANIMATION_SCALE_SETTINGS) {
+        await runCmd('adb', adbArgs(device, ['shell', 'settings', 'put', 'global', key, scale]));
+      }
+      return { scale, keys: [...ANDROID_ANIMATION_SCALE_SETTINGS] };
     }
     case 'appearance': {
       const target = await resolveAndroidAppearanceTarget(device, state);

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -21,6 +21,8 @@ import {
 import { adbArgs } from './adb.ts';
 import { deriveAndroidScrollableContentHints } from './scroll-hints.ts';
 
+const UI_HIERARCHY_DUMP_TIMEOUT_MS = 8_000;
+
 export async function snapshotAndroid(
   device: DeviceInfo,
   options: SnapshotOptions = {},
@@ -67,9 +69,24 @@ async function deriveScrollableContentHintsIfNeeded(
 }
 
 export async function dumpUiHierarchy(device: DeviceInfo): Promise<string> {
-  return withRetry(() => dumpUiHierarchyOnce(device), {
-    shouldRetry: isRetryableAdbError,
-  });
+  try {
+    return await withRetry(() => dumpUiHierarchyOnce(device), {
+      shouldRetry: isRetryableAdbError,
+    });
+  } catch (error) {
+    if (isUiHierarchyDumpTimeout(error)) {
+      throw new AppError(
+        'COMMAND_FAILED',
+        'Android UI hierarchy dump timed out while waiting for the UI to become idle',
+        {
+          ...(error.details ?? {}),
+          hint: 'If the app has looping animations, use screenshot as visual truth, try settings animations off, then retry snapshot. Stock Android UIAutomator may still time out on app-owned infinite animations.',
+        },
+        error,
+      );
+    }
+    throw error;
+  }
 }
 
 async function dumpUiHierarchyOnce(device: DeviceInfo): Promise<string> {
@@ -77,7 +94,7 @@ async function dumpUiHierarchyOnce(device: DeviceInfo): Promise<string> {
   const streamed = await runCmd(
     'adb',
     adbArgs(device, ['exec-out', 'uiautomator', 'dump', '/dev/tty']),
-    { allowFailure: true },
+    { allowFailure: true, timeoutMs: UI_HIERARCHY_DUMP_TIMEOUT_MS },
   );
   const fromStream = extractUiDumpXml(streamed.stdout, streamed.stderr);
   if (fromStream) return fromStream;
@@ -88,7 +105,7 @@ async function dumpUiHierarchyOnce(device: DeviceInfo): Promise<string> {
   const dumpResult = await runCmd(
     'adb',
     adbArgs(device, ['shell', 'uiautomator', 'dump', dumpPath]),
-    { allowFailure: true },
+    { allowFailure: true, timeoutMs: UI_HIERARCHY_DUMP_TIMEOUT_MS },
   );
   const actualPath = resolveDumpPath(dumpPath, dumpResult.stdout, dumpResult.stderr);
 
@@ -133,6 +150,14 @@ function isRetryableAdbError(err: unknown): boolean {
   if (stderr.includes('timed out')) return true;
   if (stderr.includes('no such file or directory')) return true;
   return false;
+}
+
+function isUiHierarchyDumpTimeout(err: unknown): err is AppError {
+  if (!(err instanceof AppError)) return false;
+  if (err.code !== 'COMMAND_FAILED') return false;
+  const timeoutMs = err.details?.timeoutMs;
+  if (typeof timeoutMs === 'number') return true;
+  return err.message.toLowerCase().includes('timed out');
 }
 
 async function dumpActivityTop(device: DeviceInfo): Promise<string | null> {

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -75,12 +75,14 @@ export async function dumpUiHierarchy(device: DeviceInfo): Promise<string> {
     });
   } catch (error) {
     if (isUiHierarchyDumpTimeout(error)) {
+      const hint =
+        'If the app has looping animations, use screenshot as visual truth, try settings animations off, then retry snapshot. Stock Android UIAutomator may still time out on app-owned infinite animations.';
       throw new AppError(
         'COMMAND_FAILED',
-        'Android UI hierarchy dump timed out while waiting for the UI to become idle',
+        `Android UI hierarchy dump timed out while waiting for the UI to become idle. ${hint}`,
         {
           ...(error.details ?? {}),
-          hint: 'If the app has looping animations, use screenshot as visual truth, try settings animations off, then retry snapshot. Stock Android UIAutomator may still time out on app-owned infinite animations.',
+          hint,
         },
         error,
       );
@@ -156,8 +158,15 @@ function isUiHierarchyDumpTimeout(err: unknown): err is AppError {
   if (!(err instanceof AppError)) return false;
   if (err.code !== 'COMMAND_FAILED') return false;
   const timeoutMs = err.details?.timeoutMs;
-  if (typeof timeoutMs === 'number') return true;
-  return err.message.toLowerCase().includes('timed out');
+  if (typeof timeoutMs !== 'number') return false;
+  const cmd = err.details?.cmd;
+  const rawArgs = err.details?.args;
+  const args = Array.isArray(rawArgs)
+    ? rawArgs.map(String)
+    : typeof rawArgs === 'string'
+      ? rawArgs.split(/\s+/)
+      : [];
+  return cmd === 'adb' && args.includes('uiautomator') && args.includes('dump');
 }
 
 async function dumpActivityTop(device: DeviceInfo): Promise<string | null> {

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -2213,7 +2213,7 @@ test('setIosSetting rejects unsupported macOS wifi setting with explicit subset 
       assert.match((error as AppError).message, /Unsupported macOS setting: wifi/i);
       assert.match(
         (error as AppError).message,
-        /wifi\|airplane\|location remain unsupported on macOS/i,
+        /wifi\|airplane\|location\|animations remain unsupported on macOS/i,
       );
       return true;
     },

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -1371,7 +1371,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     usageOverride: SETTINGS_USAGE_OVERRIDE,
     listUsageOverride: 'settings [area] [options]',
     helpDescription:
-      'Toggle OS settings, appearance, and app permissions (macOS supports only settings appearance <light|dark|toggle> and settings permission <grant|reset> <accessibility|screen-recording|input-monitoring>; wifi|airplane|location remain unsupported on macOS; mobile permission actions use the active session app)',
+      'Toggle OS settings, animation scales, appearance, and app permissions (macOS supports only settings appearance <light|dark|toggle> and settings permission <grant|reset> <accessibility|screen-recording|input-monitoring>; wifi|airplane|location|animations remain unsupported on macOS; mobile permission actions use the active session app)',
     summary: 'Change OS settings and app permissions',
     positionalArgs: ['setting', 'state', 'target?', 'mode?'],
     allowedFlags: [],

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -430,6 +430,8 @@ agent-device settings airplane on
 agent-device settings airplane off
 agent-device settings location on
 agent-device settings location off
+agent-device settings animations off
+agent-device settings animations on
 agent-device settings appearance light
 agent-device settings appearance dark
 agent-device settings appearance toggle
@@ -453,7 +455,8 @@ agent-device settings permission reset screen-recording --platform macos
 
 - iOS `settings` support is simulator-only except for `settings appearance` and the macOS permission subset on macOS.
 - macOS supports only `settings appearance <light|dark|toggle>` and `settings permission <grant|reset> <accessibility|screen-recording|input-monitoring>`.
-- `settings wifi|airplane|location` remain intentionally unsupported on macOS.
+- `settings wifi|airplane|location|animations` remain intentionally unsupported on macOS.
+- Android `settings animations off|on` toggles the global `window_animation_scale`, `transition_animation_scale`, and `animator_duration_scale` values. Use it as an opt-in stabilizer for automation runs with heavy system or app animations, then restore with `settings animations on` when needed.
 - `settings appearance` maps to macOS appearance, iOS simulator appearance, and Android night mode.
 - Face ID and Touch ID controls are iOS simulator-only.
 - Fingerprint simulation is supported on Android targets where `cmd fingerprint` or `adb emu finger` is available.

--- a/website/docs/docs/snapshots.md
+++ b/website/docs/docs/snapshots.md
@@ -40,7 +40,8 @@ It does not automatically switch to AX.
 - If `snapshot -i` returns 0 nodes on Android but the screen is visibly populated, trust `screenshot` as visual truth, wait briefly, then take one fresh `snapshot -i`.
 - If `snapshot -i -d <n>` says the interactive output is empty at that depth, retry once without `-d` before taking more shallow snapshots.
 - Re-snapshot after any UI mutation before reusing refs.
-- On Android after navigation or submit, if `snapshot -i` disagrees with the visible screen, trust `screenshot`, wait briefly, then take one fresh snapshot instead of looping stale snapshots.
+- On Android after navigation or submit, snapshot capture retries suspicious trees for a short post-action deadline and `@ref` interactions refresh while that freshness window is active. If `snapshot -i` still disagrees with the visible screen, trust `screenshot`, wait briefly, then take one fresh snapshot instead of looping stale snapshots.
+- For automation runs affected by Android animation churn, use `settings animations off` as an opt-in stabilizer and restore with `settings animations on` after the run.
 - Use `diff snapshot` between mutations to validate structural changes with lower output volume.
 - Use `snapshot --diff` when you discover the feature from snapshot help, but keep `diff snapshot` as the default exploration command.
 - Keep `--raw` for troubleshooting only when you need the full tree instead of visible-first output.


### PR DESCRIPTION
## Summary

Improve Android stale snapshot recovery and bounded UIAutomator failures.

- Retry suspicious post-navigation Android snapshots until a short freshness deadline, and refresh Android `@ref` interactions while freshness tracking is active.
- Keep internal Android `@ref` refreshes best-effort, preserve comparable freshness baselines after refreshed `@ref` actions, and avoid treating narrow interactive trees as stale sharp drops.
- Add `settings animations off|on` for Android global animation scales.
- Bound Android UI hierarchy dumps with a targeted timeout hint for looping animation cases.
- Update docs and agent-device skill guidance for Android stale snapshots and animation-heavy runs.

Touched files: 20. Scope stayed within Android snapshot/settings freshness plus docs/tests.

## Validation

- `pnpm format`
- `pnpm check:quick`
- `pnpm exec vitest run src/daemon/handlers/__tests__/interaction.test.ts`
- `pnpm exec vitest run src/daemon/handlers/__tests__/snapshot-handler.test.ts src/daemon/handlers/__tests__/interaction.test.ts src/platforms/android/__tests__/snapshot.test.ts`
- `pnpm check:unit`
- `pnpm build`
- Manual RNCLI83 Android check on `/Users/thymikee/Developer/RNCLI83` with temporary `ReactNative.Animated.loop`: `settings animations off` applied successfully, `screenshot` succeeded, and `snapshot -i` failed after the bounded 8s UIAutomator timeout with the new targeted hint. Temporary app changes were removed and `settings animations on` was restored.