### PR TITLE
fix: preserve scoped Android snapshot refs

### DIFF
--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -226,9 +226,10 @@ test('handleFindCommands click returns deterministic metadata across locator var
       positionals: ['Increment', 'click'],
       nodes: [hittableParentNoRect, nonHittableChildWithRect],
       invoke: async () => ({ platformSpecificRef: 'XCUIElementTypeView' }),
-      expectedKeys: ['locator', 'query', 'ref'],
+      expectedKeys: ['locator', 'query', 'ref', 'x', 'y'],
       expectedLocator: 'any',
       expectedQuery: 'Increment',
+      expectedCoordinates: { x: 100, y: 50 },
     },
     {
       label: 'keeps explicit label locator in metadata',

--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -11,6 +11,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { CommandFlags } from '../../../core/dispatch.ts';
 import { handleSessionCommands } from '../session.ts';
+import { healReplayAction } from '../session-replay-heal.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionAction } from '../../types.ts';
 import type { DeviceInfo } from '../../../utils/device.ts';
@@ -88,6 +89,59 @@ function tokenizeReplayLine(line: string): string[] {
   }
   return tokens;
 }
+
+test('replay heal snapshot refresh clears stale scoped snapshot source', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-scope-source-'));
+  const sessionsDir = path.join(tempRoot, 'sessions');
+  const sessionStore = new SessionStore(sessionsDir);
+  const sessionName = 'heal-scope-source-session';
+  const session = makeSession(sessionName);
+  session.snapshotScopeSource = {
+    nodes: [
+      {
+        ref: 'e1',
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        label: 'Stale button',
+      },
+    ],
+    createdAt: Date.now(),
+    backend: 'xctest',
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatchCommand.mockResolvedValue({
+    nodes: [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        label: 'Continue',
+        rect: { x: 0, y: 0, width: 100, height: 44 },
+        hittable: true,
+      },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const healed = await healReplayAction({
+    action: {
+      ts: Date.now(),
+      command: 'click',
+      positionals: ['label="Continue"'],
+      flags: {},
+      result: {},
+    },
+    sessionName,
+    logPath: '/tmp/replay.log',
+    sessionStore,
+  });
+
+  expect(healed?.positionals[0]).toContain('label="Continue"');
+  expect(sessionStore.get(sessionName)?.snapshotScopeSource).toBeUndefined();
+});
 
 test('replay --update heals selector and rewrites replay file', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-'));

--- a/src/daemon/handlers/__tests__/snapshot-scoped-refs.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-scoped-refs.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { handleSnapshotCommands } from '../snapshot.ts';
+import type { RawSnapshotNode, SnapshotState } from '../../../utils/snapshot.ts';
+import { dispatchCommand } from '../../../core/dispatch.ts';
+import { makeAndroidSession } from '../../../__tests__/test-utils/index.ts';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return {
+    ...actual,
+    dispatchCommand: vi.fn(async () => ({})),
+  };
+});
+
+const mockDispatch = vi.mocked(dispatchCommand);
+const ANDROID_SCRIPT_ERROR = 'Unable to load script. Make sure you are running Metro.';
+
+beforeEach(() => {
+  mockDispatch.mockReset();
+  mockDispatch.mockResolvedValue({});
+});
+
+test('snapshot resolves @ref scope with the stored source after scoped output replaces refs', async () => {
+  const sessionStore = makeSessionStore('agent-device-snapshot-scoped-refs-');
+  const sessionName = 'android-ref-scope-repeat';
+  const session = makeAndroidSession(sessionName, { snapshot: androidRefScopeSourceSnapshot() });
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockResolvedValue({
+    nodes: scopedScriptErrorNodes(),
+    truncated: false,
+    backend: 'android',
+  });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await requestScopedSnapshot(sessionName, sessionStore, '@e3');
+
+    expect(response?.ok).toBe(true);
+    if (response?.ok) expect(response.data?.nodes).toHaveLength(2);
+  }
+
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
+  expect(mockDispatch.mock.calls.map((call) => call[4])).toEqual([
+    expect.objectContaining({ snapshotScope: ANDROID_SCRIPT_ERROR }),
+    expect.objectContaining({ snapshotScope: ANDROID_SCRIPT_ERROR }),
+  ]);
+  expect(sessionStore.get(sessionName)?.snapshot?.nodes).toHaveLength(2);
+  expect(sessionStore.get(sessionName)?.snapshotScopeSource?.nodes[2]?.ref).toBe('e3');
+});
+
+test('empty @ref-scoped snapshot output does not replace the stored session snapshot', async () => {
+  const sessionStore = makeSessionStore('agent-device-snapshot-scoped-refs-');
+  const sessionName = 'android-empty-scope-preserve';
+  const session = makeAndroidSession(sessionName, { snapshot: currentScreenSnapshot() });
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockResolvedValue({
+    nodes: [],
+    truncated: false,
+    backend: 'android',
+  });
+
+  const response = await requestScopedSnapshot(sessionName, sessionStore, '@e1');
+
+  expect(response?.ok).toBe(true);
+  if (response?.ok) expect(response.data?.nodes).toEqual([]);
+  expect(sessionStore.get(sessionName)?.snapshot?.nodes[0]?.label).toBe('Current screen');
+});
+
+function requestScopedSnapshot(
+  sessionName: string,
+  sessionStore: ReturnType<typeof makeSessionStore>,
+  snapshotScope: string,
+) {
+  return handleSnapshotCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'snapshot',
+      positionals: [],
+      flags: { snapshotScope },
+    },
+    sessionName,
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+  });
+}
+
+function currentScreenSnapshot(): SnapshotState {
+  return {
+    nodes: [
+      { ref: 'e1', index: 0, depth: 0, type: 'android.widget.TextView', label: 'Current screen' },
+    ],
+    createdAt: Date.now(),
+    backend: 'android',
+  };
+}
+
+function androidRefScopeSourceSnapshot(): SnapshotState {
+  return {
+    nodes: [
+      {
+        ref: 'e1',
+        index: 0,
+        depth: 0,
+        type: 'android.widget.FrameLayout',
+        rect: { x: 0, y: 0, width: 390, height: 844 },
+      },
+      {
+        ref: 'e2',
+        index: 1,
+        depth: 1,
+        parentIndex: 0,
+        type: 'androidx.recyclerview.widget.RecyclerView',
+        rect: { x: 0, y: 80, width: 390, height: 600 },
+      },
+      {
+        ref: 'e3',
+        index: 2,
+        depth: 2,
+        parentIndex: 1,
+        type: 'android.widget.TextView',
+        label: ANDROID_SCRIPT_ERROR,
+        value: ANDROID_SCRIPT_ERROR,
+        rect: { x: 16, y: 120, width: 358, height: 200 },
+      },
+      {
+        ref: 'e4',
+        index: 3,
+        depth: 3,
+        parentIndex: 2,
+        type: 'android.widget.TextView',
+        label: 'loadJSBundleFromAssets',
+        rect: { x: 16, y: 140, width: 358, height: 40 },
+      },
+    ],
+    createdAt: Date.now(),
+    backend: 'android',
+  };
+}
+
+function scopedScriptErrorNodes(): RawSnapshotNode[] {
+  return [
+    {
+      index: 0,
+      depth: 0,
+      type: 'android.widget.TextView',
+      label: ANDROID_SCRIPT_ERROR,
+      value: ANDROID_SCRIPT_ERROR,
+      rect: { x: 16, y: 120, width: 358, height: 200 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.widget.TextView',
+      label: 'loadJSBundleFromAssets',
+      rect: { x: 16, y: 140, width: 358, height: 40 },
+    },
+  ];
+}

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -9,6 +9,7 @@ import { ensureDeviceReady } from '../device-ready.ts';
 import { extractNodeText, findNearestHittableAncestor } from '../snapshot-processing.ts';
 import { readTextForNode } from './interaction-read.ts';
 import { captureSnapshot } from './snapshot-capture.ts';
+import { setSessionSnapshot } from '../session-snapshot.ts';
 import { errorResponse } from './response.ts';
 import { getActiveAndroidSnapshotFreshness } from '../android-snapshot-freshness.ts';
 import { dispatchFindReadOnlyViaRuntime } from '../selector-runtime.ts';
@@ -109,7 +110,7 @@ export async function handleFindCommands(params: {
     lastSnapshotAt = now;
     lastNodes = nodes;
     if (session) {
-      session.snapshot = snapshot;
+      setSessionSnapshot(session, snapshot);
       sessionStore.set(sessionName, session);
     }
     return { nodes, truncated: snapshot.truncated, backend: snapshot.backend };

--- a/src/daemon/handlers/interaction-runtime.ts
+++ b/src/daemon/handlers/interaction-runtime.ts
@@ -8,6 +8,7 @@ import { createAgentDevice, localCommandPolicy } from '../../runtime.ts';
 import { AppError } from '../../utils/errors.ts';
 import type { SessionState } from '../types.ts';
 import { createUnsupportedArtifactAdapter } from '../runtime-artifacts.ts';
+import { setSessionSnapshot } from '../session-snapshot.ts';
 import type { InteractionHandlerParams } from './interaction-common.ts';
 import type { CaptureSnapshotForSession } from './interaction-snapshot.ts';
 
@@ -34,7 +35,7 @@ export function createInteractionRuntime(
           : undefined,
       set: (record) => {
         if (!record.snapshot) return;
-        session.snapshot = record.snapshot;
+        setSessionSnapshot(session, record.snapshot);
         params.sessionStore.set(params.sessionName, session);
       },
     },

--- a/src/daemon/handlers/interaction-snapshot.ts
+++ b/src/daemon/handlers/interaction-snapshot.ts
@@ -4,6 +4,7 @@ import type { SessionState } from '../types.ts';
 import type { SnapshotState } from '../../utils/snapshot.ts';
 import type { ContextFromFlags } from './interaction-common.ts';
 import { captureSnapshot } from './snapshot-capture.ts';
+import { setSessionSnapshot } from '../session-snapshot.ts';
 
 export type CaptureSnapshotForSession = (
   session: SessionState,
@@ -38,7 +39,7 @@ export async function captureSnapshotForSession(
     logPath: dispatchContext.logPath ?? '',
     androidFreshnessMode: options.androidFreshnessMode,
   });
-  session.snapshot = snapshot;
+  setSessionSnapshot(session, snapshot);
   sessionStore.set(session.name, session);
-  return session.snapshot;
+  return snapshot;
 }

--- a/src/daemon/handlers/session-replay-heal.ts
+++ b/src/daemon/handlers/session-replay-heal.ts
@@ -1,4 +1,5 @@
 import { dispatchCommand } from '../../core/dispatch.ts';
+import { setSessionSnapshot } from '../session-snapshot.ts';
 import {
   attachRefs,
   type RawSnapshotNode,
@@ -198,7 +199,7 @@ async function captureSnapshotForReplay(
     createdAt: Date.now(),
     backend: data?.backend,
   };
-  session.snapshot = snapshot;
+  setSessionSnapshot(session, snapshot);
   sessionStore.set(session.name, session);
   return snapshot;
 }

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -60,7 +60,7 @@ export async function captureSnapshot(params: CaptureSnapshotParams): Promise<{
   const data = await captureSnapshotData(params);
   clearAndroidSnapshotFreshness(params.session);
   return {
-    snapshot: buildSnapshotState(data, params.flags),
+    snapshot: buildSnapshotState(data, resolveSnapshotStateFlags(params)),
     analysis: data.analysis,
   };
 }
@@ -146,7 +146,19 @@ async function captureSnapshotAttempt(
   const data = await captureSnapshotData(params);
   return {
     data,
-    snapshot: buildSnapshotState(data, params.flags),
+    snapshot: buildSnapshotState(data, resolveSnapshotStateFlags(params)),
+  };
+}
+
+function resolveSnapshotStateFlags(
+  params: Pick<CaptureSnapshotParams, 'flags' | 'snapshotScope'>,
+): CaptureSnapshotParams['flags'] {
+  if (params.snapshotScope === undefined) {
+    return params.flags;
+  }
+  return {
+    ...params.flags,
+    snapshotScope: params.snapshotScope,
   };
 }
 
@@ -350,8 +362,16 @@ export function resolveSnapshotScope(
   if (!ref) {
     return errorResponse('INVALID_ARGS', `Invalid ref scope: ${snapshotScope}`);
   }
-  const node = findNodeByRef(session.snapshot.nodes, ref);
-  const resolved = node ? resolveRefLabel(node, session.snapshot.nodes) : undefined;
+  const candidates = [
+    session.snapshot,
+    ...(session.snapshotScopeSource ? [session.snapshotScopeSource] : []),
+  ];
+  let resolved: string | undefined;
+  for (const snapshot of candidates) {
+    const node = findNodeByRef(snapshot.nodes, ref);
+    resolved = node ? resolveRefLabel(node, snapshot.nodes) : undefined;
+    if (resolved) break;
+  }
   if (!resolved) {
     return errorResponse('COMMAND_FAILED', `Ref ${snapshotScope} not found or has no label`);
   }

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -23,6 +23,7 @@ import { handleInteractionCommands } from './handlers/interaction.ts';
 import { handleLeaseCommands } from './handlers/lease.ts';
 import { buildSnapshotState, captureSnapshotData } from './handlers/snapshot-capture.ts';
 import { assertSessionSelectorMatches } from './session-selector.ts';
+import { setSessionSnapshot } from './session-snapshot.ts';
 import { applyRequestLockPolicy } from './request-lock-policy.ts';
 import { resolveEffectiveSessionName } from './session-routing.ts';
 import { normalizeTenantId, resolveSessionIsolationMode } from './config.ts';
@@ -473,7 +474,7 @@ async function applyScreenshotOverlay(
     snapshotScope: undefined,
   });
   const overlaySnapshot = buildSnapshotState(overlaySnapshotData, undefined);
-  session.snapshot = overlaySnapshot;
+  setSessionSnapshot(session, overlaySnapshot);
   const overlayRefs = await annotateScreenshotWithRefs({
     screenshotPath: data.path as string,
     snapshot: overlaySnapshot,

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -31,6 +31,7 @@ import type { IsCommandOptions } from '../commands/selector-read.ts';
 import { isSupportedPredicate } from './is-predicates.ts';
 import type { ContextFromFlags } from './handlers/interaction-common.ts';
 import { createUnsupportedArtifactAdapter } from './runtime-artifacts.ts';
+import { setSessionSnapshot } from './session-snapshot.ts';
 import { getActiveAndroidSnapshotFreshness } from './android-snapshot-freshness.ts';
 import {
   describeAndroidEscapeSurface,
@@ -232,7 +233,7 @@ function createSelectorRuntimeForDevice(params: {
       get: (name) => (name === params.sessionName ? toCommandSession(params.session) : undefined),
       set: (record) => {
         if (!params.session || !record.snapshot) return;
-        params.session.snapshot = record.snapshot;
+        setSessionSnapshot(params.session, record.snapshot);
         params.sessionStore.set(params.sessionName, params.session);
       },
     },
@@ -312,7 +313,7 @@ function createSelectorBackend(params: {
         snapshotScope,
       });
       if (session) {
-        session.snapshot = capture.snapshot;
+        setSessionSnapshot(session, capture.snapshot);
         sessionStore.set(sessionName, session);
       }
       lastSnapshotAt = timestamp;
@@ -405,7 +406,7 @@ async function captureWaitSnapshot(params: {
     logPath: params.logPath ?? '',
   });
   if (params.session) {
-    params.session.snapshot = capture.snapshot;
+    setSessionSnapshot(params.session, capture.snapshot);
     params.sessionStore.set(params.sessionName, params.session);
   }
   return capture.snapshot;

--- a/src/daemon/session-snapshot.ts
+++ b/src/daemon/session-snapshot.ts
@@ -1,0 +1,7 @@
+import type { SnapshotState } from '../utils/snapshot.ts';
+import type { SessionState } from './types.ts';
+
+export function setSessionSnapshot(session: SessionState, snapshot: SnapshotState): void {
+  session.snapshot = snapshot;
+  session.snapshotScopeSource = undefined;
+}

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -138,19 +138,74 @@ function createSnapshotRuntime(params: {
           throw new AppError('UNKNOWN', 'snapshot runtime did not produce session state');
         }
         const current = sessionStore.get(sessionName);
-        const nextSession = buildSnapshotSession({
-          session: current,
+        sessionStore.set(
           sessionName,
-          device,
-          snapshot: record.snapshot,
-          appBundleId: record.appBundleId,
-        });
-        if (record.appName) nextSession.appName = record.appName;
-        sessionStore.set(sessionName, nextSession);
+          buildNextSnapshotSession({
+            current,
+            sessionName,
+            device,
+            record,
+            refScopedSnapshot: isRefScopedSnapshot(req),
+          }),
+        );
       },
     },
     policy: localCommandPolicy(),
   });
+}
+
+function buildNextSnapshotSession(params: {
+  current: SessionState | undefined;
+  sessionName: string;
+  device: SessionState['device'];
+  record: CommandSessionRecord;
+  refScopedSnapshot: boolean;
+}): SessionState {
+  const { current, sessionName, device, record, refScopedSnapshot } = params;
+  if (!record.snapshot) {
+    throw new AppError('UNKNOWN', 'snapshot runtime did not produce session state');
+  }
+  const keepCurrentSnapshot = shouldKeepCurrentSnapshot(current, record, refScopedSnapshot);
+  const snapshot = keepCurrentSnapshot ? current.snapshot : record.snapshot;
+  const nextSession = buildSnapshotSession({
+    session: current,
+    sessionName,
+    device,
+    snapshot,
+    appBundleId: record.appBundleId,
+  });
+  nextSession.snapshotScopeSource = resolveNextSnapshotScopeSource({
+    current,
+    keepCurrentSnapshot,
+    refScopedSnapshot,
+  });
+  if (record.appName) nextSession.appName = record.appName;
+  return nextSession;
+}
+
+function isRefScopedSnapshot(req: DaemonRequest): boolean {
+  return req.flags?.snapshotScope?.trim().startsWith('@') === true;
+}
+
+function shouldKeepCurrentSnapshot(
+  current: SessionState | undefined,
+  record: CommandSessionRecord,
+  refScopedSnapshot: boolean,
+): current is SessionState & { snapshot: NonNullable<SessionState['snapshot']> } {
+  return (
+    refScopedSnapshot && record.snapshot?.nodes.length === 0 && current?.snapshot !== undefined
+  );
+}
+
+function resolveNextSnapshotScopeSource(params: {
+  current: SessionState | undefined;
+  keepCurrentSnapshot: boolean;
+  refScopedSnapshot: boolean;
+}): SessionState['snapshotScopeSource'] {
+  const { current, keepCurrentSnapshot, refScopedSnapshot } = params;
+  if (!refScopedSnapshot) return undefined;
+  if (keepCurrentSnapshot) return current?.snapshotScopeSource;
+  return current?.snapshotScopeSource ?? current?.snapshot;
 }
 
 function createDaemonSnapshotBackend(params: {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -164,6 +164,8 @@ export type SessionState = {
   appBundleId?: string;
   appName?: string;
   snapshot?: SnapshotState;
+  /** Source snapshot used to resolve repeated `snapshot -s @ref` after scoped output replaces refs. */
+  snapshotScopeSource?: SnapshotState;
   androidSnapshotFreshness?: AndroidSnapshotFreshness;
   trace?: {
     outPath: string;

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -436,6 +436,59 @@ test('formatSnapshotText normalizes RecyclerView containers to list', () => {
   assert.match(text, /^  \[content below list hidden\]$/m);
 });
 
+test('formatSnapshotText renders hidden-below list hints after visible descendants', () => {
+  const text = withNoColor(() =>
+    formatSnapshotText({
+      nodes: [
+        {
+          ref: 'e1',
+          index: 0,
+          depth: 0,
+          type: 'android.view.ViewGroup',
+          rect: { x: 0, y: 0, width: 390, height: 844 },
+        },
+        {
+          ref: 'e2',
+          index: 1,
+          depth: 1,
+          parentIndex: 0,
+          type: 'androidx.recyclerview.widget.RecyclerView',
+          rect: { x: 0, y: 80, width: 390, height: 600 },
+          hiddenContentBelow: true,
+        },
+        {
+          ref: 'e3',
+          index: 2,
+          depth: 2,
+          parentIndex: 1,
+          type: 'android.widget.TextView',
+          label: 'Text view',
+          rect: { x: 16, y: 120, width: 358, height: 80 },
+        },
+        {
+          ref: 'e4',
+          index: 3,
+          depth: 3,
+          parentIndex: 2,
+          type: 'android.widget.TextView',
+          label: 'loadJSBundleFromAssets',
+          rect: { x: 16, y: 140, width: 358, height: 40 },
+        },
+      ],
+      truncated: false,
+    }),
+  );
+
+  assert.match(text, /^@e2 \[list\]$/m);
+  assert.match(text, /^  @e3 \[text\] "Text view"$/m);
+  assert.match(text, /^    @e4 \[text\] "loadJSBundleFromAssets"$/m);
+  assert.match(text, /^  \[content below list hidden\]$/m);
+  assert.ok(
+    text.indexOf('@e4 [text] "loadJSBundleFromAssets"') <
+      text.indexOf('[content below list hidden]'),
+  );
+});
+
 test('formatSnapshotText marks visible scroll areas with hidden content above and below', () => {
   const text = withNoColor(() =>
     formatSnapshotText({

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -569,10 +569,28 @@ function detectPossibleRepeatedNavSubtree(nodes: SnapshotNode[]): boolean {
 }
 
 function renderSnapshotDisplayLines(lines: ReturnType<typeof buildSnapshotDisplayLines>): string[] {
-  return lines.flatMap((line) => [line.text, ...readHiddenContentHintLines(line)]);
+  const output: string[] = [];
+  const pendingBelow: ReturnType<typeof buildSnapshotDisplayLines> = [];
+  const flushClosedBelowHints = (nextDepth: number) => {
+    while (pendingBelow.length > 0 && nextDepth <= pendingBelow[pendingBelow.length - 1]!.depth) {
+      output.push(...readHiddenContentHintLines(pendingBelow.pop()!, 'below'));
+    }
+  };
+
+  for (const line of lines) {
+    flushClosedBelowHints(line.depth);
+    output.push(line.text);
+    output.push(...readHiddenContentHintLines(line, 'above'));
+    if (line.node.hiddenContentBelow) {
+      pendingBelow.push(line);
+    }
+  }
+  flushClosedBelowHints(0);
+  return output;
 }
 
 function buildFlattenedSnapshotDisplayLines(nodes: SnapshotNode[]): string[] {
+  // Flattened output has no subtree boundary to defer below-hints past.
   return buildSnapshotDisplayLines(nodes, { summarizeTextSurfaces: true }).flatMap((line) => [
     formatSnapshotLine(line.node, 0, false, line.type, { summarizeTextSurfaces: true }),
     ...readHiddenContentHintLines({ ...line, depth: 0 }),
@@ -581,16 +599,17 @@ function buildFlattenedSnapshotDisplayLines(nodes: SnapshotNode[]): string[] {
 
 function readHiddenContentHintLines(
   line: ReturnType<typeof buildSnapshotDisplayLines>[number],
+  direction?: 'above' | 'below',
 ): string[] {
   const target = hintTargetLabel(line.type);
   if (!target) {
     return [];
   }
   const hints: string[] = [];
-  if (line.node.hiddenContentAbove) {
+  if (line.node.hiddenContentAbove && direction !== 'below') {
     hints.push(`[content above ${target} hidden]`);
   }
-  if (line.node.hiddenContentBelow) {
+  if (line.node.hiddenContentBelow && direction !== 'above') {
     hints.push(`[content below ${target} hidden]`);
   }
   if (hints.length === 0) {


### PR DESCRIPTION
## Summary

Fix Android scoped snapshots so `snapshot -s @ref` resolves against the prior ref source without double-filtering by the raw ref.
Render hidden-below list hints after visible descendants and keep scoped snapshot fallback state from leaking after unrelated snapshot refreshes.

Review and CI follow-up: centralized session snapshot replacement through `setSessionSnapshot`, cleared the scope source for replay-heal refreshes too, moved scoped-ref coverage into a focused test file to keep Fallow clean, and updated the stale `find` metadata expectation.

Touched files: 15. Scope stayed within snapshot/session formatting and session snapshot refresh paths.

## Validation

- `pnpm exec vitest run src/daemon/handlers/__tests__/find.test.ts`
- `pnpm exec vitest run src/daemon/handlers/__tests__/snapshot-scoped-refs.test.ts`
- `pnpm exec vitest run src/daemon/handlers/__tests__/snapshot-handler.test.ts`
- `pnpm format`
- `pnpm check:quick`
- `pnpm check:fallow`
- `pnpm check:unit`
