### PR TITLE
feat: add react devtools passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browse
 
 Use `agent-device` for on-device UI automation, screenshots/recordings, app logs, network inspection, and performance snapshots.
 
-When the task needs the React component tree, props, state, hooks, or render profiling, pair it with the complementary [`agent-react-devtools`](https://github.com/callstackincubator/agent-react-devtools) project. The two tools solve different layers of the same debugging workflow.
+When the task needs the React Native component tree, props, state, hooks, or render profiling, use the bundled passthrough:
+
+```bash
+agent-device react-devtools status
+agent-device react-devtools get tree --depth 3
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+```
+
+`react-devtools` dynamically runs pinned `agent-react-devtools@0.4.0` commands 1:1, so `agent-device` covers both the device/app runtime layer and React component internals without making React DevTools part of the daemon.
 
 ## Command Flow
 
@@ -77,6 +87,7 @@ For people:
 For agents:
 
 - [agent-device skill](skills/agent-device/SKILL.md)
+- [react-devtools skill](skills/react-devtools/SKILL.md)
 - [dogfood skill](skills/dogfood/SKILL.md)
 - [agent-device skill on ClawHub](https://clawhub.ai/okwasniewski/agent-device)
 

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -71,4 +71,4 @@ Use this skill as a router with mandatory defaults. Read this file first. For no
 - Need desktop surfaces, menu bar behavior, or macOS-specific interaction rules: [references/macos-desktop.md](references/macos-desktop.md)
 - Need remote HTTP transport, `connect --remote-config`, or tenant leases on a remote macOS host: [references/remote-tenancy.md](references/remote-tenancy.md)
   This includes remote React Native runs where `agent-device` now prepares Metro locally and manages the local Metro companion tunnel automatically.
-- Need the React component tree, props, state, hooks, or render profiling: pair `agent-device` with the complementary [`agent-react-devtools`](https://github.com/callstackincubator/agent-react-devtools) project when available.
+- Need the React Native component tree, props, state, hooks, or render profiling: use `agent-device react-devtools ...` and the [react-devtools skill](../react-devtools/SKILL.md).

--- a/skills/agent-device/references/debugging.md
+++ b/skills/agent-device/references/debugging.md
@@ -4,7 +4,7 @@
 
 Open this file when the task turns into failure triage, logs, network inspection, permission prompts, setup trouble, or unstable session behavior.
 
-If the debugging task needs the React component tree, props, state, hooks, or render profiling, pair `agent-device` with the complementary [`agent-react-devtools`](https://github.com/callstackincubator/agent-react-devtools) project instead of trying to infer those internals from the accessibility tree or app logs alone.
+If the debugging task needs the React Native component tree, props, state, hooks, or render profiling, use `agent-device react-devtools ...` and the `skills/react-devtools` workflow instead of trying to infer those internals from the accessibility tree or app logs alone.
 
 ## Main commands to reach for first
 

--- a/skills/agent-device/references/exploration.md
+++ b/skills/agent-device/references/exploration.md
@@ -20,7 +20,7 @@ Open this file when the app or screen is already running and you need to discove
 - User asks what is visible on screen: `snapshot`
 - User asks for exact text from a known target: `get text`
 - User asks you to tap, type, or choose an element: `snapshot -i`, then act
-- User asks for the React component tree, props/state/hooks, or render profiling: pair `agent-device` with the complementary [`agent-react-devtools`](https://github.com/callstackincubator/agent-react-devtools) project
+- User asks for the React Native component tree, props/state/hooks, or render profiling: use `agent-device react-devtools ...` and the `skills/react-devtools` workflow
 - React Native dev or debug build shows warning/error UI: capture enough evidence to identify it, dismiss it if it is not the requested behavior, then continue the flow and report it in the summary
 - The on-screen keyboard is blocking the next step: `keyboard dismiss`; on iOS do this only while an app session is active, and use `keyboard status|get` only on Android
 - UI does not expose the answer: say so plainly; do not browse or force the app into a new state unless asked

--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -166,7 +166,7 @@ agent-device --session {SESSION} close
 - Re-snapshot after any mutation (navigation, modal, list update, form submit).
 - Use `fill` for clear-then-type semantics; use `type` for incremental typing behavior checks.
 - Keep logs optional and targeted: enable/read app logs only when useful for diagnosis.
-- If the issue appears rooted in React internals rather than device/app runtime behavior, pair `agent-device` with the complementary [`agent-react-devtools`](https://github.com/callstackincubator/agent-react-devtools) project for component-tree or render-profiling inspection.
+- If the issue appears rooted in React Native internals rather than device/app runtime behavior, use `agent-device react-devtools ...` and the `skills/react-devtools` workflow for component-tree or render-profiling inspection.
 - Never read source code of the app under test; findings must come from observed runtime behavior.
 - Write each issue immediately to avoid losing evidence.
 - Never delete screenshots/videos/report artifacts during a session.

--- a/skills/react-devtools/SKILL.md
+++ b/skills/react-devtools/SKILL.md
@@ -20,6 +20,8 @@ The first run may download the pinned package from npm. `agent-device` global fl
 5. Profile only around the interaction being investigated.
 6. Verify the fix with the same command sequence and interaction.
 
+For cross-platform validation, prefer an isolated `--state-dir` over a named `--session` while booting, installing, or opening with explicit `--device`, `--udid`, or `--serial` selectors. Restart `agent-device react-devtools` between iOS and Android runs so `status`, `get tree`, and profiling clearly refer to the currently launched app.
+
 ## Main commands
 
 ```bash
@@ -41,6 +43,7 @@ agent-device react-devtools profile rerenders --limit 5
 - Start component-tree reads with `get tree --depth 3` or `find <name>` to keep output bounded.
 - Labels like `@c5` reset when the app reloads or components remount. After reload, run `wait --connected` and inspect again.
 - Profiling only captures renders between `profile start` and `profile stop`.
+- On Android, set `adb reverse tcp:8097 tcp:8097` for React DevTools. If Metro is local, also set `adb reverse tcp:8081 tcp:8081`.
 
 ## References
 

--- a/skills/react-devtools/SKILL.md
+++ b/skills/react-devtools/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when the task needs React Native internals that are not visible i
 
 Run commands through `agent-device react-devtools`. The command dynamically runs pinned `agent-react-devtools@0.4.0` and passes arguments through 1:1.
 
-The first run may download the pinned package from npm. Put downstream flags after `react-devtools` so they pass through to `agent-react-devtools`.
+The first run may download the pinned package from npm. `agent-device` global flags work before or after `react-devtools`; use `--` before downstream flags only when they intentionally share an `agent-device` global flag name.
 
 ## Default flow
 

--- a/skills/react-devtools/SKILL.md
+++ b/skills/react-devtools/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: react-devtools
+description: Inspect and profile React Native component trees from agent-device. Use when debugging React Native props, state, hooks, render causes, slow components, excessive re-renders, or questions like why a component re-rendered.
+---
+
+# react-devtools
+
+Use this skill when the task needs React Native internals that are not visible in the accessibility tree: component hierarchy, props, state, hooks, render causes, or profiling data.
+
+Run commands through `agent-device react-devtools`. The command dynamically runs pinned `agent-react-devtools@0.4.0` and passes arguments through 1:1.
+
+## Default flow
+
+1. Use `agent-device` to open the React Native app and verify the visible state when needed.
+2. Check `agent-device react-devtools status`.
+3. If no app is connected, start or wait for the devtools daemon, then reload or relaunch the app.
+4. Inspect with `get tree`, `find`, and `get component`.
+5. Profile only around the interaction being investigated.
+6. Verify the fix with the same command sequence and interaction.
+
+## Main commands
+
+```bash
+agent-device react-devtools status
+agent-device react-devtools wait --connected
+agent-device react-devtools get tree --depth 3
+agent-device react-devtools find <ComponentName>
+agent-device react-devtools get component @c5
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+```
+
+## Decision rules
+
+- Need current UI text, refs, screenshots, logs, network, or device metrics: use the `agent-device` skill.
+- Need props, state, hooks, component ownership, render causes, or React profiler data: use this skill.
+- Start component-tree reads with `get tree --depth 3` or `find <name>` to keep output bounded.
+- Labels like `@c5` reset when the app reloads or components remount. After reload, run `wait --connected` and inspect again.
+- Profiling only captures renders between `profile start` and `profile stop`.
+
+## References
+
+| File                                    | When to read                                  |
+| --------------------------------------- | --------------------------------------------- |
+| [commands.md](references/commands.md)   | Command reference and common inspection flows |
+| [profiling.md](references/profiling.md) | Render profiling workflow and interpretation  |

--- a/skills/react-devtools/SKILL.md
+++ b/skills/react-devtools/SKILL.md
@@ -9,6 +9,8 @@ Use this skill when the task needs React Native internals that are not visible i
 
 Run commands through `agent-device react-devtools`. The command dynamically runs pinned `agent-react-devtools@0.4.0` and passes arguments through 1:1.
 
+The first run may download the pinned package from npm. Put downstream flags after `react-devtools` so they pass through to `agent-react-devtools`.
+
 ## Default flow
 
 1. Use `agent-device` to open the React Native app and verify the visible state when needed.

--- a/skills/react-devtools/SKILL.md
+++ b/skills/react-devtools/SKILL.md
@@ -20,7 +20,7 @@ The first run may download the pinned package from npm. `agent-device` global fl
 5. Profile only around the interaction being investigated.
 6. Verify the fix with the same command sequence and interaction.
 
-For cross-platform validation, prefer an isolated `--state-dir` over a named `--session` while booting, installing, or opening with explicit `--device`, `--udid`, or `--serial` selectors. Restart `agent-device react-devtools` between iOS and Android runs so `status`, `get tree`, and profiling clearly refer to the currently launched app.
+For cross-platform validation with explicit `--device`, `--udid`, or `--serial` selectors, prefer an isolated `--state-dir` over separate named sessions. Named sessions enable bound-session locks during setup. Restart `agent-device react-devtools` between iOS and Android runs so `status`, `get tree`, and profiling clearly refer to the currently launched app.
 
 ## Main commands
 

--- a/skills/react-devtools/references/commands.md
+++ b/skills/react-devtools/references/commands.md
@@ -16,32 +16,9 @@ agent-device react-devtools wait --component <ComponentName> --timeout 30
 - Most commands auto-start the daemon, but `start` is useful before launching or reloading the app.
 - React Native development builds connect to the daemon on port 8097. For Android emulators or physical devices, use `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host. If the app also uses local Metro, set `adb reverse tcp:8081 tcp:8081`.
 
-## Cross-platform validation setup
+## Validation Notes
 
-Use this when validating the same React Native app on both iOS and Android simulators.
-
-```bash
-STATE_DIR=/tmp/agent-device-react-devtools-validate
-agent-device react-devtools stop
-agent-device react-devtools start
-agent-device --state-dir "$STATE_DIR" open <ios-bundle-id> --platform ios --device "<simulator>"
-agent-device react-devtools wait --connected --timeout 30
-agent-device react-devtools get tree --depth 3
-agent-device --state-dir "$STATE_DIR" close
-
-agent-device react-devtools stop
-agent-device react-devtools start
-adb -s <serial> reverse tcp:8081 tcp:8081
-adb -s <serial> reverse tcp:8097 tcp:8097
-agent-device --state-dir "$STATE_DIR" open <android-package> --platform android --serial <serial>
-agent-device react-devtools wait --connected --timeout 30
-agent-device react-devtools get tree --depth 3
-agent-device --state-dir "$STATE_DIR" close
-agent-device react-devtools stop
-```
-
-- Use an isolated `--state-dir` for validation runs so stale local or remote connection state cannot affect results.
-- Do not combine a named `--session` with explicit target selectors during setup unless you intentionally want bound-session lock behavior. For setup with `--device`, `--udid`, or `--serial`, an isolated state directory is usually simpler.
+- When validating the same app across iOS and Android with explicit `--device`, `--udid`, or `--serial` selectors, prefer an isolated `--state-dir` over separate named sessions. A named `--session` enables bound-session lock behavior, so setup commands with explicit target selectors can be rejected.
 - Restart the React DevTools daemon between platforms so `status`, `get tree`, and profiling output belong to the currently launched app.
 - Verify the app is visibly loaded with `snapshot` before collecting React internals. Use `react-devtools` for component state and profiling, not for proving the device/app surface is open.
 

--- a/skills/react-devtools/references/commands.md
+++ b/skills/react-devtools/references/commands.md
@@ -14,7 +14,36 @@ agent-device react-devtools wait --component <ComponentName> --timeout 30
 
 - `status` shows the daemon port, connected apps, component count, profiling state, uptime, and last connection event.
 - Most commands auto-start the daemon, but `start` is useful before launching or reloading the app.
-- React Native development builds connect to the daemon on port 8097. For Android physical devices, use `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host.
+- React Native development builds connect to the daemon on port 8097. For Android emulators or physical devices, use `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host. If the app also uses local Metro, set `adb reverse tcp:8081 tcp:8081`.
+
+## Cross-platform validation setup
+
+Use this when validating the same React Native app on both iOS and Android simulators.
+
+```bash
+STATE_DIR=/tmp/agent-device-react-devtools-validate
+agent-device react-devtools stop
+agent-device react-devtools start
+agent-device --state-dir "$STATE_DIR" open <ios-bundle-id> --platform ios --device "<simulator>"
+agent-device react-devtools wait --connected --timeout 30
+agent-device react-devtools get tree --depth 3
+agent-device --state-dir "$STATE_DIR" close
+
+agent-device react-devtools stop
+agent-device react-devtools start
+adb -s <serial> reverse tcp:8081 tcp:8081
+adb -s <serial> reverse tcp:8097 tcp:8097
+agent-device --state-dir "$STATE_DIR" open <android-package> --platform android --serial <serial>
+agent-device react-devtools wait --connected --timeout 30
+agent-device react-devtools get tree --depth 3
+agent-device --state-dir "$STATE_DIR" close
+agent-device react-devtools stop
+```
+
+- Use an isolated `--state-dir` for validation runs so stale local or remote connection state cannot affect results.
+- Do not combine a named `--session` with explicit target selectors during setup unless you intentionally want bound-session lock behavior. For setup with `--device`, `--udid`, or `--serial`, an isolated state directory is usually simpler.
+- Restart the React DevTools daemon between platforms so `status`, `get tree`, and profiling output belong to the currently launched app.
+- Verify the app is visibly loaded with `snapshot` before collecting React internals. Use `react-devtools` for component state and profiling, not for proving the device/app surface is open.
 
 ## Component Inspection
 

--- a/skills/react-devtools/references/commands.md
+++ b/skills/react-devtools/references/commands.md
@@ -1,0 +1,85 @@
+# React DevTools Commands
+
+All commands are run through `agent-device react-devtools`.
+
+## Connection
+
+```bash
+agent-device react-devtools start
+agent-device react-devtools stop
+agent-device react-devtools status
+agent-device react-devtools wait --connected --timeout 30
+agent-device react-devtools wait --component <ComponentName> --timeout 30
+```
+
+- `status` shows the daemon port, connected apps, component count, profiling state, uptime, and last connection event.
+- Most commands auto-start the daemon, but `start` is useful before launching or reloading the app.
+- React Native development builds connect to the daemon on port 8097. For Android physical devices, use `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host.
+
+## Component Inspection
+
+```bash
+agent-device react-devtools get tree --depth 3
+agent-device react-devtools get component @c5
+agent-device react-devtools find Button
+agent-device react-devtools find Button --exact
+agent-device react-devtools count
+agent-device react-devtools errors
+```
+
+- `get tree` prints a component hierarchy with labels like `@c1`, `@c2`.
+- Use `--depth` on large apps. Start at `--depth 3` or `--depth 4`.
+- `get component` accepts a label or numeric React fiber id and shows props, state, and hooks.
+- `find` searches by display name. Use `--exact` when fuzzy results are noisy.
+- `errors` lists components with React-tracked warnings or errors.
+
+## Profiling
+
+```bash
+agent-device react-devtools profile start "interaction name"
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+agent-device react-devtools profile report @c5
+agent-device react-devtools profile timeline --limit 20
+agent-device react-devtools profile commit 3
+agent-device react-devtools profile export profile.json
+agent-device react-devtools profile diff before.json after.json --limit 10
+```
+
+- `profile slow` ranks components by average render duration.
+- `profile rerenders` ranks components by render count.
+- `profile report @cN` shows render causes and changed props/state/hooks for one component.
+- `profile timeline` lists commits. Use `--limit` and `--offset` for long sessions.
+- `profile export` writes React DevTools Profiler JSON that can be diffed later.
+
+## Common Flows
+
+Inspect a component:
+
+```bash
+agent-device react-devtools status
+agent-device react-devtools get tree --depth 3
+agent-device react-devtools find SearchScreen
+agent-device react-devtools get component @c12
+```
+
+Profile a slow interaction:
+
+```bash
+agent-device react-devtools profile start "slow search"
+# Trigger the interaction with agent-device or ask the user to perform it.
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+```
+
+Verify a render fix:
+
+```bash
+agent-device react-devtools profile start "after fix"
+# Repeat the same interaction.
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+```

--- a/skills/react-devtools/references/profiling.md
+++ b/skills/react-devtools/references/profiling.md
@@ -1,0 +1,74 @@
+# React Native Profiling
+
+Use this workflow when the user reports slow interactions, excessive re-renders, unstable props, or unclear render causes.
+
+## Baseline
+
+```bash
+agent-device react-devtools status
+agent-device react-devtools count
+agent-device react-devtools get tree --depth 3
+```
+
+If the app is not connected, run:
+
+```bash
+agent-device react-devtools start
+agent-device react-devtools wait --connected
+```
+
+Then reload or relaunch the React Native app if needed.
+
+## Capture One Interaction
+
+```bash
+agent-device react-devtools profile start "short label"
+# Trigger exactly the interaction being investigated.
+agent-device react-devtools profile stop
+```
+
+Keep the profiling window narrow. Extra navigation, warm-up work, or unrelated gestures make the report harder to interpret.
+
+## Identify Suspects
+
+```bash
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+```
+
+- A component with high average render time is a slow-render suspect.
+- A component with high render count is a re-render suspect.
+- A component can be both.
+
+## Drill In
+
+```bash
+agent-device react-devtools profile report @c12
+agent-device react-devtools get component @c12
+```
+
+Use `profile report` to identify render causes and changed keys. Use `get component` to inspect current props, state, and hooks.
+
+Common interpretations:
+
+| Signal                                     | Meaning                             | Typical follow-up                              |
+| ------------------------------------------ | ----------------------------------- | ---------------------------------------------- |
+| `props-changed` with function props        | Parent may pass unstable callbacks  | Check whether the parent can use `useCallback` |
+| `props-changed` with object or array props | Parent may pass unstable references | Check whether the parent can use `useMemo`     |
+| `parent-rendered` with many child renders  | Child has no bailout                | Check whether `React.memo` is appropriate      |
+| `state-changed`                            | Component state caused the render   | Check whether the state update is necessary    |
+| `hooks-changed`                            | Hook value or dependency changed    | Inspect hook values and dependencies           |
+
+## Verify
+
+After making a change, repeat the same interaction:
+
+```bash
+agent-device react-devtools profile start "after fix"
+# Repeat the same interaction.
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+```
+
+Compare render counts, average durations, changed keys, and commit counts against the baseline.

--- a/src/__tests__/cli-help.test.ts
+++ b/src/__tests__/cli-help.test.ts
@@ -95,6 +95,14 @@ test('appstate --help prints command help and skips daemon dispatch', async () =
   assert.match(result.stdout, /Global flags:/);
 });
 
+test('help react-devtools prints passthrough command help and skips daemon dispatch', async () => {
+  const result = await runCliCapture(['help', 'react-devtools']);
+  assert.equal(result.code, 0);
+  assert.equal(result.daemonCalls, 0);
+  assert.match(result.stdout, /Usage:\n  agent-device react-devtools \[\.\.\.args\]/);
+  assert.match(result.stdout, /React Native component trees/);
+});
+
 test('help unknown command prints error plus global usage and skips daemon dispatch', async () => {
   const result = await runCliCapture(['help', 'not-a-command']);
   assert.equal(result.code, 1);

--- a/src/__tests__/cli-react-devtools.test.ts
+++ b/src/__tests__/cli-react-devtools.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import {
@@ -19,4 +20,12 @@ test('react-devtools passthrough pins agent-react-devtools package version', () 
     '--depth',
     '3',
   ]);
+});
+
+test('react-devtools docs mention the pinned package version', () => {
+  const docs = ['README.md', 'website/docs/docs/commands.md', 'skills/react-devtools/SKILL.md'];
+
+  for (const file of docs) {
+    assert.match(fs.readFileSync(file, 'utf8'), new RegExp(AGENT_REACT_DEVTOOLS_PACKAGE));
+  }
 });

--- a/src/__tests__/cli-react-devtools.test.ts
+++ b/src/__tests__/cli-react-devtools.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  AGENT_REACT_DEVTOOLS_PACKAGE,
+  buildReactDevtoolsNpmExecArgs,
+} from '../cli/commands/react-devtools.ts';
+
+test('react-devtools passthrough pins agent-react-devtools package version', () => {
+  assert.equal(AGENT_REACT_DEVTOOLS_PACKAGE, 'agent-react-devtools@0.4.0');
+  assert.deepEqual(buildReactDevtoolsNpmExecArgs(['get', 'tree', '--depth', '3']), [
+    'exec',
+    '--yes',
+    '--package',
+    'agent-react-devtools@0.4.0',
+    '--',
+    'agent-react-devtools',
+    'get',
+    'tree',
+    '--depth',
+    '3',
+  ]);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import {
 } from './client.ts';
 import { materializeRemoteConnectionForCommand } from './cli/commands/connection-runtime.ts';
 import { tryRunClientBackedCommand } from './cli/commands/router.ts';
+import { runReactDevtoolsCommand } from './cli/commands/react-devtools.ts';
 import {
   createRequestId,
   emitDiagnostic,
@@ -144,6 +145,25 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
       }
 
       const { command, positionals } = parsed;
+      if (command === 'react-devtools') {
+        try {
+          const exitCode = await runReactDevtoolsCommand(positionals);
+          process.exit(exitCode);
+          return;
+        } catch (error) {
+          const normalized = normalizeError(error, {
+            diagnosticId: getDiagnosticsMeta().diagnosticId,
+            logPath: flushDiagnosticsToSessionFile({ force: true }) ?? undefined,
+          });
+          if (parsed.flags.json) {
+            printJson({ success: false, error: normalized });
+          } else {
+            printHumanError(normalized, { showDetails: parsed.flags.verbose });
+          }
+          process.exit(1);
+          return;
+        }
+      }
       let binding: ReturnType<typeof resolveBindingSettings>;
       let flags: typeof parsed.flags;
       let daemonPaths: ReturnType<typeof resolveDaemonPaths>;

--- a/src/cli/commands/react-devtools.ts
+++ b/src/cli/commands/react-devtools.ts
@@ -1,0 +1,32 @@
+import { runCmdStreaming } from '../../utils/exec.ts';
+
+export const AGENT_REACT_DEVTOOLS_VERSION = '0.4.0';
+export const AGENT_REACT_DEVTOOLS_PACKAGE = `agent-react-devtools@${AGENT_REACT_DEVTOOLS_VERSION}`;
+const AGENT_REACT_DEVTOOLS_BIN = 'agent-react-devtools';
+
+export function buildReactDevtoolsNpmExecArgs(args: string[]): string[] {
+  return [
+    'exec',
+    '--yes',
+    '--package',
+    AGENT_REACT_DEVTOOLS_PACKAGE,
+    '--',
+    AGENT_REACT_DEVTOOLS_BIN,
+    ...args,
+  ];
+}
+
+export async function runReactDevtoolsCommand(args: string[]): Promise<number> {
+  const result = await runCmdStreaming('npm', buildReactDevtoolsNpmExecArgs(args), {
+    cwd: process.cwd(),
+    env: process.env,
+    allowFailure: true,
+    onStdoutChunk: (chunk) => {
+      process.stdout.write(chunk);
+    },
+    onStderrChunk: (chunk) => {
+      process.stderr.write(chunk);
+    },
+  });
+  return result.exitCode;
+}

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -93,6 +93,7 @@ export const commandCatalog: readonly CommandCatalogEntry[] = [
   { command: 'disconnect', category: 'environment', status: 'planned' },
   { command: 'connection', category: 'environment', status: 'planned' },
   { command: 'metro', category: 'environment', status: 'planned' },
+  { command: 'react-devtools', category: 'environment', status: 'implemented' },
   { command: 'record', category: 'capability-gated', status: 'implemented' },
   { command: 'trace', category: 'capability-gated', status: 'implemented' },
   { command: 'replay', category: 'capability-gated', status: 'planned' },

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -168,12 +168,30 @@ test('parseArgs recognizes network include flag', () => {
 
 test('parseArgs preserves react-devtools arguments as passthrough positionals', () => {
   const parsed = parseArgs(
-    ['--json', 'react-devtools', 'profile', 'diff', '--threshold', '10', '--limit=5'],
+    [
+      'react-devtools',
+      'profile',
+      'diff',
+      '--threshold',
+      '10',
+      '--limit=5',
+      '--json',
+      '--session',
+      'rn',
+    ],
     { strictFlags: true },
   );
   assert.equal(parsed.command, 'react-devtools');
   assert.equal(parsed.flags.json, true);
+  assert.equal(parsed.flags.session, 'rn');
   assert.deepEqual(parsed.positionals, ['profile', 'diff', '--threshold', '10', '--limit=5']);
+});
+
+test('parseArgs supports explicit passthrough boundary for react-devtools global flag names', () => {
+  const parsed = parseArgs(['react-devtools', '--', 'status', '--json'], { strictFlags: true });
+  assert.equal(parsed.command, 'react-devtools');
+  assert.equal(parsed.flags.json, false);
+  assert.deepEqual(parsed.positionals, ['status', '--json']);
 });
 
 test('parseArgs accepts push with payload file', () => {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -166,6 +166,16 @@ test('parseArgs recognizes network include flag', () => {
   assert.equal(parsed.flags.networkInclude, 'headers');
 });
 
+test('parseArgs preserves react-devtools arguments as passthrough positionals', () => {
+  const parsed = parseArgs(
+    ['--json', 'react-devtools', 'profile', 'diff', '--threshold', '10', '--limit=5'],
+    { strictFlags: true },
+  );
+  assert.equal(parsed.command, 'react-devtools');
+  assert.equal(parsed.flags.json, true);
+  assert.deepEqual(parsed.positionals, ['profile', 'diff', '--threshold', '10', '--limit=5']);
+});
+
 test('parseArgs accepts push with payload file', () => {
   const parsed = parseArgs(['push', 'com.example.app', './payload.json'], { strictFlags: true });
   assert.equal(parsed.command, 'push');

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -50,6 +50,10 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (command === 'react-devtools') {
+      positionals.push(arg);
+      continue;
+    }
     if (parseFlags && arg === '--') {
       parseFlags = false;
       continue;

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -50,10 +50,6 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (command === 'react-devtools') {
-      positionals.push(arg);
-      continue;
-    }
     if (parseFlags && arg === '--') {
       parseFlags = false;
       continue;
@@ -73,6 +69,10 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
 
     const [token, inlineValue] = isLongFlag ? splitLongFlag(arg) : [arg, undefined];
     const definition = getFlagDefinition(token);
+    if (shouldPassThroughReactDevtoolsFlag(command, definition)) {
+      positionals.push(arg);
+      continue;
+    }
     if (!definition) {
       if (shouldTreatUnknownDashTokenAsPositional(command, positionals, arg)) {
         if (!command) command = arg;
@@ -99,6 +99,15 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
   }
 
   return { command, positionals, flags, warnings, providedFlags };
+}
+
+function shouldPassThroughReactDevtoolsFlag(
+  command: string | null,
+  definition: FlagDefinition | undefined,
+): boolean {
+  if (command !== 'react-devtools') return false;
+  if (!definition) return true;
+  return !isFlagSupportedForCommand(definition.key, command);
 }
 
 export function finalizeParsedArgs(

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -154,6 +154,7 @@ const FIND_SNAPSHOT_FLAGS = ['snapshotDepth', 'snapshotRaw'] as const satisfies 
 
 const AGENT_SKILLS = [
   { label: 'agent-device', description: 'Canonical mobile automation flows' },
+  { label: 'react-devtools', description: 'React Native component tree and render profiling' },
   { label: 'dogfood', description: 'Exploratory QA and bug hunts' },
 ] as const;
 
@@ -173,6 +174,7 @@ const EXAMPLE_LINES = [
   'agent-device open Settings --platform ios',
   'agent-device open TextEdit --platform macos',
   'agent-device snapshot -i',
+  'agent-device react-devtools get tree --depth 3',
   'agent-device fill @e3 "test@example.com"',
   'agent-device replay ./session.ad',
   'agent-device test ./suite --platform android',
@@ -1149,6 +1151,17 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     summary: 'Show performance metrics',
     positionalArgs: [],
     allowedFlags: [],
+  },
+  'react-devtools': {
+    usageOverride: 'react-devtools [...args]',
+    listUsageOverride: 'react-devtools [...args]',
+    helpDescription:
+      'Run pinned agent-react-devtools commands for React Native component trees, props/state/hooks, and render profiling',
+    summary: 'Inspect and profile React Native component trees',
+    positionalArgs: ['args?'],
+    allowsExtraPositionals: true,
+    allowedFlags: [],
+    skipCapabilityCheck: true,
   },
   back: {
     usageOverride: 'back [--in-app|--system]',

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -555,6 +555,8 @@ agent-device react-devtools profile rerenders --limit 5
 ```
 
 - `react-devtools` dynamically runs pinned `agent-react-devtools@0.4.0` through npm and passes arguments through 1:1.
+- The first run may download the pinned package from npm; later runs can reuse the npm cache.
+- Put downstream flags after `react-devtools` so they pass through to `agent-react-devtools`.
 - Use it when a React Native workflow needs component hierarchy, props, state, hooks, render causes, slow components, or re-render counts.
 - Keep using `snapshot`, `press`, `fill`, `logs`, `network`, and `perf` for device/app runtime evidence. Use `react-devtools` for React internals.
 - React Native development builds can connect to the DevTools daemon on port 8097. For Android physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host.

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -559,7 +559,8 @@ agent-device react-devtools profile rerenders --limit 5
 - `agent-device` global flags work before or after `react-devtools`. Use `--` before downstream flags only when they intentionally share an `agent-device` global flag name.
 - Use it when a React Native workflow needs component hierarchy, props, state, hooks, render causes, slow components, or re-render counts.
 - Keep using `snapshot`, `press`, `fill`, `logs`, `network`, and `perf` for device/app runtime evidence. Use `react-devtools` for React internals.
-- React Native development builds can connect to the DevTools daemon on port 8097. For Android physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host.
+- React Native development builds can connect to the DevTools daemon on port 8097. For Android emulators or physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host. If Metro is local, also run `adb reverse tcp:8081 tcp:8081`.
+- For cross-platform validation, use an isolated `--state-dir`, avoid named `--session` during setup with explicit `--device`/`--udid`/`--serial` selectors unless you want bound-session locks, and restart `react-devtools` between iOS and Android runs.
 
 ## Media and logs
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -556,7 +556,7 @@ agent-device react-devtools profile rerenders --limit 5
 
 - `react-devtools` dynamically runs pinned `agent-react-devtools@0.4.0` through npm and passes arguments through 1:1.
 - The first run may download the pinned package from npm; later runs can reuse the npm cache.
-- Put downstream flags after `react-devtools` so they pass through to `agent-react-devtools`.
+- `agent-device` global flags work before or after `react-devtools`. Use `--` before downstream flags only when they intentionally share an `agent-device` global flag name.
 - Use it when a React Native workflow needs component hierarchy, props, state, hooks, render causes, slow components, or re-render counts.
 - Keep using `snapshot`, `press`, `fill`, `logs`, `network`, and `perf` for device/app runtime evidence. Use `react-devtools` for React internals.
 - React Native development builds can connect to the DevTools daemon on port 8097. For Android physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host.

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -540,6 +540,25 @@ agent-device metrics --json
 - Interpretation note: this startup metric is command round-trip timing and does not represent true first frame / first interactive app instrumentation.
 - CPU data is a lightweight process snapshot, so an idle app may legitimately read as `0`.
 
+## React Native component internals
+
+```bash
+agent-device react-devtools status
+agent-device react-devtools wait --connected
+agent-device react-devtools get tree --depth 3
+agent-device react-devtools get component @c5
+agent-device react-devtools find Button
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+```
+
+- `react-devtools` dynamically runs pinned `agent-react-devtools@0.4.0` through npm and passes arguments through 1:1.
+- Use it when a React Native workflow needs component hierarchy, props, state, hooks, render causes, slow components, or re-render counts.
+- Keep using `snapshot`, `press`, `fill`, `logs`, `network`, and `perf` for device/app runtime evidence. Use `react-devtools` for React internals.
+- React Native development builds can connect to the DevTools daemon on port 8097. For Android physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host.
+
 ## Media and logs
 
 ```bash

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -560,7 +560,7 @@ agent-device react-devtools profile rerenders --limit 5
 - Use it when a React Native workflow needs component hierarchy, props, state, hooks, render causes, slow components, or re-render counts.
 - Keep using `snapshot`, `press`, `fill`, `logs`, `network`, and `perf` for device/app runtime evidence. Use `react-devtools` for React internals.
 - React Native development builds can connect to the DevTools daemon on port 8097. For Android emulators or physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host. If Metro is local, also run `adb reverse tcp:8081 tcp:8081`.
-- For cross-platform validation, use an isolated `--state-dir`, avoid named `--session` during setup with explicit `--device`/`--udid`/`--serial` selectors unless you want bound-session locks, and restart `react-devtools` between iOS and Android runs.
+- For cross-platform validation with explicit target selectors, prefer an isolated `--state-dir` over separate named sessions. Named sessions enable bound-session locks during setup. Restart `react-devtools` between iOS and Android runs.
 
 ## Media and logs
 

--- a/website/docs/docs/debugging-profiling.md
+++ b/website/docs/docs/debugging-profiling.md
@@ -13,11 +13,20 @@ Use `agent-device` when the task moves past UI automation and you need runtime e
 - Performance snapshots with `perf` / `metrics`
 - Screenshots, recordings, and replayable repro flows
 
-## What to use instead
+## React Native component internals
 
-If the task needs the React component tree, props, state, hooks, or render profiling, pair `agent-device` with the complementary [`agent-react-devtools`](https://github.com/callstackincubator/agent-react-devtools) project.
+If the task needs the React Native component tree, props, state, hooks, or render profiling, use the `react-devtools` passthrough:
 
-`agent-device` is centered on the device and app runtime layer. `agent-react-devtools` is the better fit for React internals.
+```bash
+agent-device react-devtools status
+agent-device react-devtools get tree --depth 3
+agent-device react-devtools get component @c5
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+```
+
+`agent-device` remains centered on the device and app runtime layer. The `react-devtools` command dynamically runs pinned `agent-react-devtools` commands for React internals.
 
 ## Fast path
 

--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -14,7 +14,7 @@ title: Introduction
 
 If you know `agent-browser`, this is the mobile-native counterpart for iOS/Android UI automation and app-level observability.
 For exploratory QA and bug-hunting workflows, see `skills/dogfood/SKILL.md` in this repository.
-For React component trees, props/state/hooks, and render profiling, pair it with the complementary [`agent-react-devtools`](https://github.com/callstackincubator/agent-react-devtools) project.
+For React Native component trees, props/state/hooks, and render profiling, use `agent-device react-devtools`, which dynamically runs pinned `agent-react-devtools` commands.
 
 ## What it’s good at
 
@@ -51,7 +51,15 @@ For React component trees, props/state/hooks, and render profiling, pair it with
 
 `agent-device` is intentionally centered on the device/app layer: UI automation, screenshots/recordings, app logs, network inspection, and performance sampling.
 
-When a debugging workflow needs React internals such as the component tree, props, state, hooks, or render profiling, use the complementary `agent-react-devtools` project alongside `agent-device` rather than as a replacement.
+When a React Native debugging workflow needs React internals such as the component tree, props, state, hooks, or render profiling, use `agent-device react-devtools` alongside normal device commands:
+
+```bash
+agent-device react-devtools status
+agent-device react-devtools get tree --depth 3
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+```
 
 ## Example
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -26,5 +26,5 @@ features:
   - title: Visual verification
     details: Capture full-resolution screenshots and video recordings for reporting and visual checks.
   - title: Complementary React internals
-    details: Pair agent-device with agent-react-devtools when you need the React component tree, props, state, hooks, or render profiling.
+    details: Use agent-device react-devtools to inspect React Native component trees, props, state, hooks, and render profiles through pinned agent-react-devtools.
 ---


### PR DESCRIPTION
## Summary

Adds `agent-device react-devtools [...args]` as a CLI-side passthrough to pinned `agent-react-devtools@0.4.0` for React Native component tree inspection and render profiling.

Updates README, website docs, and bundled skills so React Native internals workflows are discoverable. Touched 20 files; scope stayed within the new command, tests, docs, and skills.

## Validation

- `pnpm format`
- `pnpm check:quick`
- `pnpm test:unit -- src/__tests__/cli-react-devtools.test.ts src/__tests__/cli-help.test.ts src/utils/__tests__/args.test.ts`
- `node --experimental-strip-types src/bin.ts react-devtools --help`
- `node --experimental-strip-types src/bin.ts help react-devtools`