### PR TITLE
feat: add Metro reload command

### DIFF
--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -16,6 +16,7 @@ Use this skill as a router with mandatory defaults. Read this file first. For no
 - Prefer `diff snapshot` after a nearby mutation when you only need to know what changed.
 - Avoid speculative mutations. You may take the smallest reversible UI action needed to unblock inspection or complete the requested task, such as dismissing a popup, closing an alert, or clearing an unintended surface.
 - In React Native dev or debug builds, check early for visible warning or error overlays, tooltips, and toasts that can steal focus or intercept taps. If they are not part of the requested behavior, dismiss them and continue. If you saw them, report them in the final summary.
+- In Metro-backed React Native dev loops, use `agent-device metro reload` for a JS app reload before falling back to `open <app> --relaunch`. It mirrors pressing `r` in the Metro terminal and preserves the native app process.
 - Do not browse the web or use external sources unless the user explicitly asks.
 - Re-snapshot after meaningful UI changes instead of reusing stale refs.
 - Treat refs in default snapshot output as actionable-now, not durable identities. If a target appears only in an off-screen summary, use `scroll <direction>` and re-snapshot until the target is visible.
@@ -60,6 +61,7 @@ Use this skill as a router with mandatory defaults. Read this file first. For no
 - If there is no simulator, no app install, or no open app session yet, switch to `bootstrap-install.md` instead of improvising setup steps.
 - Use the smallest unblock action first when transient UI blocks inspection, but do not navigate, search, or enter new text just to make the UI reveal data unless the user asked for that interaction.
 - In React Native dev or debug apps, treat visible warning or error overlays as transient blockers unless the user is explicitly asking you to diagnose them. Dismiss them when safe, then continue the requested flow.
+- For React Native code changes where the app is already connected to Metro, prefer `agent-device metro reload`, then wait and re-snapshot. Use `open <app> --relaunch` only when Metro reload does not reconnect or native startup state must reset.
 - Do not use external lookups to compensate for missing on-screen data unless the user asked for them.
 - If the needed information is not exposed on screen, say that plainly instead of compensating with extra navigation, text entry, or web search.
 - Prefer `@ref` or selector targeting over raw coordinates.

--- a/skills/agent-device/references/bootstrap-install.md
+++ b/skills/agent-device/references/bootstrap-install.md
@@ -115,6 +115,7 @@ agent-device --session auth snapshot -i
 - Use semantic session names when you need multiple concurrent runs.
 - Use `--save-script=<path>` on `close` when you want to keep a replay script.
 - For dev loops where state can linger, prefer `open <app> --relaunch`.
+- For Metro-backed React Native JS changes with the app already running, prefer `metro reload` instead of `open <app> --relaunch`; it asks Metro to reload connected apps without restarting the native process.
 - In iOS sessions, use `open <app>` for the app itself. Use `open <url>` for deep links, and `open <app> <url>` when you need to launch the app and deep link in one step.
 - On iOS, `appstate` is session-scoped and requires the matching active session on the target device.
 

--- a/skills/agent-device/references/exploration.md
+++ b/skills/agent-device/references/exploration.md
@@ -21,6 +21,7 @@ Open this file when the app or screen is already running and you need to discove
 - User asks for exact text from a known target: `get text`
 - User asks you to tap, type, or choose an element: `snapshot -i`, then act
 - User asks for the React Native component tree, props/state/hooks, or render profiling: use `agent-device react-devtools ...` and the `skills/react-devtools` workflow
+- User asks to reload a Metro-backed React Native app after JS changes: `agent-device metro reload`, then wait briefly and re-run `snapshot` or `snapshot -i`
 - React Native dev or debug build shows warning/error UI: capture enough evidence to identify it, dismiss it if it is not the requested behavior, then continue the flow and report it in the summary
 - The on-screen keyboard is blocking the next step: `keyboard dismiss`; on iOS do this only while an app session is active, and use `keyboard status|get` only on Android
 - UI does not expose the answer: say so plainly; do not browse or force the app into a new state unless asked
@@ -59,6 +60,16 @@ Open this file when the app or screen is already running and you need to discove
 - Not blocking the task: dismiss and continue.
 - Blocking or recurring: switch to [debugging.md](debugging.md) and collect evidence.
 - Seen at any point: mention in the final summary even if dismissed.
+
+**React Native Metro reload.** When a dev app is already running and connected to Metro, prefer a Metro reload over restarting the native app process:
+
+```bash
+agent-device metro reload
+agent-device wait 1000
+agent-device snapshot -i
+```
+
+Use `--metro-host`, `--metro-port`, or `--bundle-url` only when the active connection does not already carry the right runtime hints. Fall back to `open <app> --relaunch` when the app is not connected to Metro, Metro reload fails, or native startup state needs a clean process.
 
 ## Common example loops
 

--- a/skills/agent-device/references/remote-tenancy.md
+++ b/skills/agent-device/references/remote-tenancy.md
@@ -9,6 +9,7 @@ Open this file for remote daemon HTTP flows that let an agent running in a Linux
 - `agent-device connect --remote-config <path>`
 - `agent-device install-from-source <url> --remote-config <path> --platform android`
 - `agent-device open <package> --remote-config <path> --relaunch`
