### PR TITLE
fix: cache Android snapshot helper installs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,24 @@ jobs:
         id: android-replay-host
         uses: ./.github/actions/setup-android-replay-host
 
-      - name: Run Android smoke replay
+      - name: Install Android SDK packages
+        run: |
+          SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
+          SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+          if [ ! -x "$SDKMANAGER" ]; then
+            SDKMANAGER="$SDK_ROOT/cmdline-tools/bin/sdkmanager"
+          fi
+          if [ ! -x "$SDKMANAGER" ]; then
+            echo "sdkmanager not found under $SDK_ROOT" >&2
+            exit 1
+          fi
+          yes | "$SDKMANAGER" --licenses >/dev/null
+          "$SDKMANAGER" "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Package npm-bundled Android snapshot helper
+        run: pnpm package:android-snapshot-helper:npm
+
+      - name: Run Android smoke checks
         uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
         with:
           api-level: 36
@@ -37,7 +54,10 @@ jobs:
           profile: pixel_7
           target: google_apis_playstore
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
-          script: node --experimental-strip-types src/bin.ts test test/integration/replays/android/01-settings.ad --retries 2 --report-junit test/artifacts/replays-android-smoke.junit.xml
+          script: |
+            set -e
+            node --experimental-strip-types src/bin.ts test test/integration/replays/android/01-settings.ad --retries 2 --report-junit test/artifacts/replays-android-smoke.junit.xml
+            sh ./test/scripts/android-snapshot-helper-release-smoke.sh
 
       - name: Upload Android artifacts
         if: always()

