### PR TITLE
feat: add cloud remote auth flow

### DIFF
--- a/skills/agent-device/references/remote-tenancy.md
+++ b/skills/agent-device/references/remote-tenancy.md
@@ -14,7 +14,8 @@ Open this file for remote daemon HTTP flows that let an agent running in a Linux
 - `agent-device snapshot --remote-config <path> -i`
 - `agent-device disconnect --remote-config <path>`
 - `agent-device connection status`
-- `AGENT_DEVICE_DAEMON_AUTH_TOKEN=...`
+- `agent-device auth status`
+- `AGENT_DEVICE_DAEMON_AUTH_TOKEN=...` for CI/service-token automation
 
 ## Most common mistake to avoid
 
@@ -30,9 +31,6 @@ Do not mix an arbitrary `--session` plus ad-hoc daemon, tenant, run, or lease fl
 Use this when the agent will run several commands in one session.
 
 ```bash
-export AGENT_DEVICE_DAEMON_AUTH_TOKEN="YOUR_TOKEN"
-export AGENT_DEVICE_PROXY_TOKEN="$AGENT_DEVICE_DAEMON_AUTH_TOKEN"
-
 agent-device connect --remote-config ./remote-config.json
 
 ARTIFACT_URL="<trusted-artifact-url>"
@@ -44,7 +42,7 @@ agent-device fill @e3 "test@example.com"
 agent-device disconnect
 ```
 
-After `connect`, normal commands use the active remote connection. End with `disconnect` to release the lease and stop the owned Metro companion.
+After `connect`, normal commands use the active remote connection. If cloud credentials are missing, `connect` starts login automatically in an interactive shell and stores a revocable CLI session that silently mints short-lived `adc_agent_...` command tokens. The cloud side remains responsible for token expiry, tenant/run claim checks, revocation, one-time device approval, and polling rate limits. End with `disconnect` to release the lease and stop the owned Metro companion.
 
 ### Self-contained script flow
 
@@ -123,7 +121,7 @@ Optional overrides stay available for advanced cases:
 }
 ```
 
-- Keep secrets in env/config managed by the operator boundary. Do not persist auth tokens in connection state.
+- Keep service tokens in env/config managed by the operator boundary. Do not persist auth tokens in connection state. Human login uses `agent-device auth login` or implicit `connect` login and stores only the CLI session credential.
 - Omit Metro fields for non-React Native flows.
 - Put `tenant`, `runId`, and `sessionIsolation` in the remote profile so agents can run `agent-device connect --remote-config ./remote-config.json` without extra scope flags. Add `platform`, `leaseBackend`, `session`, or Metro overrides only when the default inference is not enough for that flow.
 - Explicit command-line flags override connected defaults. Use them intentionally when switching session, platform, target, tenant, run, or lease scope.
@@ -137,7 +135,8 @@ Optional overrides stay available for advanced cases:
 
 - Start the daemon in HTTP mode with `AGENT_DEVICE_DAEMON_SERVER_MODE=http|dual` on the host.
 - Point the profile or env at the remote host with `daemonBaseUrl` or `AGENT_DEVICE_DAEMON_BASE_URL=http(s)://host:port[/base-path]`.
-- For non-loopback remote hosts, set `AGENT_DEVICE_DAEMON_AUTH_TOKEN` or `--daemon-auth-token`. The client rejects non-loopback remote daemon URLs without auth.
+- For humans, run `connect --remote-config <path>` and let it refresh or create the CLI session. Use `agent-device auth status` to inspect it and `agent-device auth logout` to remove it.
+- For CI/non-interactive shells, set `AGENT_DEVICE_DAEMON_AUTH_TOKEN=adc_live_...` or pass `--daemon-auth-token`. The client does not start device-code polling in CI by default.
 - Prefer an auth hook such as `AGENT_DEVICE_HTTP_AUTH_HOOK` when the host needs caller validation or tenant injection.
 
 ## Lease debug fallback

--- a/src/__tests__/cli-config.test.ts
+++ b/src/__tests__/cli-config.test.ts
@@ -523,6 +523,38 @@ test('missing explicit remote config path returns parse error before daemon disp
   fs.rmSync(root, { recursive: true, force: true });
 });
 
