### PR TITLE
fix: harden Node runtime cleanup

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -5,11 +5,11 @@ inputs:
   node-version:
     description: 'Node.js version'
     required: false
-    default: '22'
+    default: '22.19'
   pnpm-version:
     description: 'pnpm version'
     required: false
-    default: '9.12.2'
+    default: '10.33.2'
   install-deps:
     description: 'Whether to install dependencies with pnpm install --frozen-lockfile'
     required: false

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/callstackincubator/agent-device/issues"
   },
   "type": "module",
+  "packageManager": "pnpm@10.33.2",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {
@@ -58,7 +59,7 @@
     }
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.19"
   },
   "bin": {
     "agent-device": "bin/agent-device.mjs"
@@ -75,7 +76,7 @@
     "build:all": "pnpm build:node && pnpm build:xcuitest",
     "ad": "node bin/agent-device.mjs",
     "lint": "oxlint . --deny-warnings",
-    "format": "oxfmt --write src test skills package.json tsconfig.json .oxlintrc.json .oxfmtrc.json '!test/skillgym/.skillgym-results/**'",
+    "format": "oxfmt --write src test skills package.json tsconfig.json tsconfig.lib.json rslib.config.ts vitest.config.ts .github/actions/setup-node-pnpm/action.yml .oxlintrc.json .oxfmtrc.json '!test/skillgym/.skillgym-results/**'",
     "fallow": "fallow --summary",
     "fallow:baseline": "(fallow dead-code --save-baseline fallow-baselines/dead-code.json --summary || true) && (fallow dupes --save-baseline fallow-baselines/dupes.json --summary || true) && (fallow health --save-baseline fallow-baselines/health.json --summary || true)",
     "check:fallow": "fallow audit",

--- a/src/__tests__/client-companion-tunnel-worker.test.ts
+++ b/src/__tests__/client-companion-tunnel-worker.test.ts
@@ -38,12 +38,15 @@ function createDeferred<T>(): Deferred<T> {
 }
 
 function waitFor<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  return Promise.race([
-    promise,
-    delay(timeoutMs).then(() => {
-      throw new Error(`Timed out waiting for ${label}.`);
-    }),
-  ]);
+  let timeout: NodeJS.Timeout | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${label}.`));
+    }, timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
 }
 
 function encodeTextFrame(text: string): Buffer {

--- a/src/__tests__/client-metro.test.ts
+++ b/src/__tests__/client-metro.test.ts
@@ -10,6 +10,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { prepareMetroRuntime, reloadMetro } from '../client-metro.ts';
 import { AppError } from '../utils/errors.ts';
+import { isProcessAlive, waitForProcessExit } from '../utils/process-identity.ts';
 
 const TEST_TOKEN = 'agent-device-proxy-test-token';
 
@@ -163,11 +164,7 @@ test('prepareMetroRuntime starts Metro, bridges through proxy, and writes runtim
       socket.destroy();
     }
     await closeServer(proxyServer);
-    if (pid) {
-      try {
-        process.kill(pid);
-      } catch {}
-    }
+    await stopProcess(pid);
     rmSync(tempRoot, { recursive: true, force: true });
   }
 });
@@ -325,4 +322,20 @@ async function closeServer(server: ReturnType<typeof createServer>): Promise<voi
       resolve();
     });
   });
+}
+
+async function stopProcess(pid: number): Promise<void> {
+  if (!pid || !isProcessAlive(pid)) return;
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    return;
+  }
+  if (await waitForProcessExit(pid, 1_500)) return;
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    return;
+  }
+  await waitForProcessExit(pid, 1_500);
 }

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -3,6 +3,7 @@ import http from 'node:http';
 import https from 'node:https';
 import fs from 'node:fs';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import { sleep } from './utils/timeouts.ts';
 import { AppError, toAppErrorCode } from './utils/errors.ts';
 import type {
@@ -1334,13 +1335,6 @@ export async function downloadRemoteArtifact(params: {
           });
           return;
         }
-        const output = fs.createWriteStream(params.destinationPath);
-        output.on('error', (error) => {
-          settle(error instanceof Error ? error : new Error(String(error)));
-        });
-        res.on('error', (error) => {
-          settle(error instanceof Error ? error : new Error(String(error)));
-        });
         res.on('aborted', () => {
           settle(
             new AppError('COMMAND_FAILED', 'Remote artifact download was interrupted', {
@@ -1349,10 +1343,10 @@ export async function downloadRemoteArtifact(params: {
             }),
           );
         });
-        output.on('finish', () => {
-          output.close(() => settle());
-        });
-        res.pipe(output);
+        void pipeline(res, fs.createWriteStream(params.destinationPath)).then(
+          () => settle(),
+          (error: unknown) => settle(error instanceof Error ? error : new Error(String(error))),
+        );
       },
     );
     const timeoutHandle = setTimeout(() => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -9,6 +9,8 @@ import { trackDownloadableArtifact } from './daemon/artifact-tracking.ts';
 import { LeaseRegistry } from './daemon/lease-registry.ts';
 import { createRequestHandler } from './daemon/request-router.ts';
 import { teardownSessionResources } from './daemon/handlers/session-close.ts';
+import { closeDaemonServers } from './daemon/server-shutdown.ts';
+import type { SessionState } from './daemon/types.ts';
 import {
   emitDiagnostic,
   flushDiagnosticsToSessionFile,
@@ -30,8 +32,9 @@ import {
   listenNetServer,
   type DaemonServer,
 } from './daemon/transport.ts';
+import { sleep } from './utils/timeouts.ts';
 
-const DAEMON_SHUTDOWN_TIMEOUT_MS = 5_000;
+const DAEMON_SESSION_TEARDOWN_TIMEOUT_MS = 5_000;
 
 const daemonPaths = resolveDaemonPaths(process.env.AGENT_DEVICE_STATE_DIR);
 const { baseDir, infoPath, lockPath, logPath, sessionsDir } = daemonPaths;
@@ -58,39 +61,6 @@ const handleRequest = createRequestHandler({
   trackDownloadableArtifact,
 });
 
-function forceCloseServer(server: DaemonServer): void {
-  server.destroyConnections?.();
-  const closeAllConnections =
-    'closeAllConnections' in server ? server.closeAllConnections : undefined;
-  if (typeof closeAllConnections === 'function') {
-    closeAllConnections.call(server);
-    return;
-  }
-  const closeIdleConnections =
-    'closeIdleConnections' in server ? server.closeIdleConnections : undefined;
-  if (typeof closeIdleConnections === 'function') closeIdleConnections.call(server);
-}
-
-async function closeDaemonServers(servers: DaemonServer[]): Promise<void> {
-  await Promise.all(
-    servers.map(async (server) => {
-      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-      await new Promise<void>((resolve) => {
-        timeoutHandle = setTimeout(() => {
-          forceCloseServer(server);
-          resolve();
-        }, DAEMON_SHUTDOWN_TIMEOUT_MS);
-        try {
-          server.close(() => resolve());
-        } catch {
-          resolve();
-        }
-      });
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-    }),
-  );
-}
-
 async function emitFatalDiagnostic(error: unknown): Promise<void> {
   await withDiagnosticsScope(
     { command: 'daemon', session: 'daemon', logPath, debug: true },
@@ -109,17 +79,25 @@ async function emitFatalDiagnostic(error: unknown): Promise<void> {
 
 async function teardownDaemonSessions(): Promise<void> {
   const sessionsToStop = sessionStore.toArray();
-  for (const session of sessionsToStop) {
-    await teardownSessionResources(session, session.name).catch((error) => {
-      process.stderr.write(
-        `Daemon session teardown error (${session.name}): ${
-          error instanceof Error ? error.message : String(error)
-        }\n`,
-      );
-    });
-    sessionStore.writeSessionLog(session);
-    sessionStore.delete(session.name);
-  }
+  await Promise.all(sessionsToStop.map(teardownDaemonSession));
+}
+
+async function teardownDaemonSession(session: SessionState) {
+  const teardown = teardownSessionResources(session, session.name).catch((error) => {
+    process.stderr.write(
+      `Daemon session teardown error (${session.name}): ${
+        error instanceof Error ? error.message : String(error)
+      }\n`,
+    );
+  });
+  await Promise.race([
+    teardown,
+    sleep(DAEMON_SESSION_TEARDOWN_TIMEOUT_MS).then(() => {
+      process.stderr.write(`Daemon session teardown timed out (${session.name}).\n`);
+    }),
+  ]);
+  sessionStore.writeSessionLog(session);
+  sessionStore.delete(session.name);
 }
 
 async function openDaemonServers(): Promise<{

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -8,6 +8,12 @@ import { createDaemonHttpServer } from './daemon/http-server.ts';
 import { trackDownloadableArtifact } from './daemon/artifact-tracking.ts';
 import { LeaseRegistry } from './daemon/lease-registry.ts';
 import { createRequestHandler } from './daemon/request-router.ts';
+import { teardownSessionResources } from './daemon/handlers/session-close.ts';
+import {
+  emitDiagnostic,
+  flushDiagnosticsToSessionFile,
+  withDiagnosticsScope,
+} from './utils/diagnostics.ts';
 import {
   acquireDaemonLock,
   parseIntegerEnv,
@@ -18,7 +24,14 @@ import {
   resolveDaemonCodeSignature,
   writeInfo,
 } from './daemon/server-lifecycle.ts';
-import { createSocketServer, listenHttpServer, listenNetServer } from './daemon/transport.ts';
+import {
+  createSocketServer,
+  listenHttpServer,
+  listenNetServer,
+  type DaemonServer,
+} from './daemon/transport.ts';
+
+const DAEMON_SHUTDOWN_TIMEOUT_MS = 5_000;
 
 const daemonPaths = resolveDaemonPaths(process.env.AGENT_DEVICE_STATE_DIR);
 const { baseDir, infoPath, lockPath, logPath, sessionsDir } = daemonPaths;
@@ -45,6 +58,115 @@ const handleRequest = createRequestHandler({
   trackDownloadableArtifact,
 });
 
+function forceCloseServer(server: DaemonServer): void {
+  server.destroyConnections?.();
+  const closeAllConnections =
+    'closeAllConnections' in server ? server.closeAllConnections : undefined;
+  if (typeof closeAllConnections === 'function') {
+    closeAllConnections.call(server);
+    return;
+  }
+  const closeIdleConnections =
+    'closeIdleConnections' in server ? server.closeIdleConnections : undefined;
+  if (typeof closeIdleConnections === 'function') closeIdleConnections.call(server);
+}
+
+async function closeDaemonServers(servers: DaemonServer[]): Promise<void> {
+  await Promise.all(
+    servers.map(async (server) => {
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      await new Promise<void>((resolve) => {
+        timeoutHandle = setTimeout(() => {
+          forceCloseServer(server);
+          resolve();
+        }, DAEMON_SHUTDOWN_TIMEOUT_MS);
+        try {
+          server.close(() => resolve());
+        } catch {
+          resolve();
+        }
+      });
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }),
+  );
+}
+
+async function emitFatalDiagnostic(error: unknown): Promise<void> {
+  await withDiagnosticsScope(
+    { command: 'daemon', session: 'daemon', logPath, debug: true },
+    async () => {
+      emitDiagnostic({
+        level: 'error',
+        phase: 'daemon_fatal',
+        data: {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      flushDiagnosticsToSessionFile({ force: true });
+    },
+  );
+}
+
+async function teardownDaemonSessions(): Promise<void> {
+  const sessionsToStop = sessionStore.toArray();
+  for (const session of sessionsToStop) {
+    await teardownSessionResources(session, session.name).catch((error) => {
+      process.stderr.write(
+        `Daemon session teardown error (${session.name}): ${
+          error instanceof Error ? error.message : String(error)
+        }\n`,
+      );
+    });
+    sessionStore.writeSessionLog(session);
+    sessionStore.delete(session.name);
+  }
+}
+
+async function openDaemonServers(): Promise<{
+  servers: DaemonServer[];
+  socketPort?: number;
+  httpPort?: number;
+}> {
+  const servers: DaemonServer[] = [];
+  let socketPort: number | undefined;
+  let httpPort: number | undefined;
+  const startSocketServer = daemonServerMode !== 'http';
+  const startHttpServer = daemonServerMode !== 'socket';
+  if (startSocketServer) {
+    const socketServer = createSocketServer(handleRequest);
+    servers.push(socketServer);
+    socketPort = await listenNetServer(socketServer);
+  }
+
+  if (startHttpServer) {
+    const httpServer = await createDaemonHttpServer({ handleRequest, token });
+    servers.push(httpServer);
+    httpPort = await listenHttpServer(httpServer);
+  }
+  return { servers, socketPort, httpPort };
+}
+
+function publishDaemonInfo(socketPort: number | undefined, httpPort: number | undefined): void {
+  writeInfo(baseDir, infoPath, logPath, {
+    socketPort,
+    httpPort,
+    token,
+    version,
+    codeSignature: daemonCodeSignature,
+    processStartTime: daemonProcessStartTime,
+  });
+  if (socketPort) process.stdout.write(`AGENT_DEVICE_DAEMON_PORT=${socketPort}\n`);
+  if (httpPort) process.stdout.write(`AGENT_DEVICE_DAEMON_HTTP_PORT=${httpPort}\n`);
+}
+
+function closeServersBestEffort(servers: DaemonServer[]): void {
+  for (const server of servers) {
+    try {
+      server.close(() => {});
+    } catch {}
+  }
+}
+
 async function start(): Promise<void> {
   const lockData = {
     pid: process.pid,
@@ -58,41 +180,15 @@ async function start(): Promise<void> {
     return;
   }
 
-  const servers: Array<{ close: (cb: (err?: Error) => void) => void }> = [];
-  let socketPort: number | undefined;
-  let httpPort: number | undefined;
-
+  let servers: DaemonServer[] = [];
   try {
-    if (daemonServerMode === 'socket' || daemonServerMode === 'dual') {
-      const socketServer = createSocketServer(handleRequest);
-      servers.push(socketServer);
-      socketPort = await listenNetServer(socketServer);
-    }
-
-    if (daemonServerMode === 'http' || daemonServerMode === 'dual') {
-      const httpServer = await createDaemonHttpServer({ handleRequest, token });
-      servers.push(httpServer);
-      httpPort = await listenHttpServer(httpServer);
-    }
-
-    writeInfo(baseDir, infoPath, logPath, {
-      socketPort,
-      httpPort,
-      token,
-      version,
-      codeSignature: daemonCodeSignature,
-      processStartTime: daemonProcessStartTime,
-    });
-    if (socketPort) process.stdout.write(`AGENT_DEVICE_DAEMON_PORT=${socketPort}\n`);
-    if (httpPort) process.stdout.write(`AGENT_DEVICE_DAEMON_HTTP_PORT=${httpPort}\n`);
+    const opened = await openDaemonServers();
+    servers = opened.servers;
+    publishDaemonInfo(opened.socketPort, opened.httpPort);
   } catch (error) {
     const appErr = asAppError(error);
     process.stderr.write(`Daemon error: ${appErr.message}\n`);
-    for (const server of servers) {
-      try {
-        server.close(() => {});
-      } catch {}
-    }
+    closeServersBestEffort(servers);
     removeInfo(infoPath);
     releaseDaemonLock(lockPath);
     process.exit(1);
@@ -100,31 +196,18 @@ async function start(): Promise<void> {
   }
 
   let shuttingDown = false;
-  const closeServers = async (): Promise<void> => {
-    await Promise.all(
-      servers.map(async (server) => {
-        await new Promise<void>((resolve) => {
-          try {
-            server.close(() => resolve());
-          } catch {
-            resolve();
-          }
-        });
-      }),
-    );
-  };
-  const shutdown = async () => {
+  const shutdown = async (options: { exitCode?: number; cause?: unknown } = {}) => {
     if (shuttingDown) return;
     shuttingDown = true;
-    await closeServers();
-    const sessionsToStop = sessionStore.toArray();
-    for (const session of sessionsToStop) {
-      sessionStore.writeSessionLog(session);
+    if (options.cause) {
+      await emitFatalDiagnostic(options.cause);
     }
+    await closeDaemonServers(servers);
+    await teardownDaemonSessions();
     await stopAllIosRunnerSessions();
     removeInfo(infoPath);
     releaseDaemonLock(lockPath);
-    process.exit(0);
+    process.exit(options.exitCode ?? 0);
   };
 
   process.on('SIGINT', () => {
@@ -139,13 +222,13 @@ async function start(): Promise<void> {
   process.on('uncaughtException', (err) => {
     const appErr = err instanceof AppError ? err : asAppError(err);
     process.stderr.write(`Daemon error: ${appErr.message}\n`);
-    void shutdown();
+    void shutdown({ exitCode: 1, cause: err });
   });
   process.on('unhandledRejection', (reason) => {
     const err = reason instanceof Error ? reason : new Error(String(reason));
     const appErr = err instanceof AppError ? err : asAppError(err);
     process.stderr.write(`Daemon error: ${appErr.message}\n`);
-    void shutdown();
+    void shutdown({ exitCode: 1, cause: err });
   });
 }
 

--- a/src/daemon/__tests__/server-shutdown.test.ts
+++ b/src/daemon/__tests__/server-shutdown.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import type { DaemonServer } from '../transport.ts';
+import { closeDaemonServers } from '../server-shutdown.ts';
+
+test('closeDaemonServers forces stuck servers after timeout', async () => {
+  let destroyed = false;
+  const server = {
+    close: () => {},
+    destroyConnections: () => {
+      destroyed = true;
+    },
+  } as unknown as DaemonServer;
+
+  const startedAt = Date.now();
+  await closeDaemonServers([server], 20);
+
+  assert.equal(destroyed, true);
+  assert.ok(Date.now() - startedAt < 500);
+});

--- a/src/daemon/__tests__/session-routing.test.ts
+++ b/src/daemon/__tests__/session-routing.test.ts
@@ -1,5 +1,6 @@
-import { test } from 'vitest';
+import { test, type TestContext } from 'vitest';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { SessionStore } from '../session-store.ts';
@@ -21,12 +22,16 @@ function makeSession(name: string): SessionState {
   };
 }
 
-function makeStore(): SessionStore {
-  return new SessionStore(path.join(os.tmpdir(), 'agent-device-session-routing-tests'));
+function makeStore(t: TestContext): SessionStore {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-routing-'));
+  t.onTestFinished(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  return new SessionStore(path.join(root, 'sessions'));
 }
 
-test('reuses lone active session for implicit default session', () => {
-  const store = makeStore();
+test('reuses lone active session for implicit default session', (t) => {
+  const store = makeStore(t);
   store.set('android', makeSession('android'));
 
   const resolved = resolveEffectiveSessionName(
@@ -43,8 +48,8 @@ test('reuses lone active session for implicit default session', () => {
   assert.equal(resolved, 'android');
 });
 
-test('keeps requested default when explicit --session is provided', () => {
-  const store = makeStore();
+test('keeps requested default when explicit --session is provided', (t) => {
+  const store = makeStore(t);
   store.set('android', makeSession('android'));
 
   const resolved = resolveEffectiveSessionName(
@@ -61,8 +66,8 @@ test('keeps requested default when explicit --session is provided', () => {
   assert.equal(resolved, 'default');
 });
 
-test('keeps requested non-default session names', () => {
-  const store = makeStore();
+test('keeps requested non-default session names', (t) => {
+  const store = makeStore(t);
   store.set('android', makeSession('android'));
 
   const resolved = resolveEffectiveSessionName(
@@ -79,8 +84,8 @@ test('keeps requested non-default session names', () => {
   assert.equal(resolved, 'maps-test');
 });
 
-test('does not reuse when multiple sessions are active', () => {
-  const store = makeStore();
+test('does not reuse when multiple sessions are active', (t) => {
+  const store = makeStore(t);
   store.set('android', makeSession('android'));
   store.set('ios', {
     ...makeSession('ios'),

--- a/src/daemon/__tests__/upload.test.ts
+++ b/src/daemon/__tests__/upload.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { Readable } from 'node:stream';
 import type { IncomingMessage } from 'node:http';
 import { receiveUpload } from '../upload.ts';
+import { streamReadableToFile } from '../artifact-download.ts';
 import { runCmdSync } from '../../utils/exec.ts';
 
 function makeUploadRequest(body: Buffer, headers: Record<string, string>): IncomingMessage {
@@ -44,6 +45,24 @@ test('receiveUpload rejects app bundle archives containing symlinks', async () =
       async () => await receiveUpload(req),
       /cannot contain symlinks or hard links/i,
     );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('streamReadableToFile removes partial files after stream errors', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-upload-error-'));
+  const destPath = path.join(tempRoot, 'partial.bin');
+  const source = new Readable({
+    read() {
+      this.push('partial');
+      this.destroy(new Error('source failed'));
+    },
+  });
+
+  try {
+    await assert.rejects(async () => await streamReadableToFile(source, destPath), /source failed/);
+    assert.equal(fs.existsSync(destPath), false);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/src/daemon/artifact-download.ts
+++ b/src/daemon/artifact-download.ts
@@ -3,6 +3,8 @@ import http, { type IncomingMessage } from 'node:http';
 import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
+import { Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { AppError } from '../utils/errors.ts';
 import { resolveTimeoutMs } from '../utils/timeouts.ts';
 
@@ -47,12 +49,6 @@ export function streamReadableToFile(
   destPath: string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const output = fs.createWriteStream(destPath);
-    const destroySource = (error: Error) => {
-      if ('destroy' in source && typeof source.destroy === 'function') {
-        source.destroy(error);
-      }
-    };
     let settled = false;
     let bytesWritten = 0;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -62,7 +58,6 @@ export function streamReadableToFile(
       settled = true;
       if (timeoutHandle) clearTimeout(timeoutHandle);
       if (error) {
-        output.destroy();
         fs.rmSync(destPath, { force: true });
         reject(error);
         return;
@@ -79,35 +74,40 @@ export function streamReadableToFile(
             timeoutMs: REQUEST_IDLE_TIMEOUT_MS,
           },
         );
-        destroySource(error);
-        output.destroy(error);
+        if ('destroy' in source && typeof source.destroy === 'function') {
+          source.destroy(error);
+        }
+        byteLimit.destroy(error);
         settle(error);
       }, REQUEST_IDLE_TIMEOUT_MS);
     };
 
-    source.on('data', (chunk: Buffer | string) => {
-      armTimeout();
-      const size = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(chunk);
-      bytesWritten += size;
-      if (bytesWritten > MAX_ARTIFACT_BYTES) {
-        const error = new AppError(
-          'INVALID_ARGS',
-          `Upload exceeds maximum size of ${MAX_ARTIFACT_BYTES} bytes`,
-        );
-        destroySource(error);
-        output.destroy(error);
-        settle(error);
-      }
+    const byteLimit = new Transform({
+      transform(chunk: Buffer | string, encoding, callback) {
+        armTimeout();
+        const size = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(chunk, encoding);
+        bytesWritten += size;
+        if (bytesWritten > MAX_ARTIFACT_BYTES) {
+          callback(
+            new AppError(
+              'INVALID_ARGS',
+              `Upload exceeds maximum size of ${MAX_ARTIFACT_BYTES} bytes`,
+            ),
+          );
+          return;
+        }
+        callback(null, chunk);
+      },
     });
 
-    source.on('error', settle);
     source.on('aborted', () => {
       settle(new AppError('COMMAND_FAILED', 'Artifact transfer was interrupted'));
     });
-    output.on('error', settle);
-    output.on('finish', () => settle());
     armTimeout();
-    source.pipe(output);
+    void pipeline(source, byteLimit, fs.createWriteStream(destPath)).then(
+      () => settle(),
+      (error: unknown) => settle(error),
+    );
   });
 }
 

--- a/src/daemon/artifact-download.ts
+++ b/src/daemon/artifact-download.ts
@@ -3,6 +3,7 @@ import http, { type IncomingMessage } from 'node:http';
 import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
+import { once } from 'node:events';
 import { Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '../utils/errors.ts';
@@ -52,14 +53,14 @@ export function streamReadableToFile(
     let settled = false;
     let bytesWritten = 0;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const output = fs.createWriteStream(destPath);
 
     const settle = (error?: unknown) => {
       if (settled) return;
       settled = true;
       if (timeoutHandle) clearTimeout(timeoutHandle);
       if (error) {
-        fs.rmSync(destPath, { force: true });
-        reject(error);
+        void removePartialFile(output, destPath).finally(() => reject(error));
         return;
       }
       resolve();
@@ -104,11 +105,23 @@ export function streamReadableToFile(
       settle(new AppError('COMMAND_FAILED', 'Artifact transfer was interrupted'));
     });
     armTimeout();
-    void pipeline(source, byteLimit, fs.createWriteStream(destPath)).then(
+    void pipeline(source, byteLimit, output).then(
       () => settle(),
       (error: unknown) => settle(error),
     );
   });
+}
+
+async function removePartialFile(output: fs.WriteStream, destPath: string): Promise<void> {
+  output.destroy();
+  if (!output.closed) {
+    try {
+      await once(output, 'close');
+    } catch {
+      // best-effort cleanup only
+    }
+  }
+  await fs.promises.rm(destPath, { force: true }).catch(() => {});
 }
 
 export async function downloadArtifactToTempDir(params: {

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -94,6 +94,19 @@ async function stopAppleRunnerForClose(session: SessionState): Promise<void> {
   });
 }
 
+export async function teardownSessionResources(
+  session: SessionState,
+  sessionName: string,
+): Promise<void> {
+  if (session.appLog) {
+    await stopAppLog(session.appLog);
+  }
+  if (isApplePlatform(session.device.platform)) {
+    await stopAppleRunnerForClose(session);
+  }
+  await cleanupRetainedMaterializedPathsForSession(sessionName).catch(() => {});
+}
+
 export async function handleCloseCommand(params: {
   req: DaemonRequest;
   sessionName: string;
@@ -105,9 +118,7 @@ export async function handleCloseCommand(params: {
   if (!session) {
     return errorResponse('SESSION_NOT_FOUND', 'No active session');
   }
-  if (session.appLog) {
-    await stopAppLog(session.appLog);
-  }
+  if (session.appLog) await stopAppLog(session.appLog);
   if (req.positionals && req.positionals.length > 0) {
     if (isApplePlatform(session.device.platform)) {
       await stopAppleRunnerForClose(session);

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -118,7 +118,9 @@ export async function handleCloseCommand(params: {
   if (!session) {
     return errorResponse('SESSION_NOT_FOUND', 'No active session');
   }
-  if (session.appLog) await stopAppLog(session.appLog);
+  if (session.appLog) {
+    await stopAppLog(session.appLog);
+  }
   if (req.positionals && req.positionals.length > 0) {
     if (isApplePlatform(session.device.platform)) {
       await stopAppleRunnerForClose(session);

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -46,6 +46,7 @@ import {
 import { recoverAndroidBlockingSystemDialog } from './android-system-dialog.ts';
 import { getRunnerSessionSnapshot } from '../platforms/ios/runner-client.ts';
 import { annotateScreenshotWithRefs } from './screenshot-overlay.ts';
+import { createRequestCanceledError, isRequestCanceled } from './request-cancel.ts';
 import {
   isNavigationSensitiveAction,
   markAndroidSnapshotFreshness,
@@ -78,6 +79,12 @@ const sessionExecutionLocks = new Map<string, Promise<unknown>>();
 // ---------------------------------------------------------------------------
 // Request preparation helpers
 // ---------------------------------------------------------------------------
+
+function throwIfRequestCanceled(req: DaemonRequest): void {
+  if (isRequestCanceled(req.meta?.requestId)) {
+    throw createRequestCanceledError();
+  }
+}
 
 function contextFromFlags(
   logPath: string,
@@ -599,6 +606,7 @@ export function createRequestHandler(
             : await resolveExecutionLockKey(scopedReq, sessionName, sessionStore);
 
           const executeSessionRequest = async (): Promise<DaemonResponse> => {
+            throwIfRequestCanceled(scopedReq);
             const existingSession = sessionStore.get(sessionName);
             if (existingSession) {
               refreshRecordingHealth(existingSession);
@@ -668,8 +676,10 @@ export function createRequestHandler(
           };
 
           if (!executionLockKey) {
+            throwIfRequestCanceled(scopedReq);
             return await executeSessionRequest();
           }
+          throwIfRequestCanceled(scopedReq);
           return await withKeyedLock(
             sessionExecutionLocks,
             executionLockKey,

--- a/src/daemon/server-shutdown.ts
+++ b/src/daemon/server-shutdown.ts
@@ -1,0 +1,39 @@
+import type { DaemonServer } from './transport.ts';
+
+const DAEMON_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+function forceCloseServer(server: DaemonServer): void {
+  server.destroyConnections?.();
+  const closeAllConnections =
+    'closeAllConnections' in server ? server.closeAllConnections : undefined;
+  if (typeof closeAllConnections === 'function') {
+    closeAllConnections.call(server);
+    return;
+  }
+  const closeIdleConnections =
+    'closeIdleConnections' in server ? server.closeIdleConnections : undefined;
+  if (typeof closeIdleConnections === 'function') closeIdleConnections.call(server);
+}
+
+export async function closeDaemonServers(
+  servers: DaemonServer[],
+  timeoutMs: number = DAEMON_SHUTDOWN_TIMEOUT_MS,
+): Promise<void> {
+  await Promise.all(
+    servers.map(async (server) => {
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      await new Promise<void>((resolve) => {
+        timeoutHandle = setTimeout(() => {
+          forceCloseServer(server);
+          resolve();
+        }, timeoutMs);
+        try {
+          server.close(() => resolve());
+        } catch {
+          resolve();
+        }
+      });
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }),
+  );
+}

--- a/src/daemon/transport.ts
+++ b/src/daemon/transport.ts
@@ -17,10 +17,17 @@ import { sleep } from '../utils/timeouts.ts';
 const disconnectAbortPollIntervalMs = 200;
 const disconnectAbortMaxWindowMs = 15_000;
 
+export type DaemonServer = (net.Server | HttpServer) & {
+  destroyConnections?: () => void;
+};
+
 export function createSocketServer(
   handleRequest: (req: DaemonRequest) => Promise<DaemonResponse>,
-): net.Server {
-  return net.createServer((socket) => {
+): DaemonServer {
+  const sockets = new Set<net.Socket>();
+  const server: DaemonServer = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
     let buffer = '';
     let inFlightRequests = 0;
     const activeRequestIds = new Set<string>();
@@ -103,6 +110,13 @@ export function createSocketServer(
       }
     });
   });
+  server.destroyConnections = () => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    sockets.clear();
+  };
+  return server;
 }
 
 export function listenNetServer(server: net.Server): Promise<number> {

--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -18,12 +18,34 @@ const ANDROID_TV_FEATURES = [
   'android.software.leanback_only',
   'android.hardware.type.television',
 ] as const;
+const ANDROID_DISCOVERY_CONCURRENCY = 3;
+const ANDROID_FEATURE_PROBE_CONCURRENCY = 2;
 
 type AndroidDeviceDiscoveryOptions = {
   serialAllowlist?: ReadonlySet<string>;
 };
 
 type AndroidAdbRunner = typeof runCmd;
+
+async function mapWithConcurrency<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, values.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(values[index]!);
+      }
+    }),
+  );
+  return results;
+}
 
 function commandOutput(result: ExecResult): string {
   return `${result.stdout}\n${result.stderr}`;
@@ -155,8 +177,10 @@ async function probeAndroidFeature(serial: string, feature: string): Promise<boo
 }
 
 async function hasAnyAndroidTvFeature(serial: string): Promise<boolean> {
-  const featureChecks = await Promise.all(
-    ANDROID_TV_FEATURES.map(async (feature) => await probeAndroidFeature(serial, feature)),
+  const featureChecks = await mapWithConcurrency(
+    ANDROID_TV_FEATURES,
+    ANDROID_FEATURE_PROBE_CONCURRENCY,
+    async (feature) => await probeAndroidFeature(serial, feature),
   );
   return featureChecks.some((value) => value === true);
 }
@@ -211,8 +235,10 @@ export async function listAndroidDevices(
     (entry) => !serialAllowlist || serialAllowlist.has(entry.serial),
   );
 
-  const devices = await Promise.all(
-    filteredEntries.map(async ({ serial, rawModel }) => {
+  const devices = await mapWithConcurrency(
+    filteredEntries,
+    ANDROID_DISCOVERY_CONCURRENCY,
+    async ({ serial, rawModel }) => {
       const [name, booted, target] = await Promise.all([
         resolveAndroidDeviceName(serial, rawModel),
         isAndroidBooted(serial),
@@ -226,7 +252,7 @@ export async function listAndroidDevices(
         target,
         booted,
       } satisfies DeviceInfo;
-    }),
+    },
   );
 
   return devices;

--- a/src/platforms/install-source.ts
+++ b/src/platforms/install-source.ts
@@ -1,8 +1,10 @@
 import dns from 'node:dns/promises';
 import net from 'node:net';
-import { promises as fs } from 'node:fs';
+import { createWriteStream, promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { AppError } from '../utils/errors.ts';
 import { runCmd } from '../utils/exec.ts';
 import { expandUserHomePath } from '../utils/path-resolution.ts';
@@ -132,20 +134,14 @@ async function downloadToTempFile(
   if (requestSignal?.aborted) {
     throw new AppError('COMMAND_FAILED', 'request canceled', { reason: 'request_canceled' });
   }
-  const controller = new AbortController();
-  const onAbort = () => {
-    controller.abort(requestSignal?.reason);
-  };
-  requestSignal?.addEventListener('abort', onAbort, { once: true });
   const timeoutMs = options?.downloadTimeoutMs ?? DEFAULT_SOURCE_DOWNLOAD_TIMEOUT_MS;
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(new Error('download timeout'));
-  }, timeoutMs);
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = requestSignal ? AbortSignal.any([requestSignal, timeoutSignal]) : timeoutSignal;
   try {
     const response = await fetch(parsedUrl, {
       headers,
       redirect: 'follow',
-      signal: controller.signal,
+      signal,
     });
     if (!response.ok) {
       throw new AppError(
@@ -166,14 +162,10 @@ async function downloadToTempFile(
         url: parsedUrl.toString(),
       });
     }
-    const file = await fs.open(destinationPath, 'w');
-    try {
-      for await (const chunk of body) {
-        await file.write(chunk);
-      }
-    } finally {
-      await file.close();
-    }
+    await pipeline(
+      Readable.from(body as unknown as AsyncIterable<Uint8Array>),
+      createWriteStream(destinationPath),
+    );
     return destinationPath;
   } catch (error) {
     if (requestSignal?.aborted) {
@@ -184,7 +176,7 @@ async function downloadToTempFile(
         error,
       );
     }
-    if (controller.signal.aborted) {
+    if (timeoutSignal.aborted) {
       throw new AppError(
         'COMMAND_FAILED',
         `App source download timed out after ${timeoutMs}ms`,
@@ -196,9 +188,6 @@ async function downloadToTempFile(
       );
     }
     throw error;
-  } finally {
-    requestSignal?.removeEventListener('abort', onAbort);
-    clearTimeout(timeoutHandle);
   }
 }
 

--- a/src/platforms/install-source.ts
+++ b/src/platforms/install-source.ts
@@ -163,7 +163,7 @@ async function downloadToTempFile(
       });
     }
     await pipeline(
-      Readable.from(body as unknown as AsyncIterable<Uint8Array>),
+      Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]),
       createWriteStream(destinationPath),
     );
     return destinationPath;

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -154,7 +154,7 @@ export async function waitForRunner(
     if (remainingMs <= 0) {
       throw buildRunnerConnectError({ port, endpoints, logPath, lastError });
     }
-    const simResponse = await postCommandViaSimulator(device, port, command, remainingMs);
+    const simResponse = await postCommandViaSimulator(device, port, command, remainingMs, signal);
     return new Response(simResponse.body, { status: simResponse.status });
   }
 
@@ -250,6 +250,7 @@ async function postCommandViaSimulator(
   port: number,
   command: RunnerCommand,
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<{ status: number; body: string }> {
   const payload = JSON.stringify(command);
   const args = buildSimctlArgsForDevice(device, [
@@ -265,7 +266,7 @@ async function postCommandViaSimulator(
     payload,
     `http://127.0.0.1:${port}/command`,
   ]);