+- `agent-device metro reload --remote-config <path>`
 - `agent-device snapshot --remote-config <path> -i`
 - `agent-device disconnect --remote-config <path>`
 - `agent-device connection status`
@@ -36,6 +37,7 @@ agent-device connect --remote-config ./remote-config.json
 ARTIFACT_URL="<trusted-artifact-url>"
 agent-device install-from-source "$ARTIFACT_URL" --platform android
 agent-device open com.example.app --relaunch
+agent-device metro reload
 agent-device snapshot -i
 agent-device fill @e3 "test@example.com"
 agent-device disconnect
@@ -73,6 +75,7 @@ The first command that needs a lease or Metro runtime prepares and persists it. 
 - `connect` stores local non-secret connection state and defers tenant lease allocation plus Metro preparation until a later command needs them.
 - Commands such as `install-from-source`, `open`, `snapshot`, and `apps` allocate or refresh the lease when needed.
 - `open` prepares Metro runtime hints when the remote profile has Metro fields and no compatible runtime is already saved.
+- `metro reload` reuses saved Metro runtime hints and asks Metro to reload connected React Native apps without restarting the native process.
 - `batch` also prepares Metro when any step opens an app and that step does not provide its own runtime.
 - `disconnect` closes the session when possible, stops the Metro companion owned by the connection, releases the lease when one was allocated, and removes local connection state.
 

--- a/src/__tests__/cli-client-commands.test.ts
+++ b/src/__tests__/cli-client-commands.test.ts
@@ -10,6 +10,7 @@ import type {
   AppInstallFromSourceOptions,
   AppOpenOptions,
   MetroPrepareOptions,
+  MetroReloadOptions,
 } from '../client.ts';
 import { AppError } from '../utils/errors.ts';
 import { resolveCliOptions } from '../utils/cli-options.ts';
@@ -193,6 +194,50 @@ test('metro prepare rejects when no public or proxy base URL is provided', async
       error.code === 'INVALID_ARGS' &&
       error.message.includes('--public-base-url <url> or --proxy-base-url <url>'),
   );
