### PR TITLE
docs: refresh README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ agent-device close
 
 Refs from the default snapshot are immediately actionable. For hidden content, scroll and re-snapshot.
 
-Choose how to run it.
+## Where To Run agent-device
 
 | Path | Best for | Start with |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -10,17 +10,24 @@
 
 Device automation CLI for AI agents. Mobile, TV, and desktop.
 
-Run the app. Inspect the UI. Collect the evidence. Repeat the flow.
+Run the app. Read the UI. Act on the screen. Capture evidence.
 
-It gives agents structured UI access, deterministic interactions, screenshots, recordings, logs, network inspection, performance data, and replayable sessions on iOS, Android, tvOS, macOS, and Linux. If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this is the same idea for apps and devices.
+Give agents a runtime loop for iOS, Android, tvOS, macOS, and Linux apps:
+
+- See current UI as compact snapshots.
+- Act through stable refs and selectors.
+- Capture screenshots, video, logs, network, perf, and React profiles.
+- Replay flows as e2e tests.
+
+If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this is the same idea for apps and devices.
 
 [![Watch the demo video](./website/docs/public/agent-device-contacts.gif)](./website/docs/public/agent-device-contacts.mp4)
 
 ## Use Cases
 
-- **QA**: explore flows, dogfood the app, run accessibility checks, capture evidence, and turn stable explorations into e2e tests.
-- **Debugging**: start from a Sentry issue, crash during development, support ticket, or bug description. Reproduce the flow, inspect logs/network/perf data, and fix with context.
-- **Development**: build from a product or engineering specification. Run the app, inspect the result, interact, debug, and iterate until the UI confirms the work.
+- **QA**: dogfood flows, run accessibility checks, capture evidence, and generate replayable e2e tests.
+- **Debugging**: start from Sentry, a development crash, a support ticket, or a bug description. Reproduce the flow and fix with UI, logs, network, and perf context.
+- **Development**: build from a product or engineering specification. Run, inspect, interact, debug, and iterate until the UI confirms the work.
 
 ## Get Started
 
@@ -35,7 +42,7 @@ Choose how to run it.
 | Path | Best for | Start with |
 | --- | --- | --- |
 | Local | Simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
-| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Use a ready setup for GitHub PRs, EAS builds, or CI validation. Coming soon. |
+| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Wire it into your pipeline today. GitHub PR and EAS templates are coming soon. |
 | Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
 
 ## Command Flow
@@ -63,9 +70,7 @@ agent-device diff snapshot -i
 agent-device close
 ```
 
-Refs shown in default snapshot output are actionable now. Hidden content is surfaced as scroll/list discovery hints; scroll and re-snapshot before acting on it.
-
-In non-JSON mode, core mutating commands print a short success acknowledgment so agents and humans can distinguish successful actions from dropped or silent no-ops.
+Refs shown in default snapshot output are actionable now. For hidden content, scroll and re-snapshot before acting.
 
 ## Features
 
@@ -73,10 +78,10 @@ In non-JSON mode, core mutating commands print a short success acknowledgment so
 - Real device and simulator support.
 - Token-efficient accessibility snapshots for agent loops.
 - MIT licensed. Free to use.
-- Automation, diffing, logging, debugging, network inspection, and profiling.
+- Automation, diffing, logging, network inspection, and profiling.
 - React Native and Expo workflows, including React component tree inspection, props/state/hooks, and render profiling.
 - Screenshots and video recordings.
-- Replayable `.ad` scripts that turn exploration into e2e tests.
+- Replayable `.ad` scripts for e2e tests.
 - Accessibility checks and dogfooding workflows.
 
 ## Used By

--- a/README.md
+++ b/README.md
@@ -68,10 +68,6 @@ Snapshots assign refs like `@e1`, `@e2`, and `@e3` to current-screen elements. R
 | CI/CD | Automated PR and merge validation with replay scripts and captured artifacts. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
 | Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
 
-## How It Works
-
-`agent-device` runs session-aware commands through platform backends: XCTest for iOS and tvOS, ADB plus the Android snapshot helper for Android, a local helper for macOS desktop automation, and AT-SPI for Linux desktop targets. See [Introduction](https://incubator.callstack.com/agent-device/docs/introduction) and [Commands](https://incubator.callstack.com/agent-device/docs/commands) for platform details.
-
 ## Capabilities
 
 - **Platforms**: iOS, Android, tvOS, Android TV, macOS, and Linux. Real devices and simulators are supported.
@@ -79,6 +75,10 @@ Snapshots assign refs like `@e1`, `@e2`, and `@e3` to current-screen elements. R
 - **Produce**: replayable `.ad` scripts, e2e test runs, snapshot and screenshot diffs, and debugging artifacts. `.ad` scripts are recorded replay files that can run locally or in CI.
 - **React Native and Expo**: component tree inspection, props/state/hooks, and render profiling.
 - **License**: MIT. Free to use.
+
+## How It Works
+
+`agent-device` runs session-aware commands through platform backends: XCTest for iOS and tvOS, ADB plus the Android snapshot helper for Android, a local helper for macOS desktop automation, and AT-SPI for Linux desktop targets. See [Introduction](https://incubator.callstack.com/agent-device/docs/introduction) and [Commands](https://incubator.callstack.com/agent-device/docs/commands) for platform details.
 
 ## Used By
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,19 @@
 [![CI](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml/badge.svg)](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-black.svg)](LICENSE)
 
-Device automation CLI for AI agents. Mobile, TV, and desktop.
+Agent-first device automation CLI. Mobile, TV, and desktop.
 
-Run the app. Read the UI. Act on the screen. Capture evidence.
+For QA and development agents that need to use real apps: run them, inspect UI state, interact, debug, and capture evidence.
 
-Give agents a runtime loop for iOS, Android, tvOS, macOS, and Linux apps:
+Screenshots are useful for humans. Compact snapshots are better for agents. `agent-device` turns app UI into token-efficient accessibility snapshots with actionable refs like `@e3`, so agents can understand the screen and act deterministically without spending the whole context window on pixels.
 
-- See current UI as compact snapshots.
-- Act through stable refs and selectors.
+What agents can do:
+
+- Open apps on iOS, Android, tvOS, macOS, and Linux.
+- Read UI state as compact snapshots.
+- Act through refs and selectors with `press`, `fill`, `scroll`, `wait`, and more.
 - Capture screenshots, video, logs, network, perf, and React profiles.
-- Replay flows as e2e tests.
+- Record `.ad` replay scripts and run them as e2e tests.
 
 If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this is the same idea for apps and devices.
 
@@ -72,7 +75,7 @@ Choose how to run it.
 
 **Quality Assurance**
 
-Dogfood flows, run accessibility checks, capture evidence, and generate replayable e2e tests.
+Dogfood flows. Capture evidence. Turn stable explorations into replayable e2e tests.
 
 ```bash
 agent-device open SampleApp --platform ios --save-script ./workflows/smoke.ad
