### PR TITLE
feat: export observability helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
       "import": "./dist/src/artifacts.js",
       "types": "./dist/src/artifacts.d.ts"
     },
+    "./observability": {
+      "import": "./dist/src/observability.js",
+      "types": "./dist/src/observability.d.ts"
+    },
     "./metro": {
       "import": "./dist/src/metro.js",
       "types": "./dist/src/metro.d.ts"

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
           io: 'src/io.ts',
           'testing/conformance': 'src/testing/conformance.ts',
           artifacts: 'src/artifacts.ts',
+          observability: 'src/observability.ts',
           metro: 'src/metro.ts',
           'remote-config': 'src/remote-config.ts',
           'install-source': 'src/install-source.ts',

--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  mapNetworkDumpToBackendResult,
+  mergeNetworkDumps,
+  readRecentNetworkTrafficFromText,
+  redactNetworkLogText,
+  type NetworkLogBackend,
+} from '../observability.ts';
+
+test('public observability parser reads recent network traffic from text', () => {
+  const dump = readRecentNetworkTrafficFromText(
+    [
+      '2026-02-24T10:00:00Z GET https://api.example.com/v1/profile status=200',
+      '2026-02-24T10:00:02Z {"method":"POST","url":"https://api.example.com/v1/login","statusCode":401,"headers":{"x-id":"abc"},"requestBody":{"email":"u@example.com"},"responseBody":{"error":"denied"}}',
+    ].join('\n'),
+    {
+      sourcePath: 'limrun://session/app.log',
+      backend: 'ios-simulator',
+      include: 'all',
+      maxEntries: 5,
+      maxScanLines: 100,
+    },
+  );
+
+  assert.equal(dump.sourcePath, 'limrun://session/app.log');
+  assert.equal(dump.matchedLines, 2);
+  assert.equal(dump.entries[0]?.url, 'https://api.example.com/v1/login');
+  assert.equal(dump.entries[0]?.status, 401);
+  assert.equal(dump.entries[0]?.headers, '{"x-id":"abc"}');
+  assert.equal(dump.entries[0]?.requestBody, '{"email":"u@example.com"}');
+  assert.equal(dump.entries[0]?.responseBody, '{"error":"denied"}');
+});
+
+test('public observability parser accepts custom backend labels', () => {
+  const backend: NetworkLogBackend = 'limrun-ios-device';
+  const dump = readRecentNetworkTrafficFromText(
+    '2026-02-24T10:00:00Z GET https://api.example.com/v1/profile status=200',
+    { backend },
+  );
+
+  assert.equal(dump.entries[0]?.url, 'https://api.example.com/v1/profile');
+});
+
+test('public observability parser preserves scan metadata at the boundary', () => {
+  const dump = readRecentNetworkTrafficFromText(
+    [
+      '2026-02-24T10:00:00Z GET https://api.example.com/old status=200',
+      ...Array.from({ length: 99 }, (_entry, index) => `ignored ${index}`),
+      '2026-02-24T10:00:01Z GET https://api.example.com/recent status=200',
+    ].join('\n'),
+    { maxEntries: 5, maxScanLines: 2 },
+  );
+
+  assert.equal(dump.sourcePath, undefined);
+  assert.equal(dump.scannedLines, 100);
+  assert.equal(dump.matchedLines, 1);
+  assert.equal(dump.entries[0]?.url, 'https://api.example.com/recent');
+  assert.deepEqual(dump.limits, {
+    maxEntries: 5,
+    maxPayloadChars: 2048,
+    maxScanLines: 100,
+  });
+});
+
+test('public observability parser preserves Android packet IDs', () => {
+  const dump = readRecentNetworkTrafficFromText(
+    [
+      '03-31 17:43:32.564 V/GIBSDK  (17434): [NetworkAgent]: packet id 23911610 added, queue size: 1',
+      '03-31 17:43:33.031 D/GIBSDK  (17434): [NetworkAgent] packet id 23911610 total elapsed request/response time, ms: 377; response code: 200;',
+      '03-31 17:43:33.031 D/GIBSDK  (17434): URL: https://www.example.com/api/fl?as=2.0',
+    ].join('\n'),
+    { backend: 'android', maxEntries: 5, maxScanLines: 100 },
+  );
+
+  assert.equal(dump.entries.length, 1);
+  assert.equal(dump.entries[0]?.packetId, '23911610');
+  assert.equal(dump.entries[0]?.metadata?.packetId, '23911610');
+});
+
+test('public observability merge de-duplicates entries and honors max entries', () => {
+  const primary = readRecentNetworkTrafficFromText(
+    '2026-02-24T10:00:00Z GET https://api.example.com/primary status=200',
+  );
+  const secondary = readRecentNetworkTrafficFromText(
+    [
+      '2026-02-24T10:00:00Z GET https://api.example.com/primary status=200',
+      '2026-02-24T10:00:01Z GET https://api.example.com/secondary status=200',
+    ].join('\n'),
+  );
+
+  const merged = mergeNetworkDumps(primary, secondary, 2);
+  const empty = mergeNetworkDumps(primary, secondary, 0);
+
+  assert.equal(merged.entries.length, 2);
+  assert.equal(merged.entries[0]?.url, 'https://api.example.com/primary');
+  assert.equal(merged.entries[1]?.url, 'https://api.example.com/secondary');
+  assert.equal(empty.entries.length, 0);
+});
+
+test('public observability mapper produces backend diagnostics result', () => {
+  const dump = readRecentNetworkTrafficFromText(
+    '2026-02-24T10:00:02Z {"method":"POST","url":"https://api.example.com/v1/login","statusCode":401,"headers":{"x-id":"abc"},"requestBody":{"email":"u@example.com"}}',
+    { backend: 'ios-simulator', include: 'all' },
+  );
+  dump.entries[0] = {
+    ...dump.entries[0],
+    packetId: 'packet-1',
+    metadata: { packetId: 'packet-1' },
+  };
+
+  const result = mapNetworkDumpToBackendResult(dump, {
+    backend: 'limrun',
+    redacted: true,
+    notes: ['Parsed recent Limrun app log output.'],
+  });
+
+  assert.equal(result.backend, 'limrun');
+  assert.equal(result.redacted, true);
+  assert.deepEqual(result.notes, ['Parsed recent Limrun app log output.']);
+  assert.equal(result.entries[0]?.url, 'https://api.example.com/v1/login');
+  assert.equal(result.entries[0]?.metadata?.packetId, 'packet-1');
+  assert.equal(result.entries[0]?.metadata?.headers, '{"x-id":"abc"}');
+  assert.equal('requestHeaders' in (result.entries[0] ?? {}), false);
+  assert.equal('raw' in (result.entries[0] ?? {}), false);
+  assert.equal('line' in (result.entries[0] ?? {}), false);
+});
+
+test('public observability mapper handles empty dumps', () => {
+  const dump = readRecentNetworkTrafficFromText('');
+  const result = mapNetworkDumpToBackendResult(dump, { backend: 'limrun' });
+
+  assert.equal(result.backend, 'limrun');
+  assert.deepEqual(result.entries, []);
+});
+
+test('public observability redaction handles network log secrets', () => {
+  const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.aVeryLongSignatureValue123456789';
+  const line =
+    `GET https://user:pass@api.example.com/path?token=secret-token&ok=1 Authorization: Bearer ${jwt} ` +
+    'Cookie: session=secret {"apiKey":"abc123"}';
+
+  const redactedLine = redactNetworkLogText(line);
+  const redactedText = redactNetworkLogText(`${line}\nnext password=secret`);
+
+  assert.equal(redactedLine.redacted, true);
+  assert.match(redactedLine.value, /REDACTED/);
+  assert.doesNotMatch(redactedLine.value, /secret-token|abc123|Bearer eyJ|session=secret/);
+  assert.equal(redactedText.redacted, true);
+  assert.doesNotMatch(redactedText.value, /password=secret/);
+
+  const parsed = readRecentNetworkTrafficFromText(redactedLine.value);
+  assert.equal(
+    parsed.entries[0]?.url,
+    'https://REDACTED:REDACTED@api.example.com/path?token=%5BREDACTED%5D&ok=1',
+  );
+});

