### PR TITLE
feat: pass through GitHub Actions artifact install sources

### DIFF
--- a/skills/agent-device/references/bootstrap-install.md
+++ b/skills/agent-device/references/bootstrap-install.md
@@ -18,6 +18,7 @@ Use this exact order when you are not sure about the installed app identifier. O
 
 - `install` or `reinstall`
 - `install-from-source` when the artifact already exists at a URL the daemon can reach
+- `install-from-source --github-actions-artifact` when a compatible remote daemon should resolve a GitHub Actions artifact
 
 ## Most common mistake to avoid
 
@@ -35,8 +36,6 @@ After setup is confirmed or completed, move to `exploration.md` before doing UI 
 - If `open <app>` fails, run `agent-device apps` and retry with a discovered app name before considering install steps.
 - Do not install or reinstall on the first attempt unless the user explicitly asks for installation or provides a concrete artifact path or URL.
 - When installation is required from a known location, prefer a checked-in shell script or other deterministic bootstrap command over ad hoc path guessing.
-
-- If `open <app>` fails, or you are not sure which app name is available on the target, run `agent-device apps` first and choose from the discovered app list instead of guessing.
 - Use `apps --platform <platform>` together with `--device`, `--udid`, or `--serial` when target selection matters.
 - Once you have the correct app name, retry `open` with that exact discovered value.
 
@@ -64,8 +63,27 @@ agent-device install com.example.app ./build/MyApp.app --platform ios --device "
 ```bash
 ARTIFACT_URL="<trusted-artifact-url>"
 agent-device install-from-source "$ARTIFACT_URL" --platform android
-GITHUB_ARTIFACT_URL="<trusted-github-actions-artifact-api-url>"
-agent-device install-from-source "$GITHUB_ARTIFACT_URL" --platform ios --header "authorization: Bearer TOKEN"
+```
+
+Daemon-resolved GitHub Actions artifacts:
+
+```bash
+agent-device install-from-source \
+  --github-actions-artifact ORG/REPO:1234567890 \
+  --platform android
+```
+
+Project config can provide an artifact name instead:
+
+```json
+{
+  "platform": "android",
+  "installSource": {
+    "type": "github-actions-artifact",
+    "repo": "ORG/REPO",
+    "artifact": "app-debug"
+  }
+}
 ```
 
 ## Install guidance
@@ -73,6 +91,7 @@ agent-device install-from-source "$GITHUB_ARTIFACT_URL" --platform ios --header 
 - Use `install <app> <path>` when the app may already be installed and you do not need a fresh-state reset.
 - Use `reinstall <app> <path>` when you explicitly need uninstall plus install as one deterministic step.
 - Use `install-from-source <url>` only when an existing artifact URL is trusted, operator-approved, and reachable by the daemon.
+- Use `--github-actions-artifact <org>/<repo>:<artifact>` when a compatible remote daemon should resolve a GitHub Actions artifact. Numeric artifacts are IDs; non-numeric artifacts are names.
 - Local `.apk`, `.aab`, `.app`, and `.ipa` paths go through `install` or `reinstall`; existing reachable URLs go through `install-from-source`.
 - Do not download, re-zip, publish temporary GitHub releases, or move CI artifacts elsewhere just to make an install command work.
 - Keep install and open as separate phases. Do not turn them into one default command flow.
@@ -80,10 +99,10 @@ agent-device install-from-source "$GITHUB_ARTIFACT_URL" --platform ios --header 
   - Android: `.apk` and `.aab`
   - iOS: `.app` and `.ipa`
 - Android URL sources can be direct `.apk` or `.aab` files.
-- Trusted artifact service URLs, currently GitHub Actions and EAS, may point at archive-backed downloads that contain one installable artifact. This includes GitHub Actions artifact ZIPs whose URL path does not end in `.zip` and ZIPs containing one nested `.apk`, `.aab`, `.ipa`, or iOS `.app` tar archive.
+- Trusted artifact service URLs may point at archive-backed downloads that contain one installable artifact. Prefer `--github-actions-artifact` for GitHub Actions artifacts that a compatible remote daemon can resolve with its own credentials.
 - If a trusted artifact archive contains multiple installables, stop and ask for the intended artifact instead of guessing.
 - `.aab` still requires `bundletool` in `PATH`, or `AGENT_DEVICE_BUNDLETOOL_JAR=<absolute-path-to-bundletool-all.jar>` with `java` in `PATH`, when the daemon installs the materialized artifact.
-- For iOS `.ipa` files, `<app>` is used as the bundle id or bundle name hint when the archive contains multiple app bundles.
+- For `.ipa` archives with multiple app bundles, `<app>` is the bundle id or bundle name selection hint.
 - After install or reinstall, later use `open <app>` with the exact discovered or known package/bundle identifier, not the artifact path.
 
 ## Choose the right starting point

--- a/skills/agent-device/references/remote-tenancy.md
+++ b/skills/agent-device/references/remote-tenancy.md
@@ -8,6 +8,7 @@ Open this file for remote daemon HTTP flows that let an agent running in a Linux
 
 - `agent-device connect --remote-config <path>`
 - `agent-device install-from-source <url> --remote-config <path> --platform android`
+- `agent-device install-from-source --github-actions-artifact <org>/<repo>:<artifact> --remote-config <path> --platform android`
 - `agent-device open <package> --remote-config <path> --relaunch`
 - `agent-device snapshot --remote-config <path> -i`
 - `agent-device disconnect --remote-config <path>`
@@ -82,12 +83,11 @@ Remote install examples:
 agent-device install com.example.app ./app.apk
 ARTIFACT_URL="<trusted-artifact-url>"
 agent-device install-from-source "$ARTIFACT_URL" --platform android
-GITHUB_ARTIFACT_URL="<trusted-github-actions-artifact-api-url>"
-agent-device install-from-source "$GITHUB_ARTIFACT_URL" --platform ios --header "authorization: Bearer TOKEN"
 ```
 
 - Use `install` or `reinstall` for local paths; remote daemons upload local artifacts automatically.
 - Use `install-from-source` only for trusted, operator-approved artifact URLs the remote daemon can reach. Do not fetch arbitrary user-supplied URLs.
+- Use `install-from-source --github-actions-artifact <org>/<repo>:<artifact>` when the remote daemon has repository credentials and supports daemon-resolved GitHub Actions artifacts.
 - For local-path versus URL artifact rules, follow [bootstrap-install.md](bootstrap-install.md).
 
 Use `agent-device connection status --session adc-android` to inspect the active connection without reading JSON state manually. Status output must not include auth tokens.
@@ -135,30 +135,47 @@ Optional overrides stay available for advanced cases:
 - Start the daemon in HTTP mode with `AGENT_DEVICE_DAEMON_SERVER_MODE=http|dual` on the host.
 - Point the profile or env at the remote host with `daemonBaseUrl` or `AGENT_DEVICE_DAEMON_BASE_URL=http(s)://host:port[/base-path]`.
 - For non-loopback remote hosts, set `AGENT_DEVICE_DAEMON_AUTH_TOKEN` or `--daemon-auth-token`. The client rejects non-loopback remote daemon URLs without auth.