@@ -85,7 +88,7 @@ agent-device test ./workflows
 
 **Development**
 
-Build from a product or engineering specification. Run, inspect, interact, debug, and iterate until the UI confirms the work.
+Build from a specification. Run the app, inspect the UI, interact, debug, and iterate until the screen matches the spec.
 
 ```bash
 agent-device open SampleApp --platform ios
@@ -96,13 +99,6 @@ agent-device screenshot ./artifacts/current-ui.png
 agent-device network dump
 agent-device perf
 ```
-
-## Concepts
-
-- **Snapshot**: compact accessibility-tree output for the current UI.
-- **Ref**: a current-screen handle like `@e3`; re-snapshot after UI changes.
-- **Selector**: a stable text, role, or label query for replay and assertions.
-- **`.ad` script**: a recorded replay file that can run locally or in CI.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://www.callstack.com/open-source?utm_campaign=generic&utm_source=github&utm_medium=referral&utm_content=agent-device" align="center">
   <picture>
-    <img alt="agent-device" src="website/docs/public/agent-device-banner.jpg">
+    <img alt="agent-device: device automation CLI for AI agents" src="website/docs/public/agent-device-banner.jpg">
   </picture>
 </a>
 
@@ -35,7 +35,7 @@ Install the CLI.
 npm install -g agent-device
 ```
 
-Prerequisites: Node.js 22+, Xcode for iOS/tvOS/macOS targets, Android SDK + ADB for Android, and macOS permissions for desktop automation. See [Installation](https://incubator.callstack.com/agent-device/docs/installation).
+Prerequisites: Node.js 22+, Xcode for iOS/tvOS/macOS targets, Android SDK + ADB for Android, and macOS Accessibility permission for desktop automation. See [Installation](https://incubator.callstack.com/agent-device/docs/installation).
 
 Try the loop.
 
@@ -46,7 +46,7 @@ agent-device apps --platform ios
 # Start a session.
 agent-device open SampleApp --platform ios
 
-# Inspect the current screen.
+# Inspect the current screen. -i returns interactive elements only.
 agent-device snapshot -i
 # @e1 [heading] "Settings"
 # @e2 [button] "Sign In"
@@ -58,14 +58,14 @@ agent-device screenshot ./artifacts/settings.png
 agent-device close
 ```
 
-Refs from the default snapshot are immediately actionable. For hidden content, scroll and re-snapshot.
+Snapshots assign refs like `@e1`, `@e2`, and `@e3` to current-screen elements. Refs from the default snapshot are immediately actionable; for hidden content, scroll and re-snapshot.
 
 ## Where To Run agent-device
 
 | Path | Best for | Start with |
 | --- | --- | --- |
-| Local | Simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
-| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
+| Local | Exploration, debugging, and development loops on simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
+| CI/CD | Automated PR and merge validation with replay scripts and captured artifacts. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
 | Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
 
 ## How It Works