-  const result = await runCmd('xcrun', args, { allowFailure: true, timeoutMs });
+  const result = await runCmd('xcrun', args, { allowFailure: true, timeoutMs, signal });
   const body = result.stdout as string;
   if (result.exitCode !== 0) {
     const reason = classifyBootFailure({

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -69,10 +69,10 @@ export async function waitForRunner(
   signal?: AbortSignal,
 ): Promise<Response> {
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  let deviceTunnelIp: string | null | undefined;
+  let deviceTunnelIp: string | undefined;
   const getEndpoints = async (timeoutBudgetMs?: number) => {
     if (device.kind === 'device' && deviceTunnelIp === undefined) {
-      deviceTunnelIp = await resolveDeviceTunnelIp(device.id, timeoutBudgetMs);
+      deviceTunnelIp = (await resolveDeviceTunnelIp(device.id, timeoutBudgetMs)) ?? undefined;
     }
     return resolveRunnerCommandEndpoints(device, port, deviceTunnelIp ?? null);
   };

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -69,7 +69,14 @@ export async function waitForRunner(
   signal?: AbortSignal,
 ): Promise<Response> {
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  let endpoints = await resolveRunnerCommandEndpoints(device, port, deadline.remainingMs());
+  let deviceTunnelIp: string | null | undefined;
+  const getEndpoints = async (timeoutBudgetMs?: number) => {
+    if (device.kind === 'device' && deviceTunnelIp === undefined) {
+      deviceTunnelIp = await resolveDeviceTunnelIp(device.id, timeoutBudgetMs);
+    }
+    return resolveRunnerCommandEndpoints(device, port, deviceTunnelIp ?? null);
+  };
+  let endpoints = await getEndpoints(deadline.remainingMs());
   let lastError: unknown = null;
   const maxAttempts = Math.max(1, Math.ceil(timeoutMs / RUNNER_CONNECT_ATTEMPT_INTERVAL_MS));
   try {
@@ -85,11 +92,7 @@ export async function waitForRunner(
           throw await buildRunnerEarlyExitError({ session, port, logPath });
         }
         if (device.kind === 'device') {
-          endpoints = await resolveRunnerCommandEndpoints(
-            device,
-            port,
-            attemptDeadline?.remainingMs(),
-          );
+          endpoints = await getEndpoints(attemptDeadline?.remainingMs());
         }
         for (const endpoint of endpoints) {
           try {
@@ -161,13 +164,12 @@ export async function waitForRunner(
 async function resolveRunnerCommandEndpoints(
   device: DeviceInfo,
   port: number,
-  timeoutBudgetMs?: number,
+  tunnelIp: string | null,
 ): Promise<string[]> {
   const endpoints = [`http://127.0.0.1:${port}/command`];
   if (device.kind !== 'device') {
     return endpoints;
   }
-  const tunnelIp = await resolveDeviceTunnelIp(device.id, timeoutBudgetMs);
   if (tunnelIp) {
     endpoints.unshift(`http://[${tunnelIp}]:${port}/command`);
   }
@@ -180,26 +182,9 @@ async function fetchWithTimeout(
   timeoutMs: number,
   requestSignal?: AbortSignal,
 ): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  let onRequestAbort: (() => void) | undefined;
-  if (requestSignal) {
-    if (requestSignal.aborted) {
-      clearTimeout(timeout);
-      controller.abort();
-    } else {
-      onRequestAbort = () => controller.abort();
-      requestSignal.addEventListener('abort', onRequestAbort, { once: true });
-    }
-  }
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-    if (onRequestAbort && requestSignal) {
-      requestSignal.removeEventListener('abort', onRequestAbort);
-    }
-  }
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = requestSignal ? AbortSignal.any([requestSignal, timeoutSignal]) : timeoutSignal;
+  return await fetch(url, { ...init, signal });
 }
 
 async function resolveDeviceTunnelIp(
@@ -323,11 +308,27 @@ export function logChunk(
   traceLogPath?: string,
   verbose?: boolean,
 ): void {
-  if (logPath) fs.appendFile(logPath, chunk, () => {});
-  if (traceLogPath) fs.appendFile(traceLogPath, chunk, () => {});
+  if (logPath) appendLogChunk(logPath, chunk);
+  if (traceLogPath) appendLogChunk(traceLogPath, chunk);
   if (verbose) {
     process.stderr.write(chunk);
   }
+}
+
+const logAppendQueues = new Map<string, Promise<void>>();
+
+function appendLogChunk(logPath: string, chunk: string): void {
+  const previous = logAppendQueues.get(logPath) ?? Promise.resolve();
+  const next = previous
+    .catch(() => {})
+    .then(() => fs.promises.appendFile(logPath, chunk))
+    .catch(() => {});
+  const queued = next.finally(() => {
+    if (logAppendQueues.get(logPath) === queued) {
+      logAppendQueues.delete(logPath);
+    }
+  });
+  logAppendQueues.set(logPath, queued);
 }
 
 export function cleanupTempFile(filePath: string): void {

--- a/src/upload-client.ts
+++ b/src/upload-client.ts
@@ -4,6 +4,8 @@ import https from 'node:https';
 import path from 'node:path';
 import os from 'node:os';
 import { createHash, randomUUID } from 'node:crypto';
+import { Writable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { AppError } from './utils/errors.ts';
 import { runCmd } from './utils/exec.ts';
 
@@ -366,11 +368,10 @@ async function streamFileToHttpRequest(options: {
     });
     req.on('close', () => clearTimeout(timeout));
 
-    const fileStream = fs.createReadStream(options.payloadPath);
-    fileStream.pipe(req);
-    fileStream.on('error', (err) => {
+    void pipeline(fs.createReadStream(options.payloadPath), req).catch((err: unknown) => {
       req.destroy();
-      reject(new AppError('COMMAND_FAILED', 'Failed to read local artifact', {}, err));
+      const error = err instanceof Error ? err : new Error(String(err));
+      reject(new AppError('COMMAND_FAILED', 'Failed to read local artifact', {}, error));
     });
   });
 }
@@ -414,13 +415,19 @@ async function finalizeDirectUpload(options: {
 
 async function computeFileHash(localPath: string): Promise<string> {
   const hash = createHash(ARTIFACT_HASH_ALGORITHM);
-  await new Promise<void>((resolve, reject) => {
-    fs.createReadStream(localPath)
-      .on('data', (chunk) => hash.update(chunk))
-      .on('error', (err) => {
-        reject(new AppError('COMMAND_FAILED', 'Failed to read local artifact', {}, err));
-      })
-      .on('end', resolve);
+  const sink = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      hash.update(chunk);
+      callback();
+    },
+  });
+  await pipeline(fs.createReadStream(localPath), sink).catch((err: unknown) => {
+    throw new AppError(
+      'COMMAND_FAILED',
+      'Failed to read local artifact',
+      {},
+      err instanceof Error ? err : undefined,
+    );
   });
   return hash.digest('hex');
 }

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -1315,6 +1315,7 @@ test('stopDaemonProcessForTakeover terminates a matching daemon process', async 
   } finally {
     if (isProcessAlive(pid)) {
       process.kill(pid, 'SIGKILL');
+      await waitForProcessExit(pid, 1_500);
     }
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -1338,6 +1339,7 @@ test('stopDaemonProcessForTakeover does not terminate non-daemon process', async
   } finally {
     if (isProcessAlive(pid)) {
       process.kill(pid, 'SIGKILL');
+      await waitForProcessExit(pid, 1_500);
     }
   }
 });

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -27,6 +27,63 @@ test('runCmd enforces timeoutMs and rejects with COMMAND_FAILED', async () => {
   );
 });
 
+test('runCmd aborts with request cancellation details', async () => {
+  const controller = new AbortController();
+  const promise = runCmd(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'], {
+    signal: controller.signal,
+  });
+  controller.abort();
+
+  await assert.rejects(promise, (error: unknown) => {
+    const err = error as { code?: string; message?: string; details?: Record<string, unknown> };
+    return (
+      err?.code === 'COMMAND_FAILED' &&
+      err.message === 'request canceled' &&
+      err.details?.reason === 'request_canceled'
+    );
+  });
+});
+
+test('runCmd abort keeps cancellation details while writing stdin', async () => {
+  const controller = new AbortController();
+  const promise = runCmd(
+    process.execPath,
+    ['-e', ['process.stdin.resume();', 'setTimeout(() => {}, 10_000);'].join('')],
+    {
+      signal: controller.signal,
+      stdin: Buffer.alloc(512_000, 'a'),
+    },
+  );
+  controller.abort();
+
+  await assert.rejects(promise, (error: unknown) => {
+    const err = error as { code?: string; message?: string; details?: Record<string, unknown> };
+    return (
+      err?.code === 'COMMAND_FAILED' &&
+      err.message === 'request canceled' &&
+      err.details?.reason === 'request_canceled'
+    );
+  });
+});
+
+test('runCmd writes stdin through pipeline', async () => {
+  const stdin = Buffer.alloc(256_000, 'a');
+  const result = await runCmd(
+    process.execPath,
+    [
+      '-e',
+      [
+        'let bytes = 0;',
+        'process.stdin.on("data", chunk => { bytes += chunk.length; });',
+        'process.stdin.on("end", () => process.stdout.write(String(bytes)));',
+      ].join(''),
+    ],
+    { stdin },
+  );
+
+  assert.equal(result.stdout, String(stdin.length));
+});
+
 test('whichCmd resolves absolute executable paths without invoking a shell', async () => {
   assert.equal(await whichCmd(process.execPath), true);
 });

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -34,14 +34,7 @@ test('runCmd aborts with request cancellation details', async () => {
   });
   controller.abort();
 
-  await assert.rejects(promise, (error: unknown) => {
-    const err = error as { code?: string; message?: string; details?: Record<string, unknown> };
-    return (
-      err?.code === 'COMMAND_FAILED' &&
-      err.message === 'request canceled' &&
-      err.details?.reason === 'request_canceled'
-    );
-  });
+  await assertRejectsRequestCanceled(promise);
 });
 
 test('runCmd abort keeps cancellation details while writing stdin', async () => {
@@ -56,14 +49,7 @@ test('runCmd abort keeps cancellation details while writing stdin', async () => 
   );
   controller.abort();
 
-  await assert.rejects(promise, (error: unknown) => {
-    const err = error as { code?: string; message?: string; details?: Record<string, unknown> };
-    return (
-      err?.code === 'COMMAND_FAILED' &&
-      err.message === 'request canceled' &&
-      err.details?.reason === 'request_canceled'
-    );
-  });
+  await assertRejectsRequestCanceled(promise);
 });
 
 test('runCmd writes stdin through pipeline', async () => {
@@ -87,6 +73,17 @@ test('runCmd writes stdin through pipeline', async () => {
 test('whichCmd resolves absolute executable paths without invoking a shell', async () => {
   assert.equal(await whichCmd(process.execPath), true);
 });
+
+async function assertRejectsRequestCanceled(promise: Promise<unknown>): Promise<void> {
+  await assert.rejects(promise, (error: unknown) => {
+    const err = error as { code?: string; message?: string; details?: Record<string, unknown> };
+    return (
+      err?.code === 'COMMAND_FAILED' &&
+      err.message === 'request canceled' &&
+      err.details?.reason === 'request_canceled'
+    );
+  });
+}
 
 test('whichCmd resolves bare commands from PATH', async () => {
   assert.equal(await whichCmd('node'), true);

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,7 +1,7 @@
 import { constants } from 'node:fs';
 import { access, stat } from 'node:fs/promises';
 import path from 'node:path';
-import { spawn, spawnSync, type StdioOptions } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess, type StdioOptions } from 'node:child_process';
 import { AppError } from './errors.ts';
 
 export type ExecResult = {
@@ -44,6 +44,22 @@ export async function runCmd(
   args: string[],
   options: ExecOptions = {},
 ): Promise<ExecResult> {
+  return await runSpawnedCommand(cmd, args, options);
+}
+
+export async function runCmdStreaming(
+  cmd: string,
+  args: string[],
+  options: ExecStreamOptions = {},
+): Promise<ExecResult> {
+  return await runSpawnedCommand(cmd, args, options);
+}
+
+function runSpawnedCommand(
+  cmd: string,
+  args: string[],
+  options: ExecStreamOptions = {},
+): Promise<ExecResult> {
   const executable = normalizeExecutableCommand(cmd);
   return new Promise((resolve, reject) => {
     const child = spawn(executable, args, {
@@ -53,82 +69,72 @@ export async function runCmd(
       detached: options.detached,
       shell: false,
     });
+    options.onSpawn?.(child);
 
     let stdout = '';
-    let stdoutBuffer: Buffer | undefined = options.binaryStdout ? Buffer.alloc(0) : undefined;
+    const stdoutChunks: Buffer[] | undefined = options.binaryStdout ? [] : undefined;
     let stderr = '';
     let didTimeout = false;
     const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
     const timeoutHandle = timeoutMs
       ? setTimeout(() => {
           didTimeout = true;
-          child.kill('SIGKILL');
+          killProcessTree(child, options.detached);
         }, timeoutMs)
       : null;
 
     if (!options.binaryStdout) child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
 
+    child.stdin.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code !== 'EPIPE') {
+        child.emit('error', err);
+      }
+    });
     if (options.stdin !== undefined) {
-      child.stdin.write(options.stdin);
+      child.stdin.end(options.stdin);
+    } else {
+      child.stdin.end();
     }
-    child.stdin.end();
 
     child.stdout.on('data', (chunk) => {
       if (options.binaryStdout) {
-        stdoutBuffer = Buffer.concat([
-          stdoutBuffer ?? Buffer.alloc(0),
-          Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
-        ]);
-      } else {
-        stdout += chunk;
+        stdoutChunks?.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        return;
       }
+      const text = String(chunk);
+      stdout += text;
+      options.onStdoutChunk?.(text);
     });
 
     child.stderr.on('data', (chunk) => {
-      stderr += chunk;
+      const text = String(chunk);
+      stderr += text;
+      options.onStderrChunk?.(text);
     });
 
     child.on('error', (err) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT') {
-        reject(new AppError('TOOL_MISSING', `${executable} not found in PATH`, { cmd }, err));
-        return;
-      }
-      reject(new AppError('COMMAND_FAILED', `Failed to run ${executable}`, { cmd, args }, err));
+      reject(createSpawnError(executable, cmd, args, err));
     });
 
     child.on('close', (code) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
       const exitCode = code ?? 1;
       if (didTimeout && timeoutMs) {
-        reject(
-          new AppError('COMMAND_FAILED', `${executable} timed out after ${timeoutMs}ms`, {
-            cmd,
-            args,
-            stdout,
-            stderr,
-            exitCode,
-            timeoutMs,
-          }),
-        );
+        reject(createTimeoutError(executable, cmd, args, timeoutMs, exitCode, stdout, stderr));
         return;
       }
       if (exitCode !== 0 && !options.allowFailure) {
-        reject(
-          new AppError('COMMAND_FAILED', `${executable} exited with code ${exitCode}`, {
-            cmd,
-            args,
-            stdout,
-            stderr,
-            exitCode,
-            processExitError: true,
-          }),
-        );
+        reject(createExitError(executable, cmd, args, exitCode, stdout, stderr));
         return;
       }
-      resolve({ stdout, stderr, exitCode, stdoutBuffer });
+      resolve({
+        stdout,
+        stderr,
+        exitCode,
+        stdoutBuffer: stdoutChunks ? Buffer.concat(stdoutChunks) : undefined,
+      });
     });
   });
 }
@@ -216,14 +222,9 @@ export function runCmdSync(cmd: string, args: string[], options: ExecOptions = {
       );
     }
     if (code === 'ENOENT') {
-      throw new AppError('TOOL_MISSING', `${executable} not found in PATH`, { cmd }, result.error);
+      throw createMissingToolError(executable, cmd, result.error);
     }
-    throw new AppError(
-      'COMMAND_FAILED',
-      `Failed to run ${executable}`,
-      { cmd, args },
-      result.error,
-    );
+    throw createCommandFailedError(executable, cmd, args, result.error);
   }
 
   const stdoutBuffer = options.binaryStdout
@@ -241,14 +242,7 @@ export function runCmdSync(cmd: string, args: string[], options: ExecOptions = {
   const exitCode = result.status ?? 1;
 
   if (exitCode !== 0 && !options.allowFailure) {
-    throw new AppError('COMMAND_FAILED', `${executable} exited with code ${exitCode}`, {
-      cmd,
-      args,
-      stdout,
-      stderr,
-      exitCode,
-      processExitError: true,
-    });
+    throw createExitError(executable, cmd, args, exitCode, stdout, stderr);
   }
 
   return { stdout, stderr, exitCode, stdoutBuffer };
@@ -269,105 +263,6 @@ export function runCmdDetached(
   });
   child.unref();
   return child.pid ?? 0;
-}
-
-export async function runCmdStreaming(
-  cmd: string,
-  args: string[],
-  options: ExecStreamOptions = {},
-): Promise<ExecResult> {
-  const executable = normalizeExecutableCommand(cmd);
-  return new Promise((resolve, reject) => {
-    const child = spawn(executable, args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      detached: options.detached,
-      shell: false,
-    });
-    options.onSpawn?.(child);
-
-    let stdout = '';
-    let stderr = '';
-    let stdoutBuffer: Buffer | undefined = options.binaryStdout ? Buffer.alloc(0) : undefined;
-    let didTimeout = false;
-    const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
-    const timeoutHandle = timeoutMs
-      ? setTimeout(() => {
-          didTimeout = true;
-          child.kill('SIGKILL');
-        }, timeoutMs)
-      : null;
-
-    if (!options.binaryStdout) child.stdout.setEncoding('utf8');
-    child.stderr.setEncoding('utf8');
-
-    if (options.stdin !== undefined) {
-      child.stdin.write(options.stdin);
-    }
-    child.stdin.end();
-
-    child.stdout.on('data', (chunk) => {
-      if (options.binaryStdout) {
-        stdoutBuffer = Buffer.concat([
-          stdoutBuffer ?? Buffer.alloc(0),
-          Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
-        ]);
-        return;
-      }
-      const text = String(chunk);
-      stdout += text;
-      options.onStdoutChunk?.(text);
-    });
-
-    child.stderr.on('data', (chunk) => {
-      const text = String(chunk);
-      stderr += text;
-      options.onStderrChunk?.(text);
-    });
-
-    child.on('error', (err) => {
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT') {
-        reject(new AppError('TOOL_MISSING', `${executable} not found in PATH`, { cmd }, err));
-        return;
-      }
-      reject(new AppError('COMMAND_FAILED', `Failed to run ${executable}`, { cmd, args }, err));
-    });
-
-    child.on('close', (code) => {
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-      const exitCode = code ?? 1;
-      if (didTimeout && timeoutMs) {
-        reject(
-          new AppError('COMMAND_FAILED', `${executable} timed out after ${timeoutMs}ms`, {
-            cmd,
-            args,
-            stdout,
-            stderr,
-            exitCode,
-            timeoutMs,
-          }),
-        );
-        return;
-      }
-      if (exitCode !== 0 && !options.allowFailure) {
-        reject(
-          new AppError('COMMAND_FAILED', `${executable} exited with code ${exitCode}`, {
-            cmd,
-            args,
-            stdout,
-            stderr,
-            exitCode,
-            processExitError: true,
-          }),
-        );
-        return;
-      }
-      resolve({ stdout, stderr, exitCode, stdoutBuffer });
-    });
-  });
 }
 
 export function runCmdBackground(
@@ -399,26 +294,12 @@ export function runCmdBackground(
 
   const wait = new Promise<ExecResult>((resolve, reject) => {
     child.on('error', (err) => {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === 'ENOENT') {
-        reject(new AppError('TOOL_MISSING', `${executable} not found in PATH`, { cmd }, err));
-        return;
-      }
-      reject(new AppError('COMMAND_FAILED', `Failed to run ${executable}`, { cmd, args }, err));
+      reject(createSpawnError(executable, cmd, args, err));
     });
     child.on('close', (code) => {
       const exitCode = code ?? 1;
       if (exitCode !== 0 && !options.allowFailure) {
-        reject(
-          new AppError('COMMAND_FAILED', `${executable} exited with code ${exitCode}`, {
-            cmd,
-            args,
-            stdout,
-            stderr,
-            exitCode,
-            processExitError: true,
-          }),
-        );
+        reject(createExitError(executable, cmd, args, exitCode, stdout, stderr));
         return;
       }
       resolve({ stdout, stderr, exitCode });
@@ -437,6 +318,64 @@ function normalizeExecutableCommand(cmd: string): string {
     });
   }
   return candidate;
+}
+
+function createSpawnError(executable: string, cmd: string, args: string[], err: Error): AppError {
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === 'ENOENT') {
+    return createMissingToolError(executable, cmd, err);
+  }
+  return createCommandFailedError(executable, cmd, args, err);
+}
+
+function createMissingToolError(executable: string, cmd: string, cause: Error): AppError {
+  return new AppError('TOOL_MISSING', `${executable} not found in PATH`, { cmd }, cause);
+}
+
+function createCommandFailedError(
+  executable: string,
+  cmd: string,
+  args: string[],
+  cause: Error,
+): AppError {
+  return new AppError('COMMAND_FAILED', `Failed to run ${executable}`, { cmd, args }, cause);
+}
+
+function createTimeoutError(
+  executable: string,
+  cmd: string,
+  args: string[],
+  timeoutMs: number,
+  exitCode: number,
+  stdout: string,
+  stderr: string,
+): AppError {
+  return new AppError('COMMAND_FAILED', `${executable} timed out after ${timeoutMs}ms`, {
+    cmd,
+    args,
+    stdout,
+    stderr,
+    exitCode,
+    timeoutMs,
+  });
+}
+
+function createExitError(
+  executable: string,
+  cmd: string,
+  args: string[],
+  exitCode: number,
+  stdout: string,
+  stderr: string,
+): AppError {
+  return new AppError('COMMAND_FAILED', `${executable} exited with code ${exitCode}`, {
+    cmd,
+    args,
+    stdout,
+    stderr,
+    exitCode,
+    processExitError: true,
+  });
 }
 
 function normalizeOverridePath(
@@ -510,4 +449,14 @@ function normalizeTimeoutMs(value: number | undefined): number | undefined {
   const timeout = Math.floor(value as number);
   if (timeout <= 0) return undefined;
   return timeout;
+}
+
+function killProcessTree(child: ChildProcess, detached: boolean | undefined): void {
+  if (detached && child.pid && process.platform !== 'win32') {
+    try {
+      process.kill(-child.pid, 'SIGKILL');
+      return;
+    } catch {}
+  }
+  child.kill('SIGKILL');
 }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -2,6 +2,8 @@ import { constants } from 'node:fs';
 import { access, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { spawn, spawnSync, type ChildProcess, type StdioOptions } from 'node:child_process';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { AppError } from './errors.ts';
 
 export type ExecResult = {
@@ -19,6 +21,7 @@ type ExecOptions = {
   stdin?: string | Buffer;
   timeoutMs?: number;
   detached?: boolean;
+  signal?: AbortSignal;
 };
 
 type ExecStreamOptions = ExecOptions & {
@@ -75,6 +78,7 @@ function runSpawnedCommand(
     const stdoutChunks: Buffer[] | undefined = options.binaryStdout ? [] : undefined;
     let stderr = '';
     let didTimeout = false;
+    let didAbort = false;
     const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
     const timeoutHandle = timeoutMs
       ? setTimeout(() => {
@@ -82,20 +86,25 @@ function runSpawnedCommand(
           killProcessTree(child, options.detached);
         }, timeoutMs)
       : null;
+    const onAbort = () => {
+      didAbort = true;
+      killProcessTree(child, options.detached);
+    };
+    if (options.signal?.aborted) {
+      onAbort();
+    } else {
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+    }
 
     if (!options.binaryStdout) child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
 
-    child.stdin.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code !== 'EPIPE') {
-        child.emit('error', err);
-      }
+    void writeChildStdin(child, options.stdin).catch((err: unknown) => {
+      if (didAbort || didTimeout) return;
+      if (isEpipeError(err)) return;
+      reject(createStdinError(executable, cmd, args, err));
+      killProcessTree(child, options.detached);
     });
-    if (options.stdin !== undefined) {
-      child.stdin.end(options.stdin);
-    } else {
-      child.stdin.end();
-    }
 
     child.stdout.on('data', (chunk) => {
       if (options.binaryStdout) {
@@ -115,12 +124,22 @@ function runSpawnedCommand(
 
     child.on('error', (err) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
-      reject(createSpawnError(executable, cmd, args, err));
+      options.signal?.removeEventListener('abort', onAbort);
+      reject(
+        didAbort
+          ? createCommandCanceledError(executable, cmd, args)
+          : createSpawnError(executable, cmd, args, err),
+      );
     });
 
     child.on('close', (code) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
+      options.signal?.removeEventListener('abort', onAbort);
       const exitCode = code ?? 1;
+      if (didAbort) {
+        reject(createCommandCanceledError(executable, cmd, args));
+        return;
+      }
       if (didTimeout && timeoutMs) {
         reject(createTimeoutError(executable, cmd, args, timeoutMs, exitCode, stdout, stderr));
         return;
@@ -341,6 +360,29 @@ function createCommandFailedError(
   return new AppError('COMMAND_FAILED', `Failed to run ${executable}`, { cmd, args }, cause);
 }
 
+function createStdinError(
+  executable: string,
+  cmd: string,
+  args: string[],
+  cause: unknown,
+): AppError {
+  return new AppError(
+    'COMMAND_FAILED',
+    `Failed to write stdin for ${executable}`,
+    { cmd, args },
+    cause instanceof Error ? cause : undefined,
+  );
+}
+
+function createCommandCanceledError(executable: string, cmd: string, args: string[]): AppError {
+  return new AppError('COMMAND_FAILED', 'request canceled', {
+    cmd,
+    args,
+    executable,
+    reason: 'request_canceled',
+  });
+}
+
 function createTimeoutError(
   executable: string,
   cmd: string,
@@ -459,4 +501,22 @@ function killProcessTree(child: ChildProcess, detached: boolean | undefined): vo
     } catch {}
   }
   child.kill('SIGKILL');
+}
+
+async function writeChildStdin(
+  child: ChildProcess,
+  stdin: string | Buffer | undefined,
+): Promise<void> {
+  if (!child.stdin) return;
+  if (stdin === undefined) {
+    child.stdin?.end();
+    return;
+  }
+  await pipeline(Readable.from([stdin]), child.stdin);
+}
+
+function isEpipeError(error: unknown): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'EPIPE'
+  );
 }

--- a/test/integration/installed-package-metro.test.ts
+++ b/test/integration/installed-package-metro.test.ts
@@ -1,15 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import crypto from 'node:crypto';
-import { execFile, execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import type { Duplex } from 'node:stream';
 import { fileURLToPath } from 'node:url';
+import { runCmd, runCmdSync } from '../../src/utils/exec.ts';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SUBPROCESS_TIMEOUT_MS = 120_000;
 
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve, reject) => {
@@ -48,43 +49,30 @@ async function execFileText(
   args: string[],
   options: { cwd: string },
 ): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    execFile(file, args, { ...options, encoding: 'utf8' }, (error, stdout, stderr) => {
-      if (error) {
-        reject(
-          new Error(
-            [error.message, stdout ? `stdout:\n${stdout}` : '', stderr ? `stderr:\n${stderr}` : '']
-              .filter(Boolean)
-              .join('\n'),
-            { cause: error },
-          ),
-        );
-        return;
-      }
-      resolve(stdout);
-    });
+  const result = await runCmd(file, args, {
+    cwd: options.cwd,
+    timeoutMs: SUBPROCESS_TIMEOUT_MS,
   });
+  return result.stdout;
 }
 
 function packInstalledPackage(tempRoot: string): string {
   const packDir = path.join(tempRoot, 'pack');
   fs.mkdirSync(packDir, { recursive: true });
-  const tarballName = execFileSync(
-    'npm',
-    ['pack', '--ignore-scripts', '--pack-destination', packDir],
-    {
-      cwd: repoRoot,
-      encoding: 'utf8',
-    },
-  ).trim();
+  const result = runCmdSync('npm', ['pack', '--ignore-scripts', '--pack-destination', packDir], {
+    cwd: repoRoot,
+    timeoutMs: SUBPROCESS_TIMEOUT_MS,
+  });
+  const tarballName = result.stdout.trim();
   return path.join(packDir, tarballName);
 }
 
 function extractInstalledPackage(tarballPath: string, consumerRoot: string): string {
   const nodeModulesRoot = path.join(consumerRoot, 'node_modules');
   fs.mkdirSync(nodeModulesRoot, { recursive: true });
-  execFileSync('tar', ['-xzf', tarballPath, '-C', nodeModulesRoot], {
+  runCmdSync('tar', ['-xzf', tarballPath, '-C', nodeModulesRoot], {
     cwd: consumerRoot,
+    timeoutMs: SUBPROCESS_TIMEOUT_MS,
   });
   const extractedPackageRoot = path.join(nodeModulesRoot, 'package');
   const installedPackageRoot = path.join(nodeModulesRoot, 'agent-device');

--- a/test/integration/recording-overlay.test.ts
+++ b/test/integration/recording-overlay.test.ts
@@ -13,161 +13,129 @@ import {
 const recordingE2EEnabled = isTruthy(process.env.AGENT_DEVICE_RECORDING_E2E);
 
 test('recording tap overlay on iOS simulator', { skip: shouldSkipIosRecordingE2E() }, () => {
-  const integration = createRecordingIntegrationContext('ios', 'recording tap overlay');
-  const outPath = path.join(integration.artifactDir(), 'ios-tap.mp4');
-  const session = ['--session', 'recording-ios-tap'];
-
-  integration.runStep('open settings', [
-    'open',
-    'com.apple.Preferences',
-    '--platform',
-    'ios',
-    '--relaunch',
-    '--json',
-    ...session,
-  ]);
-  integration.runStep('record start', ['record', 'start', outPath, '--json', ...session]);
-  integration.runStep('tap general', ['click', 'role=cell', 'label=General', '--json', ...session]);
-  const stop = integration.runStep('record stop', ['record', 'stop', '--json', ...session]);
-
-  assertRecordingArtifacts(stop, outPath);
-  const manifest = inspectRecording(
-    outPath,
-    stop.json?.data?.telemetryPath,
-    integration.artifactDir(),
-    'ios-tap',
-  );
-  assertOverlayForKind(manifest, 'tap', { minPixelCount: 180, maxCenterDistance: 80 });
+  runRecordingOverlayCase({
+    platform: 'ios',
+    testName: 'recording tap overlay',
+    outFile: 'ios-tap.mp4',
+    sessionName: 'recording-ios-tap',
+    openArgs: ['open', 'com.apple.Preferences', '--platform', 'ios', '--relaunch', '--json'],
+    steps: [['tap general', ['click', 'role=cell', 'label=General', '--json']]],
+    inspectPrefix: 'ios-tap',
+    overlayKind: 'tap',
+    overlayOptions: { minPixelCount: 180, maxCenterDistance: 80 },
+  });
 });
 
 test('recording scroll overlay on iOS simulator', { skip: shouldSkipIosRecordingE2E() }, () => {
-  const integration = createRecordingIntegrationContext('ios', 'recording scroll overlay');
-  const outPath = path.join(integration.artifactDir(), 'ios-scroll.mp4');
-  const session = ['--session', 'recording-ios-scroll'];
-
-  integration.runStep('open settings', [
-    'open',
-    'com.apple.Preferences',
-    '--platform',
-    'ios',
-    '--relaunch',
-    '--json',
-    ...session,
-  ]);
-  integration.runStep('record start', ['record', 'start', outPath, '--json', ...session]);
-  integration.runStep('scroll down', ['scroll', 'down', '0.45', '--json', ...session]);
-  const stop = integration.runStep('record stop', ['record', 'stop', '--json', ...session]);
-
-  assertRecordingArtifacts(stop, outPath);
-  const manifest = inspectRecording(
-    outPath,
-    stop.json?.data?.telemetryPath,
-    integration.artifactDir(),
-    'ios-scroll',
-  );
-  assertOverlayForKind(manifest, 'scroll', { minPixelCount: 5 });
+  runRecordingOverlayCase({
+    platform: 'ios',
+    testName: 'recording scroll overlay',
+    outFile: 'ios-scroll.mp4',
+    sessionName: 'recording-ios-scroll',
+    openArgs: ['open', 'com.apple.Preferences', '--platform', 'ios', '--relaunch', '--json'],
+    steps: [['scroll down', ['scroll', 'down', '0.45', '--json']]],
+    inspectPrefix: 'ios-scroll',
+    overlayKind: 'scroll',
+    overlayOptions: { minPixelCount: 5 },
+  });
 });
 
 test('recording back-swipe overlay on iOS simulator', { skip: shouldSkipIosRecordingE2E() }, () => {
-  const integration = createRecordingIntegrationContext('ios', 'recording back swipe overlay');
-  const outPath = path.join(integration.artifactDir(), 'ios-back-swipe.mp4');
-  const session = ['--session', 'recording-ios-back-swipe'];
-
-  integration.runStep('open settings', [
-    'open',
-    'com.apple.Preferences',
-    '--platform',
-    'ios',
-    '--relaunch',
-    '--json',
-    ...session,
-  ]);
-  integration.runStep('record start', ['record', 'start', outPath, '--json', ...session]);
-  integration.runStep('open general', ['press', '201', '319', '--json', ...session]);
-  integration.runStep('edge swipe', [
-    'swipe',
-    '10',
-    '400',
-    '250',
-    '400',
-    '250',
-    '--json',
-    ...session,
-  ]);
-  const stop = integration.runStep('record stop', ['record', 'stop', '--json', ...session]);
-
-  assertRecordingArtifacts(stop, outPath);
-  const manifest = inspectRecording(
-    outPath,
-    stop.json?.data?.telemetryPath,
-    integration.artifactDir(),
-    'ios-back-swipe',
-  );
-  assertOverlayForKind(manifest, 'back-swipe', { minPixelCount: 80 });
+  runRecordingOverlayCase({
+    platform: 'ios',
+    testName: 'recording back swipe overlay',
+    outFile: 'ios-back-swipe.mp4',
+    sessionName: 'recording-ios-back-swipe',
+    openArgs: ['open', 'com.apple.Preferences', '--platform', 'ios', '--relaunch', '--json'],
+    steps: [
+      ['open general', ['press', '201', '319', '--json']],
+      ['edge swipe', ['swipe', '10', '400', '250', '400', '250', '--json']],
+    ],
+    inspectPrefix: 'ios-back-swipe',
+    overlayKind: 'back-swipe',
+    overlayOptions: { minPixelCount: 80 },
+  });
 });
 
 test('recording tap overlay on Android emulator', { skip: shouldSkipAndroidRecordingE2E() }, () => {
-  const integration = createRecordingIntegrationContext('android', 'recording tap overlay');
-  const outPath = path.join(integration.artifactDir(), 'android-tap.mp4');
-  const session = ['--session', 'recording-android-tap'];
-
-  integration.runStep('open settings', [
-    'open',
-    'settings',
-    '--platform',
-    'android',
-    '--relaunch',
-    '--json',
-    ...session,
-  ]);
-  integration.runStep('record start', ['record', 'start', outPath, '--json', ...session]);
-  integration.runStep('tap apps', ['press', '672', '1362', '--json', ...session]);
-  integration.runStep('scroll down', ['scroll', 'down', '0.2', '--json', ...session]);
-  integration.runStep('settle', ['wait', '1200', '--json', ...session]);
-  const stop = integration.runStep('record stop', ['record', 'stop', '--json', ...session]);
-
-  assertRecordingArtifacts(stop, outPath);
-  const manifest = inspectRecording(
-    outPath,
-    stop.json?.data?.telemetryPath,
-    integration.artifactDir(),
-    'android-tap',
-  );
-  assertOverlayForKind(manifest, 'tap', { minPixelCount: 180, maxCenterDistance: 80 });
+  runRecordingOverlayCase({
+    platform: 'android',
+    testName: 'recording tap overlay',
+    outFile: 'android-tap.mp4',
+    sessionName: 'recording-android-tap',
+    openArgs: ['open', 'settings', '--platform', 'android', '--relaunch', '--json'],
+    steps: [
+      ['tap apps', ['press', '672', '1362', '--json']],
+      ['scroll down', ['scroll', 'down', '0.2', '--json']],
+      ['settle', ['wait', '1200', '--json']],
+    ],
+    inspectPrefix: 'android-tap',
+    overlayKind: 'tap',
+    overlayOptions: { minPixelCount: 180, maxCenterDistance: 80 },
+  });
 });
 
 test(
   'recording scroll overlay on Android emulator',
   { skip: shouldSkipAndroidRecordingE2E() },
   () => {
-    const integration = createRecordingIntegrationContext('android', 'recording scroll overlay');
-    const outPath = path.join(integration.artifactDir(), 'android-scroll.mp4');
-    const session = ['--session', 'recording-android-scroll'];
+    runRecordingOverlayCase({
+      platform: 'android',
+      testName: 'recording scroll overlay',
+      outFile: 'android-scroll.mp4',
+      sessionName: 'recording-android-scroll',
+      openArgs: ['open', 'settings', '--platform', 'android', '--relaunch', '--json'],
+      steps: [
+        ['scroll down', ['scroll', 'down', '0.45', '--json']],
+        ['settle', ['wait', '1200', '--json']],
+      ],
+      inspectPrefix: 'android-scroll',
+      overlayKind: 'scroll',
+      overlayOptions: { minPixelCount: 5 },
+    });
+  },
+);
 
-    integration.runStep('open settings', [
-      'open',
-      'settings',
-      '--platform',
-      'android',
-      '--relaunch',
-      '--json',
-      ...session,
-    ]);
+type RecordingOverlayCase = {
+  platform: 'ios' | 'android';
+  testName: string;
+  outFile: string;
+  sessionName: string;
+  openArgs: string[];
+  steps: Array<[string, string[]]>;
+  inspectPrefix: string;
+  overlayKind: string;
+  overlayOptions: { minPixelCount: number; maxCenterDistance?: number };
+};
+
+function runRecordingOverlayCase(options: RecordingOverlayCase): void {
+  const integration = createRecordingIntegrationContext(options.platform, options.testName);
+  const outPath = path.join(integration.artifactDir(), options.outFile);
+  const session = ['--session', options.sessionName];
+  let recordingStarted = false;
+  let recordingStopped = false;
+
+  try {
+    integration.runStep('open settings', [...options.openArgs, ...session]);
     integration.runStep('record start', ['record', 'start', outPath, '--json', ...session]);
-    integration.runStep('scroll down', ['scroll', 'down', '0.45', '--json', ...session]);
-    integration.runStep('settle', ['wait', '1200', '--json', ...session]);
+    recordingStarted = true;
+    for (const [label, args] of options.steps) {
+      integration.runStep(label, [...args, ...session]);
+    }
     const stop = integration.runStep('record stop', ['record', 'stop', '--json', ...session]);
-
+    recordingStopped = true;
     assertRecordingArtifacts(stop, outPath);
     const manifest = inspectRecording(
       outPath,
       stop.json?.data?.telemetryPath,
       integration.artifactDir(),
-      'android-scroll',
+      options.inspectPrefix,
     );
-    assertOverlayForKind(manifest, 'scroll', { minPixelCount: 5 });
-  },
-);
+    assertOverlayForKind(manifest, options.overlayKind, options.overlayOptions);
+  } finally {
+    cleanupRecordingSession(integration, session, recordingStarted, recordingStopped);
+  }
+}
 
 function createRecordingIntegrationContext(platform: 'ios' | 'android', testName: string) {
   const runId = new Date().toISOString().replaceAll(':', '-');
@@ -177,6 +145,18 @@ function createRecordingIntegrationContext(platform: 'ios' | 'android', testName
     testName,
     extraEnv: { ...process.env, AGENT_DEVICE_STATE_DIR: stateDir },
   });
+}
+
+function cleanupRecordingSession(
+  integration: ReturnType<typeof createRecordingIntegrationContext>,
+  session: string[],
+  recordingStarted: boolean,
+  recordingStopped: boolean,
+): void {
+  if (recordingStarted && !recordingStopped) {
+    integration.runCleanupStep('cleanup record stop', ['record', 'stop', '--json', ...session]);
+  }
+  integration.runCleanupStep('cleanup close', ['close', '--json', ...session]);
 }
 
 function assertRecordingArtifacts(result: ReturnType<typeof runCliJson>, outPath: string): void {

--- a/test/integration/test-helpers.ts
+++ b/test/integration/test-helpers.ts
@@ -4,6 +4,9 @@ import path from 'node:path';
 import { PNG } from 'pngjs';
 import { runCmdSync } from '../../src/utils/exec.ts';
 
+const CLI_TIMEOUT_MS = 120_000;
+const RECORDING_INSPECT_TIMEOUT_MS = 60_000;
+
 export type CliJsonResult = {
   status: number;
   json?: any;
@@ -69,6 +72,7 @@ export function runCliJson(args: string[], options?: { env?: NodeJS.ProcessEnv }
     {
       allowFailure: true,
       env: options?.env,
+      timeoutMs: CLI_TIMEOUT_MS,
     },
   );
   let json: any;
@@ -109,6 +113,22 @@ export function createIntegrationTestContext(options: IntegrationTestContextOpti
 
   function runStep(step: string, args: string[], expectedStatus = 0): CliJsonResult {
     const result = runCliJson(args, { env: extraEnv });
+    recordStep(step, args, result);
+    maybeCaptureSnapshot(args, result);
+    if (result.status !== expectedStatus) {
+      failWithContext(step, args, result);
+    }
+    return result;
+  }
+
+  function runCleanupStep(step: string, args: string[]): CliJsonResult {
+    const result = runCliJson(args, { env: extraEnv });
+    recordStep(step, args, result);
+    maybeCaptureSnapshot(args, result);
+    return result;
+  }
+
+  function recordStep(step: string, args: string[], result: CliJsonResult): void {
     const errorCode =
       typeof result.json?.error?.code === 'string' ? (result.json.error.code as string) : undefined;
     const errorMessage =
@@ -123,11 +143,6 @@ export function createIntegrationTestContext(options: IntegrationTestContextOpti
       errorCode,
       errorMessage,
     });
-    maybeCaptureSnapshot(args, result);
-    if (result.status !== expectedStatus) {
-      failWithContext(step, args, result);
-    }
-    return result;
   }
 
   function assertResult(
@@ -276,6 +291,7 @@ export function createIntegrationTestContext(options: IntegrationTestContextOpti
 
   return {
     runStep,
+    runCleanupStep,
     assertResult,
     artifactDir: ensureArtifactDir,
   };
@@ -300,7 +316,7 @@ export function runRecordingInspect(params: {
       '--output-dir',
       params.outputDir,
     ],
-    { allowFailure: true },
+    { allowFailure: true, timeoutMs: RECORDING_INSPECT_TIMEOUT_MS },
   );
   assert.equal(result.exitCode, 0, result.stderr || result.stdout || 'recording inspect failed');
   const manifestPath = path.join(params.outputDir, 'manifest.json');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,17 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "isolatedModules": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
     "types": ["node"]
   },
   "include": ["src", "test"]


### PR DESCRIPTION
## Summary

Harden Node runtime, daemon shutdown, process/stream cleanup, platform discovery, and test lifecycle handling.

Fixes included:
- Pin local/CI package management to pnpm 10.33.2 and Node 22.19.
- Add `packageManager`, raise the Node engine floor, and expand `format` coverage for tooling config files.
- Switch TypeScript checking to NodeNext resolution and add type-stripping guardrails: `verbatimModuleSyntax`, `erasableSyntaxOnly`, and `rewriteRelativeImportExtensions`.
- Make daemon fatal errors exit non-zero and emit daemon-level diagnostics.
- Add bounded daemon server shutdown with forced socket/HTTP connection teardown.
- Extract daemon server shutdown into a focused helper and cover the forced-close timeout path.
- Tear down daemon sessions in parallel with a per-session timeout during shutdown.
- Share session resource teardown between daemon shutdown and `close`, including app logs, Apple runners, and retained materialized paths.
- Re-check request cancellation around queued session execution locks.
- Avoid per-chunk `Buffer.concat` in exec stdout capture and consolidate spawn/error handling.
- Add `AbortSignal` support to `runCmd` and return the daemon-recognized request-canceled error shape on abort.
- Write `runCmd` stdin through `pipeline(Readable.from(...), child.stdin)` and keep benign early `EPIPE` handling.
- Thread request cancellation into the iOS simulator curl fallback path.
- Kill detached process groups on command timeout or abort.
- Move artifact upload/download and hashing paths to `pipeline()` for better stream teardown/backpressure.
- Close partial artifact write streams before deleting failed/timed-out downloads.
- Use `Readable.fromWeb` for fetch response download streams.
- Use `AbortSignal.timeout` / `AbortSignal.any` for fetch timeout handling where applicable.
- Cache only positive physical-device runner tunnel IP resolution results so transient null probes can retry.
- Serialize iOS runner log appends to avoid unordered concurrent writes.
- Limit Android device discovery and TV feature probe concurrency to reduce adb pressure.
- Add subprocess timeouts to integration helpers and installed-package checks.
- Clear test timeout timers, await killed child processes, isolate session-routing temp stores, and add recording overlay cleanup.
- Refactor new cleanup code enough to keep fallow complexity failures cleared.

Touched-file count: 24. Scope intentionally spans tooling, daemon lifecycle, process I/O, platform discovery, and test cleanup from the requested all-around audit follow-ups.
Docs/skills were not updated because no CLI behavior, flags, workflows, or user-facing docs changed.

## Validation

pnpm install --lockfile-only --frozen-lockfile
pnpm format
pnpm typecheck
pnpm vitest run src/utils/__tests__/exec.test.ts src/platforms/ios/__tests__/runner-transport.test.ts
pnpm vitest run src/daemon/__tests__/server-shutdown.test.ts src/utils/__tests__/exec.test.ts src/platforms/ios/__tests__/runner-transport.test.ts src/platforms/__tests__/install-source.test.ts
pnpm exec node --test test/integration/smoke-daemon-http.test.ts test/integration/smoke-open-remote-config.test.ts
pnpm vitest run src/daemon/__tests__/http-server.test.ts src/daemon/__tests__/artifact-materialization.test.ts src/utils/__tests__/daemon-client.test.ts
pnpm vitest run src/daemon/__tests__/upload.test.ts src/platforms/ios/__tests__/runner-transport.test.ts
pnpm check:fallow
pnpm check:unit
pnpm check