--- a/src/commands/diagnostics-format.ts
+++ b/src/commands/diagnostics-format.ts
@@ -9,6 +9,10 @@ import type {
   DiagnosticsNetworkCommandResult,
   DiagnosticsPerfCommandResult,
 } from './diagnostics-types.ts';
+import {
+  redactNetworkLogText as redactText,
+  redactNetworkUrl,
+} from '../observability-redaction.ts';
 
 const PAYLOAD_MAX_CHARS = 2048;
 const MESSAGE_MAX_CHARS = 4096;
@@ -132,19 +136,10 @@ function redactHeaders(headers: Record<string, string> | undefined): {
 }
 
 function redactUrl(url: string): { value: string; redacted: boolean } {
-  try {
-    const parsed = new URL(url);
-    let redacted = false;
-    for (const key of Array.from(parsed.searchParams.keys())) {
-      if (SECRET_KEY_PATTERN.test(key)) {
-        parsed.searchParams.set(key, '[REDACTED]');
-        redacted = true;
-      }
-    }
-    return { value: parsed.toString(), redacted };
-  } catch {
-    return redactAndTruncate(url, PAYLOAD_MAX_CHARS) as { value: string; redacted: boolean };
-  }
+  return (
+    redactNetworkUrl(url) ??
+    (redactAndTruncate(url, PAYLOAD_MAX_CHARS) as { value: string; redacted: boolean })
+  );
 }
 
 function redactPayload(value: string | undefined): { value?: string; redacted: boolean } {
@@ -205,36 +200,6 @@ function redactAndTruncate(
   if (value === undefined) return { redacted: false };
   const result = redactText(value);
   return truncateRedacted(result.value, maxChars, result.redacted);
-}
-
-function redactText(value: string): { value: string; redacted: boolean } {
-  let redacted = false;
-  let next = value.replaceAll(
-    /(authorization|token|secret|password|passwd|api[-_]?key)=([^&\s]+)/gi,
-    (_match, key) => {
-      redacted = true;
-      return `${String(key)}=[REDACTED]`;
-    },
-  );
-  next = next.replaceAll(
-    /("(?:authorization|cookie|token|secret|password|passwd|api[-_]?key)"\s*:\s*")([^"]*)(")/gi,
-    (_match, prefix, _value, suffix) => {
-      redacted = true;
-      return `${String(prefix)}[REDACTED]${String(suffix)}`;
-    },
-  );
-  next = next.replaceAll(/\b(Bearer\s+)([^\s",;]+)/gi, (_match, prefix) => {
-    redacted = true;
-    return `${String(prefix)}[REDACTED]`;
-  });
-  next = next.replaceAll(
-    /((?:authorization|cookie|token|secret|password|passwd|api[-_]?key)\s*[:=]\s*)([^\s,;]+)/gi,
-    (_match, prefix) => {
-      redacted = true;
-      return `${String(prefix)}[REDACTED]`;
-    },
-  );
-  return { value: next, redacted };
 }
 
 function truncateRedacted(

--- a/src/daemon/network-log.ts
+++ b/src/daemon/network-log.ts
@@ -16,6 +16,7 @@ const ANDROID_NEARBY_LINE_RADIUS = 5;
 // OkHttp/Retrofit interceptor logs can spread request→response pairs across
 // many interleaved logcat lines.
 const ANDROID_PACKET_SCAN_RADIUS = 12;
+export const NETWORK_LOG_MEMORY_PATH = '<memory>';
 
 export type NetworkIncludeMode = 'summary' | 'headers' | 'body' | 'all';
 export type NetworkLogBackend = 'ios-simulator' | 'ios-device' | 'android' | 'macos';
@@ -140,7 +141,7 @@ export function readRecentNetworkTrafficFromText(
   }
 
   return {
-    path: options?.path ?? '<memory>',
+    path: options?.path ?? NETWORK_LOG_MEMORY_PATH,
     exists: true,
     scannedLines: lines.length,
     matchedLines: entries.length,

--- a/src/observability-redaction.ts
+++ b/src/observability-redaction.ts
@@ -1,0 +1,84 @@
+const SECRET_KEY_PATTERN = /(?:authorization|cookie|token|secret|password|passwd|api[-_]?key)/i;
+const JWT_LIKE_PATTERN = /\b[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b/g;
+
+export type RedactionResult = {
+  value: string;
+  redacted: boolean;
+};
+
+export function redactNetworkLogText(text: string): RedactionResult {
+  let redacted = false;
+  let next = text;
+  next = next.replaceAll(
+    /(authorization|token|secret|password|passwd|api[-_]?key)=([^&\s]+)/gi,
+    (_match, key) => {
+      redacted = true;
+      return `${String(key)}=[REDACTED]`;
+    },
+  );
+  next = next.replaceAll(
+    /("(?:authorization|cookie|token|secret|password|passwd|api[-_]?key)"\s*:\s*")([^"]*)(")/gi,
+    (_match, prefix, _value, suffix) => {
+      redacted = true;
+      return `${String(prefix)}[REDACTED]${String(suffix)}`;
+    },
+  );
+  next = next.replaceAll(/\b(Bearer\s+)([^\s",;]+)/gi, (_match, prefix) => {
+    redacted = true;
+    return `${String(prefix)}[REDACTED]`;
+  });
+  next = next.replaceAll(
+    /((?:authorization|cookie|token|secret|password|passwd|api[-_]?key)\s*[:=]\s*)([^\s,;&]+)/gi,
+    (_match, prefix) => {
+      redacted = true;
+      return `${String(prefix)}[REDACTED]`;
+    },
+  );
+  next = next.replaceAll(JWT_LIKE_PATTERN, () => {
+    redacted = true;
+    return '[REDACTED]';
+  });
+  next = redactUrlLikeValues(next, () => {
+    redacted = true;
+  });
+  return { value: next, redacted };
+}
+
+export function redactNetworkUrl(url: string): RedactionResult | undefined {
+  try {
+    const parsed = new URL(url);
+    let redacted = redactUrlSearchParams(parsed);
+    if (parsed.username || parsed.password) {
+      parsed.username = 'REDACTED';
+      parsed.password = 'REDACTED';
+      redacted = true;
+    }
+    return { value: parsed.toString(), redacted };
+  } catch {
+    return undefined;
+  }
+}
+
+function redactUrlLikeValues(value: string, markRedacted: () => void): string {
+  if (!/(https?:\/\/|token|secret|password|authorization|cookie|api[-_]?key)/i.test(value)) {
+    return value;
+  }
+  return value.replaceAll(/https?:\/\/[^\s"'<>)]+/gi, (candidate) => {
+    const result = redactNetworkUrl(candidate);
+    if (!result) return candidate;
+    if (result.redacted) markRedacted();
+    return result.value;
+  });
+}
+
+function redactUrlSearchParams(parsed: URL): boolean {
+  let redacted = false;
+  for (const key of Array.from(parsed.searchParams.keys())) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      // URLSearchParams intentionally percent-encodes the marker in the final URL.
+      parsed.searchParams.set(key, '[REDACTED]');
+      redacted = true;
+    }
+  }
+  return redacted;
+}

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,191 @@
+import type { BackendDumpNetworkResult, BackendNetworkEntry } from './backend.ts';
+import {
+  NETWORK_LOG_MEMORY_PATH,
+  readRecentNetworkTrafficFromText as readRecentNetworkTrafficFromTextInternal,
+  type NetworkEntry,
+  type NetworkIncludeMode as ParserNetworkIncludeMode,
+  type NetworkLogBackend as ParserNetworkLogBackend,
+} from './daemon/network-log.ts';
+export { redactNetworkLogText, type RedactionResult } from './observability-redaction.ts';
+
+export type NetworkIncludeMode = ParserNetworkIncludeMode;
+
+export type NetworkLogBackend = ParserNetworkLogBackend | (string & {});
+
+export type ParsedNetworkEntry = {
+  url: string;
+  timestamp?: string;
+  method?: string;
+  status?: number;
+  durationMs?: number;
+  headers?: string;
+  requestBody?: string;
+  responseBody?: string;
+  raw?: string;
+  line?: number;
+  packetId?: string;
+  metadata?: {
+    packetId?: string;
+    [key: string]: unknown;
+  };
+};
+
+export type ParsedNetworkDump = {
+  sourcePath?: string;
+  scannedLines: number;
+  matchedLines: number;
+  entries: ParsedNetworkEntry[];
+  include: NetworkIncludeMode;
+  limits: {
+    maxEntries: number;
+    maxPayloadChars: number;
+    maxScanLines: number;
+  };
+};
+
+export function readRecentNetworkTrafficFromText(
+  content: string,
+  options?: {
+    sourcePath?: string;
+    backend?: NetworkLogBackend;
+    maxEntries?: number;
+    include?: NetworkIncludeMode;
+    maxPayloadChars?: number;
+    maxScanLines?: number;
+  },
+): ParsedNetworkDump {
+  const dump = readRecentNetworkTrafficFromTextInternal(content, {
+    path: options?.sourcePath,
+    backend: toParserNetworkBackend(options?.backend),
+    maxEntries: options?.maxEntries,
+    include: options?.include,
+    maxPayloadChars: options?.maxPayloadChars,
+    maxScanLines: options?.maxScanLines,
+  });
+  return toParsedNetworkDump(dump, options?.sourcePath);
+}
+
+export function mergeNetworkDumps(
+  primary: ParsedNetworkDump,
+  secondary: ParsedNetworkDump,
+  maxEntries = primary.limits.maxEntries,
+): ParsedNetworkDump {
+  // Keep this public merge decoupled from daemon NetworkDump, which carries
+  // filesystem-only fields like exists/path.
+  const limit = Math.max(0, maxEntries);
+  const entries = primary.entries.slice(0, limit);
+  const seen = new Set(entries.map((entry) => networkEntryKey(entry)));
+  for (const entry of secondary.entries) {
+    if (entries.length >= limit) break;
+    const key = networkEntryKey(entry);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    entries.push(entry);
+  }
+  return {
+    ...primary,
+    matchedLines: entries.length,
+    entries,
+  };
+}
+
+export function mapNetworkDumpToBackendResult(
+  dump: ParsedNetworkDump,
+  options?: {
+    backend?: string;
+    redacted?: boolean;
+    notes?: readonly string[];
+  },
+): BackendDumpNetworkResult {
+  // The parser exposes diagnostic raw/line/header fields. Backend results keep
+  // raw transport details out of first-class fields and preserve them only as metadata.
+  return {
+    entries: dump.entries.map((entry) => toBackendNetworkEntry(entry)),
+    ...(options?.backend ? { backend: options.backend } : {}),
+    ...(options?.redacted !== undefined ? { redacted: options.redacted } : {}),
+    ...(options?.notes ? { notes: options.notes } : {}),
+  };
+}
+
+function toParsedNetworkDump(
+  dump: {
+    path?: string;
+    scannedLines: number;
+    matchedLines: number;
+    entries: NetworkEntry[];
+    include: NetworkIncludeMode;
+    limits: ParsedNetworkDump['limits'];
+  },
+  sourcePath: string | undefined,
+): ParsedNetworkDump {
+  const resolvedSourcePath =
+    sourcePath ?? (dump.path === NETWORK_LOG_MEMORY_PATH ? undefined : dump.path);
+  return {
+    ...(resolvedSourcePath ? { sourcePath: resolvedSourcePath } : {}),
+    scannedLines: dump.scannedLines,
+    matchedLines: dump.matchedLines,
+    entries: dump.entries.map((entry) => ({
+      url: entry.url,
+      ...(entry.timestamp ? { timestamp: entry.timestamp } : {}),
+      ...(entry.method ? { method: entry.method } : {}),
+      ...(entry.status !== undefined ? { status: entry.status } : {}),
+      ...(entry.durationMs !== undefined ? { durationMs: entry.durationMs } : {}),
+      ...(entry.headers ? { headers: entry.headers } : {}),
+      ...(entry.requestBody !== undefined ? { requestBody: entry.requestBody } : {}),
+      ...(entry.responseBody !== undefined ? { responseBody: entry.responseBody } : {}),
+      ...(entry.raw ? { raw: entry.raw } : {}),
+      ...(entry.line !== undefined ? { line: entry.line } : {}),
+      ...(entry.packetId
+        ? { packetId: entry.packetId, metadata: { packetId: entry.packetId } }
+        : {}),
+    })),
+    include: dump.include,
+    limits: dump.limits,
+  };
+}
+
+function toBackendNetworkEntry(entry: ParsedNetworkEntry): BackendNetworkEntry {
+  const metadata = buildBackendMetadata(entry);
+  return {
+    ...(entry.timestamp ? { timestamp: entry.timestamp } : {}),
+    ...(entry.method ? { method: entry.method } : {}),
+    url: entry.url,
+    ...(entry.status !== undefined ? { status: entry.status } : {}),
+    ...(entry.durationMs !== undefined ? { durationMs: entry.durationMs } : {}),
+    ...(entry.requestBody !== undefined ? { requestBody: entry.requestBody } : {}),
+    ...(entry.responseBody !== undefined ? { responseBody: entry.responseBody } : {}),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+function buildBackendMetadata(entry: ParsedNetworkEntry): Record<string, unknown> | undefined {
+  const metadata: Record<string, unknown> = { ...(entry.metadata ?? {}) };
+  if (entry.packetId && metadata.packetId === undefined) {
+    metadata.packetId = entry.packetId;
+  }
+  if (entry.headers && metadata.headers === undefined) {
+    metadata.headers = entry.headers;
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function networkEntryKey(entry: ParsedNetworkEntry): string {
+  return `${entry.timestamp ?? ''}|${entry.method ?? ''}|${entry.url}|${entry.status ?? ''}|${entry.raw ?? ''}`;
+}
+
+function toParserNetworkBackend(
+  backend: NetworkLogBackend | undefined,
+): ParserNetworkLogBackend | undefined {
+  switch (backend) {
+    case 'ios-simulator':
+      return 'ios-simulator';
+    case 'ios-device':
+      return 'ios-device';
+    case 'android':
+      return 'android';
+    case 'macos':
+      return 'macos';
+    default:
+      return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Export `agent-device/observability` with portable network dump parsing, merge, backend mapping, and text redaction helpers.
Reuse the existing network parser, keep filesystem log reading internal, keep daemon backend typing closed, and expose custom backend labels only at the public boundary. Touched 7 files; scope stayed within observability/parser exports and tests.

## Validation

- `pnpm format`
- `pnpm vitest run src/__tests__/observability.test.ts`
- `pnpm check:tooling`
- `pnpm check:unit`