@@ -76,16 +76,13 @@ Refs from the default snapshot are immediately actionable. For hidden content, s
 
 - **Platforms**: iOS, Android, tvOS, Android TV, macOS, and Linux. Real devices and simulators are supported.
 - **Capture**: screenshots, video, logs, network traffic, performance data, accessibility snapshots, and React render profiles.
-- **Produce**: replayable `.ad` scripts, e2e test runs, diff output, and debugging artifacts.
+- **Produce**: replayable `.ad` scripts, e2e test runs, snapshot and screenshot diffs, and debugging artifacts. `.ad` scripts are recorded replay files that can run locally or in CI.
 - **React Native and Expo**: component tree inspection, props/state/hooks, and render profiling.
 - **License**: MIT. Free to use.
 
 ## Used By
 
-Used by teams and developers at Callstack, Expensify, [Shopify](https://x.com/mustafa01ali/status/2035155157982289998), [Kindred](https://x.com/sregg/status/2045231628369191075), Total Wine & More, [LegendList](https://x.com/jmeistrich/status/2036398735698305178), [HerLyfe](https://x.com/oliverbowman_), App & Flow, and more.
-
-- [Oliver Bowman](https://x.com/oliverbowman_), HerLyfe: reduced the feedback loop in agentic workflows.
-- [Jay Meistrich](https://x.com/jmeistrich/status/2036398735698305178), LegendList: used it for Android phone and iOS simulator testing while developing LegendList optimizations.
+Used by teams and developers at Callstack, Expensify, Shopify, Kindred, Total Wine & More, LegendList, HerLyfe, App & Flow, and more.
 
 ## Documentation
 
@@ -107,4 +104,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Made at Callstack
 
-agent-device is an open source project and will always remain free to use. Callstack is a group of React and React Native geeks. Contact us at hello@callstack.com if you need any help with these technologies or just want to say hi.
+agent-device is an open source project and will always remain free to use. Try the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml), use [Agent Device Cloud](https://agent-device.dev/cloud), or contact us at hello@callstack.com.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Choose how to run it.
 | Path | Best for | Start with |
 | --- | --- | --- |
 | Local | Simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
-| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Wire it into your pipeline today. GitHub PR and EAS templates are coming soon. |
+| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
 | Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
 
 ## Command Flow

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Device automation CLI for AI agents. Mobile, TV, and desktop apps.
 
 It is built around token-efficient accessibility snapshots, not pixel-first screenshots. Agents read compact UI trees, use refs like `@e3` for deterministic actions, and capture screenshots, video, logs, network, perf, and React profiles only when evidence is needed.
 
-Built for two workflows:
+Built for two agentic workflows:
 
 - **Quality Assurance**: dogfood flows, validate PR builds, capture evidence, and turn stable explorations into `.ad` e2e tests.
 - **Development**: build from specs, reproduce crashes and support issues, inspect logs/network/perf data, and iterate until the UI matches the work.

--- a/README.md
+++ b/README.md
@@ -12,19 +12,16 @@
 [![CI](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml/badge.svg)](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-black.svg)](LICENSE)
 
-Agent-first device automation CLI. Mobile, TV, and desktop.
+Device automation CLI for AI agents. Mobile, TV, and desktop apps.
 
-For QA and development agents that need to use real apps: run them, inspect UI state, interact, debug, and capture evidence.
+`agent-device` lets coding agents run real apps, inspect UI state, interact with visible elements, and collect debugging evidence from the terminal.
 
-Screenshots are useful for humans. Compact snapshots are better for agents. `agent-device` turns app UI into token-efficient accessibility snapshots with actionable refs like `@e3`, so agents can understand the screen and act deterministically without spending the whole context window on pixels.
+It is built around token-efficient accessibility snapshots, not pixel-first screenshots. Agents read compact UI trees, use refs like `@e3` for deterministic actions, and capture screenshots, video, logs, network, perf, and React profiles only when evidence is needed.
 
-What agents can do:
+Built for two workflows:
 
-- Open apps on iOS, Android, tvOS, macOS, and Linux.
-- Read UI state as compact snapshots.
-- Act through refs and selectors with `press`, `fill`, `scroll`, `wait`, and more.
-- Capture screenshots, video, logs, network, perf, and React profiles.
-- Record `.ad` replay scripts and run them as e2e tests.
+- **Quality Assurance**: dogfood flows, validate PR builds, capture evidence, and turn stable explorations into `.ad` e2e tests.
+- **Development**: build from specs, reproduce crashes and support issues, inspect logs/network/perf data, and iterate until the UI matches the work.
 
 If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this is the same idea for apps and devices.
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ agent-device snapshot -i
 # @e2 [button] "Sign In"
 # @e3 [text-field] "Email"
 
-# Act, check what changed, and close.
+# Act, capture a screenshot, and close.
 agent-device fill @e3 "test"
-agent-device diff snapshot -i
+agent-device screenshot ./artifacts/settings.png
 agent-device close
 ```
 
@@ -78,7 +78,7 @@ Dogfood flows, run accessibility checks, capture evidence, and generate replayab
 agent-device open SampleApp --platform ios --save-script ./workflows/smoke.ad
 agent-device snapshot -i
 agent-device fill @e3 "test"
-agent-device diff snapshot -i
+agent-device screenshot ./artifacts/smoke.png
 agent-device close
 agent-device test ./workflows
 ```
@@ -92,7 +92,7 @@ agent-device open SampleApp --platform ios
 agent-device logs clear --restart
 agent-device snapshot -i
 agent-device fill @e3 "test"
-agent-device diff snapshot -i
+agent-device screenshot ./artifacts/current-ui.png
 agent-device network dump
 agent-device perf
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is built around token-efficient accessibility snapshots, not pixel-first scre
 
 Built for two agentic workflows:
 
-- **Quality Assurance**: dogfood flows, validate PR builds, capture evidence, and turn stable explorations into `.ad` e2e tests.
+- **Quality Assurance**: dogfood flows, validate PR builds, check accessibility coverage, capture evidence, and turn stable explorations into `.ad` e2e tests.
 - **Development**: build from specs, reproduce crashes and support issues, inspect logs/network/perf data, and iterate until the UI matches the work.
 
 If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this is the same idea for apps and devices.
@@ -72,20 +72,21 @@ Choose how to run it.
 
 **Quality Assurance**
 
-Dogfood flows. Capture evidence. Turn stable explorations into replayable e2e tests.
+Exploration to replayable check:
 
 ```bash
 agent-device open SampleApp --platform ios --save-script ./workflows/smoke.ad
 agent-device snapshot -i
 agent-device fill @e3 "test"
 agent-device screenshot ./artifacts/smoke.png
+# Compare screenshot vs snapshot output for accessibility gaps.
 agent-device close
 agent-device test ./workflows
 ```
 
 **Development**
 
-Build from a specification. Run the app, inspect the UI, interact, debug, and iterate until the screen matches the spec.
+Implementation and debugging loop:
 
 ```bash
 agent-device open SampleApp --platform ios
@@ -93,13 +94,14 @@ agent-device logs clear --restart
 agent-device snapshot -i
 agent-device fill @e3 "test"
 agent-device screenshot ./artifacts/current-ui.png
+agent-device react-devtools get tree --depth 3
 agent-device network dump
 agent-device perf
 ```
 
 ## How It Works
 
-`agent-device` runs session-aware commands through platform backends: XCTest for iOS and tvOS, ADB plus the Android snapshot helper for Android, a local helper for macOS desktop automation, and AT-SPI for Linux desktop targets.
+`agent-device` runs session-aware commands through platform backends: XCTest for iOS and tvOS, ADB plus the Android snapshot helper for Android, a local helper for macOS desktop automation, and AT-SPI for Linux desktop targets. See [Introduction](https://incubator.callstack.com/agent-device/docs/introduction) and [Commands](https://incubator.callstack.com/agent-device/docs/commands) for platform details.
 
 ## Capabilities
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 # agent-device
 
+[![npm version](https://img.shields.io/npm/v/agent-device.svg)](https://www.npmjs.com/package/agent-device)
+[![CI](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml/badge.svg)](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-black.svg)](LICENSE)
+
 Device automation CLI for AI agents. Mobile, TV, and desktop.
 
 Run the app. Read the UI. Act on the screen. Capture evidence.
@@ -21,15 +25,9 @@ Give agents a runtime loop for iOS, Android, tvOS, macOS, and Linux apps:
 
 If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this is the same idea for apps and devices.
 
-[![Watch the demo video](./website/docs/public/agent-device-contacts.gif)](./website/docs/public/agent-device-contacts.mp4)
+![agent-device demo showing an agent inspecting and interacting with a contacts app](./website/docs/public/agent-device-contacts.gif)
 
-## Use Cases
-
-- **QA**: dogfood flows, run accessibility checks, capture evidence, and generate replayable e2e tests.
-- **Debugging**: start from Sentry, a development crash, a support ticket, or a bug description. Reproduce the flow and fix with UI, logs, network, and perf context.
-- **Development**: build from a product or engineering specification. Run, inspect, interact, debug, and iterate until the UI confirms the work.
-
-## Get Started
+## Quick Start
 
 Install the CLI.
 
@@ -37,17 +35,9 @@ Install the CLI.
 npm install -g agent-device
 ```
 
-Choose how to run it.
+Prerequisites: Node.js 22+, Xcode for iOS/tvOS/macOS targets, Android SDK + ADB for Android, and macOS permissions for desktop automation. See [Installation](https://incubator.callstack.com/agent-device/docs/installation).
 
-| Path | Best for | Start with |
-| --- | --- | --- |
-| Local | Simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
-| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
-| Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
-
-## Command Flow
-
-The canonical loop is:
+Try the loop.
 
 ```bash
 # Find the app.
@@ -62,27 +52,69 @@ agent-device snapshot -i
 # @e2 [button] "Sign In"
 # @e3 [text-field] "Email"
 
-# Act on visible elements with press, fill, scroll, and more.
+# Act, check what changed, and close.
 agent-device fill @e3 "test"
-
-# Check what changed, then close the session.
 agent-device diff snapshot -i
 agent-device close
 ```
 
-Refs shown in default snapshot output are actionable now. For hidden content, scroll and re-snapshot before acting.
+Refs from the default snapshot are immediately actionable. For hidden content, scroll and re-snapshot.
 
-## Features
+Choose how to run it.
 
-- Mobile, TV, and desktop coverage: iOS, Android, tvOS, Android TV, macOS, and Linux.
-- Real device and simulator support.
-- Token-efficient accessibility snapshots for agent loops.
-- MIT licensed. Free to use.
-- Automation, diffing, logging, network inspection, and profiling.
-- React Native and Expo workflows, including pinned `agent-react-devtools@0.4.0` for component tree inspection, props/state/hooks, and render profiling.
-- Screenshots and video recordings.
-- Replayable `.ad` scripts for e2e tests.
-- Accessibility checks and dogfooding workflows.
+| Path | Best for | Start with |
+| --- | --- | --- |
+| Local | Simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
+| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
+| Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
+
+## Workflows
+
+**Quality Assurance**
+
+Dogfood flows, run accessibility checks, capture evidence, and generate replayable e2e tests.
+
+```bash
+agent-device open SampleApp --platform ios --save-script ./workflows/smoke.ad
+agent-device snapshot -i
+agent-device fill @e3 "test"
+agent-device diff snapshot -i
+agent-device close
+agent-device test ./workflows
+```
+
+**Development**
+
+Build from a product or engineering specification. Run, inspect, interact, debug, and iterate until the UI confirms the work.
+
+```bash
+agent-device open SampleApp --platform ios
+agent-device logs clear --restart
+agent-device snapshot -i
+agent-device fill @e3 "test"
+agent-device diff snapshot -i
+agent-device network dump
+agent-device perf
+```
+
+## Concepts
+
+- **Snapshot**: compact accessibility-tree output for the current UI.
+- **Ref**: a current-screen handle like `@e3`; re-snapshot after UI changes.
+- **Selector**: a stable text, role, or label query for replay and assertions.
+- **`.ad` script**: a recorded replay file that can run locally or in CI.
+
+## How It Works
+
+`agent-device` runs session-aware commands through platform backends: XCTest for iOS and tvOS, ADB plus the Android snapshot helper for Android, a local helper for macOS desktop automation, and AT-SPI for Linux desktop targets.
+
+## Capabilities
+
+- **Platforms**: iOS, Android, tvOS, Android TV, macOS, and Linux. Real devices and simulators are supported.
+- **Capture**: screenshots, video, logs, network traffic, performance data, accessibility snapshots, and React render profiles.
+- **Produce**: replayable `.ad` scripts, e2e test runs, diff output, and debugging artifacts.
+- **React Native and Expo**: component tree inspection, props/state/hooks, and render profiling through pinned `agent-react-devtools@0.4.0`.
+- **License**: MIT. Free to use.
 
 ## Used By
 
@@ -91,14 +123,14 @@ Used by teams and developers at Callstack, Expensify, [Shopify](https://x.com/mu
 - [Oliver Bowman](https://x.com/oliverbowman_), HerLyfe: reduced the feedback loop in agentic workflows.
 - [Jay Meistrich](https://x.com/jmeistrich/status/2036398735698305178), LegendList: used it for Android phone and iOS simulator testing while developing LegendList optimizations.
 
-## Where To Go Next
+## Documentation
 
-For people:
+- [Installation](https://incubator.callstack.com/agent-device/docs/installation)
+- [Commands](https://incubator.callstack.com/agent-device/docs/commands)
+- [Replay & E2E](https://incubator.callstack.com/agent-device/docs/replay-e2e)
+- [Known limitations](https://incubator.callstack.com/agent-device/docs/known-limitations)
 
-- [Website](https://agent-device.dev/)
-- [Docs](https://incubator.callstack.com/agent-device/docs/introduction)
-
-For agents:
+Agent integration:
 
 - [agent-device skill](skills/agent-device/SKILL.md)
 - [react-devtools skill](skills/react-devtools/SKILL.md)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Device automation CLI for AI agents. Mobile, TV, and desktop apps.
 
-`agent-device` lets coding agents run real apps, inspect UI state, interact with visible elements, and collect debugging evidence from the terminal.
+`agent-device` lets coding agents run real apps, inspect UI state, interact with visible elements, and collect debugging evidence through one CLI.
 
 It is built around token-efficient accessibility snapshots, not pixel-first screenshots. Agents read compact UI trees, locate elements through refs like `@e3`, perform touch and text actions, and capture screenshots, video, logs, network, perf, and React profiles only when evidence is needed.
 
@@ -64,7 +64,7 @@ Snapshots assign refs like `@e1`, `@e2`, and `@e3` to current-screen elements. R
 
 | Path | Best for | Start with |
 | --- | --- | --- |
-| Local | Exploration, debugging, and development loops on simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
+| Local | Exploration, debugging, and development loops on simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Follow the Quick Start. |
 | CI/CD | Automated PR and merge validation with replay scripts and captured artifacts. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
 | Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
 
@@ -72,7 +72,7 @@ Snapshots assign refs like `@e1`, `@e2`, and `@e3` to current-screen elements. R
 
 - **Platforms**: iOS, Android, tvOS, Android TV, macOS, and Linux. Real devices and simulators are supported.
 - **Capture**: screenshots, video, logs, network traffic, performance data, accessibility snapshots, and React render profiles.
-- **Produce**: replayable `.ad` scripts, e2e test runs, snapshot and screenshot diffs, and debugging artifacts. `.ad` scripts are recorded replay files that can run locally or in CI.
+- **Produce**: replayable `.ad` scripts (recorded replay files that run locally or in CI), e2e test runs, snapshot and screenshot diffs, and debugging artifacts.
 - **React Native and Expo**: component tree inspection, props/state/hooks, and render profiling.
 - **License**: MIT. Free to use.
 
@@ -104,4 +104,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Made at Callstack
 
-agent-device is an open source project and will always remain free to use. Try the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml), use [Agent Device Cloud](https://agent-device.dev/cloud), or contact us at hello@callstack.com.
+agent-device is open source and MIT licensed. Try the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml), use [Agent Device Cloud](https://agent-device.dev/cloud), or contact us at hello@callstack.com.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Device automation CLI for AI agents. Mobile, TV, and desktop apps.
 
 `agent-device` lets coding agents run real apps, inspect UI state, interact with visible elements, and collect debugging evidence from the terminal.
 
-It is built around token-efficient accessibility snapshots, not pixel-first screenshots. Agents read compact UI trees, use refs like `@e3` for deterministic actions, and capture screenshots, video, logs, network, perf, and React profiles only when evidence is needed.
+It is built around token-efficient accessibility snapshots, not pixel-first screenshots. Agents read compact UI trees, locate elements through refs like `@e3`, perform touch and text actions, and capture screenshots, video, logs, network, perf, and React profiles only when evidence is needed.
 
 Built for two agentic workflows:
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ agent-device perf
 - **Platforms**: iOS, Android, tvOS, Android TV, macOS, and Linux. Real devices and simulators are supported.
 - **Capture**: screenshots, video, logs, network traffic, performance data, accessibility snapshots, and React render profiles.
 - **Produce**: replayable `.ad` scripts, e2e test runs, diff output, and debugging artifacts.
-- **React Native and Expo**: component tree inspection, props/state/hooks, and render profiling through pinned `agent-react-devtools@0.4.0`.
+- **React Native and Expo**: component tree inspection, props/state/hooks, and render profiling.
 - **License**: MIT. Free to use.
 
 ## Used By

--- a/README.md
+++ b/README.md
@@ -68,37 +68,6 @@ Choose how to run it.
 | CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Start with the [EAS workflow template](https://github.com/callstackincubator/eas-agent-device/blob/main/.eas/workflows/agent-qa-mobile.yml). GitHub Actions template coming soon. |
 | Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
 
-## Workflows
-
-**Quality Assurance**
-
-Exploration to replayable check:
-
-```bash
-agent-device open SampleApp --platform ios --save-script ./workflows/smoke.ad
-agent-device snapshot -i
-agent-device fill @e3 "test"
-agent-device screenshot ./artifacts/smoke.png
-# Compare screenshot vs snapshot output for accessibility gaps.
-agent-device close
-agent-device test ./workflows
-```
-
-**Development**
-
-Implementation and debugging loop:
-
-```bash
-agent-device open SampleApp --platform ios
-agent-device logs clear --restart
-agent-device snapshot -i
-agent-device fill @e3 "test"
-agent-device screenshot ./artifacts/current-ui.png
-agent-device react-devtools get tree --depth 3
-agent-device network dump
-agent-device perf
-```
-
 ## How It Works
 
 `agent-device` runs session-aware commands through platform backends: XCTest for iOS and tvOS, ADB plus the Android snapshot helper for Android, a local helper for macOS desktop automation, and AT-SPI for Linux desktop targets. See [Introduction](https://incubator.callstack.com/agent-device/docs/introduction) and [Commands](https://incubator.callstack.com/agent-device/docs/commands) for platform details.

--- a/README.md
+++ b/README.md
@@ -8,78 +8,83 @@
 
 # agent-device
 
-`agent-device` is a CLI for UI automation and app observability on iOS, tvOS, macOS, Android, and AndroidTV. It is built for agent-driven workflows: inspect the UI, interact deterministically, collect logs/network/perf evidence when behavior breaks, and keep the whole flow session-aware and replayable.
+Device automation CLI for AI agents. Mobile, TV, and desktop.
 
-If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this project applies the same broad idea to mobile apps and devices.
+Run the app. Inspect the UI. Collect the evidence. Repeat the flow.
+
+It gives agents structured UI access, deterministic interactions, screenshots, recordings, logs, network inspection, performance data, and replayable sessions on iOS, Android, tvOS, macOS, and Linux. If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), this is the same idea for apps and devices.
 
 [![Watch the demo video](./website/docs/public/agent-device-contacts.gif)](./website/docs/public/agent-device-contacts.mp4)
 
-## Project Goals
+## Use Cases
 
-- Give agents a practical way to understand mobile UI state through structured snapshots.
-- Keep automation flows token-efficient enough for real agent loops.
-- Make common interactions reliable enough for repeated automation runs.
-- Make debugging evidence easy to collect through logs, network inspection, and performance snapshots.
-- Keep automation grounded in sessions, selectors, and replayable flows instead of one-off scripts.
+- **QA**: explore flows, dogfood the app, run accessibility checks, capture evidence, and turn stable explorations into e2e tests.
+- **Debugging**: start from a Sentry issue, crash during development, support ticket, or bug description. Reproduce the flow, inspect logs/network/perf data, and fix with context.
+- **Development**: build from a product or engineering specification. Run the app, inspect the result, interact, debug, and iterate until the UI confirms the work.
 
-## Core Ideas
+## Get Started
 
-- Sessions: open a target once, interact within that session, then close it cleanly.
-- Snapshots: inspect the current accessibility tree in a compact form and get current-screen refs for exploration.
-- Refs vs selectors: use refs for discovery, use selectors for durable replay and assertions.
-- Observability: collect session logs, inspect recent HTTP traffic with `network dump`, and sample CPU/memory with `perf`.
-- Tests: run deterministic `.ad` scripts as a light e2e test suite.
-- Replay scripts: save `.ad` flows with `--save-script`, replay one script with `replay`, or run a folder/glob as a serial suite with `test`.
-  `test` supports metadata-aware retries up to 3 additional attempts, per-test timeouts, flaky pass reporting, and runner-managed artifacts under `.agent-device/test-artifacts` by default. Each attempt writes `replay.ad` and `result.txt`; failed attempts also keep copied logs and artifacts when available.
-- Human docs vs agent skills: docs explain the system for people; skills provide compact operating guidance for agents.
-
-## Complementary Tooling
-
-Use `agent-device` for on-device UI automation, screenshots/recordings, app logs, network inspection, and performance snapshots.
-
-When the task needs the React Native component tree, props, state, hooks, or render profiling, use the bundled passthrough:
+Install the CLI.
 
 ```bash
-agent-device react-devtools status
-agent-device react-devtools get tree --depth 3
-agent-device react-devtools profile start
-agent-device react-devtools profile stop
-agent-device react-devtools profile slow --limit 5
+npm install -g agent-device
 ```
 
-`react-devtools` dynamically runs pinned `agent-react-devtools@0.4.0` commands 1:1, so `agent-device` covers both the device/app runtime layer and React component internals without making React DevTools part of the daemon.
+Choose how to run it.
 
-When an Android session is connected through a remote bridge profile, `react-devtools` automatically opens a lease-scoped companion tunnel for the local DevTools daemon on port 8097 and cleans it up when the command exits.
-
-Remote Android React DevTools assumes the React Native-bundled DevTools behavior in React Native 0.83+. Older browser/Chromium DevTools workflows are not assumed to exist inside remote sandboxes. Expo projects should be verified against the SDK's bundled React Native version before relying on this path; this release does not claim a separately verified Expo SDK version.
+| Path | Best for | Start with |
+| --- | --- | --- |
+| Local | Simulators, emulators, physical devices, macOS apps, and Linux desktop targets. | Bring your own devices and wire `agent-device` into your agent workflow. |
+| CI/CD | Smoke checks, replay suites, QA flows, debugging, and PR validation. | Use a ready setup for GitHub PRs, EAS builds, or CI validation. Coming soon. |
+| Cloud | Linux runners, managed devices, and remote execution. | Use [Agent Device Cloud](https://agent-device.dev/cloud) or [contact Callstack](mailto:hello@callstack.com) for team-scale QA. |
 
 ## Command Flow
 
 The canonical loop is:
 
 ```bash
+# Find the app.
 agent-device apps --platform ios
+
+# Start a session.
 agent-device open SampleApp --platform ios
+
+# Inspect the current screen.
 agent-device snapshot -i
-agent-device press @e3
+# @e1 [heading] "Settings"
+# @e2 [button] "Sign In"
+# @e3 [text-field] "Email"
+
+# Act on visible elements with press, fill, scroll, and more.
+agent-device fill @e3 "test"
+
+# Check what changed, then close the session.
 agent-device diff snapshot -i
-agent-device fill @e5 "test"
-agent-device press @e5
-agent-device type " more" --delay-ms 80
 agent-device close
 ```
 
-In practice, most work follows the same pattern:
-
-1. Discover the exact app id with `apps` if the package or bundle name is uncertain.
-2. `open` a target app or URL.
-3. `snapshot -i` to inspect the current screen.
-4. `press`, `fill`, `scroll`, `get`, or `wait` using refs or selectors. On iOS and Android, default snapshot text follows the same visible-first contract: refs shown in default output are actionable now, while hidden content is surfaced as scroll/list discovery hints instead of tappable off-screen refs. If the target only appears in a hidden-content hint, use `scroll <direction>` and re-snapshot.
-   Use `rotate <orientation>` when a flow needs a deterministic portrait or landscape state on mobile targets.
-5. `diff snapshot` or re-snapshot after UI changes.
-6. `close` when the session is finished.
+Refs shown in default snapshot output are actionable now. Hidden content is surfaced as scroll/list discovery hints; scroll and re-snapshot before acting on it.
 
 In non-JSON mode, core mutating commands print a short success acknowledgment so agents and humans can distinguish successful actions from dropped or silent no-ops.
+
+## Features
+
+- Mobile, TV, and desktop coverage: iOS, Android, tvOS, Android TV, macOS, and Linux.
+- Real device and simulator support.
+- Token-efficient accessibility snapshots for agent loops.
+- MIT licensed. Free to use.
+- Automation, diffing, logging, debugging, network inspection, and profiling.
+- React Native and Expo workflows, including React component tree inspection, props/state/hooks, and render profiling.
+- Screenshots and video recordings.
+- Replayable `.ad` scripts that turn exploration into e2e tests.
+- Accessibility checks and dogfooding workflows.
+
+## Used By
+
+Used by teams and developers at Callstack, Expensify, [Shopify](https://x.com/mustafa01ali/status/2035155157982289998), [Kindred](https://x.com/sregg/status/2045231628369191075), Total Wine & More, [LegendList](https://x.com/jmeistrich/status/2036398735698305178), [HerLyfe](https://x.com/oliverbowman_), App & Flow, and more.
+
+- [Oliver Bowman](https://x.com/oliverbowman_), HerLyfe: reduced the feedback loop in agentic workflows.
+- [Jay Meistrich](https://x.com/jmeistrich/status/2036398735698305178), LegendList: used it for Android phone and iOS simulator testing while developing LegendList optimizations.
 
 ## Where To Go Next
 
@@ -87,11 +92,6 @@ For people:
 
 - [Website](https://agent-device.dev/)
 - [Docs](https://incubator.callstack.com/agent-device/docs/introduction)
-- [Skillgym starter](test/skillgym/README.md)
-
-Local benchmark starter:
-
-- `pnpm test:skillgym`
 
 For agents:
 
@@ -99,18 +99,6 @@ For agents:
 - [react-devtools skill](skills/react-devtools/SKILL.md)
 - [dogfood skill](skills/dogfood/SKILL.md)
 - [agent-device skill on ClawHub](https://clawhub.ai/okwasniewski/agent-device)
-
-## Install
-
-```bash
-npm install -g agent-device
-```
-
-`agent-device` now performs a lightweight background upgrade check for interactive CLI runs and, when a newer package is available, suggests a global reinstall command. Updating the package also refreshes the bundled `skills/` shipped with the CLI.
-
-Set `AGENT_DEVICE_NO_UPDATE_NOTIFIER=1` to disable the notice.
-
-On macOS, `agent-device` includes a local `agent-device-macos-helper` source package that is built on demand for desktop permission checks, alert handling, and helper-backed desktop snapshot surfaces. Release distribution should use a signed/notarized helper build; source checkouts fall back to a local Swift build. Local helper overrides through `AGENT_DEVICE_MACOS_HELPER_BIN` must use an absolute executable path.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Refs shown in default snapshot output are actionable now. For hidden content, sc
 - Token-efficient accessibility snapshots for agent loops.
 - MIT licensed. Free to use.
 - Automation, diffing, logging, network inspection, and profiling.
-- React Native and Expo workflows, including React component tree inspection, props/state/hooks, and render profiling.
+- React Native and Expo workflows, including pinned `agent-react-devtools@0.4.0` for component tree inspection, props/state/hooks, and render profiling.
 - Screenshots and video recordings.
 - Replayable `.ad` scripts for e2e tests.
 - Accessibility checks and dogfooding workflows.

--- a/src/__tests__/cli-react-devtools.test.ts
+++ b/src/__tests__/cli-react-devtools.test.ts
@@ -43,7 +43,7 @@ test('react-devtools passthrough pins agent-react-devtools package version', () 
 });
 
 test('react-devtools docs mention the pinned package version', () => {
-  const docs = ['README.md', 'website/docs/docs/commands.md', 'skills/react-devtools/SKILL.md'];
+  const docs = ['website/docs/docs/commands.md', 'skills/react-devtools/SKILL.md'];
 
   for (const file of docs) {
     assert.match(fs.readFileSync(file, 'utf8'), new RegExp(AGENT_REACT_DEVTOOLS_PACKAGE));


### PR DESCRIPTION
## Summary

Refresh README positioning around use cases, setup paths, command flow, features, and social proof.

Touched files: 1 (`README.md`). Scope stayed README-only.

## Validation

- `git diff --check`
- Tests not run; README-only docs change.