-- Direct JSON-RPC callers can authenticate with request params, `Authorization: Bearer <token>`, or `x-agent-device-token`.
 - Prefer an auth hook such as `AGENT_DEVICE_HTTP_AUTH_HOOK` when the host needs caller validation or tenant injection.
 
-## Manual lease debug fallback
+## Lease debug fallback
 
-The main agent flow should use `connect`. Use manual JSON-RPC only for host-side automation or daemon-side auth/scope debugging, and only against trusted daemon hosts.
+The main agent flow should use `connect` and `connection status`. For daemon-side auth, scope, or lease debugging, inspect host-side daemon logs and operator tooling instead of issuing raw daemon RPC from the agent shell.
+
+## GitHub Actions artifact install
+
+Use this when a compatible remote daemon resolves GitHub Actions artifacts server-side. Do not download CI artifacts locally or add a local `GITHUB_TOKEN` just to install CI output.
+
+Artifact ID shape:
 
 ```bash
-curl -fsS "$AGENT_DEVICE_DAEMON_BASE_URL/rpc" \
-  -H "Authorization: Bearer $AGENT_DEVICE_DAEMON_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": "lease-1",
-    "method": "agent_device.lease.allocate",
-    "params": {
-      "tenantId": "acme",
-      "runId": "run-123",
-      "backend": "android-instance"
-    }
-  }'
+agent-device install-from-source \
+  --github-actions-artifact OWNER/REPO:1234567890 \
+  --remote-config ./remote-config.json \
+  --platform android
 ```
 
-Related daemon methods are `agent_device.lease.allocate`, `agent_device.lease.heartbeat`, `agent_device.lease.release`, and `agent_device.command`.
+Artifact-name shape:
+
+```bash
+agent-device install-from-source \
+  --github-actions-artifact OWNER/REPO:app-debug \
+  --remote-config ./remote-config.json \
+  --platform ios
+```
+
+Config shape:
+
+```json
+{
+  "installSource": {
+    "type": "github-actions-artifact",
+    "repo": "OWNER/REPO",
+    "artifact": "app-debug"
+  }
+}
+```
+
+Numeric artifacts are passed as artifact IDs. Non-numeric artifacts are passed as artifact names.
 
 ## Failure semantics and trust notes
 

--- a/src/__tests__/cli-client-commands.test.ts
+++ b/src/__tests__/cli-client-commands.test.ts
@@ -56,6 +56,115 @@ test('install-from-source forwards URL and repeated headers to client.apps.insta
   });
 });
 