+test('connection status with remote config stays local without cloud auth', async () => {
+  const { root, home, project } = makeTempWorkspace();
+  const stateDir = path.join(root, 'state');
+  const remoteConfig = path.join(project, 'agent-device.remote.json');
+  fs.writeFileSync(
+    remoteConfig,
+    JSON.stringify({
+      daemonBaseUrl: 'https://bridge.agent-device.dev',
+      tenant: 'acme',
+      runId: 'run-123',
+    }),
+    'utf8',
+  );
+
+  const result = await runCliCapture(
+    ['connection', 'status', '--remote-config', remoteConfig, '--state-dir', stateDir, '--json'],
+    {
+      cwd: project,
+      env: { HOME: home, CI: 'true' },
+      sendToDaemon: async () => {
+        throw new Error('connection status should not contact daemon or cloud auth');
+      },
+    },
+  );
+
+  assert.equal(result.code, null);
+  assert.equal(result.calls.length, 0);
+  assert.match(result.stdout, /"connected": false/);
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
 test('normal commands accept direct remote-config usage', async () => {
   const { root, home, project } = makeTempWorkspace();
   const stateDir = path.join(root, 'state');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import { applyDefaultPlatformBinding, resolveBindingSettings } from './utils/ses
 import { resolveCliOptions } from './utils/cli-options.ts';
 import { maybeRunUpgradeNotifier } from './utils/update-check.ts';
 import { resolveRemoteConnectionDefaults } from './remote-connection-state.ts';
+import { resolveRemoteAuthForCli } from './cli/auth-session.ts';
 import type { CliFlags, FlagKey } from './utils/command-schema.ts';
 import type { SessionRuntimeHints } from './contracts.ts';
 
@@ -241,6 +242,16 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
           parsedBatchSteps = readBatchSteps(flags);
         }
 
+        if (shouldResolveRemoteAuth(command)) {
+          const authResolution = await resolveRemoteAuthForCli({
+            command,
+            flags: effectiveFlags,
+            stateDir: daemonPaths.baseDir,
+            env: process.env,
+          });
+          effectiveFlags = authResolution.flags;
+        }
+
         if (effectiveFlags.remoteConfig && shouldMaterializeRemoteConnection(command)) {
           const materializationClient = createAgentDeviceClient(
             buildClientConfig(effectiveFlags, resolvedRuntime),
@@ -412,6 +423,10 @@ function resolveActiveConnectionDefaults(options: {
 
 function shouldMaterializeRemoteConnection(command: string): boolean {
   return !REMOTE_MATERIALIZATION_DEFERRED_COMMANDS.has(command);
+}
+
+function shouldResolveRemoteAuth(command: string): boolean {
+  return command !== 'auth' && command !== 'connection';
 }
 
 function shouldWarnOpenMayMissRemoteRuntime(options: {

--- a/src/cli/__tests__/auth-session.test.ts
+++ b/src/cli/__tests__/auth-session.test.ts
@@ -1,0 +1,266 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  loginWithDeviceAuth,
+  readCliSession,
+  removeCliSession,
+  resolveRemoteAuth,
+  resolveCliSessionPath,
+  summarizeCliSession,
+  writeCliSession,
+} from '../auth-session.ts';
+
+const baseFlags = {
+  json: false,
+  help: false,
+  version: false,
+  daemonBaseUrl: 'https://daemon.example',
+  tenant: 'acme',
+  runId: 'run-123',
+};
+
+test('remote auth uses AGENT_DEVICE_DAEMON_AUTH_TOKEN without login', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-auth-env-'));
+  const calls: string[] = [];
+  const result = await resolveRemoteAuth({
+    command: 'connect',
+    flags: baseFlags,
+    stateDir: tempRoot,
+    allowInteractiveLogin: true,
+    env: { AGENT_DEVICE_DAEMON_AUTH_TOKEN: 'adc_live_service' },
+    io: {
+      fetch: async (url) => {
+        calls.push(String(url));
+        return jsonResponse({});
+      },
+    },
+  });
+
+  assert.equal(result.source, 'env');
+  assert.deepEqual(calls, []);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('remote auth fails in CI with service token instructions', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-auth-ci-'));
+
+  await assert.rejects(
+    async () =>
+      await resolveRemoteAuth({
+        command: 'connect',
+        flags: { ...baseFlags, daemonBaseUrl: 'https://bridge.agent-device.dev' },
+        stateDir: tempRoot,
+        allowInteractiveLogin: true,
+        env: { CI: 'true' },
+        io: { stdinIsTTY: true, stdoutIsTTY: true },
+      }),
+    /cannot perform interactive login/,
+  );
+
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('remote auth leaves non-cloud remote daemons to existing daemon auth validation', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-auth-non-cloud-'));
+  writeCliSession({
+    stateDir: tempRoot,
+    session: {
+      version: 1,
+      id: 'session-non-cloud',
+      cloudBaseUrl: 'https://cloud.example',
+      refreshCredential: 'adc_refresh_should_not_be_used',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    },
+  });
+  const result = await resolveRemoteAuth({
+    command: 'connect',
+    flags: baseFlags,
+    stateDir: tempRoot,
+    allowInteractiveLogin: true,
+    env: {},
+    io: {
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      fetch: async () => {
+        throw new Error('non-cloud remote daemons must not refresh cloud sessions');
+      },
+    },
+  });
+
+  assert.equal(result.source, 'none');
+  assert.equal(result.flags.daemonAuthToken, undefined);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('remote auth refreshes a stored CLI session into an agent token', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-auth-refresh-'));
+  writeCliSession({
+    stateDir: tempRoot,
+    session: {
+      version: 1,
+      id: 'session-1',
+      cloudBaseUrl: 'https://cloud.example',
+      workspaceId: 'acme',
+      refreshCredential: 'adc_refresh_secret',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-12-01T00:00:00.000Z',
+    },
+  });
+
+  const bodies: unknown[] = [];
+  const result = await resolveRemoteAuth({
+    command: 'snapshot',
+    flags: { ...baseFlags, daemonBaseUrl: 'https://bridge.agent-device.dev' },
+    stateDir: tempRoot,
+    allowInteractiveLogin: false,
+    env: {},
+    io: {
+      now: () => Date.parse('2026-02-01T00:00:00.000Z'),
+      fetch: async (_url, init) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return jsonResponse({ accessToken: 'adc_agent_fresh', expiresAt: '2026-02-01T01:00:00Z' });
+      },
+    },
+  });
+
+  assert.equal(result.source, 'cli-session');
+  assert.equal(result.flags.daemonAuthToken, 'adc_agent_fresh');
+  assert.deepEqual(bodies, [
+    {
+      refreshCredential: 'adc_refresh_secret',
+      tenant: 'acme',
+      runId: 'run-123',
+      daemonBaseUrl: 'https://bridge.agent-device.dev',
+    },
+  ]);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('remote auth fails immediately when stored CLI session is revoked', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-auth-revoked-'));
+  writeCliSession({
+    stateDir: tempRoot,
+    session: {
+      version: 1,
+      id: 'session-revoked',
+      cloudBaseUrl: 'https://cloud.example',
+      refreshCredential: 'adc_refresh_revoked',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    },
+  });
+
+  await assert.rejects(
+    async () =>
+      await resolveRemoteAuth({
+        command: 'connect',
+        flags: { ...baseFlags, daemonBaseUrl: 'https://bridge.agent-device.dev' },
+        stateDir: tempRoot,
+        allowInteractiveLogin: true,
+        env: {},
+        io: {
+          fetch: async () => jsonResponse({ status: 'revoked' }),
+        },
+      }),
+    /Stored cloud CLI session was revoked/,
+  );
+
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('device login opens browser, stores CLI session, and returns agent token', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-auth-login-'));
+  const opened: string[] = [];
+  let stderr = '';
+  const requests: string[] = [];
+
+  const login = await loginWithDeviceAuth({
+    stateDir: tempRoot,
+    flags: baseFlags,
+    env: { AGENT_DEVICE_CLOUD_BASE_URL: 'https://cloud.example' },
+    io: {
+      stdinIsTTY: true,
+      stdoutIsTTY: true,
+      stderr: {
+        write: (chunk: string) => {
+          stderr += chunk;
+          return true;
+        },
+      },
+      openBrowser: async (url) => {
+        opened.push(url);
+      },
+      fetch: async (url) => {
+        requests.push(String(url));
+        if (String(url).endsWith('/api/control-plane/device-auth/start')) {
+          return jsonResponse({
+            deviceCode: 'device-secret',
+            userCode: 'ABCD-EFGH',
+            verificationUri: 'https://cloud.example/authorize',
+            verificationUriComplete: 'https://cloud.example/device?user_code=ABCD-EFGH',
+            expiresIn: 600,
+            interval: 1,
+          });
+        }
+        return jsonResponse({
+          status: 'approved',
+          accessToken: 'adc_agent_login',
+          expiresAt: '2026-02-01T01:00:00Z',
+          cliSession: {
+            id: 'session-2',
+            refreshCredential: 'adc_refresh_login',
+            workspaceId: 'acme',
+            accountId: 'acct-1',
+            name: 'CLI on laptop',
+            expiresAt: '2026-06-01T00:00:00Z',
+          },
+        });
+      },
+    },
+  });
+
+  assert.equal(login.accessToken, 'adc_agent_login');
+  assert.deepEqual(opened, ['https://cloud.example/device?user_code=ABCD-EFGH']);
+  assert.match(stderr, /Opening https:\/\/cloud\.example\/authorize/);
+  assert.doesNotMatch(stderr, /ABCD-EFGH/);
+  assert.deepEqual(requests, [
+    'https://cloud.example/api/control-plane/device-auth/start',
+    'https://cloud.example/api/control-plane/device-auth/poll',
+  ]);
+  assert.equal(readCliSession({ stateDir: tempRoot })?.refreshCredential, 'adc_refresh_login');
+  if (process.platform !== 'win32') {
+    const mode = fs.statSync(resolveCliSessionPath(tempRoot)).mode & 0o777;
+    assert.equal(mode, 0o600);
+  }
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('auth summary and logout do not expose stored refresh credentials', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-auth-summary-'));
+  writeCliSession({
+    stateDir: tempRoot,
+    session: {
+      version: 1,
+      id: 'session-3',
+      cloudBaseUrl: 'https://cloud.example',
+      refreshCredential: 'adc_refresh_hidden',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    },
+  });
+
+  const status = summarizeCliSession({ stateDir: tempRoot });
+  assert.equal(status.authenticated, true);
+  assert.equal(JSON.stringify(status).includes('adc_refresh_hidden'), false);
+  assert.equal(removeCliSession({ stateDir: tempRoot }), true);
+  assert.equal(summarizeCliSession({ stateDir: tempRoot }).authenticated, false);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/src/cli/auth-session.ts
+++ b/src/cli/auth-session.ts
@@ -1,0 +1,515 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { runCmd } from '../utils/exec.ts';
+import { AppError } from '../utils/errors.ts';
+import type { CliFlags } from '../utils/command-schema.ts';
+
+const DEFAULT_CLOUD_BASE_URL = 'https://cloud.agent-device.dev';
+const DEVICE_AUTH_START_PATH = '/api/control-plane/device-auth/start';
+const DEVICE_AUTH_POLL_PATH = '/api/control-plane/device-auth/poll';
+const CLI_SESSION_REFRESH_PATH = '/api/control-plane/cli-session/refresh';
+const API_KEYS_PATH = '/api-keys';
+const DEVICE_POLL_TIMEOUT_MS = 10 * 60 * 1000;
+const HTTP_TIMEOUT_MS = 15_000;
+const MIN_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+export type CliSessionRecord = {
+  version: 1;
+  id: string;
+  cloudBaseUrl: string;
+  workspaceId?: string;
+  accountId?: string;
+  name?: string;
+  refreshCredential: string;
+  createdAt: string;
+  expiresAt?: string;
+};
+
+export type RemoteAuthResolution = {
+  flags: CliFlags;
+  source: 'flag' | 'env' | 'cli-session' | 'login' | 'none';
+};
+
+type EnvMap = Record<string, string | undefined>;
+
+type DeviceAuthStartResponse = {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete?: string;
+  expiresIn?: number;
+  interval?: number;
+};
+
+type DeviceAuthPollResponse = {
+  status?: string;
+  error?: string;
+  accessToken?: string;
+  expiresAt?: string;
+  cliSession?: {
+    id?: string;
+    refreshCredential?: string;
+    refreshToken?: string;
+    workspaceId?: string;
+    accountId?: string;
+    name?: string;
+    expiresAt?: string;
+  };
+};
+
+type CliSessionRefreshResponse = {
+  accessToken?: string;
+  expiresAt?: string;
+  status?: string;
+  error?: string;
+};
+
+type AuthIo = {
+  env?: EnvMap;
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
+  stderr?: Pick<NodeJS.WriteStream, 'write'>;
+  now?: () => number;
+  fetch?: typeof fetch;
+  openBrowser?: (url: string) => Promise<void>;
+};
+
+export async function resolveRemoteAuthForCli(options: {
+  command: string;
+  flags: CliFlags;
+  stateDir: string;
+  env?: EnvMap;
+}): Promise<RemoteAuthResolution> {
+  return await resolveRemoteAuth({
+    command: options.command,
+    flags: options.flags,
+    stateDir: options.stateDir,
+    allowInteractiveLogin: options.command === 'connect' && !options.flags.noLogin,
+    env: options.env,
+  });
+}
+
+export async function resolveRemoteAuth(options: {
+  command: string;
+  flags: CliFlags;
+  stateDir: string;
+  allowInteractiveLogin: boolean;
+  env?: EnvMap;
+  io?: AuthIo;
+}): Promise<RemoteAuthResolution> {
+  const env = options.env ?? options.io?.env ?? process.env;
+  if (!options.flags.daemonBaseUrl) return { flags: options.flags, source: 'none' };
+  if (hasToken(options.flags.daemonAuthToken)) return { flags: options.flags, source: 'flag' };
+  if (hasToken(env.AGENT_DEVICE_DAEMON_AUTH_TOKEN)) {
+    return { flags: options.flags, source: 'env' };
+  }
+  if (!shouldUseCloudAuth(options.flags.daemonBaseUrl, env)) {
+    return { flags: options.flags, source: 'none' };
+  }
+
+  const session = readCliSession({ stateDir: options.stateDir });
+  if (session && !isExpired(session.expiresAt, options.io?.now)) {
+    const refreshed = await refreshAgentToken({
+      session,
+      flags: options.flags,
+      env,
+      io: options.io,
+    });
+    return {
+      flags: { ...options.flags, daemonAuthToken: refreshed.accessToken },
+      source: 'cli-session',
+    };
+  }
+
+  if (!options.allowInteractiveLogin) {
+    if (options.flags.noLogin) {
+      throw new AppError('UNAUTHORIZED', 'Remote daemon authentication is required.', {
+        hint: 'Run agent-device auth login, unset --no-login, or set AGENT_DEVICE_DAEMON_AUTH_TOKEN.',
+      });
+    }
+    throw buildNonInteractiveLoginError(options.command, env);
+  }
+
+  const login = await loginWithDeviceAuth({
+    stateDir: options.stateDir,
+    flags: options.flags,
+    env,
+    io: options.io,
+  });
+  return {
+    flags: { ...options.flags, daemonAuthToken: login.accessToken },
+    source: 'login',
+  };
+}
+
+export async function loginWithDeviceAuth(options: {
+  stateDir: string;
+  flags: CliFlags;
+  env?: EnvMap;
+  io?: AuthIo;
+  commandLabel?: string;
+}): Promise<{ accessToken: string; expiresAt?: string; session: CliSessionRecord }> {
+  const env = options.env ?? options.io?.env ?? process.env;
+  const authMode = detectAuthMode(env, options.io);
+  if (authMode === 'non-interactive') {
+    throw buildNonInteractiveLoginError(options.commandLabel ?? 'agent-device connect', env);
+  }
+  const cloudBaseUrl = resolveCloudBaseUrl(env);
+  const start = await postJson<DeviceAuthStartResponse>({
+    baseUrl: cloudBaseUrl,
+    pathName: DEVICE_AUTH_START_PATH,
+    body: {
+      client: 'agent-device',
+      tenant: options.flags.tenant,
+      runId: options.flags.runId,
+      daemonBaseUrl: options.flags.daemonBaseUrl,
+      session: options.flags.session,
+    },
+    fetchImpl: options.io?.fetch,
+  });
+  assertDeviceAuthStart(start);
+
+  const verificationUrl = start.verificationUriComplete ?? start.verificationUri;
+  const printableUrl =
+    authMode === 'local-browser'
+      ? start.verificationUri
+      : appendUserCode(start.verificationUri, start.userCode);
+  if (authMode === 'local-browser') {
+    writeStderr(options.io, `Opening ${start.verificationUri}...\n`);
+    await openBrowser(verificationUrl, options.io);
+  } else {
+    writeStderr(
+      options.io,
+      `Open this URL on your machine:\n${printableUrl}\n\nWaiting for approval for 10 minutes...\n`,
+    );
+  }
+
+  const approved = await pollDeviceAuth({
+    cloudBaseUrl,
+    deviceCode: start.deviceCode,
+    expiresIn: start.expiresIn,
+    interval: start.interval,
+    fetchImpl: options.io?.fetch,
+    now: options.io?.now,
+  });
+  const refreshCredential =
+    approved.cliSession?.refreshCredential ?? approved.cliSession?.refreshToken;
+  if (!hasToken(approved.accessToken) || !hasToken(refreshCredential)) {
+    throw new AppError('UNAUTHORIZED', 'Device authorization did not return CLI credentials.');
+  }
+  const nowIso = new Date(options.io?.now?.() ?? Date.now()).toISOString();
+  const session: CliSessionRecord = {
+    version: 1,
+    id: approved.cliSession?.id ?? `cli-${Date.now().toString(36)}`,
+    cloudBaseUrl,
+    workspaceId: approved.cliSession?.workspaceId,
+    accountId: approved.cliSession?.accountId,
+    name: approved.cliSession?.name,
+    refreshCredential,
+    createdAt: nowIso,
+    expiresAt: approved.cliSession?.expiresAt,
+  };
+  writeCliSession({ stateDir: options.stateDir, session });
+  return { accessToken: approved.accessToken, expiresAt: approved.expiresAt, session };
+}
+
+export function readCliSession(options: { stateDir: string }): CliSessionRecord | null {
+  const filePath = resolveCliSessionPath(options.stateDir);
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Partial<CliSessionRecord>;
+    if (
+      parsed.version !== 1 ||
+      !hasToken(parsed.id) ||
+      !hasToken(parsed.cloudBaseUrl) ||
+      !hasToken(parsed.refreshCredential) ||
+      !hasToken(parsed.createdAt)
+    ) {
+      return null;
+    }
+    return parsed as CliSessionRecord;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCliSession(options: { stateDir: string; session: CliSessionRecord }): void {
+  const filePath = resolveCliSessionPath(options.stateDir);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(filePath, `${JSON.stringify(options.session, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Best effort on filesystems that do not support POSIX mode bits.
+  }
+}
+
+export function removeCliSession(options: { stateDir: string }): boolean {
+  const filePath = resolveCliSessionPath(options.stateDir);
+  if (!fs.existsSync(filePath)) return false;
+  fs.rmSync(filePath, { force: true });
+  return true;
+}
+
+export function resolveCliSessionPath(stateDir: string): string {
+  return path.join(stateDir, 'auth', 'cli-session.json');
+}
+
+export function summarizeCliSession(options: { stateDir: string; now?: () => number }): {
+  authenticated: boolean;
+  source: 'cli-session' | 'none';
+  sessionId?: string;
+  cloudBaseUrl?: string;
+  workspaceId?: string;
+  accountId?: string;
+  name?: string;
+  createdAt?: string;
+  expiresAt?: string;
+  expired?: boolean;
+} {
+  const session = readCliSession({ stateDir: options.stateDir });
+  if (!session) return { authenticated: false, source: 'none' };
+  return {
+    authenticated: true,
+    source: 'cli-session',
+    sessionId: session.id,
+    cloudBaseUrl: session.cloudBaseUrl,
+    workspaceId: session.workspaceId,
+    accountId: session.accountId,
+    name: session.name,
+    createdAt: session.createdAt,
+    expiresAt: session.expiresAt,
+    expired: isExpired(session.expiresAt, options.now),
+  };
+}
+
+async function refreshAgentToken(options: {
+  session: CliSessionRecord;
+  flags: CliFlags;
+  env: EnvMap;
+  io?: AuthIo;
+}): Promise<{ accessToken: string; expiresAt?: string }> {
+  const cloudBaseUrl = resolveCloudBaseUrl(options.env, options.session.cloudBaseUrl);
+  const response = await postJson<CliSessionRefreshResponse>({
+    baseUrl: cloudBaseUrl,
+    pathName: CLI_SESSION_REFRESH_PATH,
+    body: {
+      refreshCredential: options.session.refreshCredential,
+      tenant: options.flags.tenant,
+      runId: options.flags.runId,
+      daemonBaseUrl: options.flags.daemonBaseUrl,
+      session: options.flags.session,
+    },
+    fetchImpl: options.io?.fetch,
+  });
+  if (hasToken(response.accessToken)) {
+    return { accessToken: response.accessToken, expiresAt: response.expiresAt };
+  }
+  if (response.status === 'revoked' || response.error === 'revoked') {
+    throw new AppError('UNAUTHORIZED', 'Stored cloud CLI session was revoked.', {
+      hint: 'Run agent-device auth login again, or set AGENT_DEVICE_DAEMON_AUTH_TOKEN.',
+      status: response.status,
+      error: response.error,
+    });
+  }
+  throw new AppError('UNAUTHORIZED', 'Failed to refresh CLI session.', {
+    hint: 'Run agent-device auth login again, or set AGENT_DEVICE_DAEMON_AUTH_TOKEN.',
+    status: response.status,
+    error: response.error,
+  });
+}
+
+async function pollDeviceAuth(options: {
+  cloudBaseUrl: string;
+  deviceCode: string;
+  expiresIn: number | undefined;
+  interval: number | undefined;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}): Promise<DeviceAuthPollResponse> {
+  const now = options.now ?? Date.now;
+  const timeoutMs = Math.min((options.expiresIn ?? 600) * 1000, DEVICE_POLL_TIMEOUT_MS);
+  const deadline = now() + timeoutMs;
+  let intervalMs = Math.max(
+    MIN_POLL_INTERVAL_MS,
+    (options.interval ?? DEFAULT_POLL_INTERVAL_MS / 1000) * 1000,
+  );
+  while (now() < deadline) {
+    const response = await postJson<DeviceAuthPollResponse>({
+      baseUrl: options.cloudBaseUrl,
+      pathName: DEVICE_AUTH_POLL_PATH,
+      body: { deviceCode: options.deviceCode },
+      fetchImpl: options.fetchImpl,
+    });
+    if (response.status === 'approved' || hasToken(response.accessToken)) return response;
+    if (response.status === 'slow_down' || response.error === 'slow_down') {
+      intervalMs += MIN_POLL_INTERVAL_MS;
+    } else if (
+      response.status !== 'authorization_pending' &&
+      response.error !== 'authorization_pending'
+    ) {
+      throw new AppError('UNAUTHORIZED', 'Device authorization was not approved.', {
+        status: response.status,
+        error: response.error,
+      });
+    }
+    await sleep(intervalMs);
+  }
+  throw new AppError('TIMEOUT', 'Device authorization expired before approval.');
+}
+
+async function postJson<T>(options: {
+  baseUrl: string;
+  pathName: string;
+  body: Record<string, unknown>;
+  fetchImpl?: typeof fetch;
+}): Promise<T> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const response = await fetchImpl(new URL(options.pathName, options.baseUrl), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(options.body),
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  });
+  const text = await response.text();
+  let parsed: unknown = {};
+  if (text.trim().length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      throw new AppError(
+        'COMMAND_FAILED',
+        `Cloud auth endpoint returned invalid JSON (${response.status}).`,
+        { status: response.status },
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+  if (!response.ok) {
+    throw new AppError('UNAUTHORIZED', `Cloud auth endpoint rejected the request.`, {
+      status: response.status,
+      response: parsed,
+    });
+  }
+  return parsed as T;
+}
+
+function assertDeviceAuthStart(response: DeviceAuthStartResponse): void {
+  if (
+    !hasToken(response.deviceCode) ||
+    !hasToken(response.userCode) ||
+    !hasToken(response.verificationUri)
+  ) {
+    throw new AppError('COMMAND_FAILED', 'Cloud auth start returned an unusable response.');
+  }
+}
+
+function detectAuthMode(
+  env: EnvMap,
+  io?: AuthIo,
+): 'local-browser' | 'device-code' | 'non-interactive' {
+  const stdinIsTTY = io?.stdinIsTTY ?? process.stdin.isTTY;
+  const stdoutIsTTY = io?.stdoutIsTTY ?? process.stdout.isTTY;
+  if (isCi(env) || !stdinIsTTY || !stdoutIsTTY) return 'non-interactive';
+  if (isRemoteShell(env)) return 'device-code';
+  return 'local-browser';
+}
+
+function isCi(env: EnvMap): boolean {
+  return env.CI === 'true' || env.GITHUB_ACTIONS === 'true' || env.BUILDKITE === 'true';
+}
+
+function isRemoteShell(env: EnvMap): boolean {
+  return Boolean(
+    env.SSH_TTY ||
+    env.SSH_CONNECTION ||
+    env.CODESPACES === 'true' ||
+    env.GITPOD_WORKSPACE_ID ||
+    env.REMOTE_CONTAINERS === 'true',
+  );
+}
+
+function buildNonInteractiveLoginError(command: string, env: EnvMap): AppError {
+  const cloudBaseUrl = resolveCloudBaseUrl(env);
+  return new AppError(
+    'UNAUTHORIZED',
+    `${command} cannot perform interactive login in CI or a non-interactive shell.`,
+    {
+      hint:
+        `Create a service/API token: ${new URL(API_KEYS_PATH, cloudBaseUrl).toString()} ` +
+        'Then set AGENT_DEVICE_DAEMON_AUTH_TOKEN=adc_live_...',
+    },
+  );
+}
+
+function resolveCloudBaseUrl(env: EnvMap, fallback?: string): string {
+  const raw = env.AGENT_DEVICE_CLOUD_BASE_URL ?? fallback ?? DEFAULT_CLOUD_BASE_URL;
+  try {
+    return new URL(raw).toString().replace(/\/+$/, '');
+  } catch (error) {
+    throw new AppError(
+      'INVALID_ARGS',
+      'Invalid AGENT_DEVICE_CLOUD_BASE_URL.',
+      { cloudBaseUrl: raw },
+      error instanceof Error ? error : undefined,
+    );
+  }
+}
+
+function shouldUseCloudAuth(daemonBaseUrl: string, env: EnvMap): boolean {
+  if (env.AGENT_DEVICE_CLOUD_AUTH === '1' || env.AGENT_DEVICE_CLOUD_AUTH === 'true') return true;
+  if (hasToken(env.AGENT_DEVICE_CLOUD_BASE_URL)) return true;
+  try {
+    const hostname = new URL(daemonBaseUrl).hostname.toLowerCase();
+    return hostname === 'agent-device.dev' || hostname.endsWith('.agent-device.dev');
+  } catch {
+    return false;
+  }
+}
+
+function appendUserCode(verificationUri: string, userCode: string): string {
+  const url = new URL(verificationUri);
+  url.searchParams.set('user_code', userCode);
+  return url.toString();
+}
+
+async function openBrowser(url: string, io?: AuthIo): Promise<void> {
+  if (io?.openBrowser) {
+    await io.openBrowser(url);
+    return;
+  }
+  const platform = process.platform;
+  try {
+    if (platform === 'darwin') {
+      await runCmd('open', [url], { allowFailure: true, timeoutMs: 5000 });
+    } else if (platform === 'win32') {
+      await runCmd('cmd', ['/c', 'start', '', url], { allowFailure: true, timeoutMs: 5000 });
+    } else {
+      await runCmd('xdg-open', [url], { allowFailure: true, timeoutMs: 5000 });
+    }
+  } catch {
+    writeStderr(io, `Open this URL on your machine:\n${url}\n`);
+  }
+}
+
+function writeStderr(io: AuthIo | undefined, text: string): void {
+  (io?.stderr ?? process.stderr).write(text);
+}
+
+function isExpired(expiresAt: string | undefined, now: (() => number) | undefined): boolean {
+  if (!expiresAt) return false;
+  const timestamp = Date.parse(expiresAt);
+  if (!Number.isFinite(timestamp)) return true;
+  return timestamp <= (now?.() ?? Date.now());
+}
+
+function hasToken(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,0 +1,56 @@
+import { resolveDaemonPaths } from '../../daemon/config.ts';
+import { AppError } from '../../utils/errors.ts';
+import { loginWithDeviceAuth, removeCliSession, summarizeCliSession } from '../auth-session.ts';
+import { writeCommandOutput } from './shared.ts';
+import type { ClientCommandHandler } from './router-types.ts';
+
+export const authCommand: ClientCommandHandler = async ({ positionals, flags }) => {
+  const subcommand = positionals[0] ?? 'status';
+  const stateDir = resolveDaemonPaths(flags.stateDir).baseDir;
+  if (subcommand === 'status') {
+    const status = summarizeCliSession({ stateDir });
+    writeCommandOutput(flags, status, () => renderAuthStatus(status));
+    return true;
+  }
+  if (subcommand === 'login') {
+    const login = await loginWithDeviceAuth({
+      stateDir,
+      flags,
+      commandLabel: 'agent-device auth login',
+    });
+    const data = {
+      authenticated: true,
+      source: 'cli-session',
+      sessionId: login.session.id,
+      cloudBaseUrl: login.session.cloudBaseUrl,
+      workspaceId: login.session.workspaceId,
+      accountId: login.session.accountId,
+      expiresAt: login.session.expiresAt,
+      agentTokenExpiresAt: login.expiresAt,
+    };
+    writeCommandOutput(flags, data, () => 'Authenticated with cloud CLI session.');
+    return true;
+  }
+  if (subcommand === 'logout') {
+    const removed = removeCliSession({ stateDir });
+    writeCommandOutput(flags, { authenticated: false, removed }, () =>
+      removed ? 'Removed stored cloud CLI session.' : 'No stored cloud CLI session.',
+    );
+    return true;
+  }
+  throw new AppError('INVALID_ARGS', 'auth accepts only: status, login, logout');
+};
+
+function renderAuthStatus(status: ReturnType<typeof summarizeCliSession>): string {
+  if (!status.authenticated) return 'Not authenticated.';
+  const lines = [
+    'Authenticated with cloud CLI session.',
+    `cloud=${status.cloudBaseUrl}`,
+    `session=${status.sessionId}`,
+    status.workspaceId ? `workspace=${status.workspaceId}` : null,
+    status.accountId ? `account=${status.accountId}` : null,
+    status.expiresAt ? `expiresAt=${status.expiresAt}` : null,
+    status.expired ? 'status=expired' : null,
+  ];
+  return lines.filter((line): line is string => Boolean(line)).join('\n');
+}

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -9,6 +9,7 @@ import { appsCommand } from './apps.ts';
 import { installCommand, reinstallCommand, installFromSourceCommand } from './install.ts';
 import { openCommand, closeCommand } from './open.ts';
 import { connectCommand, connectionCommand, disconnectCommand } from './connection.ts';
+import { authCommand } from './auth.ts';
 import { snapshotCommand } from './snapshot.ts';
 import { screenshotCommand, diffCommand } from './screenshot.ts';
 import { clientCommandMethodHandlers } from './client-command.ts';
@@ -33,6 +34,7 @@ const dedicatedClientApiHandlers = {
   connect: connectCommand,
   disconnect: disconnectCommand,
   connection: connectionCommand,
+  auth: authCommand,
   open: openCommand,
   close: closeCommand,
   [CLIENT_COMMANDS.snapshot]: snapshotCommand,

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -92,6 +92,7 @@ export const commandCatalog: readonly CommandCatalogEntry[] = [
   { command: 'connect', category: 'environment', status: 'planned' },
   { command: 'disconnect', category: 'environment', status: 'planned' },
   { command: 'connection', category: 'environment', status: 'planned' },
+  { command: 'auth', category: 'environment', status: 'planned' },
   { command: 'metro', category: 'environment', status: 'planned' },
   { command: 'react-devtools', category: 'environment', status: 'implemented' },
   { command: 'record', category: 'capability-gated', status: 'implemented' },

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -401,7 +401,7 @@ test('parseArgs recognizes daemon transport/state/tenant isolation flags', () =>
   assert.equal(parsed.flags.leaseId, 'abcd1234ef567890');
 });
 
-test('parseArgs recognizes connect lease backend and force flags', () => {
+test('parseArgs recognizes connect lease backend force and no-login flags', () => {
   const parsed = parseArgs(
     [
       'connect',
@@ -414,6 +414,7 @@ test('parseArgs recognizes connect lease backend and force flags', () => {
       '--lease-backend',
       'android-instance',
       '--force',
+      '--no-login',
     ],
     { strictFlags: true },
   );
@@ -421,6 +422,20 @@ test('parseArgs recognizes connect lease backend and force flags', () => {
   assert.equal(parsed.flags.remoteConfig, './remote.json');
   assert.equal(parsed.flags.leaseBackend, 'android-instance');
   assert.equal(parsed.flags.force, true);
+  assert.equal(parsed.flags.noLogin, true);
+});
+
+test('parseArgs accepts auth management subcommands', () => {
+  const status = parseArgs(['auth', 'status'], { strictFlags: true });
+  assert.equal(status.command, 'auth');
+  assert.deepEqual(status.positionals, ['status']);
+
+  const login = parseArgs(['auth', 'login', '--remote-config', './remote.json'], {
+    strictFlags: true,
+  });
+  assert.equal(login.command, 'auth');
+  assert.deepEqual(login.positionals, ['login']);
+  assert.equal(login.flags.remoteConfig, './remote.json');
 });
 
 test('parseArgs recognizes explicit config file flag', () => {

--- a/src/utils/__tests__/diagnostics.test.ts
+++ b/src/utils/__tests__/diagnostics.test.ts
@@ -64,6 +64,9 @@ test('diagnostics redacts sensitive fields', async () => {
             token: 'secret-token',
             text: 'sensitive text',
             nested: { authorization: 'Bearer abc' },
+            agentToken: 'adc_agent_secret',
+            deviceUrl: 'https://cloud.agent-device.dev/device?user_code=ABCD-EFGH',
+            userCode: 'ABCD-EFGH',
             safe: 'ok',
           },
         });
@@ -81,6 +84,9 @@ test('diagnostics redacts sensitive fields', async () => {
     assert.equal(payload.token, '[REDACTED]');
     assert.equal(payload.text, 'sensitive text');
     assert.equal(payload.nested?.authorization, '[REDACTED]');
+    assert.equal(payload.agentToken, '[REDACTED]');
+    assert.equal(payload.deviceUrl, '[REDACTED]');
+    assert.equal(payload.userCode, '[REDACTED]');
     assert.equal(payload.safe, 'ok');
   } finally {
     process.env.HOME = previousHome;

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -17,6 +17,7 @@ export type CliFlags = {
   leaseId?: string;
   leaseBackend?: 'ios-simulator' | 'ios-instance' | 'android-instance';
   force?: boolean;
+  noLogin?: boolean;
   sessionLock?: 'reject' | 'strip';
   sessionLocked?: boolean;
   sessionLockConflicts?: 'reject' | 'strip';
@@ -280,6 +281,13 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--force',
     usageDescription: 'Force connection state replacement when reconnecting',
+  },
+  {
+    key: 'noLogin',
+    names: ['--no-login'],
+    type: 'boolean',
+    usageLabel: '--no-login',
+    usageDescription: 'Connect: fail instead of starting implicit cloud login',
   },
   {
     key: 'sessionLock',
@@ -1024,12 +1032,14 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
   },
   connect: {
     usageOverride:
-      'connect --remote-config <path> [--tenant <id>] [--run-id <id>] [--lease-backend <backend>] [--force]',
-    helpDescription: 'Connect to a remote daemon and save remote session state',
+      'connect --remote-config <path> [--tenant <id>] [--run-id <id>] [--lease-backend <backend>] [--force] [--no-login]',
+    helpDescription:
+      'Connect to a remote daemon, authenticate when needed, and save remote session state',
     summary: 'Connect to remote daemon',
     positionalArgs: [],
     allowedFlags: [
       'force',
+      'noLogin',
       'metroProjectRoot',
       'metroKind',
       'metroPublicBaseUrl',
@@ -1061,6 +1071,15 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     helpDescription: 'Inspect active remote connection state',
     summary: 'Inspect remote connection',
     positionalArgs: ['status'],
+    allowedFlags: [],
+    skipCapabilityCheck: true,
+  },
+  auth: {
+    usageOverride: 'auth status|login|logout',
+    listUsageOverride: 'auth status|login|logout',
+    helpDescription: 'Manage cloud CLI authentication',
+    summary: 'Manage cloud authentication',
+    positionalArgs: ['status|login|logout'],
     allowedFlags: [],
     skipCapabilityCheck: true,
   },

--- a/src/utils/redaction.ts
+++ b/src/utils/redaction.ts
@@ -1,7 +1,7 @@
 const SENSITIVE_KEY_RE =
-  /(token|secret|password|authorization|cookie|api[_-]?key|access[_-]?key|private[_-]?key)/i;
+  /(token|secret|password|authorization|cookie|api[_-]?key|access[_-]?key|private[_-]?key|user[_-]?code|device[_-]?code|refresh[_-]?credential)/i;
 const SENSITIVE_VALUE_RE =
-  /(bearer\s+[a-z0-9._-]+|(?:api[_-]?key|token|secret|password)\s*[=:]\s*\S+)/i;
+  /(bearer\s+[a-z0-9._-]+|adc_(?:agent|live|refresh|cli)_[a-z0-9._-]+|(?:api[_-]?key|token|secret|password|user[_-]?code|device[_-]?code)\s*[=:]\s*\S+)/i;
 
 export function redactDiagnosticData<T>(input: T): T {
   return redactValue(input, new WeakSet<object>()) as T;

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -53,7 +53,8 @@ agent-device app-switcher
 - In `batch`, steps that omit `platform` still inherit the parent batch `--platform`; lock-mode defaults do not override that parent setting.
 - Tenant-scoped daemon runs can pass `--tenant`, `--session-isolation tenant`, `--run-id`, and `--lease-id` to enforce lease admission.
 - Remote daemon clients can pass `--daemon-base-url http(s)://host:port[/base-path]` to skip local daemon discovery/startup and call a remote HTTP daemon directly.
-- Use `--daemon-auth-token <token>` (or `AGENT_DEVICE_DAEMON_AUTH_TOKEN`) for non-loopback remote daemon URLs; the client sends it in both the JSON-RPC request token and HTTP auth headers.
+- Use `--daemon-auth-token <token>` (or `AGENT_DEVICE_DAEMON_AUTH_TOKEN`) for explicit service/API-token automation against non-loopback remote daemon URLs; the client sends it in both the JSON-RPC request token and HTTP auth headers.
+- For human cloud access, `connect --remote-config ...` refreshes a stored CLI session into a short-lived `adc_agent_...` token. If no CLI session exists, interactive shells start login automatically; CI and non-interactive shells fail with API-token setup instructions. Use `--no-login` to disable implicit login.
 - For remote `connect --remote-config` flows, see [Remote Metro workflow](#remote-metro-workflow).
 - Android React Native relaunch flows require an installed package name for `open --relaunch`; install/reinstall the APK first, then relaunch by package. `open <apk|aab> --relaunch` is rejected because runtime hints are written through the installed app sandbox.
 - For Metro-backed React Native JS changes, use `metro reload` before `open <app> --relaunch`; it mirrors pressing `r` in the Metro terminal and keeps the native process alive.
@@ -719,7 +720,9 @@ agent-device disconnect --remote-config ./agent-device.remote.json
 ```
 
 - `--remote-config <path>` points to a remote workflow profile that captures stable host, tenant/run, and any optional session, platform, lease backend, or Metro overrides for `connect`.
-- `connect --remote-config ...` is the main agent flow. It generates a local session name when needed, stores the remote scope locally, and defers tenant lease allocation plus Metro preparation until a later command needs them.
+- `connect --remote-config ...` is the main agent flow. It generates a local session name when needed, authenticates to cloud when credentials are missing, stores the remote scope locally, and defers tenant lease allocation plus Metro preparation until a later command needs them.
+- Auth management commands are available for inspection and recovery: `agent-device auth status`, `agent-device auth login`, and `agent-device auth logout`. Human login stores a revocable CLI session locally; it does not create or persist an `adc_live_...` service token.
+- Cloud auth uses three credential classes: `adc_agent_...` short-lived command tokens, revocable CLI session refresh credentials, and explicit `adc_live_...` service/API tokens for CI. The CLI implements credential selection, CI refusal, local storage permissions, logout, and output redaction; the cloud API must enforce token expiry, tenant/run scope, revocation, one-time device approval, polling rate limits, and dashboard/API separation.
 - Deferred Metro preparation also applies to `batch` when any step opens an app and the batch does not provide its own per-step runtime.
 - After `connect`, `snapshot`, `press`, `fill`, `screenshot`, and other normal commands reuse active connection state so agents do not repeat remote host/session/lease selectors inline. Passing the same `--remote-config` to a normal command is also supported for self-contained scripts; the CLI reuses matching saved state or creates it before dispatch.
 - Self-contained remote scripts should end with `disconnect --remote-config <path>` or `disconnect` to release the lease and stop the owned Metro companion.


### PR DESCRIPTION
## Summary

Add CLI-side cloud remote authentication for `connect --remote-config`: env/service token resolution, stored CLI-session refresh into short-lived agent tokens, implicit interactive login, CI/non-interactive refusal, and explicit `auth status|login|logout` management.

Cleanup pass after security/API review:
- revoked CLI sessions fail immediately instead of falling through to generic auth handling
- docs distinguish CLI controls from cloud-side requirements for expiry, tenant/run scope, revocation, one-time approval, rate limiting, and dashboard/API separation
- redaction covers `adc_*` tokens, user/device codes, and auth URLs

Touched files: 12. Scope stayed within CLI remote-auth/connection surface, command schema/routing, tests, docs, and skill guidance. Cloud server/dashboard endpoints are documented as required follow-up because this repo does not contain that service.

## Validation

- `pnpm format`
- `pnpm vitest run src/cli/__tests__/auth-session.test.ts src/utils/__tests__/args.test.ts src/utils/__tests__/diagnostics.test.ts`
- `pnpm check:quick`
- `pnpm test:unit`
