### PR TITLE
feat: expose daemon embedding and Android ADB APIs

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -17,6 +17,7 @@
     "src/bin.ts",
     "src/companion-tunnel.ts",
     "src/daemon.ts",
+    "src/daemon-embedding.ts",
     "src/utils/update-check-entry.ts",
     "test/scripts/metro-prepare-packaged-smoke.mjs",
     "test/integration/*.test.ts",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Snapshots assign refs like `@e1`, `@e2`, and `@e3` to current-screen elements. R
 
 `agent-device` runs session-aware commands through platform backends: XCTest for iOS and tvOS, ADB plus the Android snapshot helper for Android, a local helper for macOS desktop automation, and AT-SPI for Linux desktop targets. See [Introduction](https://incubator.callstack.com/agent-device/docs/introduction) and [Commands](https://incubator.callstack.com/agent-device/docs/commands) for platform details.
 
+Node consumers can use the typed client and public subpaths for bridge integrations. `agent-device/android-adb` exposes the Android ADB provider contract and reusable helpers for ADB-backed app listing and foreground state. `agent-device/daemon` exposes the supported daemon embedding surface for integrations that intentionally reuse the upstream request router.
+
 ## Used By
 
 Used by teams and developers at Callstack, Expensify, Shopify, Kindred, Total Wine & More, LegendList, HerLyfe, App & Flow, and more.
@@ -101,6 +103,7 @@ Used by teams and developers at Callstack, Expensify, Shopify, Kindred, Total Wi
 ## Documentation
 
 - [Installation](https://incubator.callstack.com/agent-device/docs/installation)
+- [Typed Client](https://incubator.callstack.com/agent-device/docs/client-api)
 - [Commands](https://incubator.callstack.com/agent-device/docs/commands)
 - [Replay & E2E](https://incubator.callstack.com/agent-device/docs/replay-e2e)
 - [Known limitations](https://incubator.callstack.com/agent-device/docs/known-limitations)

--- a/fallow-baselines/dupes.json
+++ b/fallow-baselines/dupes.json
@@ -103,7 +103,7 @@
     "src/client.ts:632-658|src/index.ts:79-105",
     "src/commands/admin.ts:306-313|src/commands/apps.ts:286-295",
     "src/commands/capture-snapshot.ts:104-110|src/commands/selector-read-shared.ts:42-47",
-    "src/commands/interactions.ts:207-215|src/core/dispatch.ts:875-883",
+    "src/commands/interactions.ts:207-215|src/core/dispatch.ts:876-884",
     "src/commands/selector-read.ts:169-178|src/commands/selector-read.ts:403-410",
     "src/contracts.ts:422-427|src/contracts.ts:457-462",
     "src/core/__tests__/dispatch-open.test.ts:17-25|src/core/__tests__/dispatch-push.test.ts:12-20",

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -217,6 +217,9 @@
     "src/core/dispatch-resolve.ts": {
       "crap_high": {
         "count": 1
+      },
+      "crap_moderate": {
+        "count": 1
       }
     },
     "src/core/dispatch.ts": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
       "import": "./dist/src/android-snapshot-helper.js",
       "types": "./dist/src/android-snapshot-helper.d.ts"
     },
+    "./daemon": {
+      "import": "./dist/src/daemon-embedding.js",
+      "types": "./dist/src/daemon-embedding.d.ts"
+    },
     "./contracts": {
       "import": "./dist/src/contracts.js",
       "types": "./dist/src/contracts.d.ts"

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
           'android-apps': 'src/android-apps.ts',
           'android-adb': 'src/android-adb.ts',
           'android-snapshot-helper': 'src/android-snapshot-helper.ts',
+          'daemon-embedding': 'src/daemon-embedding.ts',
           contracts: 'src/contracts.ts',
           selectors: 'src/selectors.ts',
           finders: 'src/finders.ts',

--- a/src/android-adb.ts
+++ b/src/android-adb.ts
@@ -9,3 +9,12 @@ export {
   type AndroidAdbProvider,
   type AndroidAdbSpawner,
 } from './platforms/android/adb-executor.ts';
+export {
+  getAndroidAppStateWithAdb,
+  listAndroidAppsWithAdb,
+} from './platforms/android/app-helpers.ts';
+export type {
+  AndroidAppListFilter,
+  AndroidAppListOptions,
+  AndroidAppListTarget,
+} from './platforms/android/app-helpers.ts';

--- a/src/core/__tests__/dispatch-resolve.test.ts
+++ b/src/core/__tests__/dispatch-resolve.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../platforms/ios/devices.ts', async (importOriginal) => {
 import {
   resolveIosDevice,
   resolveTargetDevice,
+  withDeviceInventoryProvider,
   withResolveTargetDeviceCacheScope,
 } from '../dispatch-resolve.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
@@ -172,4 +173,29 @@ test('resolveTargetDevice reuses cache across nested request scopes', async () =
   });
 
   assert.equal(mockListAppleDevices.mock.calls.length, 1);
+});
+
+test('resolveTargetDevice uses injected device inventory without local discovery', async () => {
+  const result = await withDeviceInventoryProvider(
+    async (request) => {
+      assert.equal(request.platform, 'ios');
+      assert.equal(request.deviceName, 'Remote iPhone');
+      return [{ ...bootedSimulator, id: 'remote-ios-1', name: 'Remote iPhone' }];
+    },
+    async () => await resolveTargetDevice({ platform: 'ios', device: 'Remote iPhone' }),
+  );
+
+  assert.equal(result.id, 'remote-ios-1');
+  assert.equal(mockListAppleDevices.mock.calls.length, 0);
+});
+
+test('resolveTargetDevice treats empty injected inventory as authoritative', async () => {
+  const err = await withDeviceInventoryProvider(
+    async () => [],
+    async () => await resolveTargetDevice({ platform: 'ios' }),
+  ).catch((error) => error);
+
+  assert.ok(err instanceof AppError);
+  assert.equal(err.code, 'DEVICE_NOT_FOUND');
+  assert.equal(mockListAppleDevices.mock.calls.length, 0);
 });

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -30,6 +30,21 @@ type ResolveDeviceFlags = Pick<
 >;
 
 const resolveTargetDeviceCacheScope = new AsyncLocalStorage<Map<string, DeviceInfo>>();
+const deviceInventoryProviderScope = new AsyncLocalStorage<DeviceInventoryProvider>();
+
+export type DeviceInventoryRequest = {
+  platform?: PlatformSelector;
+  target?: DeviceTarget;
+  deviceName?: string;
+  udid?: string;
+  serial?: string;
+  iosSimulatorSetPath?: string;
+  androidSerialAllowlist?: string[];
+};
+
+export type DeviceInventoryProvider = (
+  request: DeviceInventoryRequest,
+) => Promise<DeviceInfo[] | null | undefined>;
 
 type AppleDeviceSelector = {
   platform?: Exclude<PlatformSelector, 'android'>;
@@ -134,6 +149,20 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
         );
       }
 
+      const injectedDevices = await readInjectedDeviceInventory({
+        ...selector,
+        iosSimulatorSetPath,
+        androidSerialAllowlist: androidSerialAllowlist
+          ? Array.from(androidSerialAllowlist).sort()
+          : undefined,
+      });
+      if (injectedDevices) {
+        return cacheResolvedTargetDevice(
+          cacheKey,
+          await resolveDevice(injectedDevices, selector, { simulatorSetPath: iosSimulatorSetPath }),
+        );
+      }
+
       if (selector.platform === 'linux') {
         const devices = await listLinuxDevices();
         return cacheResolvedTargetDevice(cacheKey, await resolveDevice(devices, selector));
@@ -179,6 +208,34 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
 export async function withResolveTargetDeviceCacheScope<T>(task: () => Promise<T>): Promise<T> {
   if (resolveTargetDeviceCacheScope.getStore()) return await task();
   return await resolveTargetDeviceCacheScope.run(new Map(), task);
+}
+
+export async function withDeviceInventoryProvider<T>(
+  provider: DeviceInventoryProvider | undefined,
+  task: () => Promise<T>,
+): Promise<T> {
+  if (!provider) return await task();
+  return await deviceInventoryProviderScope.run(provider, task);
+}
+
+export async function withTargetDeviceResolutionScope<T>(
+  provider: DeviceInventoryProvider | undefined,
+  task: () => Promise<T>,
+): Promise<T> {
+  return await withDeviceInventoryProvider(
+    provider,
+    async () => await withResolveTargetDeviceCacheScope(task),
+  );
+}
+
+async function readInjectedDeviceInventory(
+  request: DeviceInventoryRequest,
+): Promise<DeviceInfo[] | null> {
+  const provider = deviceInventoryProviderScope.getStore();
+  if (!provider) return null;
+  const devices = await provider(request);
+  if (devices === undefined || devices === null) return null;
+  return devices.map((device) => ({ ...device }));
 }
 
 function readResolveTargetDeviceCache(cacheKey: string): DeviceInfo | undefined {

--- a/src/daemon-embedding.ts
+++ b/src/daemon-embedding.ts
@@ -1,0 +1,38 @@
+export { createRequestHandler } from './daemon/request-router.ts';
+export type { AndroidAdbProviderResolver, RequestRouterDeps } from './daemon/request-router.ts';
+export { withDeviceInventoryProvider } from './core/dispatch-resolve.ts';
+export type { DeviceInventoryProvider, DeviceInventoryRequest } from './core/dispatch-resolve.ts';
+export { SessionStore } from './daemon/session-store.ts';
+export { LeaseRegistry } from './daemon/lease-registry.ts';
+export type {
+  AdmissionRequest,
+  AllocateLeaseRequest,
+  HeartbeatLeaseRequest,
+  LeaseRegistryOptions,
+  ReleaseLeaseRequest,
+  SimulatorLease,
+} from './daemon/lease-registry.ts';
+export {
+  cleanupDownloadableArtifact,
+  cleanupUploadedArtifact,
+  prepareDownloadableArtifact,
+  prepareUploadedArtifact,
+  trackDownloadableArtifact,
+  trackUploadedArtifact,
+} from './daemon/artifact-tracking.ts';
+export type {
+  DaemonArtifact,
+  DaemonInstallSource,
+  DaemonRequest,
+  DaemonResponse,
+  DaemonResponseData,
+  SessionRuntimeHints,
+  SessionState,
+} from './daemon/types.ts';
+export type { DeviceInfo, Platform, PlatformSelector } from './utils/device.ts';
+export type {
+  AndroidAdbExecutor,
+  AndroidAdbExecutorOptions,
+  AndroidAdbExecutorResult,
+  AndroidAdbProvider,
+} from './android-adb.ts';

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -1,15 +1,14 @@
 import path from 'node:path';
-import type { CommandFlags } from '../core/dispatch.ts';
 import {
   withAndroidAdbProvider,
   type AndroidAdbExecutor,
   type AndroidAdbProvider,
 } from '../platforms/android/adb-executor.ts';
+import { dispatchCommand, resolveTargetDevice, type CommandFlags } from '../core/dispatch.ts';
 import {
-  dispatchCommand,
-  resolveTargetDevice,
-  withResolveTargetDeviceCacheScope,
-} from '../core/dispatch.ts';
+  type DeviceInventoryProvider,
+  withTargetDeviceResolutionScope,
+} from '../core/dispatch-resolve.ts';
 import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
 import { AppError, normalizeError, toAppErrorCode } from '../utils/errors.ts';
 import type { DeviceInfo } from '../utils/device.ts';
@@ -86,7 +85,7 @@ const leaseAdmissionExemptCommands = new Set([
 const sessionExecutionExemptCommands = new Set(leaseAdmissionExemptCommands);
 const sessionExecutionLocks = new Map<string, Promise<unknown>>();
 
-type AndroidAdbProviderResolver = (params: {
+export type AndroidAdbProviderResolver = (params: {
   req: DaemonRequest;
   device: DeviceInfo;
   session?: SessionState;
@@ -603,6 +602,7 @@ export type RequestRouterDeps = {
   sessionStore: SessionStore;
   leaseRegistry: LeaseRegistry;
   androidAdbProvider?: AndroidAdbProviderResolver;
+  deviceInventoryProvider?: DeviceInventoryProvider;
   trackDownloadableArtifact: (opts: {
     artifactPath: string;
     tenantId?: string;
@@ -619,6 +619,7 @@ export function createRequestHandler(
     sessionStore,
     leaseRegistry,
     androidAdbProvider,
+    deviceInventoryProvider,
     trackDownloadableArtifact,
   } = deps;
 
@@ -639,7 +640,7 @@ export function createRequestHandler(
         }
 
         try {
-          return await withResolveTargetDeviceCacheScope(async () => {
+          return await withTargetDeviceResolutionScope(deviceInventoryProvider, async () => {
             const scopedReq = scopeRequestSession(req);
             emitDiagnostic({
               level: 'info',

--- a/src/platforms/android/__tests__/app-helpers.test.ts
+++ b/src/platforms/android/__tests__/app-helpers.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import type { AndroidAdbExecutor } from '../adb-executor.ts';
+import { createDeviceAdbExecutor } from '../adb-executor.ts';
+import { getAndroidAppStateWithAdb, listAndroidAppsWithAdb } from '../app-helpers.ts';
+
+async function withMockedAdbScript(script: string, run: () => Promise<void>): Promise<void> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-device-android-app-helpers-'));
+  const adbPath = path.join(tmpDir, 'adb');
+  await fs.writeFile(adbPath, script, 'utf8');
+  await fs.chmod(adbPath, 0o755);
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${tmpDir}${path.delimiter}${previousPath ?? ''}`;
+  try {
+    await run();
+  } finally {
+    process.env.PATH = previousPath;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('listAndroidAppsWithAdb uses an injected executor', async () => {
+  const calls: string[][] = [];
+  const adb: AndroidAdbExecutor = async (args) => {
+    calls.push(args);
+    if (args.includes('query-activities')) {
+      return {
+        exitCode: 0,
+        stdout: 'com.example.alpha/.MainActivity\ncom.example.beta/.MainActivity\n',
+        stderr: '',
+      };
+    }
+    return {
+      exitCode: 0,
+      stdout: 'package:com.example.beta\n',
+      stderr: '',
+    };
+  };
+
+  const apps = await listAndroidAppsWithAdb(adb, { filter: 'user-installed', target: 'mobile' });
+
+  assert.deepEqual(apps, [{ package: 'com.example.beta', name: 'Beta' }]);
+  assert.deepEqual(calls, [
+    [
+      'shell',
+      'cmd',
+      'package',
+      'query-activities',
+      '--brief',
+      '-a',
+      'android.intent.action.MAIN',
+      '-c',
+      'android.intent.category.LAUNCHER',
+    ],
+    ['shell', 'pm', 'list', 'packages', '-3'],
+  ]);
+});
+
+test('Android app helpers work with a local ADB provider', async () => {
+  await withMockedAdbScript(
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "-s" ]; then',
+      '  shift',
+      '  shift',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$3" = "window" ]; then',
+      '  echo "mCurrentFocus=Window{42 u0 com.example.app/.MainActivity}"',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$3" = "package" ]; then',
+      '  echo "com.example.app/.MainActivity"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    async () => {
+      const adb = createDeviceAdbExecutor({
+        platform: 'android',
+        id: 'emulator-5554',
+        name: 'Pixel',
+        kind: 'emulator',
+        booted: true,
+      });
+
+      const [apps, state] = await Promise.all([
+        listAndroidAppsWithAdb(adb, { target: 'mobile' }),
+        getAndroidAppStateWithAdb(adb),
+      ]);
+
+      assert.deepEqual(apps, [{ package: 'com.example.app', name: 'Example' }]);
+      assert.deepEqual(state, { package: 'com.example.app', activity: '.MainActivity' });
+    },
+  );
+});
+
+test('getAndroidAppStateWithAdb parses focus output from failed commands', async () => {
+  const calls: string[][] = [];
+  const adb: AndroidAdbExecutor = async (args) => {
+    calls.push(args);
+    return {
+      exitCode: 1,
+      stdout: 'mCurrentFocus=Window{42 u0 com.example.app/.MainActivity}\n',
+      stderr: 'dumpsys warning',
+    };
+  };
+
+  const state = await getAndroidAppStateWithAdb(adb);
+
+  assert.deepEqual(state, { package: 'com.example.app', activity: '.MainActivity' });
+  assert.deepEqual(calls, [['shell', 'dumpsys', 'window', 'windows']]);
+});

--- a/src/platforms/android/app-helpers.ts
+++ b/src/platforms/android/app-helpers.ts
@@ -1,0 +1,121 @@
+import { AppError } from '../../utils/errors.ts';
+import type { AndroidAdbExecutor } from './adb-executor.ts';
+import {
+  parseAndroidForegroundApp,
+  parseAndroidLaunchablePackages,
+  parseAndroidUserInstalledPackages,
+  type AndroidForegroundApp,
+} from './app-parsers.ts';
+import { inferAndroidAppName } from './app-lifecycle.ts';
+
+const ANDROID_LAUNCHER_CATEGORY = 'android.intent.category.LAUNCHER';
+const ANDROID_LEANBACK_CATEGORY = 'android.intent.category.LEANBACK_LAUNCHER';
+
+export type AndroidAppListFilter = 'user-installed' | 'all';
+export type AndroidAppListTarget = 'mobile' | 'tv' | 'auto';
+
+export type AndroidAppListOptions = {
+  filter?: AndroidAppListFilter;
+  target?: AndroidAppListTarget;
+};
+
+export async function listAndroidAppsWithAdb(
+  adb: AndroidAdbExecutor,
+  options: AndroidAppListOptions = {},
+): Promise<Array<{ package: string; name: string }>> {
+  const launchable = await listAndroidLaunchablePackagesWithAdb(adb, options.target ?? 'auto');
+  const packageIds =
+    options.filter === 'user-installed'
+      ? (await listAndroidUserInstalledPackagesWithAdb(adb)).filter((pkg) => launchable.has(pkg))
+      : Array.from(launchable);
+  return packageIds
+    .map((packageName) => ({ package: packageName, name: inferAndroidAppName(packageName) }))
+    .sort((a, b) => a.package.localeCompare(b.package));
+}
+
+export async function getAndroidAppStateWithAdb(
+  adb: AndroidAdbExecutor,
+): Promise<AndroidForegroundApp> {
+  const windowFocus = await readAndroidFocusWithAdb(adb, [
+    ['shell', 'dumpsys', 'window', 'windows'],
+    ['shell', 'dumpsys', 'window'],
+  ]);
+  if (windowFocus) return windowFocus;
+
+  const activityFocus = await readAndroidFocusWithAdb(adb, [
+    ['shell', 'dumpsys', 'activity', 'activities'],
+    ['shell', 'dumpsys', 'activity'],
+  ]);
+  if (activityFocus) return activityFocus;
+  return {};
+}
+
+async function listAndroidLaunchablePackagesWithAdb(
+  adb: AndroidAdbExecutor,
+  target: AndroidAppListTarget,
+): Promise<Set<string>> {
+  const discoveredPackages = (
+    await Promise.all(
+      resolveAndroidLaunchCategoriesForAdb(target).map(async (category) => {
+        const result = await adb(buildAndroidQueryActivitiesArgs(category), {
+          allowFailure: true,
+        });
+        return result.exitCode === 0 ? parseAndroidLaunchablePackageOutput(result.stdout) : [];
+      }),
+    )
+  ).flat();
+  return new Set(discoveredPackages);
+}
+
+function resolveAndroidLaunchCategoriesForAdb(target: AndroidAppListTarget): string[] {
+  switch (target) {
+    case 'mobile':
+      return [ANDROID_LAUNCHER_CATEGORY];
+    case 'tv':
+      return [ANDROID_LEANBACK_CATEGORY];
+    default:
+      return [ANDROID_LAUNCHER_CATEGORY, ANDROID_LEANBACK_CATEGORY];
+  }
+}
+
+function buildAndroidQueryActivitiesArgs(category: string): string[] {
+  return [
+    'shell',
+    'cmd',
+    'package',
+    'query-activities',
+    '--brief',
+    '-a',
+    'android.intent.action.MAIN',
+    '-c',
+    category,
+  ];
+}
+
+function parseAndroidLaunchablePackageOutput(stdout: string): string[] {
+  return stdout.trim().length === 0 ? [] : parseAndroidLaunchablePackages(stdout);
+}
+
+async function listAndroidUserInstalledPackagesWithAdb(adb: AndroidAdbExecutor): Promise<string[]> {
+  const result = await adb(['shell', 'pm', 'list', 'packages', '-3'], { allowFailure: true });
+  if (result.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', 'Failed to list Android user-installed apps', {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    });
+  }
+  return parseAndroidUserInstalledPackages(result.stdout);
+}
+
+async function readAndroidFocusWithAdb(
+  adb: AndroidAdbExecutor,
+  commands: string[][],
+): Promise<AndroidForegroundApp | null> {
+  for (const args of commands) {
+    const result = await adb(args, { allowFailure: true });
+    const parsed = parseAndroidForegroundApp(result.stdout ?? '');
+    if (parsed) return parsed;
+  }
+  return null;
+}

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -68,8 +68,23 @@ Public subpath API exposed for Node consumers:
   - `prepareAndroidSnapshotHelperArtifactFromManifestUrl(options)`
   - `verifyAndroidSnapshotHelperArtifact(artifact)`
   - types: `AndroidAdbExecutor`, `AndroidSnapshotHelperArtifact`, `AndroidSnapshotHelperManifest`, `AndroidSnapshotHelperOutput`, `AndroidSnapshotHelperParsedSnapshot`
+- `agent-device/android-adb`
+  - `createDeviceAdbExecutor(device)`
+  - `resolveAndroidAdbExecutor(device, executor?)`
+  - `spawnAndroidAdbBySerial(serial, args, options?)`
+  - `withAndroidAdbProvider(provider, task)`
+  - `listAndroidAppsWithAdb(executor, options?)`
+  - `getAndroidAppStateWithAdb(executor)`
+  - types: `AndroidAdbProvider`, `AndroidAdbExecutor`, `AndroidAdbExecutorOptions`, `AndroidAdbExecutorResult`, `AndroidAdbSpawner`
+- `agent-device/daemon`
+  - `createRequestHandler(deps)`
+  - `withDeviceInventoryProvider(provider, task)`
+  - `SessionStore`
+  - `LeaseRegistry`
+  - artifact tracking helpers
+  - request router, lease, session, device inventory, and Android ADB provider types for daemon embedders
 
-The `contracts`, `selectors`, `finders`, `install-source`, `android-apps`, `artifacts`, `batch`, `metro`, `remote-config`, and `io` subpaths remain available for compatibility. The former hosted-runtime subpaths `agent-device/commands`, `agent-device/backend`, `agent-device/testing/conformance`, and `agent-device/observability` are no longer published.
+The `contracts`, `selectors`, `finders`, `install-source`, `android-apps`, `android-adb`, `daemon`, `artifacts`, `batch`, `metro`, `remote-config`, and `io` subpaths remain available for compatibility. The former hosted-runtime subpaths `agent-device/commands`, `agent-device/backend`, `agent-device/testing/conformance`, and `agent-device/observability` are no longer published.
 
 ## Basic usage
 
@@ -140,6 +155,58 @@ const snapshot = parseAndroidSnapshotHelperXml(output.xml, output.metadata);
 Helper captures report `metadata.captureMode` as `interactive-windows` when Android returns
 interactive window roots, or `active-window` when the helper falls back to
 `getRootInActiveWindow()`. `metadata.windowCount` is the number of serialized roots.
+
+## Android ADB providers
+
+Use `agent-device/android-adb` when a bridge owns Android device access but wants upstream command
+behavior for ADB-shaped operations. Executors receive arguments after `adb`; local callers can use
+`createDeviceAdbExecutor(device)`, while remote bridges can route the same argument arrays through
+an ADB tunnel.
+
+The provider contract covers normal stdout/stderr commands, binary stdout, stdin, timeout/signal
+cancellation, device-scoped command interception through `withAndroidAdbProvider`, and optional
+long-running spawn support for logcat-style streams.
+
+```ts
+import {
+  getAndroidAppStateWithAdb,
+  listAndroidAppsWithAdb,
+  withAndroidAdbProvider,
+} from 'agent-device/android-adb';
+
+const provider = {
+  exec: async (args, options) => await runAdbThroughRemoteTunnel(args, options),
+};
+
+await withAndroidAdbProvider(provider, async () => {
+  const apps = await listAndroidAppsWithAdb(provider.exec, { filter: 'user-installed' });
+  const foreground = await getAndroidAppStateWithAdb(provider.exec);
+});
+```
+
+## Daemon embedding
+
+Use `agent-device/daemon` only when an integration wants to embed the upstream request router.
+The subpath is intentionally backend-neutral: it exports `createRequestHandler`, `SessionStore`,
+`LeaseRegistry`, artifact tracking helpers, daemon request/response/session types, device inventory
+provider types, and Android ADB provider hook types. Control-plane policy such as tenant auth,
+billing, external lease ownership, storage, and uploads remains the embedder's responsibility; pass
+those decisions through the dependency object instead of deep-importing daemon internals.
+
+`RequestRouterDeps.deviceInventoryProvider` can supply the full target candidate list for a request.
+When it returns an array, even an empty one, the daemon resolver treats that inventory as
+authoritative and does not call local host discovery such as `adb devices`, `simctl`, or Linux
+desktop discovery. Return `undefined` or `null` to fall back to local discovery for that request.
+
+`RequestRouterDeps.androidAdbProvider` can supply an Android command provider for the resolved
+request device. Device inventory controls discovery; the Android ADB provider controls command
+execution for Android paths that already use the provider seam. Until a command family has provider
+coverage, it may still require local host ADB access.
+
+Initial daemon conformance scope is the shared request/response contract in
+`agent-device/contracts`, request-router embedding through `createRequestHandler`, authoritative
+device inventory injection, artifact metadata shaping, and Android ADB provider behavior. Bridge
+implementations should validate those surfaces before relying on deeper daemon internals.
 
 ## Command methods
 


### PR DESCRIPTION
## Summary

Expose `agent-device/daemon` for embedded daemon request handling while keeping the surface backend-neutral.

Extend `agent-device/android-adb` with reusable Android app list/state helpers that work with the upstream ADB executor/provider seam from `main`.

Add device inventory injection and an explicit `androidAdbProvider` daemon dependency so embedders can provide both discovery candidates and Android command execution where provider coverage exists.

Touched files: 14. Scope stayed within daemon embedding, Android ADB helpers, docs, and validation baselines. Follow-up scope remains full Android provider coverage, first-class port reverse helpers, and executable conformance.

## Validation

`pnpm exec vitest run src/platforms/android/__tests__/app-helpers.test.ts src/core/__tests__/dispatch-resolve.test.ts src/daemon/__tests__/request-router-android-open-adb-provider.test.ts src/daemon/__tests__/request-router-android-perf.test.ts`

`pnpm exec vitest run src/platforms/android/__tests__/app-helpers.test.ts`

`pnpm check:fallow`

`pnpm check:tooling`

`node --input-type=module -e "import('agent-device/android-adb').then(m => console.log(typeof m.createDeviceAdbExecutor, typeof m.listAndroidAppsWithAdb))"`

`node --input-type=module -e "import('agent-device/daemon').then(m => console.log(typeof m.createRequestHandler, typeof m.withDeviceInventoryProvider, typeof m.SessionStore))"`

GitHub CI `Unit Tests` passed on the latest pushed commit. Local `pnpm check:unit` was also attempted: 171/172 test files and 1566/1567 tests passed, but `src/__tests__/client-metro-packaged.test.ts` failed once because the packaged smoke child process returned `status: null`; the same test passed when rerun directly with `pnpm exec vitest run src/__tests__/client-metro-packaged.test.ts`.