### PR TITLE
fix: stop companion retrying invalid registrations

### DIFF
--- a/src/__tests__/client-companion-tunnel-worker.test.ts
+++ b/src/__tests__/client-companion-tunnel-worker.test.ts
@@ -568,6 +568,76 @@ test('metro companion worker reconnects after the bridge closes immediately afte
   assert.equal(bridgeConnections, 2);
 });
 
+test('metro companion worker exits after non-retryable registration failure', async () => {
+  let registerAttempts = 0;
+
+  const localServer = http.createServer((_, res) => {
+    res.writeHead(404);
+    res.end('not found');
+  });
+  cleanupTasks.push(() => closeServer(localServer));
+  const localPort = await listen(localServer);
+
+  const bridgeServer = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1');
+    if (req.method === 'POST' && url.pathname === '/api/metro/companion/register') {
+      registerAttempts += 1;
+      req.resume();
+      req.on('end', () => {
+        res.writeHead(401, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            ok: false,
+            error: { code: 'UNAUTHORIZED', message: 'Invalid token' },
+          }),
+        );
+      });
+      return;
+    }
+    res.writeHead(404);
+    res.end('not found');
+  });
+  cleanupTasks.push(() => closeServer(bridgeServer));
+  const bridgePort = await listen(bridgeServer);
+
+  const companion = spawn(
+    process.execPath,
+    ['--experimental-strip-types', 'src/companion-tunnel.ts', '--agent-device-run-metro-companion'],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        AGENT_DEVICE_COMPANION_TUNNEL_SERVER_BASE_URL: `http://127.0.0.1:${bridgePort}`,
+        AGENT_DEVICE_COMPANION_TUNNEL_BEARER_TOKEN: 'bad-token',
+        AGENT_DEVICE_COMPANION_TUNNEL_LOCAL_BASE_URL: `http://127.0.0.1:${localPort}`,
+        AGENT_DEVICE_COMPANION_TUNNEL_REGISTER_PATH: '/api/metro/companion/register',
+        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_TENANT_ID: 'tenant-1',
+        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_RUN_ID: 'run-1',
+        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_LEASE_ID: 'lease-1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  cleanupTasks.push(() => stopChild(companion));
+
+  let stderr = '';
+  companion.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  const exit = await waitFor(
+    new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+      companion.once('exit', (code, signal) => resolve({ code, signal }));
+    }),
+    5_000,
+    'worker exit after non-retryable registration failure',
+  );
+
+  assert.equal(exit.signal, null, `unexpected worker stderr: ${stderr}`);
+  assert.equal(exit.code, 0, `unexpected worker stderr: ${stderr}`);
+  assert.equal(registerAttempts, 1);
+});
+
 test('metro companion worker exits after its state file is removed', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-metro-companion-worker-'));
   const statePath = path.join(tempRoot, 'metro-companion.json');

--- a/src/__tests__/client-companion-tunnel-worker.test.ts
+++ b/src/__tests__/client-companion-tunnel-worker.test.ts
@@ -27,6 +27,16 @@ type ParsedWebSocketFrame = {
   nextOffset: number;
 };
 
+type CompanionWorkerProcess = {
+  companion: ReturnType<typeof spawn>;
+  earlyExit: Promise<never>;
+  readStderr: () => string;
+  waitForExit: (
+    label: string,
+    timeoutMs?: number,
+  ) => Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+};
+
 function createDeferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -154,6 +164,43 @@ function attachWebSocketFrameParser(
   });
 }
 
+function acceptWebSocketUpgrade(req: http.IncomingMessage, socket: Duplex): boolean {
+  const key = req.headers['sec-websocket-key'];
+  if (typeof key !== 'string') {
+    socket.destroy();
+    return false;
+  }
+  const accept = crypto
+    .createHash('sha1')
+    .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest('base64');
+  socket.write(
+    [
+      'HTTP/1.1 101 Switching Protocols',
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      `Sec-WebSocket-Accept: ${accept}`,
+      '\r\n',
+    ].join('\r\n'),
+  );
+  return true;
+}
+
+function writeNotFound(res: http.ServerResponse): void {
+  res.writeHead(404);
+  res.end('not found');
+}
+
+function writeSuccessfulRegistration(res: http.ServerResponse, bridgePort: number): void {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      ok: true,
+      data: { ws_url: `ws://127.0.0.1:${bridgePort}/bridge` },
+    }),
+  );
+}
+
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
@@ -182,6 +229,12 @@ async function closeServer(server: http.Server): Promise<void> {
   });
 }
 
