### PR TITLE
fix: use artifacts route for daemon downloads

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1229,7 +1229,7 @@ function buildDaemonHttpUrl(baseUrl: string, route: 'health' | 'rpc'): string {
 
 function buildDaemonArtifactUrl(baseUrl: string, artifactId: string): string {
   const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-  return new URL(`upload/${encodeURIComponent(artifactId)}`, normalizedBase).toString();
+  return new URL(`artifacts/${encodeURIComponent(artifactId)}`, normalizedBase).toString();
 }
 
 async function materializeRemoteArtifacts(

--- a/src/daemon/__tests__/http-server.test.ts
+++ b/src/daemon/__tests__/http-server.test.ts
@@ -311,7 +311,7 @@ test('HTTP artifact download streams registered files', async (ctx) => {
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  const response = await callGet(port, `/upload/${artifactId}`, {
+  const response = await callGet(port, `/artifacts/${artifactId}`, {
     authorization: 'Bearer test-token',
   });
   assert.equal(response.statusCode, 200);
@@ -350,7 +350,7 @@ test('HTTP artifact download rejects requests without the daemon token', async (
     fs.rmSync(root, { recursive: true, force: true });
   });
 
-  const response = await callGet(port, `/upload/${artifactId}`);
+  const response = await callGet(port, `/artifacts/${artifactId}`);
   assert.equal(response.statusCode, 401);
   assert.match(response.body, /Invalid token/);
 });

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -406,7 +406,7 @@ export async function createDaemonHttpServer(options: {
       return;
     }
 
-    if (req.method === 'GET' && req.url?.startsWith('/upload/')) {
+    if (req.method === 'GET' && req.url?.startsWith('/artifacts/')) {
       void handleArtifactDownload(req, res, authHook, token);
       return;
     }
@@ -611,7 +611,7 @@ async function handleArtifactDownload(
   authHook: HttpAuthHook | null,
   expectedToken?: string,
 ): Promise<void> {
-  const artifactId = req.url?.slice('/upload/'.length) ?? '';
+  const artifactId = req.url?.slice('/artifacts/'.length) ?? '';
   if (!artifactId) {
     res.statusCode = 400;
     res.end('Missing artifact id');

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -1090,7 +1090,7 @@ test('sendToDaemon downloads remote artifacts and rewrites local paths', async (
             callback?.();
             return;
           }
-          if (this.options.method === 'GET' && String(this.options.path).includes('/upload/')) {
+          if (this.options.method === 'GET' && String(this.options.path).includes('/artifacts/')) {
             res.end(Buffer.from('png-binary'));
             callback?.();
             return;
@@ -1160,7 +1160,7 @@ test('sendToDaemon downloads remote artifacts and rewrites local paths', async (
     assert.deepEqual(seenPaths, [
       '/agent-device/health',
       '/agent-device/rpc',
-      '/agent-device/upload/artifact-123',
+      '/agent-device/artifacts/artifact-123',
     ]);
     assert.match(
       String((rpcRequest as any)?.params?.positionals?.[0]),
@@ -1196,7 +1196,7 @@ test('downloadRemoteArtifact times out stalled artifact responses and removes pa
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-remote-artifact-timeout-'));
   const destinationPath = path.join(tempRoot, 'artifacts', 'screen.png');
   const server = http.createServer((req, _res) => {
-    if (req.url?.includes('/upload/')) {
+    if (req.url?.includes('/artifacts/')) {
       return;
     }
   });


### PR DESCRIPTION
## Summary

Change daemon artifact download URLs from `/upload/:artifactId` to `/artifacts/:artifactId` so bridge routing can keep artifact downloads separate from upload endpoints.

Updated the daemon HTTP download route and remote artifact download tests to use `/artifacts/:artifactId`; no `/upload/:artifactId` download route or test coverage remains. Upload endpoints (`POST /upload`, `/upload/preflight`, `/upload/finalize`) are unchanged.

Touched files: 4. Scope stayed within daemon artifact download behavior. Docs/skills were not updated because this is an internal route shape, not a CLI or workflow surface change.

## Validation

- `pnpm format`
- `pnpm check:quick`
- `pnpm check:unit`
- `rg -n "startsWith\('/upload/'\)|slice\('/upload/'|includes\('/upload/'\)|/agent-device/upload/|callGet\([^\n]*upload|GET.*upload|/upload/\$\{artifactId\}" src test`