+test('install-from-source forwards GitHub Actions artifact flag to client.apps.installFromSource', async () => {
+  let observed: AppInstallFromSourceOptions | undefined;
+  const client = createStubClient({
+    installFromSource: async (options) => {
+      observed = options;
+      return {
+        launchTarget: 'com.example.demo',
+        packageName: 'com.example.demo',
+        identifiers: { appId: 'com.example.demo', package: 'com.example.demo' },
+      };
+    },
+  });
+
+  const handled = await tryRunClientBackedCommand({
+    command: 'install-from-source',
+    positionals: [],
+    flags: {
+      json: false,
+      help: false,
+      version: false,
+      platform: 'android',
+      githubActionsArtifact: 'thymikee/RNCLI83:6635342232',
+    },
+    client,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(observed?.platform, 'android');
+  assert.deepEqual(observed?.source, {
+    kind: 'github-actions-artifact',
+    owner: 'thymikee',
+    repo: 'RNCLI83',
+    artifactId: 6635342232,
+  });
+});
+
+test('install-from-source preserves colons in GitHub Actions artifact names', async () => {
+  let observed: AppInstallFromSourceOptions | undefined;
+  const client = createStubClient({
+    installFromSource: async (options) => {
+      observed = options;
+      return {
+        launchTarget: 'com.example.demo',
+        packageName: 'com.example.demo',
+        identifiers: { appId: 'com.example.demo', package: 'com.example.demo' },
+      };
+    },
+  });
+
+  await tryRunClientBackedCommand({
+    command: 'install-from-source',
+    positionals: [],
+    flags: {
+      json: false,
+      help: false,
+      version: false,
+      githubActionsArtifact: 'thymikee/RNCLI83:app:debug:pr-19',
+    },
+    client,
+  });
+
+  assert.deepEqual(observed?.source, {
+    kind: 'github-actions-artifact',
+    owner: 'thymikee',
+    repo: 'RNCLI83',
+    artifactName: 'app:debug:pr-19',
+  });
+});
+
+test('install-from-source forwards configured GitHub Actions artifact name to client.apps.installFromSource', async () => {
+  let observed: AppInstallFromSourceOptions | undefined;
+  const client = createStubClient({
+    installFromSource: async (options) => {
+      observed = options;
+      return {
+        launchTarget: 'com.example.demo',
+        packageName: 'com.example.demo',
+        identifiers: { appId: 'com.example.demo', package: 'com.example.demo' },
+      };
+    },
+  });
+
+  const handled = await tryRunClientBackedCommand({
+    command: 'install-from-source',
+    positionals: [],
+    flags: {
+      json: false,
+      help: false,
+      version: false,
+      platform: 'android',
+      installSource: {
+        kind: 'github-actions-artifact',
+        owner: 'thymikee',
+        repo: 'RNCLI83',
+        artifactName: 'rn-android-emulator-debug-pr-19',
+      },
+    },
+    client,
+  });
+
+  assert.equal(handled, true);
+  assert.deepEqual(observed?.source, {
+    kind: 'github-actions-artifact',
+    owner: 'thymikee',
+    repo: 'RNCLI83',
+    artifactName: 'rn-android-emulator-debug-pr-19',
+  });
+});
+
 test('install-from-source rejects malformed header syntax', async () => {
   const client = createStubClient({
     installFromSource: async () => {
@@ -80,6 +189,34 @@ test('install-from-source rejects malformed header syntax', async () => {
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&
       error.message.includes('Expected "name:value"'),
+  );
+});
+
+test('install-from-source rejects headers with GitHub Actions artifact sources', async () => {
+  const client = createStubClient({
+    installFromSource: async () => {
+      throw new Error('unexpected call');
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      tryRunClientBackedCommand({
+        command: 'install-from-source',
+        positionals: [],
+        flags: {
+          json: false,
+          help: false,
+          version: false,
+          githubActionsArtifact: 'thymikee/RNCLI83:6635342232',
+          header: ['authorization: Bearer token'],
+        },
+        client,
+      }),
+    (error) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message.includes('--header is only supported for URL sources'),
   );
 });
 

--- a/src/__tests__/cli-config.test.ts
+++ b/src/__tests__/cli-config.test.ts
@@ -149,6 +149,46 @@ test('config and env can set appsFilter through canonical enum values', async ()
   fs.rmSync(root, { recursive: true, force: true });
 });
 
+test('config can provide install-from-source GitHub Actions artifact source', async () => {
+  const { root, home, project } = makeTempWorkspace();
+  fs.mkdirSync(path.join(home, '.agent-device'), { recursive: true });
+  fs.writeFileSync(
+    path.join(project, 'agent-device.json'),
+    JSON.stringify({
+      platform: 'android',
+      installSource: {
+        type: 'github-actions-artifact',
+        repo: 'thymikee/RNCLI83',
+        artifact: 'rn-android-emulator-debug-pr-19',
+      },
+    }),
+    'utf8',
+  );
+
+  const result = await runCliCapture(['install-from-source', '--json'], {
+    cwd: project,
+    env: { HOME: home },
+    sendToDaemon: async () => ({
+      ok: true,
+      data: {
+        packageName: 'com.example.demo',
+      },
+    }),
+  });
+
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.flags?.platform, 'android');
+  assert.deepEqual(result.calls[0]?.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'thymikee',
+    repo: 'RNCLI83',
+    artifactName: 'rn-android-emulator-debug-pr-19',
+  });
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
 test('command-specific config defaults are ignored for commands that do not support them', async () => {
   const { root, home, project } = makeTempWorkspace();
   fs.mkdirSync(path.join(home, '.agent-device'), { recursive: true });

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -294,6 +294,34 @@ test('apps.installFromSource derives Android launchTarget from packageName when 
   });
 });
 
+test('apps.installFromSource forwards GitHub Actions artifact sources unchanged', async () => {
+  const setup = createTransport(async () => ({
+    ok: true,
+    data: {
+      packageName: 'com.example.ci',
+    },
+  }));
+  const client = createAgentDeviceClient(setup.config, { transport: setup.transport });
+
+  await client.apps.installFromSource({
+    platform: 'android',
+    source: {
+      kind: 'github-actions-artifact',
+      owner: 'acme',
+      repo: 'mobile',
+      artifactId: 1234567890,
+    },
+  });
+
+  assert.equal(setup.calls.length, 1);
+  assert.deepEqual(setup.calls[0]?.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    artifactId: 1234567890,
+  });
+});
+
 test('apps.list forwards filters and returns daemon app names', async () => {
   const setup = createTransport(async () => ({
     ok: true,

--- a/src/__tests__/contracts-schema-public.test.ts
+++ b/src/__tests__/contracts-schema-public.test.ts
@@ -87,6 +87,102 @@ test('public contract schemas validate daemon requests and lease payloads', () =
   assert.equal(node.ref, 'e1');
 });
 
+test('public daemon request schema accepts GitHub Actions artifact install sources', () => {
+  const artifactIdRequest = daemonCommandRequestSchema.parse({
+    command: 'install_source',
+    positionals: [],
+    flags: { platform: 'android' },
+    meta: {
+      installSource: {
+        kind: 'github-actions-artifact',
+        owner: 'acme',
+        repo: 'mobile',
+        artifactId: 1234567890,
+      },
+    },
+  });
+  const artifactNameRequest = daemonCommandRequestSchema.parse({
+    command: 'install_source',
+    positionals: [],
+    flags: { platform: 'ios' },
+    meta: {
+      installSource: {
+        kind: 'github-actions-artifact',
+        owner: 'acme',
+        repo: 'mobile',
+        runId: 987654321,
+        artifactName: 'app-debug',
+      },
+    },
+  });
+  const latestArtifactNameRequest = daemonCommandRequestSchema.parse({
+    command: 'install_source',
+    positionals: [],
+    flags: { platform: 'android' },
+    meta: {
+      installSource: {
+        kind: 'github-actions-artifact',
+        owner: 'acme',
+        repo: 'mobile',
+        artifactName: 'app-debug',
+      },
+    },
+  });
+
+  assert.deepEqual(artifactIdRequest.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    artifactId: 1234567890,
+  });
+  assert.deepEqual(artifactNameRequest.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    runId: 987654321,
+    artifactName: 'app-debug',
+  });
+  assert.deepEqual(latestArtifactNameRequest.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    artifactName: 'app-debug',
+  });
+  assert.throws(
+    () =>
+      daemonCommandRequestSchema.parse({
+        command: 'install_source',
+        positionals: [],
+        meta: {
+          installSource: {
+            kind: 'github-actions-artifact',
+            owner: 'acme',
+            repo: 'mobile',
+            artifactId: 1234567890,
+            runId: 987654321,
+            artifactName: 'app-debug',
+          },
+        },
+      }),
+    /either artifactId or artifactName, not both/,
+  );
+  assert.throws(
+    () =>
+      daemonCommandRequestSchema.parse({
+        command: 'install_source',
+        positionals: [],
+        meta: {
+          installSource: {
+            kind: 'github-actions-artifact',
+            owner: ' ',
+            repo: 'mobile',
+          },
+        },
+      }),
+    /owner/,
+  );
+});
+
 test('public contract exports normalize and hint app errors', () => {
   const normalized = normalizeError(new AppError(invalidArgsCode, 'Invalid command'));
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -3,6 +3,7 @@ import { serializeDeployResult, serializeInstallFromSourceResult } from '../../c
 import type { CliFlags } from '../../utils/command-schema.ts';
 import type { AgentDeviceClient, AppDeployResult } from '../../client.ts';
 import { buildSelectionOptions, writeCommandMessage } from './shared.ts';
+import { parseGitHubActionsArtifactInstallSourceSpec } from '../../utils/install-source-config.ts';
 import type { ClientCommandHandler } from './router-types.ts';
 
 export const installCommand: ClientCommandHandler = async ({ positionals, flags, client }) => {
@@ -59,26 +60,47 @@ async function runInstallFromSourceCommand(
   flags: CliFlags,
   client: AgentDeviceClient,
 ) {
-  const url = positionals[0]?.trim();
-  if (!url) {
-    throw new AppError('INVALID_ARGS', 'install-from-source requires: install-from-source <url>');
-  }
-  if (positionals.length > 1) {
+  const source = resolveInstallSource(positionals, flags);
+  if (source.kind !== 'url' && flags.header && flags.header.length > 0) {
     throw new AppError(
       'INVALID_ARGS',
-      'install-from-source accepts exactly one positional argument: <url>',
+      'install-from-source --header is only supported for URL sources',
     );
   }
   return await client.apps.installFromSource({
     ...buildSelectionOptions(flags),
     retainPaths: flags.retainPaths,
     retentionMs: flags.retentionMs,
-    source: {
-      kind: 'url',
-      url,
-      headers: parseInstallSourceHeaders(flags.header),
-    },
+    source,
   });
+}
+
+function resolveInstallSource(positionals: string[], flags: CliFlags) {
+  const url = positionals[0]?.trim();
+  if (positionals.length > 1) {
+    throw new AppError(
+      'INVALID_ARGS',
+      'install-from-source accepts either one <url> positional or --github-actions-artifact',
+    );
+  }
+  const githubArtifactSource = flags.githubActionsArtifact
+    ? parseGitHubActionsArtifactInstallSourceSpec(flags.githubActionsArtifact)
+    : undefined;
+  const configuredSource = flags.installSource;
+  const sourceCount = (url ? 1 : 0) + (githubArtifactSource ? 1 : 0) + (configuredSource ? 1 : 0);
+  if (sourceCount !== 1) {
+    throw new AppError(
+      'INVALID_ARGS',
+      'install-from-source requires exactly one source: <url>, --github-actions-artifact, or config installSource',
+    );
+  }
+  if (githubArtifactSource) return githubArtifactSource;
+  if (configuredSource) return configuredSource;
+  return {
+    kind: 'url' as const,
+    url: url!,
+    headers: parseInstallSourceHeaders(flags.header),
+  };
 }
 
 function parseInstallSourceHeaders(

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -18,7 +18,23 @@ export type DaemonInstallSource =
   | {
       kind: 'path';
       path: string;
-    };
+    }
+  | ({
+      kind: 'github-actions-artifact';
+      owner: string;
+      repo: string;
+    } & (
+      | {
+          artifactId: number;
+        }
+      | {
+          runId: number;
+          artifactName: string;
+        }
+      | {
+          artifactName: string;
+        }
+    ));
 
 export type DaemonLockPolicy = 'reject' | 'strip';
 export type LeaseBackend = 'ios-simulator' | 'ios-instance' | 'android-instance';
@@ -157,6 +173,14 @@ function expectString(input: unknown, path: string): string {
   return input;
 }
 
+function expectNonEmptyString(input: unknown, path: string): string {
+  const value = expectString(input, path).trim();
+  if (!value) {
+    fail(path, 'Expected a non-empty string');
+  }
+  return value;
+}
+
 function expectInteger(input: unknown, path: string): number {
   if (!Number.isInteger(input)) {
     fail(path, 'Expected an integer');
@@ -234,6 +258,41 @@ function expectStringRecord(input: unknown, path: string): Record<string, string
   return result;
 }
 
+function parseGitHubActionsArtifactInstallSource(
+  record: Record<string, unknown>,
+  path: string,
+): DaemonInstallSource {
+  const owner = expectNonEmptyString(record.owner, `${path}.owner`);
+  const repo = expectNonEmptyString(record.repo, `${path}.repo`);
+  const hasArtifactId = record.artifactId !== undefined;
+  const hasRunId = record.runId !== undefined;
+  const hasArtifactName = record.artifactName !== undefined;
+  if (hasArtifactId && (hasRunId || hasArtifactName)) {
+    fail(`${path}`, 'Expected either artifactId or artifactName, not both');
+  }
+  if (!hasArtifactId && hasRunId && !hasArtifactName) {
+    fail(`${path}`, 'Expected artifactName when runId is specified');
+  }
+  if (!hasArtifactId && !hasArtifactName) {
+    fail(`${path}`, 'Expected artifactId or artifactName');
+  }
+  if (hasArtifactId) {
+    return {
+      kind: 'github-actions-artifact',
+      owner,
+      repo,
+      artifactId: expectInteger(record.artifactId, `${path}.artifactId`),
+    };
+  }
+  return {
+    kind: 'github-actions-artifact',
+    owner,
+    repo,
+    ...(hasRunId ? { runId: expectInteger(record.runId, `${path}.runId`) } : {}),
+    artifactName: expectNonEmptyString(record.artifactName, `${path}.artifactName`),
+  };
+}
+
 function parseDaemonInstallSource(input: unknown, path: string): DaemonInstallSource {
   const record = expectObject(input, path);
   const kind = expectString(record.kind, `${path}.kind`);
@@ -251,7 +310,10 @@ function parseDaemonInstallSource(input: unknown, path: string): DaemonInstallSo
       path: expectString(record.path, `${path}.path`),
     };
   }
-  fail(`${path}.kind`, 'Expected "url" or "path"');
+  if (kind === 'github-actions-artifact') {
+    return parseGitHubActionsArtifactInstallSource(record, path);
+  }
+  fail(`${path}.kind`, 'Expected "url", "path", or "github-actions-artifact"');
 }
 
 export const daemonRuntimeSchema = schema<SessionRuntimeHints>((input, path) => {

--- a/src/daemon/__tests__/http-server.test.ts
+++ b/src/daemon/__tests__/http-server.test.ts
@@ -233,6 +233,114 @@ test('HTTP install_from_source RPC maps typed params to an install_source daemon
   });
 });
 
+test('HTTP install_from_source RPC accepts GitHub Actions artifact sources', async (ctx) => {
+  if (!(await supportsLoopbackBind())) {
+    ctx.skip();
+    return;
+  }
+
+  let observedRequest: DaemonRequest | undefined;
+  const server = await createDaemonHttpServer({
+    handleRequest: async (req: DaemonRequest): Promise<DaemonResponse> => {
+      observedRequest = req;
+      return { ok: true, data: { launchTarget: 'com.example.archive' } };
+    },
+    token: 'test-token',
+  });
+  const port = await listen(server);
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
+  const artifactIdResponse = await callRpc(port, {
+    jsonrpc: '2.0',
+    id: 'rpc-install-source-gh-artifact-id',
+    method: 'agent_device.install_from_source',
+    params: {
+      token: 'test-token',
+      session: 'bootstrap',
+      platform: 'android',
+      source: {
+        kind: 'github-actions-artifact',
+        owner: 'acme',
+        repo: 'mobile',
+        artifactId: '1234567890',
+      },
+    },
+  });
+
+  assert.equal(artifactIdResponse.statusCode, 200);
+  assert.equal((artifactIdResponse.json as { result?: { ok?: boolean } }).result?.ok, true);
+  assert.deepEqual(observedRequest?.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    artifactId: 1234567890,
+  });
+
+  const latestArtifactNameResponse = await callRpc(port, {
+    jsonrpc: '2.0',
+    id: 'rpc-install-source-gh-artifact-name',
+    method: 'agent_device.install_from_source',
+    params: {
+      token: 'test-token',
+      session: 'bootstrap',
+      platform: 'android',
+      source: {
+        kind: 'github-actions-artifact',
+        owner: 'acme',
+        repo: 'mobile',
+        artifactName: 'app-debug',
+      },
+    },
+  });
+
+  assert.equal(latestArtifactNameResponse.statusCode, 200);
+  assert.equal((latestArtifactNameResponse.json as { result?: { ok?: boolean } }).result?.ok, true);
+  assert.deepEqual(observedRequest?.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    artifactName: 'app-debug',
+  });
+
+  const artifactNameResponse = await callRpc(port, {
+    jsonrpc: '2.0',
+    id: 'rpc-install-source-gh',
+    method: 'agent_device.install_from_source',
+    params: {
+      token: 'test-token',
+      session: 'bootstrap',
+      platform: 'android',
+      source: {
+        kind: 'github-actions-artifact',
+        owner: 'acme',
+        repo: 'mobile',
+        runId: '1234567890',
+        artifactName: 'app-debug',
+      },
+    },
+  });
+
+  assert.equal(artifactNameResponse.statusCode, 200);
+  assert.equal((artifactNameResponse.json as { result?: { ok?: boolean } }).result?.ok, true);
+  assert.deepEqual(observedRequest?.meta?.installSource, {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    runId: 1234567890,
+    artifactName: 'app-debug',
+  });
+});
+
 test('HTTP release_materialized_paths RPC maps typed params to a release_materialized_paths daemon request', async (ctx) => {
   if (!(await supportsLoopbackBind())) {
     ctx.skip();

--- a/src/daemon/handlers/__tests__/install-source.test.ts
+++ b/src/daemon/handlers/__tests__/install-source.test.ts
@@ -109,6 +109,21 @@ test('resolveInstallSource leaves URL sources unchanged even when upload metadat
   resolved.cleanup();
 });
 
+test('resolveInstallSource rejects GitHub Actions artifact sources on the local daemon', () => {
+  expect(() =>
+    resolveInstallSource(
+      makeRequest({
+        installSource: {
+          kind: 'github-actions-artifact',
+          owner: 'acme',
+          repo: 'mobile',
+          artifactId: 1234567890,
+        },
+      }),
+    ),
+  ).toThrow(/compatible remote daemon/i);
+});
+
 test('install_from_source returns Android package identity resolved after install when artifact inspection is empty', async () => {
   const sessionStore = makeSessionStore();
   const session = makeAndroidSession('default');

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -166,6 +166,75 @@ function readBooleanParam(params: Record<string, unknown>, key: string): boolean
   return typeof value === 'boolean' ? value : undefined;
 }
 
+function readRequiredGitHubArtifactText(
+  record: Record<string, unknown>,
+  key: 'owner' | 'repo' | 'artifactName',
+): string {
+  const value = typeof record[key] === 'string' ? record[key].trim() : '';
+  if (!value) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Invalid params: source.${key} is required for github-actions-artifact sources`,
+    );
+  }
+  return value;
+}
+
+function readGitHubArtifactInteger(record: Record<string, unknown>, key: 'artifactId' | 'runId') {
+  const value = record[key];
+  const parsed =
+    typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isInteger(parsed)) {
+    throw new AppError('INVALID_ARGS', `Invalid params: source.${key} must be an integer`);
+  }
+  return parsed;
+}
+
+function parseGitHubActionsArtifactSource(record: Record<string, unknown>): DaemonInstallSource {
+  const owner = readRequiredGitHubArtifactText(record, 'owner');
+  const repo = readRequiredGitHubArtifactText(record, 'repo');
+  const hasArtifactId = record.artifactId !== undefined;
+  const hasRunId = record.runId !== undefined;
+  const hasArtifactName = record.artifactName !== undefined;
+  if (hasArtifactId && (hasRunId || hasArtifactName)) {
+    throw new AppError(
+      'INVALID_ARGS',
+      'Invalid params: source must specify either artifactId or artifactName, not both',
+    );
+  }
+  if (!hasArtifactId && hasRunId && !hasArtifactName) {
+    throw new AppError(
+      'INVALID_ARGS',
+      'Invalid params: source.artifactName is required when source.runId is specified',
+    );
+  }
+  if (!hasArtifactId && !hasArtifactName) {
+    throw new AppError(
+      'INVALID_ARGS',
+      'Invalid params: source must specify artifactId or artifactName',
+    );
+  }
+  if (hasArtifactId) {
+    return {
+      kind: 'github-actions-artifact',
+      owner,
+      repo,
+      artifactId: readGitHubArtifactInteger(record, 'artifactId'),
+    };
+  }
+  let runId: number | undefined;
+  if (hasRunId) {
+    runId = readGitHubArtifactInteger(record, 'runId');
+  }
+  return {
+    kind: 'github-actions-artifact',
+    owner,
+    repo,
+    ...(hasRunId ? { runId } : {}),
+    artifactName: readRequiredGitHubArtifactText(record, 'artifactName'),
+  };
+}
+
 function toLeaseDaemonRequest(
   command: 'lease_allocate' | 'lease_heartbeat' | 'lease_release',
   params: Record<string, unknown>,
@@ -229,7 +298,13 @@ function parseInstallSource(params: Record<string, unknown>): DaemonInstallSourc
     }
     return { kind: 'path', path: artifactPath };
   }
-  throw new AppError('INVALID_ARGS', 'Invalid params: source.kind must be "url" or "path"');
+  if (record.kind === 'github-actions-artifact') {
+    return parseGitHubActionsArtifactSource(record);
+  }
+  throw new AppError(
+    'INVALID_ARGS',
+    'Invalid params: source.kind must be "url", "path", or "github-actions-artifact"',
+  );
 }
 
 function toInstallFromSourceDaemonRequest(

--- a/src/daemon/install-source-resolution.ts
+++ b/src/daemon/install-source-resolution.ts
@@ -1,26 +1,49 @@
 import { AppError } from '../utils/errors.ts';
+import type { MaterializeInstallSource } from '../platforms/install-source.ts';
 import { cleanupUploadedArtifact, prepareUploadedArtifact } from './artifact-tracking.ts';
 import type { DaemonInstallSource, DaemonRequest } from './types.ts';
 
-function requireInstallSource(req: DaemonRequest): DaemonInstallSource {
+function assertUnsupportedInstallSource(source: never): never {
+  throw new AppError(
+    'UNSUPPORTED_OPERATION',
+    `install_from_source ${String((source as DaemonInstallSource).kind)} sources require a compatible remote daemon`,
+  );
+}
+
+function requireInstallSource(req: DaemonRequest): MaterializeInstallSource {
   const source = req.meta?.installSource;
   if (!source) {
     throw new AppError('INVALID_ARGS', 'install_from_source requires a source payload');
   }
-  if (source.kind === 'url') {
-    if (!source.url || source.url.trim().length === 0) {
-      throw new AppError('INVALID_ARGS', 'install_from_source url source requires a non-empty url');
-    }
-    return source;
+  switch (source.kind) {
+    case 'url':
+      if (!source.url || source.url.trim().length === 0) {
+        throw new AppError(
+          'INVALID_ARGS',
+          'install_from_source url source requires a non-empty url',
+        );
+      }
+      return source;
+    case 'path':
+      if (!source.path || source.path.trim().length === 0) {
+        throw new AppError(
+          'INVALID_ARGS',
+          'install_from_source path source requires a non-empty path',
+        );
+      }
+      return source;
+    case 'github-actions-artifact':
+      throw new AppError(
+        'UNSUPPORTED_OPERATION',
+        'install_from_source github-actions-artifact sources require a compatible remote daemon',
+      );
+    default:
+      assertUnsupportedInstallSource(source);
   }
-  if (!source.path || source.path.trim().length === 0) {
-    throw new AppError('INVALID_ARGS', 'install_from_source path source requires a non-empty path');
-  }
-  return source;
 }
 
 export function resolveInstallSource(req: DaemonRequest): {
-  source: DaemonInstallSource;
+  source: MaterializeInstallSource;
   cleanup: () => void;
 } {
   const source = requireInstallSource(req);

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -4,11 +4,11 @@ import type {
   DaemonRequestMeta as PublicDaemonRequestMeta,
   DaemonResponse as PublicDaemonResponse,
   DaemonResponseData as PublicDaemonResponseData,
+  DaemonInstallSource as PublicDaemonInstallSource,
   LeaseBackend,
   SessionRuntimeHints as PublicSessionRuntimeHints,
 } from '../contracts.ts';
 export type { DaemonLockPolicy } from '../contracts.ts';
-import type { MaterializeInstallSource } from '../platforms/install-source.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
 import type { SessionSurface } from '../core/session-surface.ts';
 import type { DeviceInfo, Platform, PlatformSelector } from '../utils/device.ts';
@@ -16,7 +16,7 @@ import type { ExecResult } from '../utils/exec.ts';
 import type { SnapshotState } from '../utils/snapshot.ts';
 import type { AppLogState } from './app-log-process.ts';
 
-export type DaemonInstallSource = MaterializeInstallSource;
+export type DaemonInstallSource = PublicDaemonInstallSource;
 export type SessionRuntimeHints = PublicSessionRuntimeHints;
 export type DaemonArtifact = PublicDaemonArtifact;
 export type DaemonResponseData = PublicDaemonResponseData;

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -230,6 +230,23 @@ test('parseArgs accepts install-from-source url and repeated headers', () => {
   assert.equal(parsed.flags.retentionMs, 60000);
 });
 
+test('parseArgs accepts install-from-source GitHub Actions artifact flag', () => {
+  const parsed = parseArgs(
+    [
+      'install-from-source',
+      '--github-actions-artifact',
+      'thymikee/RNCLI83:6635342232',
+      '--platform',
+      'android',
+    ],
+    { strictFlags: true },
+  );
+  assert.equal(parsed.command, 'install-from-source');
+  assert.deepEqual(parsed.positionals, []);
+  assert.equal(parsed.flags.githubActionsArtifact, 'thymikee/RNCLI83:6635342232');
+  assert.equal(parsed.flags.platform, 'android');
+});
+
 test('parseArgs accepts metro prepare arguments', () => {
   const parsed = parseArgs(
     [
@@ -688,7 +705,10 @@ test('parseArgs rejects conflicting back mode flags', () => {
 
 test('usage includes concise top-level commands', () => {
   const usageText = usage();
-  assert.match(usageText, /install-from-source <url>/);
+  assert.match(
+    usageText,
+    /install-from-source <url> \| install-from-source --github-actions-artifact/,
+  );
   assert.match(usageText, /metro prepare --public-base-url <url>/);
   assert.match(usageText, /batch --steps <json> \| --steps-file <path>/);
   assert.match(usageText, /network dump/);

--- a/src/utils/__tests__/cli-option-schema.test.ts
+++ b/src/utils/__tests__/cli-option-schema.test.ts
@@ -71,6 +71,8 @@ test('configurable option specs are filtered by command support', () => {
     getConfigurableOptionSpecs('install-from-source').map((spec) => spec.key),
   );
   assert.equal(installFromSourceSpecs.has('header'), true);
+  assert.equal(installFromSourceSpecs.has('installSource'), true);
+  assert.equal(installFromSourceSpecs.has('githubActionsArtifact'), false);
 });
 
 test('option schema resolves tokens back to canonical option specs', () => {

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -862,6 +862,37 @@ test('sendToDaemon preserves install_source payload metadata for remote HTTP RPC
     });
     assert.equal((rpcRequest as any)?.params?.meta?.retainMaterializedPaths, true);
     assert.equal((rpcRequest as any)?.params?.meta?.materializedPathRetentionMs, 60_000);
+
+    seenPaths.length = 0;
+    rpcRequest = null;
+
+    const githubArtifactResponse = await sendToDaemon({
+      session: 'default',
+      command: 'install_source',
+      positionals: [],
+      flags: { platform: 'android' },
+      meta: {
+        requestId: 'req-install-source-gh',
+        installSource: {
+          kind: 'github-actions-artifact',
+          owner: 'acme',
+          repo: 'mobile',
+          runId: 1234567890,
+          artifactName: 'app-debug',
+        },
+      },
+    });
+
+    assert.equal(githubArtifactResponse.ok, true);
+    assert.deepEqual(seenPaths, ['/agent-device/health', '/agent-device/rpc']);
+    assert.deepEqual((rpcRequest as any)?.params?.meta?.installSource, {
+      kind: 'github-actions-artifact',
+      owner: 'acme',
+      repo: 'mobile',
+      runId: 1234567890,
+      artifactName: 'app-debug',
+    });
+    assert.equal((rpcRequest as any)?.params?.meta?.uploadedArtifactId, undefined);
   } finally {
     (http as unknown as { request: typeof http.request }).request = originalHttpRequest;
     if (previousBaseUrl === undefined) delete process.env.AGENT_DEVICE_DAEMON_BASE_URL;

--- a/src/utils/cli-config.ts
+++ b/src/utils/cli-config.ts
@@ -9,6 +9,7 @@ import {
   getOptionSpec,
   parseOptionValueFromSource,
 } from './cli-option-schema.ts';
+import { parseInstallSourceConfig } from './install-source-config.ts';
 
 type EnvMap = Record<string, string | undefined>;
 
@@ -99,6 +100,10 @@ function parseConfigObject(
 ): Partial<CliFlags> {
   const flags: Partial<CliFlags> = {};
   for (const [rawKey, rawValue] of Object.entries(source)) {
+    if (rawKey === 'installSource') {
+      flags.installSource = parseInstallSourceConfig(rawValue, sourceLabel);
+      continue;
+    }
     const key = rawKey as FlagKey;
     const spec = getOptionSpec(key);
     if (!spec) {
@@ -120,6 +125,7 @@ function parseConfigObject(
 function readEnvFlagDefaults(env: EnvMap, command: string | null): Partial<CliFlags> {
   const flags: Partial<CliFlags> = {};
   for (const spec of getConfigurableOptionSpecs(command)) {
+    if (spec.key === 'installSource') continue;
     const envNames = spec.env.names;
     const envValue = envNames
       .map((name) => ({ name, value: env[name] }))

--- a/src/utils/cli-option-schema.ts
+++ b/src/utils/cli-option-schema.ts
@@ -28,6 +28,7 @@ const CONFIG_EXCLUDED_FLAG_KEYS = new Set<FlagKey>([
   'help',
   'version',
   'batchSteps',
+  'githubActionsArtifact',
 ]);
 
 const LEGACY_ENV_VAR_NAMES: Partial<Record<FlagKey, string[]>> = {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -1,5 +1,6 @@
 import { SETTINGS_USAGE_OVERRIDE } from '../core/settings-contract.ts';
 import { SESSION_SURFACES } from '../core/session-surface.ts';
+import type { DaemonInstallSource } from '../contracts.ts';
 
 export type CliFlags = {
   json: boolean;
@@ -78,6 +79,8 @@ export type CliFlags = {
   pattern?: 'one-way' | 'ping-pong';
   activity?: string;
   header?: string[];
+  githubActionsArtifact?: string;
+  installSource?: DaemonInstallSource;
   saveScript?: boolean | string;
   shutdown?: boolean;
   relaunch?: boolean;
@@ -531,6 +534,19 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     multiple: true,
     usageLabel: '--header <name:value>',
     usageDescription: 'install-from-source: repeatable HTTP header for URL downloads',
+  },
+  {
+    key: 'githubActionsArtifact',
+    names: ['--github-actions-artifact'],
+    type: 'string',
+    usageLabel: '--github-actions-artifact <owner/repo:artifact>',
+    usageDescription: 'install-from-source: GitHub Actions artifact resolved by a remote daemon',
+  },
+  {
+    key: 'installSource',
+    // Config-only virtual option; parsed explicitly from JSON before generic string options.
+    names: [],
+    type: 'string',
   },
   {
     key: 'session',
@@ -1067,10 +1083,19 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowedFlags: [],
   },
   'install-from-source': {
-    helpDescription: 'Install app from a URL source through the normal daemon artifact flow',
-    summary: 'Install app from a URL source',
-    positionalArgs: ['url'],
-    allowedFlags: ['header', 'retainPaths', 'retentionMs'],
+    usageOverride:
+      'install-from-source <url> | install-from-source --github-actions-artifact <owner/repo:artifact>',
+    listUsageOverride: 'install-from-source <url> | install-from-source --github-actions-artifact',
+    helpDescription: 'Install app from a URL or remote-resolved source',
+    summary: 'Install app from a source',
+    positionalArgs: ['url?'],
+    allowedFlags: [
+      'header',
+      'githubActionsArtifact',
+      'installSource',
+      'retainPaths',
+      'retentionMs',
+    ],
   },
   push: {
     helpDescription: 'Simulate push notification payload delivery',

--- a/src/utils/install-source-config.ts
+++ b/src/utils/install-source-config.ts
@@ -1,0 +1,111 @@
+import type { DaemonInstallSource } from '../contracts.ts';
+import { AppError } from './errors.ts';
+
+export function parseGitHubActionsArtifactInstallSourceSpec(
+  spec: string,
+  sourceLabel: string = '--github-actions-artifact',
+): DaemonInstallSource {
+  const separator = spec.indexOf(':');
+  if (separator <= 0 || separator === spec.length - 1) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `${sourceLabel} must use owner/repo:artifact, for example thymikee/RNCLI83:6635342232`,
+    );
+  }
+  const { owner, repo } = parseRepositorySlug(spec.slice(0, separator), sourceLabel);
+  return buildGitHubActionsArtifactInstallSource(
+    owner,
+    repo,
+    spec.slice(separator + 1),
+    `${sourceLabel} artifact`,
+  );
+}
+
+export function parseInstallSourceConfig(value: unknown, sourceLabel: string): DaemonInstallSource {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AppError('INVALID_ARGS', `${sourceLabel} installSource must be an object.`);
+  }
+  const record = value as Record<string, unknown>;
+  const type = readRequiredText(record.type, `${sourceLabel} installSource.type`);
+  if (type !== 'github-actions-artifact') {
+    throw new AppError(
+      'INVALID_ARGS',
+      `${sourceLabel} installSource.type must be "github-actions-artifact".`,
+    );
+  }
+  const { owner, repo } = parseRepositorySlug(
+    readRequiredText(record.repo, `${sourceLabel} installSource.repo`),
+    `${sourceLabel} installSource.repo`,
+  );
+  return buildGitHubActionsArtifactInstallSource(
+    owner,
+    repo,
+    record.artifact,
+    `${sourceLabel} installSource.artifact`,
+  );
+}
+
+function buildGitHubActionsArtifactInstallSource(
+  owner: string,
+  repo: string,
+  artifact: unknown,
+  artifactField: string,
+): DaemonInstallSource {
+  if (typeof artifact === 'number' || isIntegerString(artifact)) {
+    return {
+      kind: 'github-actions-artifact',
+      owner,
+      repo,
+      artifactId: readInteger(artifact, artifactField),
+    };
+  }
+  const artifactName = readRequiredText(artifact, artifactField);
+  return {
+    kind: 'github-actions-artifact',
+    owner,
+    repo,
+    artifactName,
+  };
+}
+
+function parseRepositorySlug(value: string, sourceLabel: string): { owner: string; repo: string } {
+  const separator = value.indexOf('/');
+  if (
+    separator <= 0 ||
+    separator === value.length - 1 ||
+    value.indexOf('/', separator + 1) !== -1
+  ) {
+    throw new AppError('INVALID_ARGS', `${sourceLabel} must use owner/repo.`);
+  }
+  const result = {
+    owner: value.slice(0, separator).trim(),
+    repo: value.slice(separator + 1).trim(),
+  };
+  if (!result.owner || !result.repo) {
+    throw new AppError('INVALID_ARGS', `${sourceLabel} must use owner/repo.`);
+  }
+  return result;
+}
+
+function readText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readRequiredText(value: unknown, field: string): string {
+  const text = readText(value);
+  if (!text) throw new AppError('INVALID_ARGS', `${field} must be a non-empty string.`);
+  return text;
+}
+
+function readInteger(value: unknown, field: string): number {
+  const parsed =
+    typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isInteger(parsed)) {
+    throw new AppError('INVALID_ARGS', `${field} must be an integer.`);
+  }
+  return parsed;
+}
+
+function isIntegerString(value: unknown): value is string {
+  return typeof value === 'string' && /^\d+$/.test(value.trim());
+}

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -252,6 +252,21 @@ If the daemon cannot determine installed app identity, the request fails instead
 - Archive-backed URL installs are only supported for trusted artifact services, currently GitHub Actions and EAS.
 - For existing reachable artifact URLs, use `source: { kind: 'url', url: ... }`.
 - For local artifacts, use `source: { kind: 'path', path: ... }` or the CLI `install`/`reinstall` commands.
+- For compatible remote daemons that resolve CI artifacts server-side, pass a GitHub Actions artifact source:
+
+```ts
+await client.apps.installFromSource({
+  platform: 'android',
+  source: {
+    kind: 'github-actions-artifact',
+    owner: 'acme',
+    repo: 'mobile',
+    artifactId: 1234567890,
+  },
+});
+```
+
+Remote daemons may also support `{ kind: 'github-actions-artifact', owner, repo, artifactName }` or `{ kind: 'github-actions-artifact', owner, repo, runId, artifactName }`. The local client preserves these payloads and does not perform GitHub authentication or artifact download.
 
 Direct Android `.apk` and `.aab` URL sources can still resolve package identity from the downloaded install artifact. Trusted GitHub Actions and EAS archive URLs may contain one installable `.apk`, `.aab`, `.ipa`, or iOS `.app` tar archive.
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -374,15 +374,16 @@ agent-device reinstall com.example.app ./build/MyApp.app --platform ios
 ```bash
 agent-device install-from-source https://example.com/builds/app.apk --platform android
 agent-device install-from-source https://example.com/builds/app.aab --platform android
-agent-device install-from-source https://api.github.com/repos/acme/app/actions/artifacts/123/zip --platform ios --header "authorization: Bearer TOKEN"
+agent-device install-from-source --github-actions-artifact thymikee/RNCLI83:6635342232 --platform android
 ```
 
 - `install-from-source <url>` installs from a URL source through the normal daemon artifact flow.
+- `install-from-source --github-actions-artifact <owner/repo:artifact>` passes a typed GitHub Actions artifact source through to a compatible remote daemon. Numeric artifacts are sent as `artifactId`; non-numeric artifacts are sent as `artifactName`.
 - Repeat `--header <name:value>` for authenticated or signed artifact requests.
 - Supports the same device coverage as `install`: Android devices/emulators, iOS simulators, and iOS physical devices.
 - Use `install` or `reinstall` for local `.apk`, `.aab`, `.app`, and `.ipa` paths; use `install-from-source` when the artifact already exists at a URL reachable by the daemon.
 - Direct Android URL sources may be `.apk` or `.aab`.
-- Trusted artifact service URLs, currently GitHub Actions and EAS, may resolve to archives containing one installable `.apk`, `.aab`, `.ipa`, or iOS `.app` tar archive.
+- Trusted artifact service URLs may resolve to archives containing one installable `.apk`, `.aab`, `.ipa`, or iOS `.app` tar archive. Prefer `--github-actions-artifact` for GitHub Actions artifacts that a compatible remote daemon can resolve with its own credentials.
 - `--retain-paths` keeps retained materialized artifact paths after install, and `--retention-ms <ms>` sets their TTL.
 - URL downloads follow the same `installFromSource()` safety checks and host restrictions as the JS client API.
 

--- a/website/docs/docs/configuration.md
+++ b/website/docs/docs/configuration.md
@@ -81,6 +81,21 @@ Common keys include:
 
 Command-specific defaults are supported too, for example `snapshotDepth`, `snapshotScope`, `activity`, `relaunch`, `shutdown`, `fps`, `quality`, `stepsFile`, or `saveScript`.
 
+`install-from-source` can also read a structured GitHub Actions artifact source from config when a compatible remote daemon resolves CI artifacts server-side:
+
+```json
+{
+  "platform": "android",
+  "installSource": {
+    "type": "github-actions-artifact",
+    "repo": "thymikee/RNCLI83",
+    "artifact": "rn-android-emulator-debug-pr-19"
+  }
+}
+```
+
+Use a numeric `artifact` value for an artifact ID. Use a string `artifact` value for an artifact name.
+
 Bound-session defaults use the same config and env mapping too:
 - `sessionLock` -> `AGENT_DEVICE_SESSION_LOCK`
 - `sessionLocked` -> `AGENT_DEVICE_SESSION_LOCKED`

--- a/website/docs/docs/quick-start.md
+++ b/website/docs/docs/quick-start.md
@@ -69,7 +69,7 @@ agent-device close
 - `.aab` requires `bundletool` in `PATH`, or `AGENT_DEVICE_BUNDLETOOL_JAR=<absolute-path-to-bundletool-all.jar>` with `java` in `PATH`.
 - Optional: `AGENT_DEVICE_ANDROID_BUNDLETOOL_MODE=<mode>` overrides bundletool `build-apks --mode` (default: `universal`).
 - `.ipa` installs extract `Payload/*.app`; if multiple app bundles exist, `<app>` selects the target by bundle id or bundle name.
-- Use `install-from-source` for existing artifact URLs, including direct Android `.apk`/`.aab` URLs and trusted GitHub Actions or EAS archives with one installable artifact.
+- Use `install-from-source` for existing artifact URLs, including direct Android `.apk`/`.aab` URLs and trusted archives with one installable artifact. Use `install-from-source --github-actions-artifact <owner/repo:artifact>` for daemon-resolved GitHub Actions artifacts.
 
 If `open` fails because no booted simulator/emulator/device is available, run `boot --platform ios|android` and retry.
 If `open` fails because the app id is wrong or missing, run `apps` and retry with the discovered package or bundle id instead of guessing.


### PR DESCRIPTION
## Summary

Add a typed GitHub Actions artifact install source that clients can pass through to compatible remote daemons.

Adds `install-from-source --github-actions-artifact <owner/repo:artifact>` plus `installSource` config parsing for daemon-resolved GitHub Actions artifacts. The CLI maps numeric artifacts to `artifactId` and names to `artifactName`, preserves the typed source through remote daemon requests, and keeps the local daemon rejection explicit.

Updated client API docs, command/config docs, and agent-device skills to route agents through the CLI/config shape instead of raw daemon RPC.

Touched-file count: 24. Scope expanded from wire passthrough to install-from-source CLI/config parsing plus docs/skills.

## Validation

- pnpm format
- pnpm check:quick
- pnpm check:unit