+async function listenNotFoundServer(): Promise<number> {
+  const server = http.createServer((_, res) => writeNotFound(res));
+  cleanupTasks.push(() => closeServer(server));
+  return listen(server);
+}
+
 async function stopChild(child: ReturnType<typeof spawn>): Promise<void> {
   if (child.exitCode !== null || child.killed) return;
   child.kill('SIGTERM');
@@ -192,6 +245,69 @@ async function stopChild(child: ReturnType<typeof spawn>): Promise<void> {
   if (exited) return;
   child.kill('SIGKILL');
   await new Promise<void>((resolve) => child.once('close', () => resolve()));
+}
+
+function spawnMetroCompanionWorker(options: {
+  bearerToken?: string;
+  bridgePort?: number;
+  localPort?: number;
+  serverBaseUrl?: string;
+  localBaseUrl?: string;
+  statePath?: string;
+}): CompanionWorkerProcess {
+  const serverBaseUrl = options.serverBaseUrl ?? `http://127.0.0.1:${options.bridgePort}`;
+  const localBaseUrl = options.localBaseUrl ?? `http://127.0.0.1:${options.localPort}`;
+  const companion = spawn(
+    process.execPath,
+    ['--experimental-strip-types', 'src/companion-tunnel.ts', '--agent-device-run-metro-companion'],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        AGENT_DEVICE_COMPANION_TUNNEL_SERVER_BASE_URL: serverBaseUrl,
+        AGENT_DEVICE_COMPANION_TUNNEL_BEARER_TOKEN: options.bearerToken ?? 'test-token',
+        AGENT_DEVICE_COMPANION_TUNNEL_LOCAL_BASE_URL: localBaseUrl,
+        AGENT_DEVICE_COMPANION_TUNNEL_REGISTER_PATH: '/api/metro/companion/register',
+        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_TENANT_ID: 'tenant-1',
+        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_RUN_ID: 'run-1',
+        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_LEASE_ID: 'lease-1',
+        ...(options.statePath
+          ? { AGENT_DEVICE_COMPANION_TUNNEL_STATE_PATH: options.statePath }
+          : {}),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  cleanupTasks.push(() => stopChild(companion));
+
+  let stderr = '';
+  companion.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  return {
+    companion,
+    get earlyExit() {
+      return new Promise<never>((_, reject) => {
+        companion.once('exit', (code, signal) => {
+          reject(
+            new Error(
+              `Metro companion exited unexpectedly with code=${String(code)} signal=${String(signal)} stderr=${stderr}`,
+            ),
+          );
+        });
+      });
+    },
+    readStderr: () => stderr,
+    waitForExit: (label, timeoutMs = 5_000) =>
+      waitFor(
+        new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+          companion.once('exit', (code, signal) => resolve({ code, signal }));
+        }),
+        timeoutMs,
+        label,
+      ),
+  };
 }
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -242,34 +358,14 @@ test('metro companion worker proxies websocket frames to the local upstream serv
   let upstreamSocketRef: Duplex | null = null;
   let bridgeSocketRef: Duplex | null = null;
 
-  const upstreamServer = http.createServer((_, res) => {
-    res.writeHead(404);
-    res.end('not found');
-  });
+  const upstreamServer = http.createServer((_, res) => writeNotFound(res));
   upstreamServer.on('upgrade', (req, socket) => {
     if (req.url !== '/echo') {
       socket.destroy();
       return;
     }
     upstreamSocketRef = socket;
-    const key = req.headers['sec-websocket-key'];
-    if (typeof key !== 'string') {
-      socket.destroy();
-      return;
-    }
-    const accept = crypto
-      .createHash('sha1')
-      .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
-      .digest('base64');
-    socket.write(
-      [
-        'HTTP/1.1 101 Switching Protocols',
-        'Upgrade: websocket',
-        'Connection: Upgrade',
-        `Sec-WebSocket-Accept: ${accept}`,
-        '\r\n',
-      ].join('\r\n'),
-    );
+    if (!acceptWebSocketUpgrade(req, socket)) return;
     attachWebSocketFrameParser(
       socket,
       (text) => {
@@ -297,18 +393,11 @@ test('metro companion worker proxies websocket frames to the local upstream serv
       });
       req.on('end', () => {
         registrationBody.resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
-        res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            ok: true,
-            data: { ws_url: `ws://127.0.0.1:${bridgePort}/bridge` },
-          }),
-        );
+        writeSuccessfulRegistration(res, bridgePort);
       });
       return;
     }
