### PR TITLE
refactor: avoid duplicate packet metadata

### DIFF
--- a/src/__tests__/observability.test.ts
+++ b/src/__tests__/observability.test.ts
@@ -75,7 +75,7 @@ test('public observability parser preserves Android packet IDs', () => {
 
   assert.equal(dump.entries.length, 1);
   assert.equal(dump.entries[0]?.packetId, '23911610');
-  assert.equal(dump.entries[0]?.metadata?.packetId, '23911610');
+  assert.equal(dump.entries[0]?.metadata?.packetId, undefined);
 });
 
 test('public observability merge de-duplicates entries and honors max entries', () => {
@@ -106,7 +106,6 @@ test('public observability mapper produces backend diagnostics result', () => {
   dump.entries[0] = {
     ...dump.entries[0],
     packetId: 'packet-1',
-    metadata: { packetId: 'packet-1' },
   };
 
   const result = mapNetworkDumpToBackendResult(dump, {

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -135,9 +135,7 @@ function toParsedNetworkDump(
       ...(entry.responseBody !== undefined ? { responseBody: entry.responseBody } : {}),
       ...(entry.raw ? { raw: entry.raw } : {}),
       ...(entry.line !== undefined ? { line: entry.line } : {}),
-      ...(entry.packetId
-        ? { packetId: entry.packetId, metadata: { packetId: entry.packetId } }
-        : {}),
+      ...(entry.packetId ? { packetId: entry.packetId } : {}),
     })),
     include: dump.include,
     limits: dump.limits,


### PR DESCRIPTION
## Summary

Keep parsed network entries from duplicating packet IDs in both `packetId` and `metadata.packetId`.
Leave `mapNetworkDumpToBackendResult` responsible for moving `packetId` into backend metadata.

## Validation

- `pnpm format`
- `pnpm vitest run src/__tests__/observability.test.ts`
- `pnpm typecheck`
- `pnpm check:tooling`
- `pnpm check:unit`