--- a/src/platforms/android/__tests__/snapshot-helper.test.ts
+++ b/src/platforms/android/__tests__/snapshot-helper.test.ts
@@ -3,14 +3,16 @@ import crypto from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { test } from 'vitest';
+import { beforeEach, test } from 'vitest';
 import {
   captureAndroidSnapshotWithHelper,
   ensureAndroidSnapshotHelper,
+  forgetAndroidSnapshotHelperInstall,
   parseAndroidSnapshotHelperManifest,
   parseAndroidSnapshotHelperOutput,
   parseAndroidSnapshotHelperXml,
   prepareAndroidSnapshotHelperArtifactFromManifestUrl,
+  resetAndroidSnapshotHelperInstallCache,
   verifyAndroidSnapshotHelperArtifact,
   type AndroidAdbExecutor,
   type AndroidSnapshotHelperManifest,
@@ -30,6 +32,10 @@ const manifest: AndroidSnapshotHelperManifest = {
   statusProtocol: 'android-snapshot-helper-v1',
   installArgs: ['install', '-r', '-t'],
 };
+
+beforeEach(() => {
+  resetAndroidSnapshotHelperInstallCache();
+});
 
 test('parseAndroidSnapshotHelperOutput reconstructs XML chunks and metadata', () => {
   const xml = '<?xml version="1.0"?><hierarchy><node text="first&#10;second" /></hierarchy>';
@@ -210,6 +216,132 @@ test('ensureAndroidSnapshotHelper installs when missing and skips current versio
 
   assert.equal(skipped.installed, false);
   assert.equal(skipped.reason, 'current');
+});
+
+test('ensureAndroidSnapshotHelper caches successful install checks per device and helper version', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapshot-helper-install-cache-'));
+  const apkPath = path.join(tmpDir, 'helper.apk');
+  await fs.writeFile(apkPath, 'helper-apk');
+  const localManifest = {
+    ...manifest,
+    sha256: sha256Text('helper-apk'),
+  };
+  const calls: string[][] = [];
+  const adb: AndroidAdbExecutor = async (args) => {
+    calls.push(args);
+    if (args.includes('--show-versioncode')) {
+      return { exitCode: 1, stdout: '', stderr: 'not found' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+  const artifact = { apkPath, manifest: localManifest };
+
+  const installed = await ensureAndroidSnapshotHelper({
+    adb,
+    artifact,
+    deviceKey: 'android:emulator-5554',
+  });
+  const cached = await ensureAndroidSnapshotHelper({
+    adb,
+    artifact,
+    deviceKey: 'android:emulator-5554',
+  });
+
+  assert.equal(installed.reason, 'missing');
+  assert.equal(cached.reason, 'current');
+  assert.equal(cached.installed, false);
+  assert.equal(cached.installedVersionCode, localManifest.versionCode);
+  assert.deepEqual(calls, [
+    [
+      'shell',
+      'cmd',
+      'package',
+      'list',
+      'packages',
+      '--show-versioncode',
+      localManifest.packageName,
+    ],
+    ['install', '-r', '-t', apkPath],
+  ]);
+
+  await ensureAndroidSnapshotHelper({
+    adb,
+    artifact,
+    deviceKey: 'android:device-2',
+  });
+  assert.equal(calls.length, 4);
+
+  forgetAndroidSnapshotHelperInstall({
+    deviceKey: 'android:emulator-5554',
+    packageName: localManifest.packageName,
+    versionCode: localManifest.versionCode,
+  });
+  await ensureAndroidSnapshotHelper({
+    adb,
+    artifact,
+    deviceKey: 'android:emulator-5554',
+  });
+  assert.equal(calls.length, 6);
+});
+
+test('ensureAndroidSnapshotHelper always policy bypasses cached install result', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'snapshot-helper-install-always-'));
+  const apkPath = path.join(tmpDir, 'helper.apk');
+  await fs.writeFile(apkPath, 'helper-apk');
+  const localManifest = {
+    ...manifest,
+    sha256: sha256Text('helper-apk'),
+  };
+  const calls: string[][] = [];
+  const adb: AndroidAdbExecutor = async (args) => {
+    calls.push(args);
+    if (args.includes('--show-versioncode')) {
+      return {
+        exitCode: 0,
+        stdout: `package:${localManifest.packageName} versionCode:${localManifest.versionCode}`,
+        stderr: '',
+      };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  };
+  const artifact = { apkPath, manifest: localManifest };
+
+  const cached = await ensureAndroidSnapshotHelper({
+    adb,
+    artifact,
+    deviceKey: 'android:emulator-5554',
+  });
+  const forced = await ensureAndroidSnapshotHelper({
+    adb,
+    artifact,
+    deviceKey: 'android:emulator-5554',
+    installPolicy: 'always',
+  });
+
+  assert.equal(cached.reason, 'current');
+  assert.equal(forced.reason, 'forced');
+  assert.equal(forced.installed, true);
+  assert.deepEqual(calls, [
+    [
+      'shell',
+      'cmd',
+      'package',
+      'list',
+      'packages',
+      '--show-versioncode',
+      localManifest.packageName,
+    ],
+    [
+      'shell',
+      'cmd',
+      'package',
+      'list',
+      'packages',
+      '--show-versioncode',
+      localManifest.packageName,
+    ],
+    ['install', '-r', '-t', apkPath],
+  ]);
 });
 
 test('verifyAndroidSnapshotHelperArtifact rejects checksum mismatch', async () => {

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -20,7 +20,11 @@ import type { DeviceInfo } from '../../../utils/device.ts';
 import { AppError } from '../../../utils/errors.ts';
 import { runCmd } from '../../../utils/exec.ts';
 import { sleep } from '../adb.ts';
-import type { AndroidAdbExecutor, AndroidSnapshotHelperManifest } from '../snapshot-helper.ts';
+import {
+  resetAndroidSnapshotHelperInstallCache,
+  type AndroidAdbExecutor,
+  type AndroidSnapshotHelperManifest,
+} from '../snapshot-helper.ts';
 
 const VALID_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+b9xkAAAAASUVORK5CYII=',
@@ -53,6 +57,7 @@ const helperManifest: AndroidSnapshotHelperManifest = {
 };
 
 beforeEach(() => {
+  resetAndroidSnapshotHelperInstallCache();
   mockRunCmd.mockReset();
   mockSleep.mockReset();
   mockSleep.mockResolvedValue(undefined);
@@ -292,6 +297,56 @@ test('snapshotAndroid falls back to stock uiautomator when helper fails', async 
     result.androidSnapshot.fallbackReason ?? '',
     /failed before returning parseable output/,
   );
+});
+
+test('snapshotAndroid re-probes helper install after helper capture failure', async () => {
+  let versionProbeCount = 0;
+  let instrumentAttempts = 0;
+  const helperAdb: AndroidAdbExecutor = async (args) => {
+    if (args.includes('--show-versioncode')) {
+      versionProbeCount += 1;
+      return {
+        exitCode: 0,
+        stdout: 'package:com.callstack.agentdevice.snapshothelper versionCode:13003',
+        stderr: '',
+      };
+    }
+    if (args.includes('instrument')) {
+      instrumentAttempts += 1;
+      if (instrumentAttempts === 1) {
+        return { exitCode: 1, stdout: '', stderr: 'instrumentation failed' };
+      }
+      return {
+        exitCode: 0,
+        stdout: helperOutput('<hierarchy><node text="helper" bounds="[0,0][10,10]" /></hierarchy>'),
+        stderr: '',
+      };
+    }
+    throw new Error(`unexpected helper adb args: ${args.join(' ')}`);
+  };
+  const stockXml =
+    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node text="stock" bounds="[0,0][10,10]" /></hierarchy>';
+  mockRunCmd.mockImplementation(async (_cmd, args) => {
+    if (args.includes('exec-out')) {
+      return { exitCode: 0, stdout: stockXml, stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+  const helperOptions = {
+    helperAdb,
+    helperArtifact: {
+      apkPath: '/tmp/helper.apk',
+      manifest: helperManifest,
+    },
+  };
+
+  const fallback = await snapshotAndroid(device, helperOptions);
+  const helper = await snapshotAndroid(device, helperOptions);
+
+  assert.equal(fallback.androidSnapshot.backend, 'uiautomator-dump');
+  assert.equal(helper.androidSnapshot.backend, 'android-helper');
+  assert.equal(helper.nodes[0]?.label, 'helper');
+  assert.equal(versionProbeCount, 2);
 });
 
 test('dumpUiHierarchy reads fallback XML when dump exits non-zero', async () => {

--- a/src/platforms/android/snapshot-helper-install.ts
+++ b/src/platforms/android/snapshot-helper-install.ts
@@ -10,9 +10,49 @@ import type {
   AndroidSnapshotHelperInstallResult,
 } from './snapshot-helper-types.ts';
 
+const installedSnapshotHelpers = new Map<string, number>();
+
+export function forgetAndroidSnapshotHelperInstall(options: {
+  deviceKey: string;
+  packageName: string;
+  versionCode: number;
+}): void {
+  forgetInstalledSnapshotHelper(
+    getInstallCacheKey(options.deviceKey, options.packageName, options.versionCode),
+  );
+}
+
+export function resetAndroidSnapshotHelperInstallCache(): void {
+  installedSnapshotHelpers.clear();
+}
+
+function getInstallCacheKey(
+  deviceKey: string | undefined,
+  packageName: string,
+  versionCode: number,
+): string | undefined {
+  return deviceKey ? `${deviceKey}\0${packageName}\0${versionCode}` : undefined;
+}
+
+function rememberInstalledSnapshotHelper(
+  cacheKey: string | undefined,
+  installedVersionCode: number,
+): void {
+  if (cacheKey) {
+    installedSnapshotHelpers.set(cacheKey, installedVersionCode);
+  }
+}
+
+function forgetInstalledSnapshotHelper(cacheKey: string | undefined): void {
+  if (cacheKey) {
+    installedSnapshotHelpers.delete(cacheKey);
+  }
+}
+
 export async function ensureAndroidSnapshotHelper(options: {
   adb: AndroidAdbExecutor;
   artifact: AndroidSnapshotHelperArtifact;
+  deviceKey?: string;
   installPolicy?: AndroidSnapshotHelperInstallPolicy;
   timeoutMs?: number;
 }): Promise<AndroidSnapshotHelperInstallResult> {
@@ -28,10 +68,27 @@ export async function ensureAndroidSnapshotHelper(options: {
       reason: 'skipped',
     };
   }
+  const installCacheKey = getInstallCacheKey(options.deviceKey, packageName, versionCode);
+  const cachedVersionCode = installCacheKey
+    ? installedSnapshotHelpers.get(installCacheKey)
+    : undefined;
+  if (installCacheKey && installPolicy !== 'always' && cachedVersionCode !== undefined) {
+    return {
+      packageName,
+      versionCode,
+      installedVersionCode: cachedVersionCode,
+      installed: false,
+      reason: 'current',
+    };
+  }
   const installedVersionCode = await readInstalledVersionCode(adb, packageName, options.timeoutMs);
   const reason = getInstallReason(installPolicy, installedVersionCode, versionCode);
 
   if (reason === 'current') {
+    if (installedVersionCode === undefined) {
+      throw new Error('Expected installed versionCode for current Android snapshot helper');
+    }
+    rememberInstalledSnapshotHelper(installCacheKey, installedVersionCode);
     return {
       packageName,
       versionCode,
@@ -51,6 +108,7 @@ export async function ensureAndroidSnapshotHelper(options: {
     timeoutMs: options.timeoutMs,
   });
   if (result.exitCode !== 0) {
+    forgetInstalledSnapshotHelper(installCacheKey);
     throw new AppError('COMMAND_FAILED', 'Failed to install Android snapshot helper', {
       packageName,
       versionCode,
@@ -60,6 +118,7 @@ export async function ensureAndroidSnapshotHelper(options: {
     });
   }
 
+  rememberInstalledSnapshotHelper(installCacheKey, versionCode);
   return {
     packageName,
     versionCode,

--- a/src/platforms/android/snapshot-helper.ts
+++ b/src/platforms/android/snapshot-helper.ts
@@ -8,7 +8,11 @@ export {
   parseAndroidSnapshotHelperOutput,
   parseAndroidSnapshotHelperXml,
 } from './snapshot-helper-capture.ts';
-export { ensureAndroidSnapshotHelper } from './snapshot-helper-install.ts';
+export {
+  ensureAndroidSnapshotHelper,
+  forgetAndroidSnapshotHelperInstall,
+  resetAndroidSnapshotHelperInstallCache,
+} from './snapshot-helper-install.ts';
 export {
   ANDROID_SNAPSHOT_HELPER_NAME,
   ANDROID_SNAPSHOT_HELPER_OUTPUT_FORMAT,

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -27,6 +27,7 @@ import {
   captureAndroidSnapshotWithHelper,
   ANDROID_SNAPSHOT_HELPER_WAIT_FOR_IDLE_TIMEOUT_MS,
   ensureAndroidSnapshotHelper,
+  forgetAndroidSnapshotHelperInstall,
   parseAndroidSnapshotHelperManifest,
   type AndroidAdbExecutor,
   type AndroidSnapshotHelperArtifact,
@@ -89,11 +90,13 @@ async function captureAndroidUiHierarchy(
 ): Promise<{ xml: string; metadata: AndroidSnapshotBackendMetadata }> {
   const helper = await resolveAndroidSnapshotHelperArtifact(options.helperArtifact);
   if (helper.artifact) {
+    const helperDeviceKey = getAndroidSnapshotHelperDeviceKey(device);
     try {
       const adb = options.helperAdb ?? createDeviceAdbExecutor(device);
       const install = await ensureAndroidSnapshotHelper({
         adb,
         artifact: helper.artifact,
+        deviceKey: helperDeviceKey,
         installPolicy: options.helperInstallPolicy,
         timeoutMs: HELPER_INSTALL_TIMEOUT_MS,
       });
@@ -125,6 +128,11 @@ async function captureAndroidUiHierarchy(
         },
       };
     } catch (error) {
+      forgetAndroidSnapshotHelperInstall({
+        deviceKey: helperDeviceKey,
+        packageName: helper.artifact.manifest.packageName,
+        versionCode: helper.artifact.manifest.versionCode,
+      });
       return await captureStockUiHierarchy(device, normalizeError(error).message);
     }
   }
@@ -182,6 +190,12 @@ async function captureStockUiHierarchy(
 
 function createDeviceAdbExecutor(device: DeviceInfo): AndroidAdbExecutor {
   return async (args, options) => await runCmd('adb', adbArgs(device, args), options);
+}
+
+function getAndroidSnapshotHelperDeviceKey(device: DeviceInfo): string {
+  // Emulator serials are port-based and can be reused after restart; capture failure invalidates
+  // this key before falling back so stale process-local entries self-heal on the next snapshot.
+  return `${device.platform}:${device.id}`;
 }
 
 async function deriveScrollableContentHintsIfNeeded(

--- a/test/scripts/android-snapshot-helper-release-smoke.sh
+++ b/test/scripts/android-snapshot-helper-release-smoke.sh
@@ -1,0 +1,164 @@
+#!/bin/sh
+set -eu
+
+PROJECT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+PACKAGE_NAME="com.callstack.agentdevice.snapshotsmoke"
+APP_LABEL="Agent Device Snapshot Smoke"
+# Keep these in sync with the Android workflow SDK packages and emulator API level.
+MIN_SDK=23
+TARGET_SDK=36
+
+SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [ -z "$SDK_ROOT" ] || [ ! -d "$SDK_ROOT" ]; then
+  echo "ANDROID_HOME or ANDROID_SDK_ROOT must point to an Android SDK" >&2
+  exit 1
+fi
+
+ANDROID_JAR="$SDK_ROOT/platforms/android-$TARGET_SDK/android.jar"
+if [ ! -f "$ANDROID_JAR" ]; then
+  echo "Missing Android platform jar: $ANDROID_JAR" >&2
+  exit 1
+fi
+
+BUILD_TOOLS_DIR="$(
+  find "$SDK_ROOT/build-tools" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort -V | tail -n 1
+)"
+if [ -z "$BUILD_TOOLS_DIR" ] || [ ! -x "$BUILD_TOOLS_DIR/aapt2" ]; then
+  echo "Missing Android build tools under $SDK_ROOT/build-tools" >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agent-device-android-helper-smoke.XXXXXX")"
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+SRC_DIR="$WORK_DIR/src/com/callstack/agentdevice/snapshotsmoke"
+CLASSES_DIR="$WORK_DIR/classes"
+DEX_DIR="$WORK_DIR/dex"
+UNSIGNED_APK="$WORK_DIR/app-unsigned.apk"
+ALIGNED_APK="$WORK_DIR/app-aligned.apk"
+APK_PATH="$WORK_DIR/app-release.apk"
+KEYSTORE="$PROJECT_DIR/android-snapshot-helper/debug.keystore"
+
+# This APK is throwaway test code signed with the helper debug keystore only for CI smoke coverage.
+mkdir -p "$SRC_DIR" "$CLASSES_DIR" "$DEX_DIR"
+
+cat > "$WORK_DIR/AndroidManifest.xml" <<EOF_MANIFEST
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="$PACKAGE_NAME">
+  <application android:theme="@style/AppTheme" android:label="$APP_LABEL" android:allowBackup="false" android:supportsRtl="true">
+    <activity android:name=".MainActivity" android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>
+EOF_MANIFEST
+
+mkdir -p "$WORK_DIR/res/values"
+cat > "$WORK_DIR/res/values/styles.xml" <<EOF_STYLES
+<resources>
+  <style name="AppTheme" parent="@android:style/Theme.Material.Light.NoActionBar" />
+</resources>
+EOF_STYLES
+
+cat > "$SRC_DIR/MainActivity.java" <<'EOF_JAVA'
+package com.callstack.agentdevice.snapshotsmoke;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+public final class MainActivity extends Activity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    LinearLayout layout = new LinearLayout(this);
+    layout.setOrientation(LinearLayout.VERTICAL);
+    layout.setGravity(Gravity.CENTER);
+    layout.setPadding(32, 32, 32, 32);
+
+    TextView title = new TextView(this);
+    title.setText("Snapshot helper release smoke");
+    title.setTextSize(22);
+    title.setGravity(Gravity.CENTER);
+    layout.addView(
+        title,
+        new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+    Button button = new Button(this);
+    button.setText("Release smoke ready");
+    layout.addView(
+        button,
+        new LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+    setContentView(layout);
+  }
+}
+EOF_JAVA
+
+javac \
+  --release 11 \
+  -classpath "$ANDROID_JAR" \
+  -d "$CLASSES_DIR" \
+  "$SRC_DIR/MainActivity.java"
+
+"$BUILD_TOOLS_DIR/d8" \
+  --min-api "$MIN_SDK" \
+  --classpath "$ANDROID_JAR" \
+  --output "$DEX_DIR" \
+  $(find "$CLASSES_DIR" -name '*.class' | sort)
+
+"$BUILD_TOOLS_DIR/aapt2" compile \
+  --dir "$WORK_DIR/res" \
+  -o "$WORK_DIR/compiled.zip"
+
+"$BUILD_TOOLS_DIR/aapt2" link \
+  --manifest "$WORK_DIR/AndroidManifest.xml" \
+  -I "$ANDROID_JAR" \
+  --min-sdk-version "$MIN_SDK" \
+  --target-sdk-version "$TARGET_SDK" \
+  --version-code 1 \
+  --version-name 1.0 \
+  -o "$UNSIGNED_APK" \
+  "$WORK_DIR/compiled.zip"
+
+zip -q -j "$UNSIGNED_APK" "$DEX_DIR/classes.dex"
+"$BUILD_TOOLS_DIR/zipalign" -f 4 "$UNSIGNED_APK" "$ALIGNED_APK"
+"$BUILD_TOOLS_DIR/apksigner" sign \
+  --ks "$KEYSTORE" \
+  --ks-pass pass:android \
+  --key-pass pass:android \
+  --out "$APK_PATH" \
+  "$ALIGNED_APK"
+"$BUILD_TOOLS_DIR/apksigner" verify --min-sdk-version "$MIN_SDK" "$APK_PATH"
+
+node --experimental-strip-types "$PROJECT_DIR/src/bin.ts" install "$PACKAGE_NAME" "$APK_PATH" --platform android
+node --experimental-strip-types "$PROJECT_DIR/src/bin.ts" open "$PACKAGE_NAME" --platform android --relaunch
+node --experimental-strip-types "$PROJECT_DIR/src/bin.ts" snapshot -i --platform android --json > "$WORK_DIR/snapshot.json"
+
+node - "$WORK_DIR/snapshot.json" <<'EOF_NODE'
+const fs = require('node:fs');
+
+const snapshot = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const nodes = snapshot?.data?.nodes ?? snapshot?.nodes ?? [];
+const androidSnapshot = snapshot?.data?.androidSnapshot ?? snapshot?.androidSnapshot;
+const labels = nodes.map((node) => String(node.label ?? node.text ?? ''));
+
+if (androidSnapshot?.backend !== 'android-helper') {
+  throw new Error(`Expected android-helper backend, received ${androidSnapshot?.backend}`);
+}
+if (!labels.some((label) => label.toLowerCase().includes('release smoke ready'))) {
+  throw new Error(`Expected release smoke label in snapshot labels: ${labels.join(', ')}`);
+}
+EOF_NODE


### PR DESCRIPTION
## Summary

Cache successful Android snapshot helper install checks per device/helper version so repeated helper-backed snapshots skip the package version probe.
Add a release-mode Android APK helper smoke that packages the helper before emulator startup, installs a generated release app, captures via the helper backend, and runs inside the existing Android emulator CI step.

Touched files: 7. Scope stayed within the Android snapshot helper path plus Android CI smoke coverage. Docs/skills were not updated because the CLI/API behavior is unchanged; this is an internal performance/reliability improvement and CI coverage addition.

Closes #455. Secondary-display investigation moved to #471. Toast capture/buffering is intentionally deferred until a real missed-toast workflow needs transient UI event support.

## Validation

- `pnpm exec vitest run src/platforms/android/__tests__/snapshot-helper.test.ts src/platforms/android/__tests__/snapshot.test.ts`
- `pnpm format`
- `pnpm check:quick`
- `pnpm check:tooling`
- `pnpm package:android-snapshot-helper:npm`
- `sh -n test/scripts/android-snapshot-helper-release-smoke.sh`
- `sh ./test/scripts/android-snapshot-helper-release-smoke.sh`
- `pnpm exec vitest run --maxWorkers=4 && pnpm test:smoke`

Known note: an unbounded `pnpm check:unit` rerun was killed locally by the OS during Vitest; the same unit/smoke bundle passed earlier, and the final bounded Vitest run plus smoke tests passed.