-    res.writeHead(404);
-    res.end('not found');
+    writeNotFound(res);
   });
   bridgeServer.on('upgrade', (req, socket) => {
     if (req.url !== '/bridge') {
@@ -316,24 +405,7 @@ test('metro companion worker proxies websocket frames to the local upstream serv
       return;
     }
     bridgeSocketRef = socket;
-    const key = req.headers['sec-websocket-key'];
-    if (typeof key !== 'string') {
-      socket.destroy();
-      return;
-    }
-    const accept = crypto
-      .createHash('sha1')
-      .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
-      .digest('base64');
-    socket.write(
-      [
-        'HTTP/1.1 101 Switching Protocols',
-        'Upgrade: websocket',
-        'Connection: Upgrade',
-        `Sec-WebSocket-Accept: ${accept}`,
-        '\r\n',
-      ].join('\r\n'),
-    );
+    if (!acceptWebSocketUpgrade(req, socket)) return;
     bridgeSocketReady.resolve(socket);
 
     attachWebSocketFrameParser(socket, (text) => {
@@ -377,38 +449,9 @@ test('metro companion worker proxies websocket frames to the local upstream serv
   });
   const bridgePort = await listen(bridgeServer);
 
-  const companion = spawn(
-    process.execPath,
-    ['--experimental-strip-types', 'src/companion-tunnel.ts', '--agent-device-run-metro-companion'],
-    {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        AGENT_DEVICE_COMPANION_TUNNEL_SERVER_BASE_URL: `http://127.0.0.1:${bridgePort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_BEARER_TOKEN: 'test-token',
-        AGENT_DEVICE_COMPANION_TUNNEL_LOCAL_BASE_URL: `http://127.0.0.1:${upstreamPort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_REGISTER_PATH: '/api/metro/companion/register',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_TENANT_ID: 'tenant-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_RUN_ID: 'run-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_LEASE_ID: 'lease-1',
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-  let stderr = '';
-  companion.stderr.on('data', (chunk) => {
-    stderr += chunk.toString();
-  });
-  cleanupTasks.push(() => stopChild(companion));
-
-  const earlyExit = new Promise<never>((_, reject) => {
-    companion.once('exit', (code, signal) => {
-      reject(
-        new Error(
-          `Metro companion exited unexpectedly with code=${String(code)} signal=${String(signal)} stderr=${stderr}`,
-        ),
-      );
-    });
+  const { earlyExit } = spawnMetroCompanionWorker({
+    bridgePort,
+    localPort: upstreamPort,
   });
 
   const bridgeSocket = await Promise.race([
@@ -463,30 +506,18 @@ test('metro companion worker reconnects after the bridge closes immediately afte
   let bridgePort = 0;
   let bridgeSocketRef: Duplex | null = null;
 
-  const localServer = http.createServer((_, res) => {
-    res.writeHead(404);
-    res.end('not found');
-  });
-  cleanupTasks.push(() => closeServer(localServer));
-  const localPort = await listen(localServer);
+  const localPort = await listenNotFoundServer();
 
   const bridgeServer = http.createServer((req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     if (req.method === 'POST' && url.pathname === '/api/metro/companion/register') {
       req.resume();
       req.on('end', () => {
-        res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            ok: true,
-            data: { ws_url: `ws://127.0.0.1:${bridgePort}/bridge` },
-          }),
-        );
+        writeSuccessfulRegistration(res, bridgePort);
       });
       return;
     }
-    res.writeHead(404);
-    res.end('not found');
+    writeNotFound(res);
   });
   bridgeServer.on('upgrade', (req, socket) => {
     if (req.url !== '/bridge') {
@@ -496,24 +527,7 @@ test('metro companion worker reconnects after the bridge closes immediately afte
     socket.on('error', () => {
       // The first bridge socket is expected to drop immediately to exercise reconnect handling.
     });
-    const key = req.headers['sec-websocket-key'];
-    if (typeof key !== 'string') {
-      socket.destroy();
-      return;
-    }
-    const accept = crypto
-      .createHash('sha1')
-      .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
-      .digest('base64');
-    socket.write(
-      [
-        'HTTP/1.1 101 Switching Protocols',
-        'Upgrade: websocket',
-        'Connection: Upgrade',
-        `Sec-WebSocket-Accept: ${accept}`,
-        '\r\n',
-      ].join('\r\n'),
-    );
+    if (!acceptWebSocketUpgrade(req, socket)) return;
     bridgeSocketRef = socket;
     bridgeConnections += 1;
     if (bridgeConnections === 1) {
@@ -529,39 +543,7 @@ test('metro companion worker reconnects after the bridge closes immediately afte
   const listenedBridgePort = await listen(bridgeServer);
   bridgePort = listenedBridgePort;
 
-  const companion = spawn(
-    process.execPath,
-    ['--experimental-strip-types', 'src/companion-tunnel.ts', '--agent-device-run-metro-companion'],
-    {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        AGENT_DEVICE_COMPANION_TUNNEL_SERVER_BASE_URL: `http://127.0.0.1:${bridgePort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_BEARER_TOKEN: 'test-token',
-        AGENT_DEVICE_COMPANION_TUNNEL_LOCAL_BASE_URL: `http://127.0.0.1:${localPort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_REGISTER_PATH: '/api/metro/companion/register',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_TENANT_ID: 'tenant-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_RUN_ID: 'run-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_LEASE_ID: 'lease-1',
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-  let stderr = '';
-  companion.stderr.on('data', (chunk) => {
-    stderr += chunk.toString();
-  });
-  cleanupTasks.push(() => stopChild(companion));
-
-  const earlyExit = new Promise<never>((_, reject) => {
-    companion.once('exit', (code, signal) => {
-      reject(
-        new Error(
-          `Metro companion exited unexpectedly with code=${String(code)} signal=${String(signal)} stderr=${stderr}`,
-        ),
-      );
-    });
-  });
+  const { earlyExit } = spawnMetroCompanionWorker({ bridgePort, localPort });
 
   await Promise.race([waitFor(bridgeReconnect.promise, 5_000, 'bridge reconnect'), earlyExit]);
 
@@ -571,12 +553,7 @@ test('metro companion worker reconnects after the bridge closes immediately afte
 test('metro companion worker exits after non-retryable registration failure', async () => {
   let registerAttempts = 0;
 
-  const localServer = http.createServer((_, res) => {
-    res.writeHead(404);
-    res.end('not found');
-  });
-  cleanupTasks.push(() => closeServer(localServer));
-  const localPort = await listen(localServer);
+  const localPort = await listenNotFoundServer();
 
   const bridgeServer = http.createServer((req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
@@ -594,47 +571,20 @@ test('metro companion worker exits after non-retryable registration failure', as
       });
       return;
     }
-    res.writeHead(404);
-    res.end('not found');
+    writeNotFound(res);
   });
   cleanupTasks.push(() => closeServer(bridgeServer));
   const bridgePort = await listen(bridgeServer);
 
-  const companion = spawn(
-    process.execPath,
-    ['--experimental-strip-types', 'src/companion-tunnel.ts', '--agent-device-run-metro-companion'],
-    {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        AGENT_DEVICE_COMPANION_TUNNEL_SERVER_BASE_URL: `http://127.0.0.1:${bridgePort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_BEARER_TOKEN: 'bad-token',
-        AGENT_DEVICE_COMPANION_TUNNEL_LOCAL_BASE_URL: `http://127.0.0.1:${localPort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_REGISTER_PATH: '/api/metro/companion/register',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_TENANT_ID: 'tenant-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_RUN_ID: 'run-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_LEASE_ID: 'lease-1',
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-  cleanupTasks.push(() => stopChild(companion));
-
-  let stderr = '';
-  companion.stderr.on('data', (chunk) => {
-    stderr += chunk.toString();
+  const companion = spawnMetroCompanionWorker({
+    bearerToken: 'bad-token',
+    bridgePort,
+    localPort,
   });
+  const exit = await companion.waitForExit('worker exit after non-retryable registration failure');
 
-  const exit = await waitFor(
-    new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-      companion.once('exit', (code, signal) => resolve({ code, signal }));
-    }),
-    5_000,
-    'worker exit after non-retryable registration failure',
-  );
-
-  assert.equal(exit.signal, null, `unexpected worker stderr: ${stderr}`);
-  assert.equal(exit.code, 0, `unexpected worker stderr: ${stderr}`);
+  assert.equal(exit.signal, null, `unexpected worker stderr: ${companion.readStderr()}`);
+  assert.equal(exit.code, 0, `unexpected worker stderr: ${companion.readStderr()}`);
   assert.equal(registerAttempts, 1);
 });
 
@@ -650,30 +600,18 @@ test('metro companion worker exits after its state file is removed', async () =>
   let bridgePort = 0;
   let bridgeSocketRef: Duplex | null = null;
 
-  const localServer = http.createServer((_, res) => {
-    res.writeHead(404);
-    res.end('not found');
-  });
-  cleanupTasks.push(() => closeServer(localServer));
-  const localPort = await listen(localServer);
+  const localPort = await listenNotFoundServer();
 
   const bridgeServer = http.createServer((req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     if (req.method === 'POST' && url.pathname === '/api/metro/companion/register') {
       req.resume();
       req.on('end', () => {
-        res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            ok: true,
-            data: { ws_url: `ws://127.0.0.1:${bridgePort}/bridge` },
-          }),
-        );
+        writeSuccessfulRegistration(res, bridgePort);
       });
       return;
     }
-    res.writeHead(404);
-    res.end('not found');
+    writeNotFound(res);
   });
   bridgeServer.on('upgrade', (req, socket) => {
     if (req.url !== '/bridge') {
@@ -681,24 +619,7 @@ test('metro companion worker exits after its state file is removed', async () =>
       return;
     }
     bridgeSocketRef = socket;
-    const key = req.headers['sec-websocket-key'];
-    if (typeof key !== 'string') {
-      socket.destroy();
-      return;
-    }
-    const accept = crypto
-      .createHash('sha1')
-      .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
-      .digest('base64');
-    socket.write(
-      [
-        'HTTP/1.1 101 Switching Protocols',
-        'Upgrade: websocket',
-        'Connection: Upgrade',
-        `Sec-WebSocket-Accept: ${accept}`,
-        '\r\n',
-      ].join('\r\n'),
-    );
+    if (!acceptWebSocketUpgrade(req, socket)) return;
     bridgeSocketReady.resolve();
   });
   cleanupTasks.push(() => closeServer(bridgeServer));
@@ -707,45 +628,15 @@ test('metro companion worker exits after its state file is removed', async () =>
   });
   bridgePort = await listen(bridgeServer);
 
-  const companion = spawn(
-    process.execPath,
-    ['--experimental-strip-types', 'src/companion-tunnel.ts', '--agent-device-run-metro-companion'],
-    {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        AGENT_DEVICE_COMPANION_TUNNEL_SERVER_BASE_URL: `http://127.0.0.1:${bridgePort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_BEARER_TOKEN: 'test-token',
-        AGENT_DEVICE_COMPANION_TUNNEL_LOCAL_BASE_URL: `http://127.0.0.1:${localPort}`,
-        AGENT_DEVICE_COMPANION_TUNNEL_REGISTER_PATH: '/api/metro/companion/register',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_TENANT_ID: 'tenant-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_RUN_ID: 'run-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_LEASE_ID: 'lease-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_STATE_PATH: statePath,
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-  cleanupTasks.push(() => stopChild(companion));
-
-  let stderr = '';
-  companion.stderr.on('data', (chunk) => {
-    stderr += chunk.toString();
-  });
+  const companion = spawnMetroCompanionWorker({ bridgePort, localPort, statePath });
 
   await waitFor(bridgeSocketReady.promise, 5_000, 'bridge websocket connection');
   fs.unlinkSync(statePath);
 
-  const exit = await waitFor(
-    new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-      companion.once('exit', (code, signal) => resolve({ code, signal }));
-    }),
-    5_000,
-    'worker exit after state cleanup',
-  );
+  const exit = await companion.waitForExit('worker exit after state cleanup');
 
-  assert.equal(exit.signal, null, `unexpected worker stderr: ${stderr}`);
-  assert.equal(exit.code, 0, `unexpected worker stderr: ${stderr}`);
+  assert.equal(exit.signal, null, `unexpected worker stderr: ${companion.readStderr()}`);
+  assert.equal(exit.code, 0, `unexpected worker stderr: ${companion.readStderr()}`);
 });
 
 test('companion tunnel entrypoint reads neutral env and exits when state file is missing', async () => {
@@ -755,40 +646,13 @@ test('companion tunnel entrypoint reads neutral env and exits when state file is
     fs.rmSync(tempRoot, { recursive: true, force: true });
   });
 
-  const companion = spawn(
-    process.execPath,
-    ['--experimental-strip-types', 'src/companion-tunnel.ts', '--agent-device-run-metro-companion'],
-    {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        AGENT_DEVICE_COMPANION_TUNNEL_SERVER_BASE_URL: 'http://127.0.0.1:1',
-        AGENT_DEVICE_COMPANION_TUNNEL_BEARER_TOKEN: 'test-token',
-        AGENT_DEVICE_COMPANION_TUNNEL_LOCAL_BASE_URL: 'http://127.0.0.1:1',
-        AGENT_DEVICE_COMPANION_TUNNEL_REGISTER_PATH: '/api/metro/companion/register',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_TENANT_ID: 'tenant-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_RUN_ID: 'run-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_SCOPE_LEASE_ID: 'lease-1',
-        AGENT_DEVICE_COMPANION_TUNNEL_STATE_PATH: statePath,
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-  cleanupTasks.push(() => stopChild(companion));
-
-  let stderr = '';
-  companion.stderr.on('data', (chunk) => {
-    stderr += chunk.toString();
+  const companion = spawnMetroCompanionWorker({
+    serverBaseUrl: 'http://127.0.0.1:1',
+    localBaseUrl: 'http://127.0.0.1:1',
+    statePath,
   });
+  const exit = await companion.waitForExit('worker exit with missing state file');
 
-  const exit = await waitFor(
-    new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-      companion.once('exit', (code, signal) => resolve({ code, signal }));
-    }),
-    5_000,
-    'worker exit with missing state file',
-  );
-
-  assert.equal(exit.signal, null, `unexpected worker stderr: ${stderr}`);
-  assert.equal(exit.code, 0, `unexpected worker stderr: ${stderr}`);
+  assert.equal(exit.signal, null, `unexpected worker stderr: ${companion.readStderr()}`);
+  assert.equal(exit.code, 0, `unexpected worker stderr: ${companion.readStderr()}`);
 });

--- a/src/__tests__/client-companion-tunnel-worker.test.ts
+++ b/src/__tests__/client-companion-tunnel-worker.test.ts
@@ -588,6 +588,62 @@ test('metro companion worker exits after non-retryable registration failure', as
   assert.equal(registerAttempts, 1);
 });
 
+test('metro companion worker retries registration failures with retry-after delay', async () => {
+  const bridgeSocketReady = createDeferred<void>();
+  const registerAttemptTimes: number[] = [];
+  let bridgePort = 0;
+  let bridgeSocketRef: Duplex | null = null;
+
+  const localPort = await listenNotFoundServer();
+
+  const bridgeServer = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1');
+    if (req.method === 'POST' && url.pathname === '/api/metro/companion/register') {
+      registerAttemptTimes.push(Date.now());
+      req.resume();
+      req.on('end', () => {
+        if (registerAttemptTimes.length === 1) {
+          res.writeHead(429, { 'content-type': 'application/json', 'retry-after': '0.05' });
+          res.end(
+            JSON.stringify({
+              ok: false,
+              error: { code: 'RATE_LIMITED', message: 'Try again later' },
+            }),
+          );
+          return;
+        }
+        writeSuccessfulRegistration(res, bridgePort);
+      });
+      return;
+    }
+    writeNotFound(res);
+  });
+  bridgeServer.on('upgrade', (req, socket) => {
+    if (req.url !== '/bridge') {
+      socket.destroy();
+      return;
+    }
+    bridgeSocketRef = socket;
+    if (!acceptWebSocketUpgrade(req, socket)) return;
+    bridgeSocketReady.resolve();
+  });
+  cleanupTasks.push(() => closeServer(bridgeServer));
+  cleanupTasks.push(async () => {
+    bridgeSocketRef?.destroy();
+  });
+  bridgePort = await listen(bridgeServer);
+
+  const { earlyExit } = spawnMetroCompanionWorker({ bridgePort, localPort });
+
+  await Promise.race([
+    waitFor(bridgeSocketReady.promise, 5_000, 'bridge websocket connection after retry'),
+    earlyExit,
+  ]);
+
+  assert.equal(registerAttemptTimes.length, 2);
+  assert.ok(registerAttemptTimes[1]! - registerAttemptTimes[0]! >= 40);
+});
+
 test('metro companion worker exits after its state file is removed', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-metro-companion-worker-'));
   const statePath = path.join(tempRoot, 'metro-companion.json');

--- a/src/client-companion-tunnel-worker.ts
+++ b/src/client-companion-tunnel-worker.ts
@@ -276,6 +276,125 @@ function shouldKeepWorkerRunning(options: CompanionTunnelWorkerOptions): boolean
   return !options.statePath || fs.existsSync(options.statePath);
 }
 
+async function handleBridgeHttpRequest(
+  bridgeSocket: WebSocket,
+  message: Extract<MetroCompanionRequest, { type: 'http-request' }>,
+  options: CompanionTunnelWorkerOptions,
+): Promise<void> {
+  try {
+    const response = await fetch(
+      new URL(message.path, `${normalizeBaseUrl(options.localBaseUrl)}/`),
+      {
+        method: message.method,
+        headers: message.headers,
+        ...(message.bodyBase64 ? { body: Buffer.from(message.bodyBase64, 'base64') } : {}),
+      },
+    );
+    const body = Buffer.from(await response.arrayBuffer());
+    sendJson(bridgeSocket, {
+      type: 'http-response',
+      requestId: message.requestId,
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      ...(body.length > 0 ? { bodyBase64: body.toString('base64') } : {}),
+    });
+  } catch (error) {
+    sendJson(bridgeSocket, {
+      type: 'http-error',
+      requestId: message.requestId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleBridgeWebSocketOpen(
+  bridgeSocket: WebSocket,
+  message: Extract<MetroCompanionRequest, { type: 'ws-open' }>,
+  options: CompanionTunnelWorkerOptions,
+  upstreamSockets: Map<string, WebSocket>,
+): Promise<void> {
+  const upstreamSocket = new WebSocket(toUpstreamWebSocketUrl(options.localBaseUrl, message.path));
+  upstreamSocket.binaryType = 'arraybuffer';
+  let opened = false;
+  upstreamSocket.addEventListener('message', (event) => {
+    void (async () => {
+      if (!opened) return;
+      const payload = await bufferFromWebSocketData(event.data);
+      sendJson(bridgeSocket, {
+        type: 'ws-frame',
+        streamId: message.streamId,
+        dataBase64: payload.toString('base64'),
+        binary: typeof event.data !== 'string',
+      });
+    })().catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+    });
+  });
+  upstreamSocket.addEventListener('close', (event) => {
+    upstreamSockets.delete(message.streamId);
+    if (!opened) return;
+    sendJson(bridgeSocket, {
+      type: 'ws-close',
+      streamId: message.streamId,
+      code: event.code,
+      reason: event.reason,
+    });
+  });
+  upstreamSocket.addEventListener('error', () => {
+    if (!opened) return;
+    sendJson(bridgeSocket, {
+      type: 'ws-close',
+      streamId: message.streamId,
+      code: 1011,
+      reason: 'Upstream WebSocket error.',
+    });
+  });
+  upstreamSockets.set(message.streamId, upstreamSocket);
+  try {
+    await waitForSocketOpen(upstreamSocket, 'Upstream');
+    opened = true;
+    sendJson(bridgeSocket, {
+      type: 'ws-open-result',
+      streamId: message.streamId,
+      success: true,
+      headers: {},
+    });
+  } catch (error) {
+    upstreamSockets.delete(message.streamId);
+    closeSocketQuietly(upstreamSocket, 1011, 'open failed');
+    sendJson(bridgeSocket, {
+      type: 'ws-open-result',
+      streamId: message.streamId,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function handleBridgeWebSocketFrame(
+  message: Extract<MetroCompanionRequest, { type: 'ws-frame' }>,
+  upstreamSockets: Map<string, WebSocket>,
+): void {
+  const upstreamSocket = upstreamSockets.get(message.streamId);
+  if (!upstreamSocket || upstreamSocket.readyState !== WS_READY_STATE_OPEN) return;
+  const payload = Buffer.from(message.dataBase64, 'base64');
+  upstreamSocket.send(message.binary ? payload : payload.toString('utf8'));
+}
+
+function handleBridgeWebSocketClose(
+  message: Extract<MetroCompanionRequest, { type: 'ws-close' }>,
+  upstreamSockets: Map<string, WebSocket>,
+): void {
+  const upstreamSocket = upstreamSockets.get(message.streamId);
+  if (!upstreamSocket) return;
+  upstreamSockets.delete(message.streamId);
+  closeSocketQuietly(
+    upstreamSocket,
+    normalizeCloseCode(message.code),
+    message.reason ?? 'bridge requested close',
+  );
+}
+
 async function handleBridgeMessage(
   bridgeSocket: WebSocket,
   message: MetroCompanionRequest,
@@ -288,109 +407,19 @@ async function handleBridgeMessage(
       return;
     }
     case 'http-request': {
-      try {
-        const response = await fetch(
-          new URL(message.path, `${normalizeBaseUrl(options.localBaseUrl)}/`),
-          {
-            method: message.method,
-            headers: message.headers,
-            ...(message.bodyBase64 ? { body: Buffer.from(message.bodyBase64, 'base64') } : {}),
-          },
-        );
-        const body = Buffer.from(await response.arrayBuffer());
-        sendJson(bridgeSocket, {
-          type: 'http-response',
-          requestId: message.requestId,
-          status: response.status,
-          headers: Object.fromEntries(response.headers.entries()),
-          ...(body.length > 0 ? { bodyBase64: body.toString('base64') } : {}),
-        });
-      } catch (error) {
-        sendJson(bridgeSocket, {
-          type: 'http-error',
-          requestId: message.requestId,
-          message: error instanceof Error ? error.message : String(error),
-        });
-      }
+      await handleBridgeHttpRequest(bridgeSocket, message, options);
       return;
     }
     case 'ws-open': {
-      const upstreamSocket = new WebSocket(
-        toUpstreamWebSocketUrl(options.localBaseUrl, message.path),
-      );
-      upstreamSocket.binaryType = 'arraybuffer';
-      let opened = false;
-      upstreamSocket.addEventListener('message', (event) => {
-        void (async () => {
-          if (!opened) return;
-          const payload = await bufferFromWebSocketData(event.data);
-          sendJson(bridgeSocket, {
-            type: 'ws-frame',
-            streamId: message.streamId,
-            dataBase64: payload.toString('base64'),
-            binary: typeof event.data !== 'string',
-          });
-        })().catch((error) => {
-          console.error(error instanceof Error ? error.message : String(error));
-        });
-      });
-      upstreamSocket.addEventListener('close', (event) => {
-        upstreamSockets.delete(message.streamId);
-        if (!opened) return;
-        sendJson(bridgeSocket, {
-          type: 'ws-close',
-          streamId: message.streamId,
-          code: event.code,
-          reason: event.reason,
-        });
-      });
-      upstreamSocket.addEventListener('error', () => {
-        if (!opened) return;
-        sendJson(bridgeSocket, {
-          type: 'ws-close',
-          streamId: message.streamId,
-          code: 1011,
-          reason: 'Upstream WebSocket error.',
-        });
-      });
-      upstreamSockets.set(message.streamId, upstreamSocket);
-      try {
-        await waitForSocketOpen(upstreamSocket, 'Upstream');
-        opened = true;
-        sendJson(bridgeSocket, {
-          type: 'ws-open-result',
-          streamId: message.streamId,
-          success: true,
-          headers: {},
-        });
-      } catch (error) {
-        upstreamSockets.delete(message.streamId);
-        closeSocketQuietly(upstreamSocket, 1011, 'open failed');
-        sendJson(bridgeSocket, {
-          type: 'ws-open-result',
-          streamId: message.streamId,
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      await handleBridgeWebSocketOpen(bridgeSocket, message, options, upstreamSockets);
       return;
     }
     case 'ws-frame': {
-      const upstreamSocket = upstreamSockets.get(message.streamId);
-      if (!upstreamSocket || upstreamSocket.readyState !== WS_READY_STATE_OPEN) return;
-      const payload = Buffer.from(message.dataBase64, 'base64');
-      upstreamSocket.send(message.binary ? payload : payload.toString('utf8'));
+      handleBridgeWebSocketFrame(message, upstreamSockets);
       return;
     }
     case 'ws-close': {
-      const upstreamSocket = upstreamSockets.get(message.streamId);
-      if (!upstreamSocket) return;
-      upstreamSockets.delete(message.streamId);
-      closeSocketQuietly(
-        upstreamSocket,
-        normalizeCloseCode(message.code),
-        message.reason ?? 'bridge requested close',
-      );
+      handleBridgeWebSocketClose(message, upstreamSockets);
       return;
     }
   }

--- a/src/client-companion-tunnel-worker.ts
+++ b/src/client-companion-tunnel-worker.ts
@@ -28,6 +28,18 @@ import type {
 import { normalizeBaseUrl } from './utils/url.ts';
 
 const COMPANION_REGISTER_TIMEOUT_MS = 5_000;
+const COMPANION_REGISTER_MAX_RETRY_DELAY_MS = 60_000;
+
+class CompanionRegistrationError extends Error {
+  readonly retryable: boolean;
+  readonly retryAfterMs: number | undefined;
+
+  constructor(message: string, retryable: boolean, retryAfterMs?: number) {
+    super(message);
+    this.retryable = retryable;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
 
 function createHeaders(serverBaseUrl: string, token: string): Record<string, string> {
   return {
@@ -88,22 +100,64 @@ async function registerCompanion(
   let payload: {
     ok?: boolean;
     data?: { ws_url?: string };
+    error?: { code?: string; details?: { retryAfterMs?: unknown } };
   };
   try {
     payload = responseText ? (JSON.parse(responseText) as typeof payload) : {};
   } catch {
-    throw new Error(
+    throw new CompanionRegistrationError(
       `Failed to register companion (${response.status}): invalid JSON response: ${formatResponseSnippet(
         responseText,
       )}`,
+      isRetryableRegisterFailure(response.status, undefined),
+      retryDelayFromResponse(response, {}),
     );
   }
   if (!response.ok || payload.ok !== true || typeof payload.data?.ws_url !== 'string') {
-    throw new Error(
+    throw new CompanionRegistrationError(
       `Failed to register companion (${response.status}): ${JSON.stringify(payload)}`,
+      isRetryableRegisterFailure(response.status, payload.error?.code),
+      retryDelayFromResponse(response, payload),
     );
   }
   return { wsUrl: payload.data.ws_url };
+}
+
+function isRetryableRegisterFailure(status: number, code: string | undefined): boolean {
+  if (code === 'RATE_LIMITED') return true;
+  if (code === 'UNAUTHORIZED' || code === 'INVALID_ARGS' || code === 'SESSION_NOT_FOUND') {
+    return false;
+  }
+  return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+}
+
+function retryDelayFromResponse(
+  response: Response,
+  payload: { error?: { details?: { retryAfterMs?: unknown } } },
+): number | undefined {
+  const detailRetryAfter = payload.error?.details?.retryAfterMs;
+  if (typeof detailRetryAfter === 'number' && Number.isFinite(detailRetryAfter)) {
+    return clampRetryDelay(detailRetryAfter);
+  }
+  const retryAfter = response.headers.get('retry-after');
+  if (!retryAfter) return undefined;
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) {
+    return clampRetryDelay(seconds * 1000);
+  }
+  const retryAt = Date.parse(retryAfter);
+  if (Number.isFinite(retryAt)) {
+    return clampRetryDelay(retryAt - Date.now());
+  }
+  return undefined;
+}
+
+function clampRetryDelay(delayMs: number): number {
+  return Math.max(0, Math.min(COMPANION_REGISTER_MAX_RETRY_DELAY_MS, Math.ceil(delayMs)));
+}
+
+function nextRetryDelay(currentDelayMs: number): number {
+  return Math.min(currentDelayMs * 2, COMPANION_REGISTER_MAX_RETRY_DELAY_MS);
 }
 
 async function unregisterCompanion(options: CompanionTunnelWorkerOptions): Promise<void> {
@@ -369,11 +423,14 @@ async function runCompanionTunnelWorker(options: CompanionTunnelWorkerOptions): 
     }
   }, COMPANION_TUNNEL_LEASE_CHECK_INTERVAL_MS);
   lifetimeHandle.unref();
+  let registerRetryDelayMs = COMPANION_TUNNEL_RECONNECT_DELAY_MS;
   while (!shutdownRequested && shouldKeepWorkerRunning(options)) {
     let registered = false;
+    let retryDelayOverrideMs: number | undefined;
     try {
       activeRegistrationComplete = false;
       const registration = await registerCompanion(options);
+      registerRetryDelayMs = COMPANION_TUNNEL_RECONNECT_DELAY_MS;
       registered = true;
       activeRegistrationComplete = true;
       if (shutdownRequested || !shouldKeepWorkerRunning(options)) {
@@ -419,11 +476,18 @@ async function runCompanionTunnelWorker(options: CompanionTunnelWorkerOptions): 
         break;
       }
       console.error(error instanceof Error ? error.message : String(error));
+      if (error instanceof CompanionRegistrationError && !error.retryable) {
+        break;
+      }
+      retryDelayOverrideMs =
+        error instanceof CompanionRegistrationError ? error.retryAfterMs : undefined;
     }
     if (shutdownRequested || !shouldKeepWorkerRunning(options)) {
       break;
     }
-    await delay(COMPANION_TUNNEL_RECONNECT_DELAY_MS);
+    const delayMs = retryDelayOverrideMs ?? registerRetryDelayMs;
+    registerRetryDelayMs = nextRetryDelay(registerRetryDelayMs);
+    await delay(delayMs);
   }
   clearInterval(lifetimeHandle);
 }

--- a/src/client-companion-tunnel-worker.ts
+++ b/src/client-companion-tunnel-worker.ts
@@ -515,7 +515,9 @@ async function runCompanionTunnelWorker(options: CompanionTunnelWorkerOptions): 
       break;
     }
     const delayMs = retryDelayOverrideMs ?? registerRetryDelayMs;
-    registerRetryDelayMs = nextRetryDelay(registerRetryDelayMs);
+    if (retryDelayOverrideMs === undefined) {
+      registerRetryDelayMs = nextRetryDelay(registerRetryDelayMs);
+    }
     await delay(delayMs);
   }
   clearInterval(lifetimeHandle);


### PR DESCRIPTION
## Summary

Stop Metro/DevTools companion workers after non-retryable registration failures such as invalid auth or lease scope.
Add retry classification with backoff for retryable registration failures.

## Validation

pnpm exec vitest run src/__tests__/client-companion-tunnel-worker.test.ts
pnpm typecheck
git diff --check -- src/client-companion-tunnel-worker.ts src/__tests__/client-companion-tunnel-worker.test.ts