### PR TITLE
feat: parametrise .ad replay scripts

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -371,6 +371,42 @@ test('client throws AppError for daemon failures', async () => {
   );
 });
 
+test('replay.run serializes client-collected AD_VAR shell env into daemon request', async () => {
+  const previousAppId = process.env.AD_VAR_APP_ID;
+  const previousWaitMs = process.env.AD_VAR_WAIT_MS;
+  const previousLegacy = process.env.AD_APP_ID;
+  process.env.AD_VAR_APP_ID = 'com.example.debug';
+  process.env.AD_VAR_WAIT_MS = '750';
+  process.env.AD_APP_ID = 'legacy-prefix-ignored';
+  try {
+    const setup = createTransport(async () => ({ ok: true, data: {} }));
+    const client = createAgentDeviceClient(setup.config, { transport: setup.transport });
+
+    await client.replay.run({
+      path: './flows/login.ad',
+      env: ['APP_ID=cli-override'],
+    });
+
+    assert.equal(setup.calls.length, 1);
+    assert.equal(setup.calls[0]?.command, 'replay');
+    assert.deepEqual(setup.calls[0]?.positionals, ['./flows/login.ad']);
+    assert.deepEqual(setup.calls[0]?.flags?.replayEnv, ['APP_ID=cli-override']);
+    const replayShellEnv = setup.calls[0]?.flags?.replayShellEnv as
+      | Record<string, string>
+      | undefined;
+    assert.equal(replayShellEnv?.AD_VAR_APP_ID, 'com.example.debug');
+    assert.equal(replayShellEnv?.AD_VAR_WAIT_MS, '750');
+    assert.equal(Object.prototype.hasOwnProperty.call(replayShellEnv ?? {}, 'AD_APP_ID'), false);
+  } finally {
+    if (previousAppId === undefined) delete process.env.AD_VAR_APP_ID;
+    else process.env.AD_VAR_APP_ID = previousAppId;
+    if (previousWaitMs === undefined) delete process.env.AD_VAR_WAIT_MS;
+    else process.env.AD_VAR_WAIT_MS = previousWaitMs;
+    if (previousLegacy === undefined) delete process.env.AD_APP_ID;
+    else process.env.AD_APP_ID = previousLegacy;
+  }
+});
+
 test('client.command.wait prepares selector options and rejects invalid selectors', async () => {
   const setup = createTransport(async () => ({
     ok: true,

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -73,6 +73,7 @@ export const genericClientCommandHandlers = {
         ...buildSelectionOptions(flags),
         path: required(positionals[0], 'replay requires path'),
         update: flags.replayUpdate,
+        env: flags.replayEnv,
       }),
   ),
   [CLIENT_COMMANDS.test]: createGenericClientCommandHandler(
@@ -83,6 +84,7 @@ export const genericClientCommandHandlers = {
         ...buildSelectionOptions(flags),
         paths: positionals,
         update: flags.replayUpdate,
+        env: flags.replayEnv,
         failFast: flags.failFast,
         timeoutMs: flags.timeoutMs,
         retries: flags.retries,

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -13,10 +13,7 @@ import { snapshotCommand } from './snapshot.ts';
 import { screenshotCommand, diffCommand } from './screenshot.ts';
 import { clientCommandMethodHandlers } from './client-command.ts';
 import { genericClientCommandHandlers } from './generic.ts';
-import type {
-  ClientCommandHandler,
-  ClientCommandHandlerMap,
-} from './router-types.ts';
+import type { ClientCommandHandler, ClientCommandHandlerMap } from './router-types.ts';
 
 export type {
   ClientCommandHandler,

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -290,6 +290,7 @@ export function buildFlags(options: InternalRequestOptions): CommandFlags {
     restart: options.restart,
     replayUpdate: options.replayUpdate,
     replayEnv: options.replayEnv,
+    replayShellEnv: options.replayShellEnv,
     failFast: options.failFast,
     timeoutMs: options.timeoutMs,
     retries: options.retries,

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -289,6 +289,7 @@ export function buildFlags(options: InternalRequestOptions): CommandFlags {
     headless: options.headless,
     restart: options.restart,
     replayUpdate: options.replayUpdate,
+    replayEnv: options.replayEnv,
     failFast: options.failFast,
     timeoutMs: options.timeoutMs,
     retries: options.retries,

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -611,12 +611,14 @@ export type FindOptions =
 export type ReplayRunOptions = AgentDeviceRequestOverrides & {
   path: string;
   update?: boolean;
+  env?: string[];
 };
 
 export type ReplayTestOptions = AgentDeviceRequestOverrides &
   AgentDeviceSelectionOptions & {
     paths: string[];
     update?: boolean;
+    env?: string[];
     failFast?: boolean;
     timeoutMs?: number;
     retries?: number;
@@ -738,6 +740,7 @@ type CommandExecutionOptions = {
   headless?: boolean;
   restart?: boolean;
   replayUpdate?: boolean;
+  replayEnv?: string[];
   failFast?: boolean;
   timeoutMs?: number;
   retries?: number;

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -741,6 +741,7 @@ type CommandExecutionOptions = {
   restart?: boolean;
   replayUpdate?: boolean;
   replayEnv?: string[];
+  replayShellEnv?: Record<string, string>;
   failFast?: boolean;
   timeoutMs?: number;
   retries?: number;

--- a/src/client.ts
+++ b/src/client.ts
@@ -408,12 +408,14 @@ export function createAgentDeviceClient(
           ...options,
           replayUpdate: options.update,
           replayEnv: options.env,
+          replayShellEnv: collectReplayClientShellEnv(process.env),
         }),
       test: async (options) =>
         await executeCommandRequest(CLIENT_COMMANDS.test, options.paths, {
           ...options,
           replayUpdate: options.update,
           replayEnv: options.env,
+          replayShellEnv: collectReplayClientShellEnv(process.env),
         }),
     },
     batch: {
@@ -521,6 +523,18 @@ function optionalString(value: string | undefined): string[] {
 
 function optionalNumber(value: number | undefined): string[] {
   return value === undefined ? [] : [String(value)];
+}
+
+const REPLAY_SHELL_ENV_PREFIX = 'AD_VAR_';
+
+function collectReplayClientShellEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === 'string' && key.startsWith(REPLAY_SHELL_ENV_PREFIX)) {
+      result[key] = value;
+    }
+  }
+  return result;
 }
 
 function mergeClientOptions(

--- a/src/client.ts
+++ b/src/client.ts
@@ -407,11 +407,13 @@ export function createAgentDeviceClient(
         await executeCommandRequest(CLIENT_COMMANDS.replay, [options.path], {
           ...options,
           replayUpdate: options.update,
+          replayEnv: options.env,
         }),
       test: async (options) =>
         await executeCommandRequest(CLIENT_COMMANDS.test, options.paths, {
           ...options,
           replayUpdate: options.update,
+          replayEnv: options.env,
         }),
     },
     batch: {

--- a/src/commands/selector-read-shared.ts
+++ b/src/commands/selector-read-shared.ts
@@ -1,4 +1,8 @@
-import type { AgentDeviceRuntime, CommandContext, CommandSessionRecord } from '../runtime-contract.ts';
+import type {
+  AgentDeviceRuntime,
+  CommandContext,
+  CommandSessionRecord,
+} from '../runtime-contract.ts';
 import { AppError } from '../utils/errors.ts';
 import type { SnapshotNode, SnapshotState } from '../utils/snapshot.ts';
 import { findNodeByRef, normalizeRef } from '../utils/snapshot.ts';

--- a/src/core/interactors.ts
+++ b/src/core/interactors.ts
@@ -55,12 +55,7 @@ import {
 import { readLinuxClipboard, writeLinuxClipboard } from '../platforms/linux/clipboard.ts';
 import type { Interactor, RunnerContext } from './interactor-types.ts';
 
-export type {
-  BackMode,
-  Interactor,
-  RunnerContext,
-  ScreenshotOptions,
-} from './interactor-types.ts';
+export type { BackMode, Interactor, RunnerContext, ScreenshotOptions } from './interactor-types.ts';
 
 export function getInteractor(device: DeviceInfo, runnerContext: RunnerContext): Interactor {
   switch (device.platform) {

--- a/src/daemon/handlers/__tests__/session-replay-script.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-script.test.ts
@@ -259,3 +259,57 @@ test('readReplayScriptMetadata rejects conflicting metadata keys in context head
       /Conflicting replay test metadata "timeoutMs"/.test(error.message),
   );
 });
+
+test('writeReplayScript round-trips ${VAR} tokens byte-for-byte across positionals and flags', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-script-vars-'));
+  const replayPath = path.join(root, 'flow.ad');
+  const actions: SessionAction[] = [
+    {
+      ts: Date.now(),
+      command: 'open',
+      positionals: ['${APP_ID}'],
+      runtime: {
+        platform: 'android',
+        metroHost: '${HOST}',
+      },
+      flags: { relaunch: true },
+    },
+    {
+      ts: Date.now(),
+      command: 'click',
+      positionals: ['label=Wait || ${EXTRA}'],
+      flags: {},
+    },
+    {
+      ts: Date.now(),
+      command: 'snapshot',
+      positionals: [],
+      flags: { snapshotScope: '${SNAPSHOT_SCOPE:-app}' },
+    },
+    {
+      ts: Date.now(),
+      command: 'fill',
+      positionals: ['@e2', 'value-${SUFFIX}'],
+      flags: {},
+    },
+  ];
+
+  writeReplayScript(replayPath, actions, makeSession());
+  const script = fs.readFileSync(replayPath, 'utf8');
+  // Each raw ${...} token must be preserved on disk.
+  assert.ok(script.includes('${APP_ID}'), `missing \${APP_ID} in:\n${script}`);
+  assert.ok(script.includes('${HOST}'), `missing \${HOST} in:\n${script}`);
+  assert.ok(script.includes('label=Wait || ${EXTRA}'), `missing \${EXTRA} in:\n${script}`);
+  assert.ok(
+    script.includes('${SNAPSHOT_SCOPE:-app}'),
+    `missing \${SNAPSHOT_SCOPE:-app} in:\n${script}`,
+  );
+  assert.ok(script.includes('value-${SUFFIX}'), `missing \${SUFFIX} in:\n${script}`);
+
+  const parsed = parseReplayScript(script);
+  assert.deepEqual(parsed[0]?.positionals, ['${APP_ID}']);
+  assert.equal(parsed[0]?.runtime?.metroHost, '${HOST}');
+  assert.deepEqual(parsed[1]?.positionals, ['label=Wait || ${EXTRA}']);
+  assert.equal(parsed[2]?.flags.snapshotScope, '${SNAPSHOT_SCOPE:-app}');
+  assert.deepEqual(parsed[3]?.positionals, ['@e2', 'value-${SUFFIX}']);
+});

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -88,18 +88,30 @@ test('buildReplayVarScope precedence: cli > shell > file > builtin', () => {
   assert.equal(shellWinsOverFile.values.K, 'shell');
 });
 
-test('collectReplayShellEnv strips AD_ prefix and ignores other vars', () => {
+test('collectReplayShellEnv strips AD_VAR_ prefix and ignores other vars', () => {
   const result = collectReplayShellEnv({
-    AD_APP_ID: 'settings',
+    AD_VAR_APP_ID: 'settings',
     PATH: '/bin',
-    AD_123: 'x',
-    AD_: 'empty',
+    AD_VAR_123: 'x',
+    AD_VAR_: 'empty',
     OTHER_VAR: 'y',
+    AD_APP_ID: 'no-legacy-prefix',
   });
   assert.equal(result.APP_ID, 'settings');
   assert.equal(result.PATH, undefined);
   assert.equal(result['123'], undefined);
   assert.equal(result[''], undefined);
+  // legacy AD_* (non AD_VAR_*) is no longer auto-imported.
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_APP_ID'), false);
+});
+
+test('collectReplayShellEnv skips keys that land in reserved AD_* namespace after strip', () => {
+  const result = collectReplayShellEnv({
+    AD_VAR_AD_SESSION: 'evil',
+    AD_VAR_AD_FOO: 'evil',
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_SESSION'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'AD_FOO'), false);
 });
 
 test('parseReplayCliEnvEntries splits KEY=VALUE and rejects invalid keys', () => {
@@ -250,7 +262,7 @@ test('runReplayScriptFile rejects replay -u on scripts with env directives', asy
   assert.equal(response.ok, false);
   if (!response.ok) {
     assert.equal(response.error.code, 'INVALID_ARGS');
-    assert.match(response.error.message, /replay -u cannot heal scripts with env directives/);
+    assert.match(response.error.message, /replay -u does not yet preserve env directives/);
   }
 });
 
@@ -287,4 +299,162 @@ test('resolveReplayAction produces dispatch-ready literals for a realistic fixtu
   assert.deepEqual(resolved[2]?.positionals, ['label=Wait || label=Apps']);
   assert.deepEqual(resolved[3]?.positionals, ['exists', 'label=Wait || label=Apps']);
   assert.equal(resolved[4]?.flags.snapshotScope, 'app');
+});
+
+test('parseReplayEnvLine rejects AD_* keys as reserved namespace', () => {
+  assert.throws(
+    () =>
+      readReplayScriptMetadata(
+        'context platform=android\nenv AD_FOO=bar\n',
+      ),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /AD_\* namespace is reserved/.test(error.message) &&
+      /AD_FOO/.test(error.message),
+  );
+});
+
+test('parseReplayCliEnvEntries rejects AD_* keys as reserved namespace', () => {
+  assert.throws(
+    () => parseReplayCliEnvEntries(['AD_FOO=x']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /AD_\* namespace is reserved/.test(error.message),
+  );
+});
+
+test('parseReplayCliEnvEntries error wording is user-friendly for invalid keys', () => {
+  assert.throws(
+    () => parseReplayCliEnvEntries(['lower=x']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /uppercase letters, digits, and underscores/.test(error.message),
+  );
+});
+
+test('buildReplayVarScope rejects AD_* keys in file env', () => {
+  assert.throws(
+    () => buildReplayVarScope({ fileEnv: { AD_FOO: 'x' } }),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /AD_\* namespace is reserved/.test(error.message),
+  );
+});
+
+test('buildReplayVarScope rejects AD_* keys in cli env', () => {
+  assert.throws(
+    () => buildReplayVarScope({ cliEnv: { AD_SESSION: 'x' } }),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /AD_\* namespace is reserved/.test(error.message),
+  );
+});
+
+test('buildReplayVarScope allows AD_* keys from builtins (trusted)', () => {
+  const scope = buildReplayVarScope({
+    builtins: { AD_SESSION: 's', AD_PLATFORM: 'android' },
+  });
+  assert.equal(scope.values.AD_SESSION, 's');
+  assert.equal(scope.values.AD_PLATFORM, 'android');
+});
+
+test('runReplayScriptFile rejects replay -u when any action contains ${VAR}', async () => {
+  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
+  const { SessionStore } = await import('../../session-store.ts');
+  const fs = await import('node:fs');
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-var-heal-'));
+  const scriptPath = path.join(root, 'flow.ad');
+  // No env directive, but positional uses ${APP}.
+  fs.writeFileSync(
+    scriptPath,
+    'context platform=android\nopen ${APP}\n',
+  );
+  const response = await runReplayScriptFile({
+    req: {
+      token: 't',
+      session: 's',
+      command: 'replay',
+      positionals: [scriptPath],
+      flags: { replayUpdate: true, replayEnv: ['APP=settings'] },
+    },
+    sessionName: 's',
+    logPath: path.join(root, 'log'),
+    sessionStore: new SessionStore(path.join(root, 'state')),
+    invoke: async () => ({ ok: true, data: {} }),
+  });
+  assert.equal(response.ok, false);
+  if (!response.ok) {
+    assert.equal(response.error.code, 'INVALID_ARGS');
+    assert.match(
+      response.error.message,
+      /replay -u does not yet preserve \$\{VAR\} substitutions/,
+    );
+  }
+});
+
+test('runReplayScriptFile dispatches resolved literals with file env overridden by CLI', async () => {
+  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
+  const { SessionStore } = await import('../../session-store.ts');
+  const fs = await import('node:fs');
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-green-'));
+  const scriptPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(
+    scriptPath,
+    [
+      'context platform=android',
+      'env APP=file-app',
+      'env SCOPE=file-scope',
+      '',
+      'open ${APP}',
+      'snapshot -s ${SCOPE}',
+      'click "at ${AD_FILENAME}"',
+    ].join('\n') + '\n',
+  );
+  const calls: Array<{ command: string; positionals?: string[]; flags?: Record<string, unknown> }> = [];
+  const response = await runReplayScriptFile({
+    req: {
+      token: 't',
+      session: 's',
+      command: 'replay',
+      positionals: [scriptPath],
+      flags: { replayEnv: ['APP=cli-app'] },
+      meta: { cwd: root },
+    },
+    sessionName: 's',
+    logPath: path.join(root, 'log'),
+    sessionStore: new SessionStore(path.join(root, 'state')),
+    invoke: async (req) => {
+      calls.push({
+        command: req.command,
+        positionals: req.positionals,
+        flags: req.flags,
+      });
+      return { ok: true, data: {} };
+    },
+  });
+  assert.equal(response.ok, true);
+  // open ${APP} -> CLI override wins.
+  assert.equal(calls[0]?.command, 'open');
+  assert.deepEqual(calls[0]?.positionals, ['cli-app']);
+  // snapshot -s ${SCOPE} -> file env fills in.
+  assert.equal(calls[1]?.command, 'snapshot');
+  assert.equal(calls[1]?.flags?.snapshotScope, 'file-scope');
+  // click with ${AD_FILENAME} resolves to the relative script path.
+  assert.equal(calls[2]?.command, 'click');
+  assert.deepEqual(calls[2]?.positionals, ['at flow.ad']);
+  // And nothing dispatched still contains a literal ${...} token.
+  for (const call of calls) {
+    for (const pos of call.positionals ?? []) {
+      assert.equal(pos.includes('${'), false, `unresolved interpolation leaked: ${pos}`);
+    }
+  }
 });

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -530,3 +530,38 @@ test('runReplayScriptFile falls back to process.env when request omits replayShe
     else process.env.AD_VAR_APP = previous;
   }
 });
+
+test('AD_ARTIFACTS resolves to per-attempt dir when artifactsDir flag is set by the test runner', async () => {
+  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
+  const { SessionStore } = await import('../../session-store.ts');
+  const fs = await import('node:fs');
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-artifacts-'));
+  const scriptPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(
+    scriptPath,
+    'context platform=android\nscreenshot "${AD_ARTIFACTS}/shot.png"\n',
+  );
+  const attemptDir = path.join(root, 'test-artifacts/run-x/flow/attempt-1');
+  const calls: Array<{ positionals?: string[] }> = [];
+  const response = await runReplayScriptFile({
+    req: {
+      token: 't',
+      session: 's',
+      command: 'replay',
+      positionals: [scriptPath],
+      flags: { artifactsDir: attemptDir },
+      meta: { cwd: root },
+    },
+    sessionName: 's',
+    logPath: path.join(root, 'log'),
+    sessionStore: new SessionStore(path.join(root, 'state')),
+    invoke: async (req) => {
+      calls.push({ positionals: req.positionals });
+      return { ok: true, data: {} };
+    },
+  });
+  assert.equal(response.ok, true);
+  assert.deepEqual(calls[0]?.positionals, [`${attemptDir}/shot.png`]);
+});

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -72,26 +72,17 @@ test('resolveReplayString substitutes variables', () => {
 
 test('resolveReplayString supports fallback with :-default', () => {
   const scope = buildReplayVarScope({});
-  assert.equal(
-    resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC),
-    'wait 500',
-  );
+  assert.equal(resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC), 'wait 500');
 });
 
 test('resolveReplayString prefers scope value over fallback', () => {
   const scope = buildReplayVarScope({ fileEnv: { WAIT_SHORT: '1000' } });
-  assert.equal(
-    resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC),
-    'wait 1000',
-  );
+  assert.equal(resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC), 'wait 1000');
 });
 
 test('resolveReplayString fallback preserves embedded braces via escapes', () => {
   const scope = buildReplayVarScope({});
-  assert.equal(
-    resolveReplayString('x ${A:-one\\}two}', scope, LOC),
-    'x one}two',
-  );
+  assert.equal(resolveReplayString('x ${A:-one\\}two}', scope, LOC), 'x one}two');
 });
 
 test('resolveReplayString supports escape for literal $', () => {
@@ -163,10 +154,10 @@ test('collectReplayShellEnv skips keys that land in reserved AD_* namespace afte
 });
 
 test('parseReplayCliEnvEntries splits KEY=VALUE and rejects invalid keys', () => {
-  assert.deepEqual(
-    parseReplayCliEnvEntries(['APP=settings', 'FOO=bar=baz']),
-    { APP: 'settings', FOO: 'bar=baz' },
-  );
+  assert.deepEqual(parseReplayCliEnvEntries(['APP=settings', 'FOO=bar=baz']), {
+    APP: 'settings',
+    FOO: 'bar=baz',
+  });
   assert.throws(() => parseReplayCliEnvEntries(['NOEQUAL']), AppError);
   assert.throws(() => parseReplayCliEnvEntries(['lower=x']), AppError);
   assert.throws(() => parseReplayCliEnvEntries(['=value']), AppError);
@@ -247,8 +238,7 @@ test('readReplayScriptMetadata parses quoted env values with spaces', () => {
 
 test('readReplayScriptMetadata rejects invalid env key', () => {
   assert.throws(
-    () =>
-      readReplayScriptMetadata('context platform=android\nenv lower=settings\n'),
+    () => readReplayScriptMetadata('context platform=android\nenv lower=settings\n'),
     (error: unknown) =>
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&
@@ -258,10 +248,7 @@ test('readReplayScriptMetadata rejects invalid env key', () => {
 
 test('readReplayScriptMetadata rejects duplicate env key', () => {
   assert.throws(
-    () =>
-      readReplayScriptMetadata(
-        'context platform=android\nenv APP=a\nenv APP=b\n',
-      ),
+    () => readReplayScriptMetadata('context platform=android\nenv APP=a\nenv APP=b\n'),
     (error: unknown) =>
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&
@@ -271,10 +258,7 @@ test('readReplayScriptMetadata rejects duplicate env key', () => {
 
 test('parseReplayScript rejects env after first action', () => {
   assert.throws(
-    () =>
-      parseReplayScript(
-        'context platform=android\nopen settings\nenv APP=late\n',
-      ),
+    () => parseReplayScript('context platform=android\nopen settings\nenv APP=late\n'),
     (error: unknown) =>
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&
@@ -390,10 +374,7 @@ test('runReplayScriptFile rejects replay -u when any action contains ${VAR}', as
   assert.equal(response.ok, false);
   if (!response.ok) {
     assert.equal(response.error.code, 'INVALID_ARGS');
-    assert.match(
-      response.error.message,
-      /replay -u does not yet preserve \$\{VAR\} substitutions/,
-    );
+    assert.match(response.error.message, /replay -u does not yet preserve \$\{VAR\} substitutions/);
   }
 });
 

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1,0 +1,290 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { AppError } from '../../../utils/errors.ts';
+import type { SessionAction } from '../../types.ts';
+import {
+  buildReplayVarScope,
+  collectReplayShellEnv,
+  parseReplayCliEnvEntries,
+  resolveReplayAction,
+  resolveReplayString,
+} from '../session-replay-vars.ts';
+import {
+  parseReplayScript,
+  parseReplayScriptDetailed,
+  readReplayScriptMetadata,
+} from '../session-replay-script.ts';
+
+const LOC = { file: 'test.ad', line: 1 };
+
+test('resolveReplayString substitutes variables', () => {
+  const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
+  assert.equal(resolveReplayString('open ${APP}', scope, LOC), 'open settings');
+});
+
+test('resolveReplayString supports fallback with :-default', () => {
+  const scope = buildReplayVarScope({});
+  assert.equal(
+    resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC),
+    'wait 500',
+  );
+});
+
+test('resolveReplayString prefers scope value over fallback', () => {
+  const scope = buildReplayVarScope({ fileEnv: { WAIT_SHORT: '1000' } });
+  assert.equal(
+    resolveReplayString('wait ${WAIT_SHORT:-500}', scope, LOC),
+    'wait 1000',
+  );
+});
+
+test('resolveReplayString fallback preserves embedded braces via escapes', () => {
+  const scope = buildReplayVarScope({});
+  assert.equal(
+    resolveReplayString('x ${A:-one\\}two}', scope, LOC),
+    'x one}two',
+  );
+});
+
+test('resolveReplayString supports escape for literal $', () => {
+  const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
+  assert.equal(resolveReplayString('\\${APP}', scope, LOC), '${APP}');
+});
+
+test('resolveReplayString throws on unresolved variable with file:line', () => {
+  const scope = buildReplayVarScope({ fileEnv: { OTHER: 'x' } });
+  assert.throws(
+    () => resolveReplayString('open ${MISSING}', scope, { file: 'a.ad', line: 7 }),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /Unresolved variable \$\{MISSING\} at a\.ad:7/.test(error.message),
+  );
+});
+
+test('resolveReplayString is case-sensitive', () => {
+  const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
+  assert.throws(() => resolveReplayString('${app}', scope, LOC), AppError);
+});
+
+test('resolveReplayString substitutes multiple vars on one line', () => {
+  const scope = buildReplayVarScope({ fileEnv: { A: '1', B: '2' } });
+  assert.equal(resolveReplayString('${A}-${B}-${A}', scope, LOC), '1-2-1');
+});
+
+test('buildReplayVarScope precedence: cli > shell > file > builtin', () => {
+  const scope = buildReplayVarScope({
+    builtins: { K: 'builtin' },
+    fileEnv: { K: 'file' },
+    shellEnv: { K: 'shell' },
+    cliEnv: { K: 'cli' },
+  });
+  assert.equal(scope.values.K, 'cli');
+
+  const shellWinsOverFile = buildReplayVarScope({
+    fileEnv: { K: 'file' },
+    shellEnv: { K: 'shell' },
+  });
+  assert.equal(shellWinsOverFile.values.K, 'shell');
+});
+
+test('collectReplayShellEnv strips AD_ prefix and ignores other vars', () => {
+  const result = collectReplayShellEnv({
+    AD_APP_ID: 'settings',
+    PATH: '/bin',
+    AD_123: 'x',
+    AD_: 'empty',
+    OTHER_VAR: 'y',
+  });
+  assert.equal(result.APP_ID, 'settings');
+  assert.equal(result.PATH, undefined);
+  assert.equal(result['123'], undefined);
+  assert.equal(result[''], undefined);
+});
+
+test('parseReplayCliEnvEntries splits KEY=VALUE and rejects invalid keys', () => {
+  assert.deepEqual(
+    parseReplayCliEnvEntries(['APP=settings', 'FOO=bar=baz']),
+    { APP: 'settings', FOO: 'bar=baz' },
+  );
+  assert.throws(() => parseReplayCliEnvEntries(['NOEQUAL']), AppError);
+  assert.throws(() => parseReplayCliEnvEntries(['lower=x']), AppError);
+  assert.throws(() => parseReplayCliEnvEntries(['=value']), AppError);
+});
+
+test('resolveReplayAction walks positionals and string flags', () => {
+  const action: SessionAction = {
+    ts: 0,
+    command: 'snapshot',
+    positionals: ['${FOO}'],
+    flags: {
+      snapshotScope: '${SCOPE}',
+      snapshotInteractiveOnly: true,
+      snapshotDepth: 3,
+    },
+  };
+  const scope = buildReplayVarScope({ fileEnv: { FOO: 'bar', SCOPE: 'app' } });
+  const resolved = resolveReplayAction(action, scope, LOC);
+  assert.deepEqual(resolved.positionals, ['bar']);
+  assert.equal(resolved.flags?.snapshotScope, 'app');
+  assert.equal(resolved.flags?.snapshotInteractiveOnly, true);
+  assert.equal(resolved.flags?.snapshotDepth, 3);
+});
+
+test('resolveReplayAction walks runtime hints', () => {
+  const action: SessionAction = {
+    ts: 0,
+    command: 'open',
+    positionals: [],
+    runtime: { platform: 'android', metroHost: '${HOST}' },
+    flags: {},
+  };
+  const scope = buildReplayVarScope({ fileEnv: { HOST: '10.0.0.1' } });
+  const resolved = resolveReplayAction(action, scope, LOC);
+  assert.equal(resolved.runtime?.metroHost, '10.0.0.1');
+});
+
+test('JSON-quoted args round-trip with ${VAR} intact after parse', () => {
+  const script = 'context platform=android\nenv SEL="label=Wait || label=Apps"\nclick "${SEL}"\n';
+  const actions = parseReplayScript(script);
+  assert.deepEqual(actions[0]?.positionals, ['${SEL}']);
+});
+
+test('parseReplayScriptDetailed tracks line numbers', () => {
+  const script = [
+    '# comment',
+    'context platform=android',
+    'env APP=settings',
+    '',
+    'open ${APP}',
+    'wait 500',
+  ].join('\n');
+  const parsed = parseReplayScriptDetailed(script);
+  assert.equal(parsed.actions.length, 2);
+  assert.deepEqual(parsed.actionLines, [5, 6]);
+});
+
+test('readReplayScriptMetadata parses env KEY=VALUE directives', () => {
+  const metadata = readReplayScriptMetadata(
+    'context platform=android\nenv APP=settings\nenv WAIT=500\nopen ${APP}\n',
+  );
+  assert.equal(metadata.env?.APP, 'settings');
+  assert.equal(metadata.env?.WAIT, '500');
+});
+
+test('readReplayScriptMetadata accepts env before context', () => {
+  const metadata = readReplayScriptMetadata('env APP=settings\ncontext platform=android\n');
+  assert.equal(metadata.platform, 'android');
+  assert.equal(metadata.env?.APP, 'settings');
+});
+
+test('readReplayScriptMetadata parses quoted env values with spaces', () => {
+  const metadata = readReplayScriptMetadata(
+    'context platform=android\nenv SEL="label=Wait || label=Apps"\n',
+  );
+  assert.equal(metadata.env?.SEL, 'label=Wait || label=Apps');
+});
+
+test('readReplayScriptMetadata rejects invalid env key', () => {
+  assert.throws(
+    () =>
+      readReplayScriptMetadata('context platform=android\nenv lower=settings\n'),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /Invalid env key "lower"/.test(error.message),
+  );
+});
+
+test('readReplayScriptMetadata rejects duplicate env key', () => {
+  assert.throws(
+    () =>
+      readReplayScriptMetadata(
+        'context platform=android\nenv APP=a\nenv APP=b\n',
+      ),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /Duplicate env directive "APP"/.test(error.message),
+  );
+});
+
+test('parseReplayScript rejects env after first action', () => {
+  assert.throws(
+    () =>
+      parseReplayScript(
+        'context platform=android\nopen settings\nenv APP=late\n',
+      ),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      /env directives must precede all actions/.test(error.message),
+  );
+});
+
+test('runReplayScriptFile rejects replay -u on scripts with env directives', async () => {
+  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
+  const { SessionStore } = await import('../../session-store.ts');
+  const fs = await import('node:fs');
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-env-heal-'));
+  const scriptPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(
+    scriptPath,
+    'context platform=android\nenv APP=settings\nopen ${APP}\n',
+  );
+  const response = await runReplayScriptFile({
+    req: {
+      token: 't',
+      session: 's',
+      command: 'replay',
+      positionals: [scriptPath],
+      flags: { replayUpdate: true },
+    },
+    sessionName: 's',
+    logPath: path.join(root, 'log'),
+    sessionStore: new SessionStore(path.join(root, 'state')),
+    invoke: async () => ({ ok: true, data: {} }),
+  });
+  assert.equal(response.ok, false);
+  if (!response.ok) {
+    assert.equal(response.error.code, 'INVALID_ARGS');
+    assert.match(response.error.message, /replay -u cannot heal scripts with env directives/);
+  }
+});
+
+test('resolveReplayAction produces dispatch-ready literals for a realistic fixture', () => {
+  const script = [
+    'context platform=android',
+    'env APP_ID=settings',
+    'env WAIT_SHORT=500',
+    'env SETTINGS_ITEMS="label=Wait || label=Apps"',
+    '',
+    'open ${APP_ID} --relaunch',
+    'wait ${WAIT_SHORT}',
+    'click "${SETTINGS_ITEMS}"',
+    'is exists "${SETTINGS_ITEMS}"',
+    'snapshot -s "${SNAPSHOT_SCOPE:-app}"',
+  ].join('\n');
+  const metadata = readReplayScriptMetadata(script);
+  const parsed = parseReplayScriptDetailed(script);
+  const scope = buildReplayVarScope({
+    builtins: { AD_PLATFORM: 'android' },
+    fileEnv: metadata.env,
+    shellEnv: { APP_ID: 'shell-wins' },
+    cliEnv: { APP_ID: 'cli-wins' },
+  });
+  const resolved = parsed.actions.map((action, index) =>
+    resolveReplayAction(action, scope, {
+      file: 'fixture.ad',
+      line: parsed.actionLines[index] ?? 0,
+    }),
+  );
+  assert.deepEqual(resolved[0]?.positionals, ['cli-wins']);
+  assert.equal(resolved[0]?.flags.relaunch, true);
+  assert.deepEqual(resolved[1]?.positionals, ['500']);
+  assert.deepEqual(resolved[2]?.positionals, ['label=Wait || label=Apps']);
+  assert.deepEqual(resolved[3]?.positionals, ['exists', 'label=Wait || label=Apps']);
+  assert.equal(resolved[4]?.flags.snapshotScope, 'app');
+});

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1,7 +1,12 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { AppError } from '../../../utils/errors.ts';
-import type { SessionAction } from '../../types.ts';
+import type { DaemonRequest, DaemonResponse, SessionAction } from '../../types.ts';
+import type { CommandFlags } from '../../../core/dispatch.ts';
+import { SessionStore } from '../../session-store.ts';
 import {
   buildReplayVarScope,
   collectReplayShellEnv,
@@ -14,8 +19,51 @@ import {
   parseReplayScriptDetailed,
   readReplayScriptMetadata,
 } from '../session-replay-script.ts';
+import { runReplayScriptFile } from '../session-replay-runtime.ts';
 
 const LOC = { file: 'test.ad', line: 1 };
+
+type CapturedInvocation = {
+  command: string;
+  positionals?: string[];
+  flags?: Record<string, unknown>;
+};
+
+async function runReplayFixture(params: {
+  label: string;
+  script: string;
+  flags?: CommandFlags;
+  invoke?: (req: DaemonRequest) => Promise<DaemonResponse>;
+}): Promise<{
+  response: DaemonResponse;
+  calls: CapturedInvocation[];
+  root: string;
+  scriptPath: string;
+}> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `agent-device-replay-${params.label}-`));
+  const scriptPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(scriptPath, params.script);
+  const calls: CapturedInvocation[] = [];
+  const defaultInvoke = async (req: DaemonRequest): Promise<DaemonResponse> => {
+    calls.push({ command: req.command, positionals: req.positionals, flags: req.flags });
+    return { ok: true, data: {} };
+  };
+  const response = await runReplayScriptFile({
+    req: {
+      token: 't',
+      session: 's',
+      command: 'replay',
+      positionals: [scriptPath],
+      flags: params.flags ?? {},
+      meta: { cwd: root },
+    },
+    sessionName: 's',
+    logPath: path.join(root, 'log'),
+    sessionStore: new SessionStore(path.join(root, 'state')),
+    invoke: params.invoke ?? defaultInvoke,
+  });
+  return { response, calls, root, scriptPath };
+}
 
 test('resolveReplayString substitutes variables', () => {
   const scope = buildReplayVarScope({ fileEnv: { APP: 'settings' } });
@@ -235,29 +283,10 @@ test('parseReplayScript rejects env after first action', () => {
 });
 
 test('runReplayScriptFile rejects replay -u on scripts with env directives', async () => {
-  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
-  const { SessionStore } = await import('../../session-store.ts');
-  const fs = await import('node:fs');
-  const os = await import('node:os');
-  const path = await import('node:path');
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-env-heal-'));
-  const scriptPath = path.join(root, 'flow.ad');
-  fs.writeFileSync(
-    scriptPath,
-    'context platform=android\nenv APP=settings\nopen ${APP}\n',
-  );
-  const response = await runReplayScriptFile({
-    req: {
-      token: 't',
-      session: 's',
-      command: 'replay',
-      positionals: [scriptPath],
-      flags: { replayUpdate: true },
-    },
-    sessionName: 's',
-    logPath: path.join(root, 'log'),
-    sessionStore: new SessionStore(path.join(root, 'state')),
-    invoke: async () => ({ ok: true, data: {} }),
+  const { response } = await runReplayFixture({
+    label: 'env-heal',
+    script: 'context platform=android\nenv APP=settings\nopen ${APP}\n',
+    flags: { replayUpdate: true },
   });
   assert.equal(response.ok, false);
   if (!response.ok) {
@@ -301,27 +330,35 @@ test('resolveReplayAction produces dispatch-ready literals for a realistic fixtu
   assert.equal(resolved[4]?.flags.snapshotScope, 'app');
 });
 
-test('parseReplayEnvLine rejects AD_* keys as reserved namespace', () => {
+test.each([
+  {
+    name: 'file env via parseReplayEnvLine',
+    run: () => readReplayScriptMetadata('context platform=android\nenv AD_FOO=bar\n'),
+    keyMatch: /AD_FOO/,
+  },
+  {
+    name: 'CLI -e via parseReplayCliEnvEntries',
+    run: () => parseReplayCliEnvEntries(['AD_FOO=x']),
+    keyMatch: /AD_FOO/,
+  },
+  {
+    name: 'buildReplayVarScope.fileEnv',
+    run: () => buildReplayVarScope({ fileEnv: { AD_FOO: 'x' } }),
+    keyMatch: /AD_FOO/,
+  },
+  {
+    name: 'buildReplayVarScope.cliEnv',
+    run: () => buildReplayVarScope({ cliEnv: { AD_SESSION: 'x' } }),
+    keyMatch: /AD_SESSION/,
+  },
+])('rejects AD_* as reserved namespace in $name', ({ run, keyMatch }) => {
   assert.throws(
-    () =>
-      readReplayScriptMetadata(
-        'context platform=android\nenv AD_FOO=bar\n',
-      ),
+    run,
     (error: unknown) =>
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&
       /AD_\* namespace is reserved/.test(error.message) &&
-      /AD_FOO/.test(error.message),
-  );
-});
-
-test('parseReplayCliEnvEntries rejects AD_* keys as reserved namespace', () => {
-  assert.throws(
-    () => parseReplayCliEnvEntries(['AD_FOO=x']),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /AD_\* namespace is reserved/.test(error.message),
+      keyMatch.test(error.message),
   );
 });
 
@@ -335,26 +372,6 @@ test('parseReplayCliEnvEntries error wording is user-friendly for invalid keys',
   );
 });
 
-test('buildReplayVarScope rejects AD_* keys in file env', () => {
-  assert.throws(
-    () => buildReplayVarScope({ fileEnv: { AD_FOO: 'x' } }),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /AD_\* namespace is reserved/.test(error.message),
-  );
-});
-
-test('buildReplayVarScope rejects AD_* keys in cli env', () => {
-  assert.throws(
-    () => buildReplayVarScope({ cliEnv: { AD_SESSION: 'x' } }),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      /AD_\* namespace is reserved/.test(error.message),
-  );
-});
-
 test('buildReplayVarScope allows AD_* keys from builtins (trusted)', () => {
   const scope = buildReplayVarScope({
     builtins: { AD_SESSION: 's', AD_PLATFORM: 'android' },
@@ -364,30 +381,11 @@ test('buildReplayVarScope allows AD_* keys from builtins (trusted)', () => {
 });
 
 test('runReplayScriptFile rejects replay -u when any action contains ${VAR}', async () => {
-  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
-  const { SessionStore } = await import('../../session-store.ts');
-  const fs = await import('node:fs');
-  const os = await import('node:os');
-  const path = await import('node:path');
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-var-heal-'));
-  const scriptPath = path.join(root, 'flow.ad');
-  // No env directive, but positional uses ${APP}.
-  fs.writeFileSync(
-    scriptPath,
-    'context platform=android\nopen ${APP}\n',
-  );
-  const response = await runReplayScriptFile({
-    req: {
-      token: 't',
-      session: 's',
-      command: 'replay',
-      positionals: [scriptPath],
-      flags: { replayUpdate: true, replayEnv: ['APP=settings'] },
-    },
-    sessionName: 's',
-    logPath: path.join(root, 'log'),
-    sessionStore: new SessionStore(path.join(root, 'state')),
-    invoke: async () => ({ ok: true, data: {} }),
+  const { response } = await runReplayFixture({
+    label: 'var-heal',
+    // No env directive, but positional uses ${APP}.
+    script: 'context platform=android\nopen ${APP}\n',
+    flags: { replayUpdate: true, replayEnv: ['APP=settings'] },
   });
   assert.equal(response.ok, false);
   if (!response.ok) {
@@ -400,46 +398,19 @@ test('runReplayScriptFile rejects replay -u when any action contains ${VAR}', as
 });
 
 test('runReplayScriptFile dispatches resolved literals with file env overridden by CLI', async () => {
-  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
-  const { SessionStore } = await import('../../session-store.ts');
-  const fs = await import('node:fs');
-  const os = await import('node:os');
-  const path = await import('node:path');
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-green-'));
-  const scriptPath = path.join(root, 'flow.ad');
-  fs.writeFileSync(
-    scriptPath,
-    [
-      'context platform=android',
-      'env APP=file-app',
-      'env SCOPE=file-scope',
-      '',
-      'open ${APP}',
-      'snapshot -s ${SCOPE}',
-      'click "at ${AD_FILENAME}"',
-    ].join('\n') + '\n',
-  );
-  const calls: Array<{ command: string; positionals?: string[]; flags?: Record<string, unknown> }> = [];
-  const response = await runReplayScriptFile({
-    req: {
-      token: 't',
-      session: 's',
-      command: 'replay',
-      positionals: [scriptPath],
-      flags: { replayEnv: ['APP=cli-app'] },
-      meta: { cwd: root },
-    },
-    sessionName: 's',
-    logPath: path.join(root, 'log'),
-    sessionStore: new SessionStore(path.join(root, 'state')),
-    invoke: async (req) => {
-      calls.push({
-        command: req.command,
-        positionals: req.positionals,
-        flags: req.flags,
-      });
-      return { ok: true, data: {} };
-    },
+  const { response, calls } = await runReplayFixture({
+    label: 'green',
+    script:
+      [
+        'context platform=android',
+        'env APP=file-app',
+        'env SCOPE=file-scope',
+        '',
+        'open ${APP}',
+        'snapshot -s ${SCOPE}',
+        'click "at ${AD_FILENAME}"',
+      ].join('\n') + '\n',
+    flags: { replayEnv: ['APP=cli-app'] },
   });
   assert.equal(response.ok, true);
   // open ${APP} -> CLI override wins.
@@ -460,71 +431,28 @@ test('runReplayScriptFile dispatches resolved literals with file env overridden 
 });
 
 test('runReplayScriptFile reads shell env from request (client-collected), not daemon process.env', async () => {
-  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
-  const { SessionStore } = await import('../../session-store.ts');
-  const fs = await import('node:fs');
-  const os = await import('node:os');
-  const path = await import('node:path');
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-shell-'));
-  const scriptPath = path.join(root, 'flow.ad');
-  fs.writeFileSync(scriptPath, 'context platform=android\nopen ${APP}\n');
   // Ensure the daemon's own process.env does NOT contain AD_VAR_APP.
   assert.equal(process.env.AD_VAR_APP, undefined);
-  const calls: string[] = [];
-  const response = await runReplayScriptFile({
-    req: {
-      token: 't',
-      session: 's',
-      command: 'replay',
-      positionals: [scriptPath],
-      // Client-collected shell env; still uses the raw AD_VAR_* prefix.
-      flags: { replayShellEnv: { AD_VAR_APP: 'client-shell-app' } },
-      meta: { cwd: root },
-    },
-    sessionName: 's',
-    logPath: path.join(root, 'log'),
-    sessionStore: new SessionStore(path.join(root, 'state')),
-    invoke: async (req) => {
-      calls.push((req.positionals ?? []).join(' '));
-      return { ok: true, data: {} };
-    },
+  const { response, calls } = await runReplayFixture({
+    label: 'shell',
+    script: 'context platform=android\nopen ${APP}\n',
+    // Client-collected shell env; still uses the raw AD_VAR_* prefix.
+    flags: { replayShellEnv: { AD_VAR_APP: 'client-shell-app' } },
   });
   assert.equal(response.ok, true);
-  assert.deepEqual(calls, ['client-shell-app']);
+  assert.deepEqual(calls[0]?.positionals, ['client-shell-app']);
 });
 
 test('runReplayScriptFile falls back to process.env when request omits replayShellEnv', async () => {
-  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
-  const { SessionStore } = await import('../../session-store.ts');
-  const fs = await import('node:fs');
-  const os = await import('node:os');
-  const path = await import('node:path');
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-shell-fallback-'));
-  const scriptPath = path.join(root, 'flow.ad');
-  fs.writeFileSync(scriptPath, 'context platform=android\nopen ${APP}\n');
   const previous = process.env.AD_VAR_APP;
   process.env.AD_VAR_APP = 'daemon-env-app';
   try {
-    const calls: string[] = [];
-    const response = await runReplayScriptFile({
-      req: {
-        token: 't',
-        session: 's',
-        command: 'replay',
-        positionals: [scriptPath],
-        flags: {},
-        meta: { cwd: root },
-      },
-      sessionName: 's',
-      logPath: path.join(root, 'log'),
-      sessionStore: new SessionStore(path.join(root, 'state')),
-      invoke: async (req) => {
-        calls.push((req.positionals ?? []).join(' '));
-        return { ok: true, data: {} };
-      },
+    const { response, calls } = await runReplayFixture({
+      label: 'shell-fallback',
+      script: 'context platform=android\nopen ${APP}\n',
     });
     assert.equal(response.ok, true);
-    assert.deepEqual(calls, ['daemon-env-app']);
+    assert.deepEqual(calls[0]?.positionals, ['daemon-env-app']);
   } finally {
     if (previous === undefined) delete process.env.AD_VAR_APP;
     else process.env.AD_VAR_APP = previous;
@@ -532,35 +460,11 @@ test('runReplayScriptFile falls back to process.env when request omits replayShe
 });
 
 test('AD_ARTIFACTS resolves to per-attempt dir when artifactsDir flag is set by the test runner', async () => {
-  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
-  const { SessionStore } = await import('../../session-store.ts');
-  const fs = await import('node:fs');
-  const os = await import('node:os');
-  const path = await import('node:path');
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-artifacts-'));
-  const scriptPath = path.join(root, 'flow.ad');
-  fs.writeFileSync(
-    scriptPath,
-    'context platform=android\nscreenshot "${AD_ARTIFACTS}/shot.png"\n',
-  );
-  const attemptDir = path.join(root, 'test-artifacts/run-x/flow/attempt-1');
-  const calls: Array<{ positionals?: string[] }> = [];
-  const response = await runReplayScriptFile({
-    req: {
-      token: 't',
-      session: 's',
-      command: 'replay',
-      positionals: [scriptPath],
-      flags: { artifactsDir: attemptDir },
-      meta: { cwd: root },
-    },
-    sessionName: 's',
-    logPath: path.join(root, 'log'),
-    sessionStore: new SessionStore(path.join(root, 'state')),
-    invoke: async (req) => {
-      calls.push({ positionals: req.positionals });
-      return { ok: true, data: {} };
-    },
+  const attemptDir = '/tmp/agent-device-replay-artifacts-stub/run-x/flow/attempt-1';
+  const { response, calls } = await runReplayFixture({
+    label: 'artifacts',
+    script: 'context platform=android\nscreenshot "${AD_ARTIFACTS}/shot.png"\n',
+    flags: { artifactsDir: attemptDir },
   });
   assert.equal(response.ok, true);
   assert.deepEqual(calls[0]?.positionals, [`${attemptDir}/shot.png`]);

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -458,3 +458,75 @@ test('runReplayScriptFile dispatches resolved literals with file env overridden 
     }
   }
 });
+
+test('runReplayScriptFile reads shell env from request (client-collected), not daemon process.env', async () => {
+  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
+  const { SessionStore } = await import('../../session-store.ts');
+  const fs = await import('node:fs');
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-shell-'));
+  const scriptPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(scriptPath, 'context platform=android\nopen ${APP}\n');
+  // Ensure the daemon's own process.env does NOT contain AD_VAR_APP.
+  assert.equal(process.env.AD_VAR_APP, undefined);
+  const calls: string[] = [];
+  const response = await runReplayScriptFile({
+    req: {
+      token: 't',
+      session: 's',
+      command: 'replay',
+      positionals: [scriptPath],
+      // Client-collected shell env; still uses the raw AD_VAR_* prefix.
+      flags: { replayShellEnv: { AD_VAR_APP: 'client-shell-app' } },
+      meta: { cwd: root },
+    },
+    sessionName: 's',
+    logPath: path.join(root, 'log'),
+    sessionStore: new SessionStore(path.join(root, 'state')),
+    invoke: async (req) => {
+      calls.push((req.positionals ?? []).join(' '));
+      return { ok: true, data: {} };
+    },
+  });
+  assert.equal(response.ok, true);
+  assert.deepEqual(calls, ['client-shell-app']);
+});
+
+test('runReplayScriptFile falls back to process.env when request omits replayShellEnv', async () => {
+  const { runReplayScriptFile } = await import('../session-replay-runtime.ts');
+  const { SessionStore } = await import('../../session-store.ts');
+  const fs = await import('node:fs');
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-shell-fallback-'));
+  const scriptPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(scriptPath, 'context platform=android\nopen ${APP}\n');
+  const previous = process.env.AD_VAR_APP;
+  process.env.AD_VAR_APP = 'daemon-env-app';
+  try {
+    const calls: string[] = [];
+    const response = await runReplayScriptFile({
+      req: {
+        token: 't',
+        session: 's',
+        command: 'replay',
+        positionals: [scriptPath],
+        flags: {},
+        meta: { cwd: root },
+      },
+      sessionName: 's',
+      logPath: path.join(root, 'log'),
+      sessionStore: new SessionStore(path.join(root, 'state')),
+      invoke: async (req) => {
+        calls.push((req.positionals ?? []).join(' '));
+        return { ok: true, data: {} };
+      },
+    });
+    assert.equal(response.ok, true);
+    assert.deepEqual(calls, ['daemon-env-app']);
+  } finally {
+    if (previous === undefined) delete process.env.AD_VAR_APP;
+    else process.env.AD_VAR_APP = previous;
+  }
+});

--- a/src/daemon/handlers/__tests__/session-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { buildReplayActionFlags, withReplayFailureContext } from '../session-replay-runtime.ts';
+import { buildNestedReplayFlags } from '../session-replay.ts';
 
 test('buildReplayActionFlags keeps allowed parent flags only', () => {
   const flags = buildReplayActionFlags(
@@ -47,4 +48,49 @@ test('withReplayFailureContext annotates replay step details', () => {
     assert.equal(response.error.details?.replayPath, '/tmp/flow.ad');
     assert.deepEqual(response.error.details?.artifactPaths, ['/tmp/snapshot.json']);
   }
+});
+
+test('buildNestedReplayFlags returns parent flags untouched when neither override is set', () => {
+  const parent = { platform: 'android' as const, timeoutMs: 5000 };
+  const result = buildNestedReplayFlags({
+    parentFlags: parent,
+    platform: undefined,
+    artifactsDir: undefined,
+  });
+  assert.strictEqual(result, parent);
+});
+
+test('buildNestedReplayFlags merges platform and artifactsDir into parent flags', () => {
+  const parent = { timeoutMs: 5000, retries: 1 };
+  const result = buildNestedReplayFlags({
+    parentFlags: parent,
+    platform: 'ios',
+    artifactsDir: '/tmp/attempt-1',
+  });
+  assert.deepEqual(result, {
+    timeoutMs: 5000,
+    retries: 1,
+    platform: 'ios',
+    artifactsDir: '/tmp/attempt-1',
+  });
+  // Parent object must not be mutated.
+  assert.equal((parent as Record<string, unknown>).artifactsDir, undefined);
+});
+
+test('buildNestedReplayFlags threads artifactsDir through even when parent lacks it', () => {
+  const result = buildNestedReplayFlags({
+    parentFlags: undefined,
+    platform: undefined,
+    artifactsDir: '/tmp/attempt-1',
+  });
+  assert.deepEqual(result, { artifactsDir: '/tmp/attempt-1' });
+});
+
+test('buildNestedReplayFlags overrides a parent artifactsDir with the attempt-level one', () => {
+  const result = buildNestedReplayFlags({
+    parentFlags: { artifactsDir: '/suite-root' },
+    platform: undefined,
+    artifactsDir: '/suite-root/flow/attempt-2',
+  });
+  assert.equal(result?.artifactsDir, '/suite-root/flow/attempt-2');
 });

--- a/src/daemon/handlers/__tests__/session-test-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-runtime.test.ts
@@ -49,9 +49,7 @@ test('runReplayTestAttempt keeps cancellation active until a timed-out replay se
 });
 
 test('runReplayTestAttempt forwards artifactsDir to the runReplay callback', async () => {
-  const runReplay = vi.fn(
-    async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
-  );
+  const runReplay = vi.fn(async (): Promise<DaemonResponse> => ({ ok: true, data: {} }));
   const cleanupSession = vi.fn(async () => {});
   await runReplayTestAttempt({
     filePath: 'flow.ad',

--- a/src/daemon/handlers/__tests__/session-test-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-runtime.test.ts
@@ -47,3 +47,21 @@ test('runReplayTestAttempt keeps cancellation active until a timed-out replay se
 
   expect(isRequestCanceled('req-timeout-open')).toBe(false);
 });
+
+test('runReplayTestAttempt forwards artifactsDir to the runReplay callback', async () => {
+  const runReplay = vi.fn(
+    async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+  );
+  const cleanupSession = vi.fn(async () => {});
+  await runReplayTestAttempt({
+    filePath: 'flow.ad',
+    sessionName: 's',
+    requestId: 'req-artifacts',
+    artifactsDir: '/tmp/attempt-1',
+    runReplay,
+    cleanupSession,
+  });
+  expect(runReplay).toHaveBeenCalledWith(
+    expect.objectContaining({ artifactsDir: '/tmp/attempt-1' }),
+  );
+});

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -71,7 +71,7 @@ export async function runReplayScriptFile(params: {
         resolvedPath: resolved,
       }),
       fileEnv: metadata.env,
-      shellEnv: collectReplayShellEnv(process.env),
+      shellEnv: collectReplayShellEnv(readShellEnvSource(req)),
       cliEnv: parseReplayCliEnvEntries(readCliEnvEntries(req)),
     });
     const shouldUpdate = req.flags?.replayUpdate === true;
@@ -196,6 +196,18 @@ function buildReplayBuiltinVars(params: {
 function readCliEnvEntries(req: DaemonRequest): string[] {
   const raw = req.flags?.replayEnv;
   return Array.isArray(raw) ? raw.filter((value): value is string => typeof value === 'string') : [];
+}
+
+function readShellEnvSource(req: DaemonRequest): NodeJS.ProcessEnv {
+  const raw = req.flags?.replayShellEnv;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const result: NodeJS.ProcessEnv = {};
+    for (const [key, value] of Object.entries(raw)) {
+      if (typeof value === 'string') result[key] = value;
+    }
+    return result;
+  }
+  return process.env;
 }
 
 export function withReplayFailureContext(

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -54,7 +54,13 @@ export async function runReplayScriptFile(params: {
     if (req.flags?.replayUpdate === true && metadata.env && Object.keys(metadata.env).length > 0) {
       return errorResponse(
         'INVALID_ARGS',
-        'replay -u cannot heal scripts with env directives yet; the writer would drop the env block.',
+        'replay -u does not yet preserve env directives. Temporarily remove the env lines, run replay -u, then restore them.',
+      );
+    }
+    if (req.flags?.replayUpdate === true && actionsContainInterpolation(actions)) {
+      return errorResponse(
+        'INVALID_ARGS',
+        'replay -u does not yet preserve ${VAR} substitutions. Resolve or inline the variables before running with -u.',
       );
     }
     const scope = buildReplayVarScope({
@@ -254,4 +260,23 @@ export function buildReplayActionFlags(
   actionFlags: SessionAction['flags'] | undefined,
 ): CommandFlags {
   return mergeParentFlags(parentFlags, { ...(actionFlags ?? {}) });
+}
+
+function actionsContainInterpolation(actions: SessionAction[]): boolean {
+  for (const action of actions) {
+    for (const positional of action.positionals ?? []) {
+      if (typeof positional === 'string' && positional.includes('${')) return true;
+    }
+    if (action.flags) {
+      for (const value of Object.values(action.flags)) {
+        if (typeof value === 'string' && value.includes('${')) return true;
+      }
+    }
+    if (action.runtime) {
+      for (const value of Object.values(action.runtime)) {
+        if (typeof value === 'string' && value.includes('${')) return true;
+      }
+    }
+  }
+  return false;
 }

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -195,7 +195,9 @@ function buildReplayBuiltinVars(params: {
 
 function readCliEnvEntries(req: DaemonRequest): string[] {
   const raw = req.flags?.replayEnv;
-  return Array.isArray(raw) ? raw.filter((value): value is string => typeof value === 'string') : [];
+  return Array.isArray(raw)
+    ? raw.filter((value): value is string => typeof value === 'string')
+    : [];
 }
 
 function readShellEnvSource(req: DaemonRequest): NodeJS.ProcessEnv {

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -1,13 +1,25 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { type CommandFlags } from '../../core/dispatch.ts';
 import { asAppError } from '../../utils/errors.ts';
 import type { DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
-import { parseReplayScript, writeReplayScript } from './session-replay-script.ts';
+import {
+  parseReplayScriptDetailed,
+  readReplayScriptMetadata,
+  writeReplayScript,
+} from './session-replay-script.ts';
 import { healReplayAction } from './session-replay-heal.ts';
 import { formatScriptActionSummary } from '../script-utils.ts';
 import { mergeParentFlags } from './handler-utils.ts';
 import { errorResponse } from './response.ts';
+import {
+  buildReplayVarScope,
+  collectReplayShellEnv,
+  parseReplayCliEnvEntries,
+  resolveReplayAction,
+  type ReplayVarScope,
+} from './session-replay-vars.ts';
 
 export async function runReplayScriptFile(params: {
   req: DaemonRequest;
@@ -35,7 +47,27 @@ export async function runReplayScriptFile(params: {
       );
     }
 
-    const actions = parseReplayScript(script);
+    const metadata = readReplayScriptMetadata(script);
+    const parsed = parseReplayScriptDetailed(script);
+    const actions = parsed.actions;
+    const actionLines = parsed.actionLines;
+    if (req.flags?.replayUpdate === true && metadata.env && Object.keys(metadata.env).length > 0) {
+      return errorResponse(
+        'INVALID_ARGS',
+        'replay -u cannot heal scripts with env directives yet; the writer would drop the env block.',
+      );
+    }
+    const scope = buildReplayVarScope({
+      builtins: buildReplayBuiltinVars({
+        req,
+        sessionName,
+        metadata,
+        resolvedPath: resolved,
+      }),
+      fileEnv: metadata.env,
+      shellEnv: collectReplayShellEnv(process.env),
+      cliEnv: parseReplayCliEnvEntries(readCliEnvEntries(req)),
+    });
     const shouldUpdate = req.flags?.replayUpdate === true;
     let healed = 0;
     for (let index = 0; index < actions.length; index += 1) {
@@ -46,6 +78,9 @@ export async function runReplayScriptFile(params: {
         req,
         sessionName,
         action,
+        scope,
+        filePath: resolved,
+        line: actionLines[index] ?? 0,
         invoke,
       });
       if (response.ok) {
@@ -71,6 +106,9 @@ export async function runReplayScriptFile(params: {
         req,
         sessionName,
         action: nextAction,
+        scope,
+        filePath: resolved,
+        line: actionLines[index] ?? 0,
         invoke,
       });
       if (!response.ok) {
@@ -106,18 +144,52 @@ async function invokeReplayAction(params: {
   req: DaemonRequest;
   sessionName: string;
   action: SessionAction;
+  scope: ReplayVarScope;
+  filePath: string;
+  line: number;
   invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
 }): Promise<DaemonResponse> {
-  const { req, sessionName, action, invoke } = params;
+  const { req, sessionName, action, scope, filePath, line, invoke } = params;
+  const resolved = resolveReplayAction(action, scope, { file: filePath, line });
   return await invoke({
     token: req.token,
     session: sessionName,
-    command: action.command,
-    positionals: action.positionals ?? [],
-    flags: buildReplayActionFlags(req.flags, action.flags),
-    runtime: action.runtime,
+    command: resolved.command,
+    positionals: resolved.positionals ?? [],
+    flags: buildReplayActionFlags(req.flags, resolved.flags),
+    runtime: resolved.runtime,
     meta: req.meta,
   });
+}
+
+function buildReplayBuiltinVars(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  metadata: ReturnType<typeof readReplayScriptMetadata>;
+  resolvedPath: string;
+}): Record<string, string> {
+  const { req, sessionName, metadata, resolvedPath } = params;
+  const flags = req.flags ?? {};
+  const cwd = req.meta?.cwd ?? process.cwd();
+  const filename = path.relative(cwd, resolvedPath) || resolvedPath;
+  const builtins: Record<string, string> = {
+    AD_SESSION: sessionName,
+    AD_FILENAME: filename,
+  };
+  const platform = (flags.platform as string | undefined) ?? metadata.platform;
+  if (platform) builtins.AD_PLATFORM = platform;
+  const device = flags.device;
+  if (typeof device === 'string' && device.length > 0) builtins.AD_DEVICE = device;
+  const artifactsDir = flags.artifactsDir;
+  if (typeof artifactsDir === 'string' && artifactsDir.length > 0) {
+    builtins.AD_ARTIFACTS = artifactsDir;
+  }
+  return builtins;
+}
+
+function readCliEnvEntries(req: DaemonRequest): string[] {
+  const raw = req.flags?.replayEnv;
+  return Array.isArray(raw) ? raw.filter((value): value is string => typeof value === 'string') : [];
 }
 
 export function withReplayFailureContext(

--- a/src/daemon/handlers/session-replay-script.ts
+++ b/src/daemon/handlers/session-replay-script.ts
@@ -14,6 +14,7 @@ import {
   parseReplaySeriesFlags,
   parseReplayRuntimeFlags,
 } from '../script-utils.ts';
+import { REPLAY_VAR_KEY_RE } from './session-replay-vars.ts';
 
 type ReplayScriptPlatform = Exclude<PlatformSelector, 'apple'>;
 
@@ -30,8 +31,6 @@ export type ReplayScriptMetadata = {
   retries?: number;
   env?: Record<string, string>;
 };
-
-const REPLAY_ENV_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
 
 export function parseReplayScript(script: string): SessionAction[] {
   return parseReplayScriptDetailed(script).actions;
@@ -110,7 +109,7 @@ function isReplayEnvLine(trimmed: string): boolean {
   return trimmed === 'env' || trimmed.startsWith('env ') || trimmed.startsWith('env\t');
 }
 
-export function parseReplayEnvLine(trimmed: string, lineNumber: number): { key: string; value: string } {
+function parseReplayEnvLine(trimmed: string, lineNumber: number): { key: string; value: string } {
   const body = trimmed.slice(3).replace(/^[\s]+/, '');
   const eqIndex = body.indexOf('=');
   if (eqIndex <= 0) {
@@ -120,7 +119,7 @@ export function parseReplayEnvLine(trimmed: string, lineNumber: number): { key: 
     );
   }
   const key = body.slice(0, eqIndex);
-  if (!REPLAY_ENV_KEY_RE.test(key)) {
+  if (!REPLAY_VAR_KEY_RE.test(key)) {
     throw new AppError(
       'INVALID_ARGS',
       `Invalid env key "${key}" on line ${lineNumber}: keys must be uppercase letters, digits, and underscores (e.g. APP_ID).`,

--- a/src/daemon/handlers/session-replay-script.ts
+++ b/src/daemon/handlers/session-replay-script.ts
@@ -146,10 +146,7 @@ function decodeReplayEnvValue(raw: string, lineNumber: number): string {
       }
       return parsed;
     } catch {
-      throw new AppError(
-        'INVALID_ARGS',
-        `Invalid quoted env value on line ${lineNumber}.`,
-      );
+      throw new AppError('INVALID_ARGS', `Invalid quoted env value on line ${lineNumber}.`);
     }
   }
   return raw;
@@ -159,10 +156,7 @@ function ingestEnvLine(metadata: ReplayScriptMetadata, trimmed: string, lineNumb
   const { key, value } = parseReplayEnvLine(trimmed, lineNumber);
   const env = metadata.env ?? {};
   if (Object.prototype.hasOwnProperty.call(env, key)) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Duplicate env directive "${key}" on line ${lineNumber}.`,
-    );
+    throw new AppError('INVALID_ARGS', `Duplicate env directive "${key}" on line ${lineNumber}.`);
   }
   env[key] = value;
   metadata.env = env;

--- a/src/daemon/handlers/session-replay-script.ts
+++ b/src/daemon/handlers/session-replay-script.ts
@@ -123,7 +123,13 @@ export function parseReplayEnvLine(trimmed: string, lineNumber: number): { key: 
   if (!REPLAY_ENV_KEY_RE.test(key)) {
     throw new AppError(
       'INVALID_ARGS',
-      `Invalid env key "${key}" on line ${lineNumber}: must match /^[A-Z_][A-Z0-9_]*$/.`,
+      `Invalid env key "${key}" on line ${lineNumber}: keys must be uppercase letters, digits, and underscores (e.g. APP_ID).`,
+    );
+  }
+  if (key.startsWith('AD_')) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Invalid env key "${key}" on line ${lineNumber}: the AD_* namespace is reserved for built-in variables. Rename ${key} to avoid the AD_ prefix.`,
     );
   }
   const rawValue = body.slice(eqIndex + 1);

--- a/src/daemon/handlers/session-replay-script.ts
+++ b/src/daemon/handlers/session-replay-script.ts
@@ -28,27 +28,58 @@ export type ReplayScriptMetadata = {
   platform?: ReplayScriptPlatform;
   timeoutMs?: number;
   retries?: number;
+  env?: Record<string, string>;
 };
 
+const REPLAY_ENV_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
+
 export function parseReplayScript(script: string): SessionAction[] {
+  return parseReplayScriptDetailed(script).actions;
+}
+
+export type ParsedReplayScript = {
+  actions: SessionAction[];
+  actionLines: number[];
+};
+
+export function parseReplayScriptDetailed(script: string): ParsedReplayScript {
   const actions: SessionAction[] = [];
+  const actionLines: number[] = [];
   const lines = script.split(/\r?\n/);
-  for (const line of lines) {
-    const parsed = parseReplayScriptLine(line);
-    if (parsed) {
-      actions.push(parsed);
+  let sawAction = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index];
+    const trimmed = rawLine.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) continue;
+    if (isReplayEnvLine(trimmed)) {
+      if (sawAction) {
+        throw new AppError(
+          'INVALID_ARGS',
+          `env directives must precede all actions (line ${index + 1}).`,
+        );
+      }
+      continue;
     }
+    const parsed = parseReplayScriptLine(rawLine);
+    if (!parsed) continue;
+    actions.push(parsed);
+    actionLines.push(index + 1);
+    sawAction = true;
   }
-  return actions;
+  return { actions, actionLines };
 }
 
 export function readReplayScriptMetadata(script: string): ReplayScriptMetadata {
   const lines = script.split(/\r?\n/);
   const metadata: ReplayScriptMetadata = {};
-  for (const line of lines) {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
     const trimmed = line.trim();
     if (trimmed.length === 0 || trimmed.startsWith('#')) continue;
-    // Metadata comes only from the leading context header block.
+    if (isReplayEnvLine(trimmed)) {
+      ingestEnvLine(metadata, trimmed, index + 1);
+      continue;
+    }
     if (!trimmed.startsWith('context ')) break;
     const platformMatch = trimmed.match(/(?:^|\s)platform=([^\s]+)/);
     if (platformMatch) {
@@ -73,6 +104,63 @@ export function readReplayScriptMetadata(script: string): ReplayScriptMetadata {
     }
   }
   return metadata;
+}
+
+function isReplayEnvLine(trimmed: string): boolean {
+  return trimmed === 'env' || trimmed.startsWith('env ') || trimmed.startsWith('env\t');
+}
+
+export function parseReplayEnvLine(trimmed: string, lineNumber: number): { key: string; value: string } {
+  const body = trimmed.slice(3).replace(/^[\s]+/, '');
+  const eqIndex = body.indexOf('=');
+  if (eqIndex <= 0) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Invalid env directive on line ${lineNumber}: expected "env KEY=VALUE".`,
+    );
+  }
+  const key = body.slice(0, eqIndex);
+  if (!REPLAY_ENV_KEY_RE.test(key)) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Invalid env key "${key}" on line ${lineNumber}: must match /^[A-Z_][A-Z0-9_]*$/.`,
+    );
+  }
+  const rawValue = body.slice(eqIndex + 1);
+  const value = decodeReplayEnvValue(rawValue, lineNumber);
+  return { key, value };
+}
+
+function decodeReplayEnvValue(raw: string, lineNumber: number): string {
+  if (raw.length === 0) return '';
+  if (raw.startsWith('"')) {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (typeof parsed !== 'string') {
+        throw new Error('not a string literal');
+      }
+      return parsed;
+    } catch {
+      throw new AppError(
+        'INVALID_ARGS',
+        `Invalid quoted env value on line ${lineNumber}.`,
+      );
+    }
+  }
+  return raw;
+}
+
+function ingestEnvLine(metadata: ReplayScriptMetadata, trimmed: string, lineNumber: number): void {
+  const { key, value } = parseReplayEnvLine(trimmed, lineNumber);
+  const env = metadata.env ?? {};
+  if (Object.prototype.hasOwnProperty.call(env, key)) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Duplicate env directive "${key}" on line ${lineNumber}.`,
+    );
+  }
+  env[key] = value;
+  metadata.env = env;
 }
 
 function assignReplayMetadataValue<Key extends keyof ReplayScriptMetadata>(

--- a/src/daemon/handlers/session-replay-vars.ts
+++ b/src/daemon/handlers/session-replay-vars.ts
@@ -1,0 +1,136 @@
+import { AppError } from '../../utils/errors.ts';
+import type { SessionAction, SessionRuntimeHints } from '../types.ts';
+
+export type ReplayVarScope = {
+  readonly values: Readonly<Record<string, string>>;
+};
+
+export type ReplayVarSources = {
+  builtins?: Record<string, string>;
+  fileEnv?: Record<string, string>;
+  shellEnv?: Record<string, string>;
+  cliEnv?: Record<string, string>;
+};
+
+const VAR_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
+const INTERPOLATION_RE =
+  /(\\\$\{)|\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:[^}\\]|\\.)*))?\}/g;
+const SHELL_PREFIX = 'AD_';
+
+export function buildReplayVarScope(sources: ReplayVarSources): ReplayVarScope {
+  const merged: Record<string, string> = {};
+  const layers: Array<Record<string, string> | undefined> = [
+    sources.builtins,
+    sources.fileEnv,
+    sources.shellEnv,
+    sources.cliEnv,
+  ];
+  for (const layer of layers) {
+    if (!layer) continue;
+    for (const [key, value] of Object.entries(layer)) {
+      merged[key] = value;
+    }
+  }
+  return { values: merged };
+}
+
+export function collectReplayShellEnv(processEnv: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [rawKey, value] of Object.entries(processEnv)) {
+    if (typeof value !== 'string') continue;
+    if (!rawKey.startsWith(SHELL_PREFIX)) continue;
+    const key = rawKey.slice(SHELL_PREFIX.length);
+    if (key.length === 0) continue;
+    if (!VAR_KEY_RE.test(key)) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+export function parseReplayCliEnvEntries(entries: readonly string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const entry of entries) {
+    const eqIndex = entry.indexOf('=');
+    if (eqIndex <= 0) {
+      throw new AppError('INVALID_ARGS', `Invalid -e entry "${entry}": expected KEY=VALUE.`);
+    }
+    const key = entry.slice(0, eqIndex);
+    if (!VAR_KEY_RE.test(key)) {
+      throw new AppError(
+        'INVALID_ARGS',
+        `Invalid -e key "${key}": must match /^[A-Z_][A-Z0-9_]*$/.`,
+      );
+    }
+    result[key] = entry.slice(eqIndex + 1);
+  }
+  return result;
+}
+
+export function resolveReplayString(
+  raw: string,
+  scope: ReplayVarScope,
+  loc: { file: string; line: number },
+): string {
+  return raw.replace(INTERPOLATION_RE, (match, escapedLiteral: string | undefined, key: string | undefined, fallback: string | undefined) => {
+    if (escapedLiteral) return '${';
+    if (!key) return match;
+    if (Object.prototype.hasOwnProperty.call(scope.values, key)) {
+      return scope.values[key];
+    }
+    if (fallback !== undefined) {
+      return fallback.replace(/\\(.)/g, '$1');
+    }
+    throw new AppError(
+      'INVALID_ARGS',
+      `Unresolved variable \${${key}} at ${loc.file}:${loc.line}.`,
+    );
+  });
+}
+
+export function resolveReplayAction(
+  action: SessionAction,
+  scope: ReplayVarScope,
+  loc: { file: string; line: number },
+): SessionAction {
+  const positionals = (action.positionals ?? []).map((token) =>
+    resolveReplayString(token, scope, loc),
+  );
+  const flags = resolveReplayFlags(action.flags, scope, loc);
+  const runtime = resolveReplayRuntime(action.runtime, scope, loc);
+  return {
+    ...action,
+    positionals,
+    flags,
+    runtime,
+  };
+}
+
+function resolveReplayFlags(
+  flags: SessionAction['flags'] | undefined,
+  scope: ReplayVarScope,
+  loc: { file: string; line: number },
+): SessionAction['flags'] {
+  if (!flags) return {};
+  const next: Record<string, unknown> = { ...flags };
+  for (const [key, value] of Object.entries(next)) {
+    if (typeof value === 'string') {
+      next[key] = resolveReplayString(value, scope, loc);
+    }
+  }
+  return next as SessionAction['flags'];
+}
+
+function resolveReplayRuntime(
+  runtime: SessionRuntimeHints | undefined,
+  scope: ReplayVarScope,
+  loc: { file: string; line: number },
+): SessionRuntimeHints | undefined {
+  if (!runtime) return undefined;
+  const next: Record<string, unknown> = { ...runtime };
+  for (const [key, value] of Object.entries(next)) {
+    if (typeof value === 'string') {
+      next[key] = resolveReplayString(value, scope, loc);
+    }
+  }
+  return next as SessionRuntimeHints;
+}

--- a/src/daemon/handlers/session-replay-vars.ts
+++ b/src/daemon/handlers/session-replay-vars.ts
@@ -13,8 +13,7 @@ export type ReplayVarSources = {
 };
 
 export const REPLAY_VAR_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
-const INTERPOLATION_RE =
-  /(\\\$\{)|\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:[^}\\]|\\.)*))?\}/g;
+const INTERPOLATION_RE = /(\\\$\{)|\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:[^}\\]|\\.)*))?\}/g;
 const SHELL_PREFIX = 'AD_VAR_';
 const RESERVED_NAMESPACE_PREFIX = 'AD_';
 
@@ -97,20 +96,28 @@ export function resolveReplayString(
   scope: ReplayVarScope,
   loc: { file: string; line: number },
 ): string {
-  return raw.replace(INTERPOLATION_RE, (match, escapedLiteral: string | undefined, key: string | undefined, fallback: string | undefined) => {
-    if (escapedLiteral) return '${';
-    if (!key) return match;
-    if (Object.prototype.hasOwnProperty.call(scope.values, key)) {
-      return scope.values[key];
-    }
-    if (fallback !== undefined) {
-      return fallback.replace(/\\(.)/g, '$1');
-    }
-    throw new AppError(
-      'INVALID_ARGS',
-      `Unresolved variable \${${key}} at ${loc.file}:${loc.line}.`,
-    );
-  });
+  return raw.replace(
+    INTERPOLATION_RE,
+    (
+      match,
+      escapedLiteral: string | undefined,
+      key: string | undefined,
+      fallback: string | undefined,
+    ) => {
+      if (escapedLiteral) return '${';
+      if (!key) return match;
+      if (Object.prototype.hasOwnProperty.call(scope.values, key)) {
+        return scope.values[key];
+      }
+      if (fallback !== undefined) {
+        return fallback.replace(/\\(.)/g, '$1');
+      }
+      throw new AppError(
+        'INVALID_ARGS',
+        `Unresolved variable \${${key}} at ${loc.file}:${loc.line}.`,
+      );
+    },
+  );
 }
 
 export function resolveReplayAction(
@@ -120,9 +127,7 @@ export function resolveReplayAction(
 ): SessionAction {
   return {
     ...action,
-    positionals: (action.positionals ?? []).map((token) =>
-      resolveReplayString(token, scope, loc),
-    ),
+    positionals: (action.positionals ?? []).map((token) => resolveReplayString(token, scope, loc)),
     flags: resolveStringProps(action.flags, scope, loc) ?? {},
     runtime: resolveStringProps(action.runtime, scope, loc),
   };
@@ -134,7 +139,7 @@ function resolveStringProps<T extends object>(
   loc: { file: string; line: number },
 ): T | undefined {
   if (!obj) return obj;
-  const next: Record<string, unknown> = { ...obj };
+  const next: Record<string, unknown> = { ...(obj as Record<string, unknown>) };
   for (const [key, value] of Object.entries(next)) {
     if (typeof value === 'string') {
       next[key] = resolveReplayString(value, scope, loc);

--- a/src/daemon/handlers/session-replay-vars.ts
+++ b/src/daemon/handlers/session-replay-vars.ts
@@ -15,19 +15,39 @@ export type ReplayVarSources = {
 const VAR_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
 const INTERPOLATION_RE =
   /(\\\$\{)|\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:[^}\\]|\\.)*))?\}/g;
-const SHELL_PREFIX = 'AD_';
+const SHELL_PREFIX = 'AD_VAR_';
+const RESERVED_NAMESPACE_PREFIX = 'AD_';
+
+function isReservedNamespaceKey(key: string): boolean {
+  return key.startsWith(RESERVED_NAMESPACE_PREFIX);
+}
+
+function reservedNamespaceError(key: string): AppError {
+  return new AppError(
+    'INVALID_ARGS',
+    `The AD_* namespace is reserved for built-in variables. Rename ${key} to avoid the AD_ prefix.`,
+  );
+}
 
 export function buildReplayVarScope(sources: ReplayVarSources): ReplayVarScope {
   const merged: Record<string, string> = {};
-  const layers: Array<Record<string, string> | undefined> = [
-    sources.builtins,
+  // builtins are trusted (set by the runtime) and may legitimately use AD_*.
+  if (sources.builtins) {
+    for (const [key, value] of Object.entries(sources.builtins)) {
+      merged[key] = value;
+    }
+  }
+  const untrustedLayers: Array<Record<string, string> | undefined> = [
     sources.fileEnv,
     sources.shellEnv,
     sources.cliEnv,
   ];
-  for (const layer of layers) {
+  for (const layer of untrustedLayers) {
     if (!layer) continue;
     for (const [key, value] of Object.entries(layer)) {
+      if (isReservedNamespaceKey(key)) {
+        throw reservedNamespaceError(key);
+      }
       merged[key] = value;
     }
   }
@@ -42,6 +62,9 @@ export function collectReplayShellEnv(processEnv: NodeJS.ProcessEnv): Record<str
     const key = rawKey.slice(SHELL_PREFIX.length);
     if (key.length === 0) continue;
     if (!VAR_KEY_RE.test(key)) continue;
+    // Belt-and-suspenders: never let the stripped key land back in the reserved
+    // AD_* namespace (e.g. shell `AD_VAR_AD_SESSION=evil` would become `AD_SESSION`).
+    if (isReservedNamespaceKey(key)) continue;
     result[key] = value;
   }
   return result;
@@ -58,8 +81,11 @@ export function parseReplayCliEnvEntries(entries: readonly string[]): Record<str
     if (!VAR_KEY_RE.test(key)) {
       throw new AppError(
         'INVALID_ARGS',
-        `Invalid -e key "${key}": must match /^[A-Z_][A-Z0-9_]*$/.`,
+        `Invalid -e key "${key}": keys must be uppercase letters, digits, and underscores (e.g. APP_ID).`,
       );
+    }
+    if (isReservedNamespaceKey(key)) {
+      throw reservedNamespaceError(key);
     }
     result[key] = entry.slice(eqIndex + 1);
   }

--- a/src/daemon/handlers/session-replay-vars.ts
+++ b/src/daemon/handlers/session-replay-vars.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../../utils/errors.ts';
-import type { SessionAction, SessionRuntimeHints } from '../types.ts';
+import type { SessionAction } from '../types.ts';
 
 export type ReplayVarScope = {
   readonly values: Readonly<Record<string, string>>;
@@ -12,7 +12,7 @@ export type ReplayVarSources = {
   cliEnv?: Record<string, string>;
 };
 
-const VAR_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
+export const REPLAY_VAR_KEY_RE = /^[A-Z_][A-Z0-9_]*$/;
 const INTERPOLATION_RE =
   /(\\\$\{)|\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-((?:[^}\\]|\\.)*))?\}/g;
 const SHELL_PREFIX = 'AD_VAR_';
@@ -61,7 +61,7 @@ export function collectReplayShellEnv(processEnv: NodeJS.ProcessEnv): Record<str
     if (!rawKey.startsWith(SHELL_PREFIX)) continue;
     const key = rawKey.slice(SHELL_PREFIX.length);
     if (key.length === 0) continue;
-    if (!VAR_KEY_RE.test(key)) continue;
+    if (!REPLAY_VAR_KEY_RE.test(key)) continue;
     // Belt-and-suspenders: never let the stripped key land back in the reserved
     // AD_* namespace (e.g. shell `AD_VAR_AD_SESSION=evil` would become `AD_SESSION`).
     if (isReservedNamespaceKey(key)) continue;
@@ -78,7 +78,7 @@ export function parseReplayCliEnvEntries(entries: readonly string[]): Record<str
       throw new AppError('INVALID_ARGS', `Invalid -e entry "${entry}": expected KEY=VALUE.`);
     }
     const key = entry.slice(0, eqIndex);
-    if (!VAR_KEY_RE.test(key)) {
+    if (!REPLAY_VAR_KEY_RE.test(key)) {
       throw new AppError(
         'INVALID_ARGS',
         `Invalid -e key "${key}": keys must be uppercase letters, digits, and underscores (e.g. APP_ID).`,
@@ -118,45 +118,27 @@ export function resolveReplayAction(
   scope: ReplayVarScope,
   loc: { file: string; line: number },
 ): SessionAction {
-  const positionals = (action.positionals ?? []).map((token) =>
-    resolveReplayString(token, scope, loc),
-  );
-  const flags = resolveReplayFlags(action.flags, scope, loc);
-  const runtime = resolveReplayRuntime(action.runtime, scope, loc);
   return {
     ...action,
-    positionals,
-    flags,
-    runtime,
+    positionals: (action.positionals ?? []).map((token) =>
+      resolveReplayString(token, scope, loc),
+    ),
+    flags: resolveStringProps(action.flags, scope, loc) ?? {},
+    runtime: resolveStringProps(action.runtime, scope, loc),
   };
 }
 
-function resolveReplayFlags(
-  flags: SessionAction['flags'] | undefined,
+function resolveStringProps<T extends object>(
+  obj: T | undefined,
   scope: ReplayVarScope,
   loc: { file: string; line: number },
-): SessionAction['flags'] {
-  if (!flags) return {};
-  const next: Record<string, unknown> = { ...flags };
+): T | undefined {
+  if (!obj) return obj;
+  const next: Record<string, unknown> = { ...obj };
   for (const [key, value] of Object.entries(next)) {
     if (typeof value === 'string') {
       next[key] = resolveReplayString(value, scope, loc);
     }
   }
-  return next as SessionAction['flags'];
-}
-
-function resolveReplayRuntime(
-  runtime: SessionRuntimeHints | undefined,
-  scope: ReplayVarScope,
-  loc: { file: string; line: number },
-): SessionRuntimeHints | undefined {
-  if (!runtime) return undefined;
-  const next: Record<string, unknown> = { ...runtime };
-  for (const [key, value] of Object.entries(next)) {
-    if (typeof value === 'string') {
-      next[key] = resolveReplayString(value, scope, loc);
-    }
-  }
-  return next as SessionRuntimeHints;
+  return next as T;
 }

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -1,8 +1,24 @@
+import type { CommandFlags } from '../../core/dispatch.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { runReplayTestSuite } from './session-test.ts';
 import { handleCloseCommand } from './session-close.ts';
 import { collectReplayActionArtifactPaths, runReplayScriptFile } from './session-replay-runtime.ts';
+import type { ReplayScriptMetadata } from './session-replay-script.ts';
+
+export function buildNestedReplayFlags(params: {
+  parentFlags: CommandFlags | undefined;
+  platform: ReplayScriptMetadata['platform'] | undefined;
+  artifactsDir: string | undefined;
+}): CommandFlags | undefined {
+  const { parentFlags, platform, artifactsDir } = params;
+  if (platform === undefined && artifactsDir === undefined) return parentFlags;
+  return {
+    ...(parentFlags ?? {}),
+    ...(platform !== undefined ? { platform } : {}),
+    ...(artifactsDir !== undefined ? { artifactsDir } : {}),
+  };
+}
 
 export async function handleSessionReplayCommands(params: {
   req: DaemonRequest;
@@ -32,6 +48,7 @@ export async function handleSessionReplayCommands(params: {
         sessionName: testSessionName,
         platform,
         requestId,
+        artifactsDir,
         artifactPaths,
       }) => {
         const captureArtifacts = (response: DaemonResponse): DaemonResponse => {
@@ -40,13 +57,19 @@ export async function handleSessionReplayCommands(params: {
           return response;
         };
 
+        const nestedFlags = buildNestedReplayFlags({
+          parentFlags: req.flags,
+          platform,
+          artifactsDir,
+        });
+
         return await runReplayScriptFile({
           req: {
             ...req,
             command: 'replay',
             session: testSessionName,
             positionals: [filePath],
-            flags: platform === undefined ? req.flags : { ...(req.flags ?? {}), platform },
+            flags: nestedFlags,
             meta: requestId ? { ...(req.meta ?? {}), requestId } : req.meta,
           },
           sessionName: testSessionName,

--- a/src/daemon/handlers/session-test-runtime.ts
+++ b/src/daemon/handlers/session-test-runtime.ts
@@ -20,17 +20,27 @@ export async function runReplayTestAttempt(params: {
   requestId: string;
   timeoutMs?: number;
   platform?: ReplayScriptMetadata['platform'];
+  artifactsDir?: string;
   runReplay: (params: {
     filePath: string;
     sessionName: string;
     platform?: ReplayScriptMetadata['platform'];
     requestId?: string;
+    artifactsDir?: string;
     artifactPaths?: Set<string>;
   }) => Promise<DaemonResponse>;
   cleanupSession: (sessionName: string) => Promise<void>;
 }): Promise<DaemonResponse> {
-  const { filePath, sessionName, requestId, timeoutMs, platform, runReplay, cleanupSession } =
-    params;
+  const {
+    filePath,
+    sessionName,
+    requestId,
+    timeoutMs,
+    platform,
+    artifactsDir,
+    runReplay,
+    cleanupSession,
+  } = params;
   registerRequestAbort(requestId);
   const artifactPaths = new Set<string>();
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -40,6 +50,7 @@ export async function runReplayTestAttempt(params: {
     sessionName,
     platform,
     requestId,
+    artifactsDir,
     artifactPaths,
   })
     .catch((error) => {

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -33,6 +33,7 @@ export async function runReplayTestSuite(params: {
     sessionName: string;
     platform?: ReplayScriptMetadata['platform'];
     requestId?: string;
+    artifactsDir?: string;
     artifactPaths?: Set<string>;
   }) => Promise<DaemonResponse>;
   cleanupSession: (sessionName: string) => Promise<void>;
@@ -118,6 +119,7 @@ async function runReplayTestCase(params: {
     sessionName: string;
     platform?: ReplayScriptMetadata['platform'];
     requestId?: string;
+    artifactsDir?: string;
     artifactPaths?: Set<string>;
   }) => Promise<DaemonResponse>;
   cleanupSession: (sessionName: string) => Promise<void>;
@@ -169,6 +171,7 @@ async function runReplayTestCase(params: {
       requestId: attemptRequestId,
       timeoutMs,
       platform: entry.metadata.platform,
+      artifactsDir: attemptArtifactsDir,
       runReplay,
       cleanupSession,
     });

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -88,6 +88,7 @@ export type CliFlags = {
   retainPaths?: boolean;
   retentionMs?: number;
   replayUpdate?: boolean;
+  replayEnv?: string[];
   failFast?: boolean;
   timeoutMs?: number;
   retries?: number;
@@ -768,6 +769,15 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     usageDescription: 'Replay: update selectors and rewrite replay file in place',
   },
   {
+    key: 'replayEnv',
+    names: ['-e', '--env'],
+    type: 'string',
+    multiple: true,
+    usageLabel: '-e KEY=VALUE, --env KEY=VALUE',
+    usageDescription:
+      'Replay/Test: inject or override a ${KEY} variable for the script (repeatable)',
+  },
+  {
     key: 'failFast',
     names: ['--fail-fast'],
     type: 'boolean',
@@ -1217,7 +1227,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
   replay: {
     helpDescription: 'Replay a recorded session',
     positionalArgs: ['path'],
-    allowedFlags: ['replayUpdate'],
+    allowedFlags: ['replayUpdate', 'replayEnv'],
     skipCapabilityCheck: true,
   },
   test: {
@@ -1229,6 +1239,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowsExtraPositionals: true,
     allowedFlags: [
       'replayUpdate',
+      'replayEnv',
       'failFast',
       'timeoutMs',
       'retries',

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -89,6 +89,7 @@ export type CliFlags = {
   retentionMs?: number;
   replayUpdate?: boolean;
   replayEnv?: string[];
+  replayShellEnv?: Record<string, string>;
   failFast?: boolean;
   timeoutMs?: number;
   retries?: number;

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -153,7 +153,7 @@ Quote `${VAR}` inside selector expressions so the whole expression is treated as
 ### Notes
 
 - `replay -u` does not yet preserve `env` directives or `${VAR}` tokens. Workaround: temporarily inline the literal values, run `-u`, re-parametrise.
-- Shell env (`AD_VAR_*`) is read from the host running the daemon, not the host running the CLI. For remote-daemon setups, set those vars on the daemon side, or use `-e` which is always client-side.
+- Shell env (`AD_VAR_*`) is collected on the CLI/client side at request time, so the same values are seen whether the daemon runs locally or remotely.
 - No nested fallback. `${A:-${B}}` is not supported.
 - Unresolved `${VAR}` fails with a `file:line` reference. Typos are loud.
 

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -87,19 +87,19 @@ click "label=${APP_ID}"
 | CLI `-e KEY=VALUE` | highest | `agent-device test flow.ad -e APP_ID=demo` |
 | Shell env prefixed `AD_VAR_` | | `AD_VAR_APP_ID=demo agent-device test flow.ad` (imported as `APP_ID`) |
 | Script `env KEY=VALUE` | | `env APP_ID=settings` in header |
-| Built-ins | lowest | `AD_PLATFORM`, `AD_SESSION`, `AD_FILENAME`, `AD_DEVICE`, `AD_ARTIFACTS` |
+| Built-ins | reserved | `AD_PLATFORM`, `AD_SESSION`, `AD_FILENAME`, `AD_DEVICE`, `AD_ARTIFACTS` |
 
 ### Built-ins
 
-Always defined; resolved last so user overrides win where applicable.
+Built-ins are provided by replay/test runtime and use the reserved `AD_*` namespace.
 
-- `AD_PLATFORM` - matches `context platform=...`
+- `AD_PLATFORM` - matches `context platform=...` or the selected platform when available
 - `AD_SESSION` - active session name
 - `AD_FILENAME` - path of the running `.ad` file
 - `AD_DEVICE` - device identifier (when `--device` is set)
-- `AD_ARTIFACTS` - suite artifacts root (when running under `test`)
+- `AD_ARTIFACTS` - attempt artifacts directory (when running under `test`)
 
-The `AD_*` namespace is reserved. User-defined keys starting with `AD_` (in `env`, `-e`, or via `AD_VAR_AD_FOO`) are rejected.
+User-defined keys starting with `AD_` are rejected in `env`, `-e`, and shell imports such as `AD_VAR_AD_FOO`, so built-ins cannot be overridden.
 
 ### Fallback and escape
 

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -87,7 +87,7 @@ click "label=${APP_ID}"
 | CLI `-e KEY=VALUE` | highest | `agent-device test flow.ad -e APP_ID=demo` |
 | Shell env prefixed `AD_VAR_` | | `AD_VAR_APP_ID=demo agent-device test flow.ad` (imported as `APP_ID`) |
 | Script `env KEY=VALUE` | | `env APP_ID=settings` in header |
-| Built-ins | reserved | `AD_PLATFORM`, `AD_SESSION`, `AD_FILENAME`, `AD_DEVICE`, `AD_ARTIFACTS` |
+| Built-ins | runtime | `AD_PLATFORM`, `AD_SESSION`, `AD_FILENAME`, `AD_DEVICE`, `AD_ARTIFACTS` |
 
 ### Built-ins
 
@@ -100,6 +100,13 @@ Built-ins are provided by replay/test runtime and use the reserved `AD_*` namesp
 - `AD_ARTIFACTS` - attempt artifacts directory (when running under `test`)
 
 User-defined keys starting with `AD_` are rejected in `env`, `-e`, and shell imports such as `AD_VAR_AD_FOO`, so built-ins cannot be overridden.
+
+Substitution happens inside parsed string values. It does not create extra arguments, so quote selectors or text values that contain spaces:
+
+```ad
+env SETTINGS="label=Account || label=Profile"
+click "${SETTINGS}"
+```
 
 ### Fallback and escape
 

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -68,36 +68,94 @@ agent-device test ./workflows --artifacts-dir ./tmp/agent-device-artifacts
 
 ## Parametrise `.ad` scripts
 
-Declare reusable values as `env` directives in the script header and reference them with `${VAR}`:
+Substitute `${VAR}` tokens in `.ad` scripts using values from the CLI, shell env, script-local `env` directives, or built-ins.
 
 ```sh
 context platform=android
 env APP_ID=settings
 env WAIT_SHORT=500
-env SETTINGS_ITEMS="label=Wait || label=\"Close app\" || label=Apps"
 
 open ${APP_ID} --relaunch
 wait ${WAIT_SHORT}
-click "${SETTINGS_ITEMS}"
+click "label=${APP_ID}"
 ```
 
-Override or inject values from the command line with `-e KEY=VALUE` (repeatable):
+### Precedence
 
-```bash
-agent-device test ./workflows/01-settings.ad -e APP_ID=com.example.debug -e WAIT_SHORT=1000
-```
+| Source | Priority | Example |
+|---|---|---|
+| CLI `-e KEY=VALUE` | highest | `agent-device test flow.ad -e APP_ID=demo` |
+| Shell env prefixed `AD_VAR_` | | `AD_VAR_APP_ID=demo agent-device test flow.ad` (imported as `APP_ID`) |
+| Script `env KEY=VALUE` | | `env APP_ID=settings` in header |
+| Built-ins | lowest | `AD_PLATFORM`, `AD_SESSION`, `AD_FILENAME`, `AD_DEVICE`, `AD_ARTIFACTS` |
 
-Shell environment variables prefixed with `AD_` are auto-imported (prefix stripped). Precedence, highest wins: CLI `-e` > `AD_*` shell env > script-local `env` > built-ins.
+### Built-ins
 
-Built-ins (always available):
+Always defined; resolved last so user overrides win where applicable.
 
 - `AD_PLATFORM` - matches `context platform=...`
 - `AD_SESSION` - active session name
 - `AD_FILENAME` - path of the running `.ad` file
-- `AD_ARTIFACTS` - suite artifacts root (when running under `test`)
 - `AD_DEVICE` - device identifier (when `--device` is set)
+- `AD_ARTIFACTS` - suite artifacts root (when running under `test`)
 
-Fallback syntax `${VAR:-default}` yields `default` when `VAR` is unset. To include a literal `${`, escape with `\${`. Unresolved variables fail the script with a `file:line` reference.
+The `AD_*` namespace is reserved. User-defined keys starting with `AD_` (in `env`, `-e`, or via `AD_VAR_AD_FOO`) are rejected.
+
+### Fallback and escape
+
+```sh
+wait ${WAIT_MS:-500}
+```
+
+`${VAR:-default}` yields `default` when `VAR` is unset.
+
+```sh
+echo "Price: \${APP}"
+```
+
+`\${APP}` emits a literal `${APP}` with no substitution.
+
+### Recipes
+
+Run one flow against two app variants in CI:
+
+```sh
+agent-device test ./flows/login.ad -e APP_ID=com.example.debug
+agent-device test ./flows/login.ad -e APP_ID=com.example.release
+```
+
+Tune timings locally without editing the script:
+
+```sh
+AD_VAR_WAIT_SHORT=2000 agent-device replay ./flow.ad
+```
+
+Extract a reusable selector. Before:
+
+```ad
+click "label=Account || label=Profile || label=User"
+wait 500
+click "label=Account || label=Profile || label=User"
+```
+
+After:
+
+```ad
+env SETTINGS="label=Account || label=Profile || label=User"
+
+click "${SETTINGS}"
+wait 500
+click "${SETTINGS}"
+```
+
+Quote `${VAR}` inside selector expressions so the whole expression is treated as a single argument.
+
+### Notes
+
+- `replay -u` does not yet preserve `env` directives or `${VAR}` tokens. Workaround: temporarily inline the literal values, run `-u`, re-parametrise.
+- Shell env (`AD_VAR_*`) is read from the host running the daemon, not the host running the CLI. For remote-daemon setups, set those vars on the daemon side, or use `-e` which is always client-side.
+- No nested fallback. `${A:-${B}}` is not supported.
+- Unresolved `${VAR}` fails with a `file:line` reference. Typos are loud.
 
 ## Update stale selectors in replay scripts
 

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -66,6 +66,39 @@ agent-device test ./workflows --artifacts-dir ./tmp/agent-device-artifacts
 - The default text reporter prints the suite summary, failed tests, and passed-on-retry flaky tests; use `--verbose` to print every test result.
 - When `--fail-fast` and retries are both set, the current test still consumes its retries before the suite stops.
 
+## Parametrise `.ad` scripts
+
+Declare reusable values as `env` directives in the script header and reference them with `${VAR}`:
+
+```sh
+context platform=android
+env APP_ID=settings
+env WAIT_SHORT=500
+env SETTINGS_ITEMS="label=Wait || label=\"Close app\" || label=Apps"
+
+open ${APP_ID} --relaunch
+wait ${WAIT_SHORT}
+click "${SETTINGS_ITEMS}"
+```
+
+Override or inject values from the command line with `-e KEY=VALUE` (repeatable):
+
+```bash
+agent-device test ./workflows/01-settings.ad -e APP_ID=com.example.debug -e WAIT_SHORT=1000
+```
+
+Shell environment variables prefixed with `AD_` are auto-imported (prefix stripped). Precedence, highest wins: CLI `-e` > `AD_*` shell env > script-local `env` > built-ins.
+
+Built-ins (always available):
+
+- `AD_PLATFORM` - matches `context platform=...`
+- `AD_SESSION` - active session name
+- `AD_FILENAME` - path of the running `.ad` file
+- `AD_ARTIFACTS` - suite artifacts root (when running under `test`)
+- `AD_DEVICE` - device identifier (when `--device` is set)
+
+Fallback syntax `${VAR:-default}` yields `default` when `VAR` is unset. To include a literal `${`, escape with `\${`. Unresolved variables fail the script with a `file:line` reference.
+
 ## Update stale selectors in replay scripts
 
 ```bash


### PR DESCRIPTION
Resolves: https://github.com/callstackincubator/agent-device/issues/432

## Summary

Add `${VAR}` substitution to `.ad` replay scripts so flows can be reused across app variants, tuned per environment, deduplicated within a file, and driven from CI. Values in `.ad` were previously literals only - a long `label=A || label=B || ...` selector repeated across several steps, or `wait 1000` / `wait 500` scattered across a tree, had no way to be named once and reused.

Fixes #<ISSUE>.

Resolution runs at dispatch time in `invokeReplayAction`. `SessionAction` keeps raw tokens, so `writeReplayScript` round-trips unchanged and the recorder stays literal-only. Precedence is high to low: CLI `-e` > `AD_*` shell env > file `env` > built-ins.

Key behaviours:

- `env KEY=VALUE` directives in the script header, quoted values supported for content with spaces or OR-chained selectors.
- `${VAR}` interpolation in positionals and string flag values, `${VAR:-default}` fallback, `\${` escape.
- CLI `-e KEY=VALUE` (repeatable) on `replay` and `test`.
- Shell env auto-import: variables prefixed `AD_*` are imported with the prefix stripped.
- Built-ins: `AD_PLATFORM`, `AD_SESSION`, `AD_FILENAME`, `AD_DEVICE`, `AD_ARTIFACTS`.
- Unresolved `${X}` throws with `file:line`.
- `replay -u` is rejected when the script has `env` entries - rewrite would drop them. Noted as a v1 limitation.

Before, the same selector and timing repeated inline:

```ad
tap label=Settings || label=Preferences || label=More || label=Account
wait 1000
tap label=Settings || label=Preferences || label=More || label=Account
wait 1000
tap label=Settings || label=Preferences || label=More || label=Account
wait 500
```

After, named once and reused:

```ad
env SETTINGS="label=Settings || label=Preferences || label=More || label=Account"
env WAIT_LONG=1000
env WAIT_SHORT=500

tap ${SETTINGS}
wait ${WAIT_LONG}
tap ${SETTINGS}
wait ${WAIT_LONG}
tap ${SETTINGS}
wait ${WAIT_SHORT}
```

CI or per-variant override without editing the file:

```sh
ad replay flow.ad -e SETTINGS="label=Settings" -e WAIT_LONG=500
AD_SETTINGS="label=Settings" ad replay flow.ad
```

Scope intentionally excluded from v1: includes / sub-scripts, conditionals, loops, computed expressions, cross-file shared vars.

Touched-file count: 10. Scope stayed within the replay script / dispatch path plus CLI plumbing and docs.

Files:

- new: `src/daemon/handlers/session-replay-vars.ts`, `src/daemon/handlers/__tests__/session-replay-vars.test.ts`
- edited: `src/cli/commands/generic.ts`, `src/client-normalizers.ts`, `src/client-types.ts`, `src/client.ts`, `src/daemon/handlers/session-replay-runtime.ts`, `src/daemon/handlers/session-replay-script.ts`, `src/utils/command-schema.ts`, `website/docs/docs/replay-e2e.md`

## Validation

- `pnpm format`
- `pnpm check:quick`
- `pnpm vitest run src/daemon/handlers/__tests__/session-replay-vars.test.ts`
- `pnpm test:smoke`
- `pnpm build`
- `git diff --check`
- Manual `ad replay` on a sample `.ad` using `env` directives, `${VAR:-default}` fallback, `\${` escape, and an unresolved `${X}` to verify the `file:line` error.
- Manual `ad replay -e K=V ...` and `AD_K=V ad replay ...` to verify CLI and shell precedence over file `env`.
- Manual `ad replay -u` on a script with `env` entries to verify the rejection.
