### PR TITLE
fix: avoid killing stopped ios runner

### DIFF
--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -6,7 +6,7 @@ import {
   type ExecBackgroundResult,
 } from '../../utils/exec.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
-import { isProcessAlive } from '../../utils/process-identity.ts';
+import { isProcessAlive, isProcessGroupAlive } from '../../utils/process-identity.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
 import {
@@ -192,7 +192,9 @@ async function stopRunnerSessionInternal(
       new Promise<void>((resolve) => setTimeout(resolve, RUNNER_STOP_WAIT_TIMEOUT_MS)),
     ]);
   } catch {}
-  await killRunnerProcessTree(session.child.pid, 'SIGKILL');
+  if (isRunnerProcessTreeAlive(session.child.pid)) {
+    await killRunnerProcessTree(session.child.pid, 'SIGKILL');
+  }
   cleanupTempFile(session.xctestrunPath);
   cleanupTempFile(session.jsonPath);
   await session.simulatorSetRedirect?.release();
@@ -272,6 +274,11 @@ export async function stopAllIosRunnerSessions(): Promise<void> {
 function isRunnerProcessAlive(pid: number | undefined): boolean {
   if (!pid) return false;
   return isProcessAlive(pid);
+}
+
+function isRunnerProcessTreeAlive(pid: number | undefined): boolean {
+  if (!pid) return false;
+  return isRunnerProcessAlive(pid) || isProcessGroupAlive(pid);
 }
 
 async function killRunnerProcessTree(

--- a/src/utils/__tests__/process-identity.test.ts
+++ b/src/utils/__tests__/process-identity.test.ts
@@ -3,12 +3,17 @@ import assert from 'node:assert/strict';
 import {
   isAgentDeviceDaemonCommand,
   isProcessAlive,
+  isProcessGroupAlive,
   readProcessStartTime,
   readProcessCommand,
 } from '../process-identity.ts';
 
 test('isProcessAlive returns false for invalid pid', () => {
   assert.equal(isProcessAlive(-1), false);
+});
+
+test('isProcessGroupAlive returns false for invalid pid', () => {
+  assert.equal(isProcessGroupAlive(-1), false);
 });
 
 test('readProcessStartTime returns value for current process', () => {

--- a/src/utils/process-identity.ts
+++ b/src/utils/process-identity.ts
@@ -18,6 +18,16 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
+export function isProcessGroupAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
 export function readProcessStartTime(pid: number): string | null {
   if (!Number.isInteger(pid) || pid <= 0) return null;
   try {


### PR DESCRIPTION
## Summary

Guard iOS runner teardown so the process tree is only SIGKILLed when the xcodebuild runner process or its process group is still alive after graceful shutdown.

This avoids unnecessary process-tree signals after XCTest has already exited cleanly while preserving cleanup for lingering runner descendants. The process-group liveness check is shared through `process-identity`.




## Validation

pnpm format
pnpm vitest run src/utils/__tests__/process-identity.test.ts
pnpm typecheck

Touched files: 3
Scope remained within runner teardown/process identity helpers.