+});
+
+test('metro reload forwards host, port, bundle URL, and timeout to client.metro.reload', async () => {
+  let observed: MetroReloadOptions | undefined;
+  const client = createStubClient({
+    installFromSource: async () => {
+      throw new Error('unexpected install call');
+    },
+    reloadMetro: async (options) => {
+      observed = options;
+      return {
+        reloaded: true,
+        reloadUrl: 'http://127.0.0.1:9090/reload',
+        status: 200,
+        body: 'OK',
+      };
+    },
+  });
+
+  const stdout = await captureStdout(async () => {
+    const handled = await tryRunClientBackedCommand({
+      command: 'metro',
+      positionals: ['reload'],
+      flags: {
+        json: false,
+        help: false,
+        version: false,
+        metroHost: '127.0.0.1',
+        metroPort: 9090,
+        bundleUrl: 'http://127.0.0.1:9090/index.bundle?platform=ios',
+        metroProbeTimeoutMs: 1500,
+      },
+      client,
+    });
+    assert.equal(handled, true);
+  });
+
+  assert.deepEqual(observed, {
+    metroHost: '127.0.0.1',
+    metroPort: 9090,
+    bundleUrl: 'http://127.0.0.1:9090/index.bundle?platform=ios',
+    timeoutMs: 1500,
+  });
+  assert.equal(stdout, 'Reloaded React Native apps via http://127.0.0.1:9090/reload\n');
 });
 
 test('screenshot forwards --overlay-refs to the client capture API', async () => {
@@ -578,6 +623,7 @@ async function captureStdout(run: () => Promise<void>): Promise<string> {
 function createStubClient(params: {
   installFromSource: AgentDeviceClient['apps']['installFromSource'];
   prepareMetro?: AgentDeviceClient['metro']['prepare'];
+  reloadMetro?: AgentDeviceClient['metro']['reload'];
   open?: AgentDeviceClient['apps']['open'];
   screenshot?: AgentDeviceClient['capture']['screenshot'];
 }): AgentDeviceClient {
@@ -682,6 +728,14 @@ function createStubClient(params: {
             bundleUrl: 'https://sandbox.example.test/index.bundle?platform=android',
           },
           bridge: null,
+        })),
+      reload:
+        params.reloadMetro ??
+        (async () => ({
+          reloaded: true,
+          reloadUrl: 'http://127.0.0.1:8081/reload',
+          status: 200,
+          body: 'OK',
         })),
     },
     capture: {

--- a/src/__tests__/client-metro.test.ts
+++ b/src/__tests__/client-metro.test.ts
@@ -8,7 +8,7 @@ import type { Socket } from 'node:net';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { prepareMetroRuntime } from '../client-metro.ts';
+import { prepareMetroRuntime, reloadMetro } from '../client-metro.ts';
 import { AppError } from '../utils/errors.ts';
 
 const TEST_TOKEN = 'agent-device-proxy-test-token';
@@ -197,6 +197,65 @@ test('prepareMetroRuntime rejects incomplete proxy configuration', async () => {
       error.code === 'INVALID_ARGS' &&
       error.message.includes('tenantId, runId, and leaseId bridge scope'),
   );
+});
+
+test('reloadMetro preserves the bundle URL route prefix', async () => {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(req.url ?? '');
+    if (req.url === '/metro/runtime-1/reload') {
+      res.statusCode = 200;
+      res.end('OK');
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+
+  try {
+    const result = await reloadMetro({
+      bundleUrl: `http://127.0.0.1:${address.port}/metro/runtime-1/index.bundle?platform=ios&dev=true`,
+      timeoutMs: 1_000,
+    });
+
+    assert.deepEqual(requests, ['/metro/runtime-1/reload']);
+    assert.deepEqual(result, {
+      reloaded: true,
+      reloadUrl: `http://127.0.0.1:${address.port}/metro/runtime-1/reload`,
+      status: 200,
+      body: 'OK',
+    });
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('reloadMetro defaults to local Metro host and port', async () => {
+  const server = createServer((req, res) => {
+    if (req.url === '/reload') {
+      res.statusCode = 200;
+      res.end('OK');
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+  server.listen(0);
+  await once(server, 'listening');
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+
+  try {
+    const result = await reloadMetro({ metroPort: address.port, timeoutMs: 1_000 });
+    assert.equal(result.reloadUrl, `http://localhost:${address.port}/reload`);
+    assert.equal(result.body, 'OK');
+  } finally {
+    await closeServer(server);
+  }
 });
 
 function writeFakeNpx(binDir: string): void {

--- a/src/__tests__/metro-public.test.ts
+++ b/src/__tests__/metro-public.test.ts
@@ -6,6 +6,7 @@ vi.mock('../client-metro.ts', async () => {
   return {
     ...actual,
     prepareMetroRuntime: vi.fn(),
+    reloadMetro: vi.fn(),
   };
 });
 
@@ -14,13 +15,14 @@ vi.mock('../client-metro-companion.ts', () => ({
   stopMetroCompanion: vi.fn(),
 }));
 
-import { prepareMetroRuntime } from '../client-metro.ts';
+import { prepareMetroRuntime, reloadMetro } from '../client-metro.ts';
 import { ensureMetroCompanion, stopMetroCompanion } from '../client-metro-companion.ts';
 import {
   buildAndroidRuntimeHints,
   buildIosRuntimeHints,
   ensureMetroTunnel,
   prepareRemoteMetro,
+  reloadRemoteMetro,
   resolveRuntimeTransport,
   stopMetroTunnel,
 } from '../metro.ts';
@@ -65,6 +67,12 @@ test('public metro helpers expose stable Node-facing wrappers', async () => {
     stopped: true,
     statePath: '/tmp/project/.agent-device/metro-companion.json',
   });
+  vi.mocked(reloadMetro).mockResolvedValue({
+    reloaded: true,
+    reloadUrl: 'http://127.0.0.1:8081/reload',
+    status: 200,
+    body: 'OK',
+  });
 
   const prepared = await prepareRemoteMetro({
     projectRoot: '/tmp/project',
@@ -87,11 +95,15 @@ test('public metro helpers expose stable Node-facing wrappers', async () => {
   await stopMetroTunnel({
     projectRoot: '/tmp/project',
   });
+  const reloaded = await reloadRemoteMetro({
+    runtime: { platform: 'ios', bundleUrl: 'http://127.0.0.1:8081/index.bundle?platform=ios' },
+  });
 
   assert.equal(prepared.reused, true);
   assert.equal(prepared.logPath, '/tmp/project/.agent-device/metro.log');
   assert.equal(tunnel.started, true);
   assert.equal(tunnel.logPath, '/tmp/project/.agent-device/metro-companion.log');
+  assert.equal(reloaded.reloaded, true);
   assert.deepEqual(vi.mocked(prepareMetroRuntime).mock.calls[0]?.[0], {
     projectRoot: '/tmp/project',
     kind: 'react-native',
@@ -112,6 +124,9 @@ test('public metro helpers expose stable Node-facing wrappers', async () => {
     runtimeFilePath: undefined,
     logPath: undefined,
     env: undefined,
+  });
+  assert.deepEqual(vi.mocked(reloadMetro).mock.calls[0]?.[0], {
+    runtime: { platform: 'ios', bundleUrl: 'http://127.0.0.1:8081/index.bundle?platform=ios' },
   });
   assert.equal(
     buildIosRuntimeHints('https://public.example.test').bundleUrl,

--- a/src/cli/commands/metro.ts
+++ b/src/cli/commands/metro.ts
@@ -4,8 +4,18 @@ import type { ClientCommandHandler } from './router-types.ts';
 
 export const metroCommand: ClientCommandHandler = async ({ positionals, flags, client }) => {
   const action = (positionals[0] ?? '').toLowerCase();
+  if (action === 'reload') {
+    const result = await client.metro.reload({
+      metroHost: flags.metroHost,
+      metroPort: flags.metroPort,
+      bundleUrl: flags.bundleUrl,
+      timeoutMs: flags.metroProbeTimeoutMs,
+    });
+    writeCommandOutput(flags, result, () => `Reloaded React Native apps via ${result.reloadUrl}`);
+    return true;
+  }
   if (action !== 'prepare') {
-    throw new AppError('INVALID_ARGS', 'metro only supports prepare');
+    throw new AppError('INVALID_ARGS', 'metro requires a subcommand: prepare or reload');
   }
   if (!flags.metroPublicBaseUrl && !flags.metroProxyBaseUrl) {
     throw new AppError(

--- a/src/client-metro.ts
+++ b/src/client-metro.ts
@@ -14,7 +14,13 @@ import { runCmdSync, runCmdDetached } from './utils/exec.ts';
 import { resolveUserPath } from './utils/path-resolution.ts';
 import { waitForProcessExit } from './utils/process-identity.ts';
 import { buildBundleUrl, normalizeBaseUrl } from './utils/url.ts';
+import {
+  resolveRuntimeTransportHints,
+  type ResolvedRuntimeTransport,
+} from './utils/runtime-transport.ts';
 
+const DEFAULT_METRO_HOST = 'localhost';
+const DEFAULT_METRO_PORT = 8081;
 const METRO_TERM_TIMEOUT_MS = 1_000;
 const METRO_KILL_TIMEOUT_MS = 1_000;
 
@@ -74,6 +80,21 @@ export type PrepareMetroRuntimeResult = {
   iosRuntime: MetroRuntimeHints;
   androidRuntime: MetroRuntimeHints;
   bridge: MetroBridgeResult | null;
+};
+
+export type ReloadMetroOptions = {
+  metroHost?: string;
+  metroPort?: number | string;
+  bundleUrl?: string;
+  runtime?: MetroRuntimeHints;
+  timeoutMs?: number | string;
+};
+
+export type ReloadMetroResult = {
+  reloaded: true;
+  reloadUrl: string;
+  status: number;
+  body: string;
 };
 
 type ProxyBridgeRequestOptions = {
@@ -249,6 +270,48 @@ async function isMetroReady(statusUrl: string, timeoutMs: number): Promise<boole
   } catch {
     return false;
   }
+}
+
+function buildReloadUrl(transport: ResolvedRuntimeTransport, pathName: string): string {
+  const url = new URL(`${transport.scheme}://localhost`);
+  url.hostname = transport.host;
+  url.port = String(transport.port);
+  url.pathname = pathName;
+  return url.toString();
+}
+
+function resolveMetroReloadPath(bundleUrl: string | undefined): string {
+  const value = normalizeOptionalString(bundleUrl);
+  if (!value) return '/reload';
+  const url = new URL(value);
+  const bundlePath = url.pathname.replace(/\/+$/, '');
+  if (!bundlePath.endsWith('/index.bundle')) return '/reload';
+  return `${bundlePath.slice(0, -'/index.bundle'.length)}/reload`;
+}
+
+function resolveMetroReloadUrl(input: ReloadMetroOptions): string {
+  const bundleUrl = normalizeOptionalString(input.bundleUrl) ?? input.runtime?.bundleUrl;
+  const hasExplicitBundleUrl = Boolean(normalizeOptionalString(input.bundleUrl));
+  const hasBundleUrl = Boolean(normalizeOptionalString(bundleUrl));
+  const metroHost =
+    normalizeOptionalString(input.metroHost) ??
+    (hasExplicitBundleUrl ? undefined : normalizeOptionalString(input.runtime?.metroHost)) ??
+    (hasBundleUrl ? undefined : DEFAULT_METRO_HOST);
+  const metroPort =
+    input.metroPort !== undefined
+      ? parsePort(input.metroPort, DEFAULT_METRO_PORT)
+      : hasExplicitBundleUrl
+        ? undefined
+        : (input.runtime?.metroPort ?? (hasBundleUrl ? undefined : DEFAULT_METRO_PORT));
+  const transport = resolveRuntimeTransportHints({
+    metroHost,
+    metroPort,
+    bundleUrl,
+  });
+  if (!transport) {
+    throw new AppError('INVALID_ARGS', 'Unable to resolve Metro host and port for reload.');
+  }
+  return buildReloadUrl(transport, resolveMetroReloadPath(bundleUrl));
 }
 
 function buildMetroCommand(
@@ -785,4 +848,24 @@ export async function prepareMetroRuntime(
   }
 
   return result;
+}
+
+export async function reloadMetro(input: ReloadMetroOptions = {}): Promise<ReloadMetroResult> {
+  const timeoutMs = parseTimeout(input.timeoutMs, 10_000, 1_000);
+  const reloadUrl = resolveMetroReloadUrl(input);
+  const response = await fetchText(reloadUrl, timeoutMs);
+  if (!response.ok) {
+    throw new AppError('COMMAND_FAILED', `Metro reload failed (${response.status}).`, {
+      reloadUrl,
+      status: response.status,
+      body: response.body,
+      hint: 'Verify Metro is running and the target React Native app is connected to this Metro instance.',
+    });
+  }
+  return {
+    reloaded: true,
+    reloadUrl,
+    status: response.status,
+    body: response.body,
+  };
 }

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -10,7 +10,11 @@ import type {
 import type { DeviceKind, DeviceTarget, Platform, PlatformSelector } from './utils/device.ts';
 import type { FindLocator } from './utils/finders.ts';
 import type { ScreenshotOverlayRef, SnapshotNode, SnapshotVisibility } from './utils/snapshot.ts';
-import type { MetroPrepareKind, PrepareMetroRuntimeResult } from './client-metro.ts';
+import type {
+  MetroPrepareKind,
+  PrepareMetroRuntimeResult,
+  ReloadMetroResult,
+} from './client-metro.ts';
 import type { MetroBridgeScope } from './client-metro-companion-contract.ts';
 
 export type { FindLocator } from './utils/finders.ts';
@@ -287,6 +291,15 @@ export type MetroPrepareOptions = {
 };
 
 export type MetroPrepareResult = PrepareMetroRuntimeResult;
+
+export type MetroReloadOptions = {
+  metroHost?: string;
+  metroPort?: number;
+  bundleUrl?: string;
+  timeoutMs?: number;
+};
+
+export type MetroReloadResult = ReloadMetroResult;
 
 export type CaptureSnapshotOptions = AgentDeviceRequestOverrides &
   AgentDeviceSelectionOptions & {
@@ -827,6 +840,7 @@ export type AgentDeviceClient = {
   };
   metro: {
     prepare: (options: MetroPrepareOptions) => Promise<MetroPrepareResult>;
+    reload: (options?: MetroReloadOptions) => Promise<MetroReloadResult>;
   };
   capture: {
     snapshot: (options?: CaptureSnapshotOptions) => Promise<CaptureSnapshotResult>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { sendToDaemon } from './daemon-client.ts';
-import { prepareMetroRuntime } from './client-metro.ts';
+import { prepareMetroRuntime, reloadMetro } from './client-metro.ts';
 import { CLIENT_COMMANDS } from './client-command-registry.ts';
 import { createAgentDeviceCommandClient, type PreparedClientCommand } from './client-commands.ts';
 import { throwDaemonError } from './daemon-error.ts';
@@ -277,6 +277,14 @@ export function createAgentDeviceClient(
           installDependenciesIfNeeded: options.installDependenciesIfNeeded,
           runtimeFilePath: options.runtimeFilePath,
           logPath: options.logPath,
+        }),
+      reload: async (options = {}) =>
+        await reloadMetro({
+          metroHost: options.metroHost,
+          metroPort: options.metroPort,
+          bundleUrl: options.bundleUrl,
+          runtime: config.runtime,
+          timeoutMs: options.timeoutMs,
         }),
     },
     capture: {
@@ -627,6 +635,8 @@ export type {
   MaterializationReleaseResult,
   MetroPrepareOptions,
   MetroPrepareResult,
+  MetroReloadOptions,
+  MetroReloadResult,
   NetworkOptions,
   PerfOptions,
   PermissionTarget,

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -1,8 +1,11 @@
-import { URL } from 'node:url';
 import type { DeviceInfo } from '../utils/device.ts';
 import { AppError, asAppError } from '../utils/errors.ts';
 import { runCmd } from '../utils/exec.ts';
 import type { SessionRuntimeHints } from './types.ts';
+import {
+  resolveRuntimeTransportHints,
+  type ResolvedRuntimeTransport,
+} from '../utils/runtime-transport.ts';
 import { adbArgs } from '../platforms/android/adb.ts';
 import {
   classifyAndroidAppTarget,
@@ -28,48 +31,10 @@ const DEFAULT_ANDROID_PREFS_XML = [
   '',
 ].join('\n');
 
-type ResolvedRuntimeTransport = {
-  host: string;
-  port: number;
-  scheme: 'http' | 'https';
-};
+export { resolveRuntimeTransportHints, trimRuntimeValue } from '../utils/runtime-transport.ts';
 
 export function hasRuntimeTransportHints(runtime: SessionRuntimeHints | undefined): boolean {
   return resolveRuntimeTransportHints(runtime) !== undefined;
-}
-
-export function resolveRuntimeTransportHints(
-  runtime: SessionRuntimeHints | undefined,
-): ResolvedRuntimeTransport | undefined {
-  if (!runtime) return undefined;
-
-  let host = trimRuntimeValue(runtime.metroHost);
-  let port = normalizePort(runtime.metroPort);
-  let scheme: 'http' | 'https' = 'http';
-  const bundleUrl = trimRuntimeValue(runtime.bundleUrl);
-  if (bundleUrl) {
-    let parsed: URL;
-    try {
-      parsed = new URL(bundleUrl);
-    } catch (error) {
-      throw new AppError(
-        'INVALID_ARGS',
-        `Invalid runtime bundle URL: ${bundleUrl}`,
-        {},
-        error as Error,
-      );
-    }
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      host ??= trimRuntimeValue(parsed.hostname);
-      port ??= normalizePort(
-        parsed.port.length > 0 ? Number(parsed.port) : defaultPortForProtocol(parsed.protocol),
-      );
-      scheme = parsed.protocol === 'https:' ? 'https' : 'http';
-    }
-  }
-
-  if (!host || !port) return undefined;
-  return { host, port, scheme };
 }
 
 export async function applyRuntimeHintsToApp(params: {
@@ -296,11 +261,6 @@ function removeAndroidPrefEntry(xml: string, key: string): string {
     );
 }
 
-export function trimRuntimeValue(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : undefined;
-}
-
 function assertAndroidRuntimePackageName(packageName: string): void {
   if (classifyAndroidAppTarget(packageName) !== 'binary') return;
   const message = formatAndroidInstalledPackageRequiredMessage(packageName);
@@ -308,18 +268,6 @@ function assertAndroidRuntimePackageName(packageName: string): void {
     package: packageName,
     hint: message,
   });
-}
-
-function normalizePort(value: number | undefined): number | undefined {
-  if (!Number.isInteger(value)) return undefined;
-  if ((value as number) <= 0 || (value as number) > 65_535) return undefined;
-  return value;
-}
-
-function defaultPortForProtocol(protocol: string): number | undefined {
-  if (protocol === 'https:') return 443;
-  if (protocol === 'http:') return 80;
-  return undefined;
 }
 
 function escapeRegex(value: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,8 @@ export type {
   MaterializationReleaseResult,
   MetroPrepareOptions,
   MetroPrepareResult,
+  MetroReloadOptions,
+  MetroReloadResult,
   NetworkOptions,
   PerfOptions,
   PermissionTarget,

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -1,8 +1,14 @@
 import type { SessionRuntimeHints } from './contracts.ts';
-import { buildMetroRuntimeHints, prepareMetroRuntime } from './client-metro.ts';
+import {
+  buildMetroRuntimeHints,
+  prepareMetroRuntime,
+  reloadMetro,
+  type ReloadMetroOptions,
+  type ReloadMetroResult,
+} from './client-metro.ts';
 import { ensureMetroCompanion, stopMetroCompanion } from './client-metro-companion.ts';
 import type { MetroBridgeScope } from './client-metro-companion-contract.ts';
-import { resolveRuntimeTransportHints } from './daemon/runtime-hints.ts';
+import { resolveRuntimeTransportHints } from './utils/runtime-transport.ts';
 export { buildBundleUrl, normalizeBaseUrl } from './utils/url.ts';
 
 export type {
@@ -132,6 +138,10 @@ export type PrepareRemoteMetroResult = {
   logPath: string;
 };
 
+export type ReloadRemoteMetroOptions = ReloadMetroOptions;
+
+export type ReloadRemoteMetroResult = ReloadMetroResult;
+
 export type EnsureMetroTunnelOptions = {
   projectRoot: string;
   serverBaseUrl: string;
@@ -203,6 +213,12 @@ export async function ensureMetroTunnel(
 
 export async function stopMetroTunnel(options: StopMetroTunnelOptions): Promise<void> {
   await stopMetroCompanion(options);
+}
+
+export async function reloadRemoteMetro(
+  options: ReloadRemoteMetroOptions = {},
+): Promise<ReloadRemoteMetroResult> {
+  return await reloadMetro(options);
 }
 
 export function buildIosRuntimeHints(baseUrl: string): MetroRuntimeHints {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -268,6 +268,31 @@ test('parseArgs accepts metro prepare arguments', () => {
   assert.equal(parsed.flags.metroNoInstallDeps, true);
 });
 
+test('parseArgs accepts metro reload arguments', () => {
+  const parsed = parseArgs(
+    [
+      'metro',
+      'reload',
+      '--metro-host',
+      '127.0.0.1',
+      '--metro-port',
+      '9090',
+      '--bundle-url',
+      'http://127.0.0.1:9090/index.bundle?platform=ios',
+      '--probe-timeout-ms',
+      '1500',
+    ],
+    { strictFlags: true },
+  );
+
+  assert.equal(parsed.command, 'metro');
+  assert.deepEqual(parsed.positionals, ['reload']);
+  assert.equal(parsed.flags.metroHost, '127.0.0.1');
+  assert.equal(parsed.flags.metroPort, 9090);
+  assert.equal(parsed.flags.bundleUrl, 'http://127.0.0.1:9090/index.bundle?platform=ios');
+  assert.equal(parsed.flags.metroProbeTimeoutMs, 1500);
+});
+
 test('parseArgs accepts remote workflow profile flag', () => {
   const parsed = parseArgs(
     [
@@ -936,7 +961,7 @@ test('usage renders concise commands inline with descriptions', () => {
   assert.match(help, /Commands:[\s\S]*\n  boot\s{2,}Boot target device\/simulator/);
   assert.match(
     help,
-    /  metro prepare --public-base-url <url> \| --proxy-base-url <url>\s{2,}Prepare local Metro runtime/,
+    /  metro prepare --public-base-url <url> \| --proxy-base-url <url>; metro reload\s{2,}Prepare Metro or reload apps/,
   );
   assert.match(help, /  batch --steps <json> \| --steps-file <path>\s{2,}Run multiple commands/);
   assert.match(help, /  test <path-or-glob>\.\.\.\s{2,}Run \.ad test suites/);
@@ -1019,10 +1044,9 @@ test('command usage shows record touch-overlay opt-out flag', () => {
 test('command usage keeps detailed descriptions', () => {
   const help = usageForCommand('metro');
   if (help === null) throw new Error('Expected command help text');
-  assert.match(
-    help,
-    /Prepare a local Metro runtime and optionally bridge it through a remote host/,
-  );
+  assert.match(help, /Prepare a local Metro runtime or ask Metro to reload/);
+  assert.match(help, /metro reload/);
+  assert.match(help, /--metro-host <host>/);
 });
 
 test('command usage shows no command flags when unsupported', () => {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -1120,12 +1120,16 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
   },
   metro: {
     usageOverride:
-      'metro prepare (--public-base-url <url> | --proxy-base-url <url>) [--project-root <path>] [--port <port>] [--kind auto|react-native|expo]',
-    listUsageOverride: 'metro prepare --public-base-url <url> | --proxy-base-url <url>',
-    helpDescription: 'Prepare a local Metro runtime and optionally bridge it through a remote host',
-    summary: 'Prepare local Metro runtime',
-    positionalArgs: ['prepare'],
+      'metro prepare (--public-base-url <url> | --proxy-base-url <url>) [--project-root <path>] [--port <port>] [--kind auto|react-native|expo]\n  agent-device metro reload [--metro-host <host>] [--metro-port <port>] [--bundle-url <url>]',
+    listUsageOverride:
+      'metro prepare --public-base-url <url> | --proxy-base-url <url>; metro reload',
+    helpDescription:
+      'Prepare a local Metro runtime or ask Metro to reload connected React Native apps',
+    summary: 'Prepare Metro or reload apps',
+    positionalArgs: ['prepare|reload'],
     allowedFlags: [
+      'metroHost',
+      'metroPort',
       'metroProjectRoot',
       'metroKind',
       'metroPublicBaseUrl',
@@ -1139,6 +1143,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
       'metroRuntimeFile',
       'metroNoReuseExisting',
       'metroNoInstallDeps',
+      'bundleUrl',
     ],
     skipCapabilityCheck: true,
   },

--- a/src/utils/runtime-transport.ts
+++ b/src/utils/runtime-transport.ts
@@ -1,0 +1,60 @@
+import { URL } from 'node:url';
+import type { SessionRuntimeHints } from '../contracts.ts';
+import { AppError } from './errors.ts';
+
+export type ResolvedRuntimeTransport = {
+  host: string;
+  port: number;
+  scheme: 'http' | 'https';
+};
+
+export function resolveRuntimeTransportHints(
+  runtime: SessionRuntimeHints | undefined,
+): ResolvedRuntimeTransport | undefined {
+  if (!runtime) return undefined;
+
+  let host = trimRuntimeValue(runtime.metroHost);
+  let port = normalizePort(runtime.metroPort);
+  let scheme: 'http' | 'https' = 'http';
+  const bundleUrl = trimRuntimeValue(runtime.bundleUrl);
+  if (bundleUrl) {
+    let parsed: URL;
+    try {
+      parsed = new URL(bundleUrl);
+    } catch (error) {
+      throw new AppError(
+        'INVALID_ARGS',
+        `Invalid runtime bundle URL: ${bundleUrl}`,
+        {},
+        error as Error,
+      );
+    }
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      host ??= trimRuntimeValue(parsed.hostname);
+      port ??= normalizePort(
+        parsed.port.length > 0 ? Number(parsed.port) : defaultPortForProtocol(parsed.protocol),
+      );
+      scheme = parsed.protocol === 'https:' ? 'https' : 'http';
+    }
+  }
+
+  if (!host || !port) return undefined;
+  return { host, port, scheme };
+}
+
+export function trimRuntimeValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizePort(value: number | undefined): number | undefined {
+  if (!Number.isInteger(value)) return undefined;
+  if ((value as number) <= 0 || (value as number) > 65_535) return undefined;
+  return value;
+}
+
+function defaultPortForProtocol(protocol: string): number | undefined {
+  if (protocol === 'https:') return 443;
+  if (protocol === 'http:') return 80;
+  return undefined;
+}

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -21,10 +21,11 @@ Public subpath API exposed for Node consumers:
 - `agent-device/metro`
   - `prepareRemoteMetro(options)`
   - `ensureMetroTunnel(options)`
+  - `reloadRemoteMetro(options)`
   - `stopMetroTunnel(options)`
   - `buildIosRuntimeHints(baseUrl)`
   - `buildAndroidRuntimeHints(baseUrl)`
-  - types: `PrepareRemoteMetroOptions`, `PrepareRemoteMetroResult`, `EnsureMetroTunnelOptions`, `EnsureMetroTunnelResult`, `StopMetroTunnelOptions`, `MetroRuntimeHints`, `MetroBridgeResult`
+  - types: `PrepareRemoteMetroOptions`, `PrepareRemoteMetroResult`, `EnsureMetroTunnelOptions`, `EnsureMetroTunnelResult`, `ReloadRemoteMetroOptions`, `ReloadRemoteMetroResult`, `StopMetroTunnelOptions`, `MetroRuntimeHints`, `MetroBridgeResult`
 - `agent-device/remote-config`
   - `resolveRemoteConfigPath(options)`
   - `resolveRemoteConfigProfile(options)`
@@ -260,6 +261,7 @@ Direct Android `.apk` and `.aab` URL sources can still resolve package identity 
 ```ts
 import {
   prepareRemoteMetro,
+  reloadRemoteMetro,
   stopMetroTunnel,
 } from 'agent-device/metro';
 import { resolveRemoteConfigProfile } from 'agent-device/remote-config';
@@ -284,13 +286,17 @@ const prepared = await prepareRemoteMetro({
 
 console.log(prepared.iosRuntime, prepared.androidRuntime);
 
+await reloadRemoteMetro({
+  runtime: prepared.iosRuntime,
+});
+
 await stopMetroTunnel({
   projectRoot: remoteConfig.profile.metroProjectRoot!,
   profileKey: remoteConfig.resolvedPath,
 });
 ```
 
-Use `agent-device/remote-config` for profile loading and path resolution, `agent-device/metro` for Metro preparation and tunnel lifecycle, and `agent-device/contracts` when a server consumer needs daemon request or runtime contract types. For bridged remote Metro, `proxyBaseUrl` is the bridge origin and `publicBaseUrl` is optional; the bridge descriptor supplies cloud iOS wildcard HTTPS hints and Android runtime-route hints.
+Use `agent-device/remote-config` for profile loading and path resolution, `agent-device/metro` for Metro preparation, reload, and tunnel lifecycle, and `agent-device/contracts` when a server consumer needs daemon request or runtime contract types. For bridged remote Metro, `proxyBaseUrl` is the bridge origin and `publicBaseUrl` is optional; the bridge descriptor supplies cloud iOS wildcard HTTPS hints and Android runtime-route hints. `reloadRemoteMetro()` calls Metro's `/reload` endpoint, matching the terminal `r` reload path for connected React Native apps.
 
 ## Selector helpers
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -56,6 +56,7 @@ agent-device app-switcher
 - Use `--daemon-auth-token <token>` (or `AGENT_DEVICE_DAEMON_AUTH_TOKEN`) for non-loopback remote daemon URLs; the client sends it in both the JSON-RPC request token and HTTP auth headers.
 - For remote `connect --remote-config` flows, see [Remote Metro workflow](#remote-metro-workflow).
 - Android React Native relaunch flows require an installed package name for `open --relaunch`; install/reinstall the APK first, then relaunch by package. `open <apk|aab> --relaunch` is rejected because runtime hints are written through the installed app sandbox.
+- For Metro-backed React Native JS changes, use `metro reload` before `open <app> --relaunch`; it mirrors pressing `r` in the Metro terminal and keeps the native process alive.
 - Remote daemon screenshots and recordings are downloaded back to the caller path, so `screenshot page.png` and `record start session.mp4` remain usable when the daemon runs on another host.
 
 ```bash
@@ -65,6 +66,7 @@ agent-device back --platform ios                                 # tap visible a
 agent-device back --system --platform ios                        # use edge-swipe or remote back action
 agent-device reinstall MyApp /path/to/app-debug.apk --platform android --serial emulator-5554
 agent-device open com.example.myapp --platform android --serial emulator-5554 --session my-session --relaunch
+agent-device metro reload
 ```
 
 ## Device isolation scopes
@@ -561,6 +563,20 @@ agent-device react-devtools profile rerenders --limit 5
 - Keep using `snapshot`, `press`, `fill`, `logs`, `network`, and `perf` for device/app runtime evidence. Use `react-devtools` for React internals.
 - React Native development builds can connect to the DevTools daemon on port 8097. For Android emulators or physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host. If Metro is local, also run `adb reverse tcp:8081 tcp:8081`.
 - For cross-platform validation with explicit target selectors, prefer an isolated `--state-dir` over separate named sessions. Named sessions enable bound-session locks during setup. Restart `react-devtools` between iOS and Android runs.
+
+## Metro reload
+
+```bash
+agent-device metro reload
+agent-device metro reload --metro-host localhost --metro-port 8081
+agent-device metro reload --bundle-url "http://localhost:8081/index.bundle?platform=ios"
+```
+
+- `metro reload` calls Metro's `/reload` endpoint, the same mechanism used by pressing `r` in the Metro terminal.
+- Use it for React Native dev builds that are already connected to Metro when JS changes should be loaded without restarting the native app process.
+- If an active remote connection has Metro runtime hints, `metro reload` uses those saved hints. Otherwise it defaults to `http://localhost:8081/reload`.
+- Pass `--metro-host`, `--metro-port`, or `--bundle-url` when you need to target a specific Metro instance.
+- Fall back to `open <app> --relaunch` when the app is not connected to Metro, reload fails, or the native process itself must restart.
 
 ## Media and logs
 


### PR DESCRIPTION
## Summary

Add `agent-device metro reload`, which calls Metro's `/reload` endpoint to reload connected React Native apps without restarting the native process.

Expose the reload path through the typed client and `agent-device/metro`, share runtime transport parsing for host/port/bundle URL handling, and update docs plus agent-device skills so agents prefer Metro reload for JS-only dev loops.

Touched files: 19. Scope stayed within Metro command/API, runtime hint parsing, tests, docs, and skills.

## Validation

- `pnpm format`
- `pnpm check:quick`
- `pnpm test:unit src/__tests__/client-metro.test.ts src/__tests__/cli-client-commands.test.ts src/utils/__tests__/args.test.ts src/__tests__/metro-public.test.ts src/daemon/__tests__/runtime-hints.test.ts`
- `pnpm test:unit src/__tests__/client-metro.test.ts src/__tests__/metro-public.test.ts`