### PR TITLE
feat: add MCP discovery router

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Minimal operating guide for AI coding agents in this repo.
 - TypeScript is strict enough to surface dead code early: `strict`, `isolatedModules`, `noUnusedLocals`, and `noUnusedParameters` are enabled.
 - The repo emits with `rslib`, not `tsc`. If declaration generation fails, inspect `tsconfig.lib.json` first.
 - `tsconfig.lib.json` needs an explicit `rootDir: "./src"` for declaration layout.
+- `server.json` MCP registry metadata must stay in sync with `package.json` `version` and `mcpName`; run `pnpm sync:mcp-metadata` after changing either field, and rely on `pnpm check:tooling`/CI to verify it.
 - Use the aggregate scripts in `package.json` when possible; they encode the expected validation bundles better than ad hoc command lists.
 
 ## Cheap Exploration
@@ -161,6 +162,7 @@ Command-only flags (like `find --first`) that don't flow to the platform layer o
 - Keep tests behavioral; do not assert shapes or cases TypeScript already proves.
 - Any TS change: `pnpm typecheck` or `pnpm check:quick`.
 - Tooling/config change (`package.json`, `tsconfig*.json`, `.oxlintrc.json`, `.oxfmtrc.json`): `pnpm check:tooling`.
+- MCP registry metadata changes (`server.json` or package `version`/`mcpName`): run `pnpm sync:mcp-metadata`, then `pnpm check:tooling`.
 - Daemon handler/shared module change: `pnpm check:unit`.
 - iOS runner/Swift change: `pnpm build:xcuitest`.
 - Cross-platform behavior change: run `pnpm test:integration`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ The CLI help is the source of truth for agents and is shipped with the installed
 
 If you install skills separately, keep the CLI on `agent-device >= 0.14.0`. Older CLIs do not include the workflow help topics that the router skills expect.
 
+### MCP Router
+
+`agent-device` also ships an official stdio MCP router for discovery-oriented clients. It exposes only `status`, `install`, and `help` tools plus workflow prompts/resources; device automation still runs through the CLI commands returned by version-matched help.
+
+```json
+{
+  "mcpServers": {
+    "agent-device": {
+      "command": "agent-device",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Registry metadata uses MCP name `io.github.callstackincubator/agent-device`, npm package `agent-device`, stdio transport, `mcpName` package verification, `server.json`, and `smithery.yaml`.
+
 ```bash
 npm install -g agent-device@latest
 agent-device --version
@@ -113,6 +130,7 @@ Agent integration:
 - [agent-device skill](skills/agent-device/SKILL.md)
 - [react-devtools skill](skills/react-devtools/SKILL.md)
 - [dogfood skill](skills/dogfood/SKILL.md)
+- MCP router: `agent-device mcp`
 - [agent-device skill on ClawHub](https://clawhub.ai/okwasniewski/agent-device)
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "agent-device",
   "version": "0.14.7",
   "description": "Agent-driven CLI for mobile UI automation, network inspection, and performance diagnostics across iOS, Android, tvOS, and macOS.",
+  "mcpName": "io.github.callstackincubator/agent-device",
   "license": "MIT",
   "author": "Callstack",
   "homepage": "https://agent-device.dev/",
@@ -92,10 +93,12 @@
     "fallow:baseline": "(fallow dead-code --save-baseline fallow-baselines/dead-code.json --summary || true) && (fallow dupes --save-baseline fallow-baselines/dupes.json --summary || true) && (fallow health --save-baseline fallow-baselines/health.json --summary || true)",
     "check:fallow": "fallow audit",
     "check:quick": "pnpm lint && pnpm typecheck",
-    "check:tooling": "pnpm lint && pnpm typecheck && pnpm build",
+    "sync:mcp-metadata": "node scripts/sync-mcp-metadata.mjs",
+    "check:mcp-metadata": "node scripts/sync-mcp-metadata.mjs --check",
+    "check:tooling": "pnpm lint && pnpm typecheck && pnpm check:mcp-metadata && pnpm build",
     "check:unit": "pnpm test:unit && pnpm test:smoke",
     "check": "pnpm check:tooling && pnpm check:fallow && pnpm check:unit",
-    "prepack": "pnpm build:all && pnpm package:android-snapshot-helper:npm",
+    "prepack": "pnpm check:mcp-metadata && pnpm build:all && pnpm package:android-snapshot-helper:npm",
     "typecheck": "tsc -p tsconfig.json",
     "test-app:install": "pnpm install --dir examples/test-app --ignore-workspace",
     "test-app:start": "pnpm --dir examples/test-app start",
@@ -127,6 +130,8 @@
     "!android-snapshot-helper/dist/*.idsig",
     "src/platforms/linux/atspi-dump.py",
     "skills",
+    "server.json",
+    "smithery.yaml",
     "README.md",
     "LICENSE"
   ],
@@ -152,7 +157,10 @@
     "diagnostics",
     "network",
     "profiling",
-    "performance"
+    "performance",
+    "mcp",
+    "model-context-protocol",
+    "mcp-server"
   ],
   "dependencies": {
     "fast-xml-parser": "^5.7.2",

--- a/scripts/sync-mcp-metadata.mjs
+++ b/scripts/sync-mcp-metadata.mjs
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const checkOnly = process.argv.includes('--check');
+const packagePath = path.join(root, 'package.json');
+const serverPath = path.join(root, 'server.json');
+
+const pkg = readJson(packagePath);
+const server = readJson(serverPath);
+const expectedName = pkg.mcpName;
+const expectedVersion = pkg.version;
+
+if (typeof expectedName !== 'string' || expectedName.length === 0) {
+  fail('package.json must define mcpName.');
+}
+if (typeof expectedVersion !== 'string' || expectedVersion.length === 0) {
+  fail('package.json must define version.');
+}
+
+server.name = expectedName;
+server.version = expectedVersion;
+if (Array.isArray(server.packages)) {
+  for (const packageEntry of server.packages) {
+    if (packageEntry?.identifier === pkg.name) {
+      packageEntry.version = expectedVersion;
+    }
+  }
+}
+
+const next = `${JSON.stringify(server, null, 2)}\n`;
+const current = fs.readFileSync(serverPath, 'utf8');
+
+if (checkOnly) {
+  if (next !== current) {
+    fail('server.json is out of sync. Run `pnpm sync:mcp-metadata`.');
+  }
+  process.exit(0);
+}
+
+if (next !== current) {
+  fs.writeFileSync(serverPath, next);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.callstackincubator/agent-device",
+  "title": "agent-device",
+  "description": "Official MCP discovery router for the agent-device CLI. It exposes status, install guidance, version-matched CLI help, prompts, and resources without exposing device automation over MCP.",
+  "repository": {
+    "url": "https://github.com/callstackincubator/agent-device",
+    "source": "github"
+  },
+  "version": "0.14.7",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "agent-device",
+      "version": "0.14.7",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,1 @@
+runtime: "typescript"

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,3 +1,14 @@
-import { runCli } from './cli.ts';
+const argv = process.argv.slice(2);
 
-runCli(process.argv.slice(2));
+if (argv[0] === 'mcp' && !argv.includes('--help') && !argv.includes('-h')) {
+  import('./mcp/server.ts')
+    .then(({ runAgentDeviceMcpServer }) => runAgentDeviceMcpServer())
+    .catch(handleStartupError);
+} else {
+  import('./cli.ts').then(({ runCli }) => runCli(argv)).catch(handleStartupError);
+}
+
+function handleStartupError(error: unknown): void {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}

--- a/src/mcp/__tests__/router.test.ts
+++ b/src/mcp/__tests__/router.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { handleMcpMessage } from '../router.ts';
+import { handleMcpPayload } from '../server.ts';
+
+test('MCP router exposes status install and help tools only', () => {
+  const response = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/list',
+  });
+
+  assert.equal(response?.jsonrpc, '2.0');
+  assert.ok(response && 'result' in response);
+  const tools = (response.result as { tools: Array<{ name: string }> }).tools;
+  assert.deepEqual(
+    tools.map((tool) => tool.name),
+    ['status', 'install', 'help'],
+  );
+});
+
+test('MCP help tool returns versioned workflow guidance', () => {
+  const response = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: {
+      name: 'help',
+      arguments: { topic: 'workflow' },
+    },
+  });
+
+  assert.ok(response && 'result' in response);
+  const result = response.result as { content: Array<{ text: string }>; isError: boolean };
+  assert.equal(result.isError, false);
+  assert.match(result.content[0]?.text ?? '', /agent-device help workflow/);
+  assert.match(result.content[0]?.text ?? '', /snapshot -i/);
+});
+
+test('MCP install tool can return npx client config', () => {
+  const response = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/call',
+    params: {
+      name: 'install',
+      arguments: { global: false, client: 'Cline' },
+    },
+  });
+
+  assert.ok(response && 'result' in response);
+  const result = response.result as { content: Array<{ text: string }> };
+  const text = result.content[0]?.text ?? '';
+  assert.match(text, /npx -y agent-device mcp/);
+  assert.match(text, /"args": \["-y","agent-device","mcp"\]/);
+  assert.match(text, /Client hint: Cline/);
+});
+
+test('MCP exposes help resources and workflow prompts', () => {
+  const resources = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 4,
+    method: 'resources/list',
+  });
+  assert.ok(resources && 'result' in resources);
+  const resourceUris = (resources.result as { resources: Array<{ uri: string }> }).resources.map(
+    (resource) => resource.uri,
+  );
+  assert.ok(resourceUris.includes('agent-device://help/workflow'));
+
+  const prompt = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 5,
+    method: 'prompts/get',
+    params: {
+      name: 'agent-device-dogfood',
+      arguments: { target: 'SampleApp on iOS' },
+    },
+  });
+  assert.ok(prompt && 'result' in prompt);
+  const result = prompt.result as { messages: Array<{ content: { text: string } }> };
+  assert.match(result.messages[0]?.content.text ?? '', /dogfood/);
+  assert.match(result.messages[0]?.content.text ?? '', /SampleApp on iOS/);
+});
+
+test('MCP initialize returns supported protocol version and unknown methods use JSON-RPC code', () => {
+  const initialized = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 6,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2099-01-01',
+    },
+  });
+  assert.ok(initialized && 'result' in initialized);
+  assert.equal((initialized.result as { protocolVersion: string }).protocolVersion, '2025-11-25');
+
+  const unknown = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 7,
+    method: 'unknown/method',
+  });
+  assert.ok(unknown && 'error' in unknown);
+  assert.equal(unknown.error.code, -32601);
+});
+
+test('MCP batch requests return one JSON-RPC array response', () => {
+  const response = handleMcpPayload([
+    {
+      jsonrpc: '2.0',
+      id: 8,
+      method: 'ping',
+    },
+    {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    },
+    {
+      jsonrpc: '2.0',
+      id: 9,
+      method: 'tools/list',
+    },
+  ]);
+
+  assert.ok(Array.isArray(response));
+  assert.equal(response.length, 2);
+  assert.equal(response[0]?.id, 8);
+  assert.equal(response[1]?.id, 9);
+});

--- a/src/mcp/catalog.ts
+++ b/src/mcp/catalog.ts
@@ -1,0 +1,235 @@
+import { buildCommandUsageText, buildUsageText } from '../utils/command-schema.ts';
+import { readVersion } from '../utils/version.ts';
+
+export const MCP_SERVER_NAME = 'agent-device';
+const MCP_REGISTRY_NAME = 'io.github.callstackincubator/agent-device';
+
+const HELP_TOPICS = [
+  'workflow',
+  'debugging',
+  'react-devtools',
+  'remote',
+  'macos',
+  'dogfood',
+] as const;
+
+type HelpTopic = (typeof HELP_TOPICS)[number];
+
+type InstallArgs = {
+  client?: string;
+  global?: boolean;
+};
+
+export function createStatusText(): string {
+  const status = {
+    name: MCP_SERVER_NAME,
+    registryName: MCP_REGISTRY_NAME,
+    version: readVersion(),
+    transport: 'stdio',
+    command: 'agent-device mcp',
+    node: process.version,
+    capabilities: {
+      tools: ['status', 'install', 'help'],
+      resources: listResources().map((resource) => resource.uri),
+      prompts: listPrompts().map((prompt) => prompt.name),
+    },
+    note: 'This MCP server routes agents to the agent-device CLI. It does not expose device automation or shell execution tools.',
+  };
+  return JSON.stringify(status, null, 2);
+}
+
+export function createInstallText(args: InstallArgs = {}): string {
+  const command = args.global === false ? 'npx -y agent-device mcp' : 'agent-device mcp';
+  const packageInstall =
+    args.global === false ? 'No global install required.' : 'npm install -g agent-device';
+  const client = args.client ? `\nClient hint: ${args.client}` : '';
+  return `${packageInstall}
+
+MCP server command:
+  ${command}
+
+Generic MCP JSON:
+  {
+    "mcpServers": {
+      "agent-device": {
+        "command": "${args.global === false ? 'npx' : 'agent-device'}",
+        "args": ${JSON.stringify(args.global === false ? ['-y', 'agent-device', 'mcp'] : ['mcp'])}
+      }
+    }
+  }
+
+Use this server for discovery and routing only. For device actions, call the CLI commands returned by the help tool, starting with:
+  agent-device help workflow${client}
+`;
+}
+
+export function createHelpText(args: { topic?: string; command?: string } = {}): string {
+  if (args.topic && args.command) {
+    throw new Error('Provide either topic or command, not both.');
+  }
+  const target = args.topic ?? args.command;
+  if (!target) return buildUsageText();
+  if (args.topic && !isHelpTopic(args.topic)) {
+    throw new Error(
+      `Unknown help topic: ${args.topic}. Expected one of: ${HELP_TOPICS.join(', ')}`,
+    );
+  }
+  const help = buildCommandUsageText(target);
+  if (!help) throw new Error(`Unknown command or help topic: ${target}`);
+  return help;
+}
+
+export function listTools(): unknown[] {
+  return [
+    {
+      name: 'status',
+      description: 'Report the installed agent-device MCP router and CLI metadata.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'install',
+      description: 'Return install and MCP client configuration snippets for agent-device.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          client: {
+            type: 'string',
+            description: 'Optional client name for labeling the returned guidance.',
+          },
+          global: {
+            type: 'boolean',
+            description: 'Use a global agent-device binary when true; use npx when false.',
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'help',
+      description: 'Return version-matched CLI help for a workflow topic or command.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          topic: {
+            type: 'string',
+            enum: HELP_TOPICS,
+            description: 'Agent workflow topic.',
+          },
+          command: {
+            type: 'string',
+            description: 'CLI command name such as snapshot, open, logs, or react-devtools.',
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  ];
+}
+
+export function listResources(): Array<{
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}> {
+  return [
+    {
+      uri: 'agent-device://install',
+      name: 'agent-device MCP install',
+      description: 'Install and client configuration snippets.',
+      mimeType: 'text/markdown',
+    },
+    {
+      uri: 'agent-device://help',
+      name: 'agent-device command list',
+      description: 'Version-matched command list and global flags.',
+      mimeType: 'text/plain',
+    },
+    ...HELP_TOPICS.map((topic) => ({
+      uri: `agent-device://help/${topic}`,
+      name: `agent-device help ${topic}`,
+      description: `Version-matched ${topic} workflow guidance.`,
+      mimeType: 'text/plain',
+    })),
+  ];
+}
+
+export function readResource(uri: string): string {
+  if (uri === 'agent-device://install') return createInstallText();
+  if (uri === 'agent-device://help') return buildUsageText();
+  const topic = uri.startsWith('agent-device://help/')
+    ? uri.slice('agent-device://help/'.length)
+    : '';
+  if (isHelpTopic(topic)) return createHelpText({ topic });
+  throw new Error(`Unknown resource: ${uri}`);
+}
+
+export function listPrompts(): Array<{ name: string; description: string; arguments: unknown[] }> {
+  return [
+    createPromptDescriptor('agent-device-workflow', 'Plan a normal app automation loop.'),
+    createPromptDescriptor('agent-device-debugging', 'Collect focused debugging evidence.'),
+    createPromptDescriptor(
+      'agent-device-dogfood',
+      'Run exploratory QA with reproducible evidence.',
+    ),
+    createPromptDescriptor(
+      'agent-device-react-native-performance',
+      'Inspect React Native renders.',
+    ),
+    createPromptDescriptor('agent-device-macos', 'Inspect a macOS app or surface.'),
+  ];
+}
+
+export function getPrompt(name: string, args: Record<string, string> = {}): unknown {
+  const topicByPrompt: Record<string, HelpTopic> = {
+    'agent-device-workflow': 'workflow',
+    'agent-device-debugging': 'debugging',
+    'agent-device-dogfood': 'dogfood',
+    'agent-device-react-native-performance': 'react-devtools',
+    'agent-device-macos': 'macos',
+  };
+  const topic = topicByPrompt[name];
+  if (!topic) throw new Error(`Unknown prompt: ${name}`);
+  const target = args.target ? ` Target: ${args.target}.` : '';
+  return {
+    description: `Use agent-device help ${topic} before planning commands.${target}`,
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: `Read the agent-device ${topic} guidance through the MCP help tool, then produce a concise command plan using agent-device CLI commands only.${target}`,
+        },
+      },
+    ],
+  };
+}
+
+function createPromptDescriptor(
+  name: string,
+  description: string,
+): {
+  name: string;
+  description: string;
+  arguments: unknown[];
+} {
+  return {
+    name,
+    description,
+    arguments: [
+      {
+        name: 'target',
+        description: 'Optional app, device, or task target.',
+        required: false,
+      },
+    ],
+  };
+}
+
+function isHelpTopic(value: string): value is HelpTopic {
+  return (HELP_TOPICS as readonly string[]).includes(value);
+}

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -1,0 +1,163 @@
+import {
+  createHelpText,
+  createInstallText,
+  createStatusText,
+  getPrompt,
+  listPrompts,
+  listResources,
+  listTools,
+  readResource,
+  MCP_SERVER_NAME,
+} from './catalog.ts';
+import { readVersion } from '../utils/version.ts';
+
+type JsonRpcId = string | number | null;
+const SUPPORTED_PROTOCOL_VERSION = '2025-11-25';
+
+export type JsonRpcMessage = {
+  jsonrpc?: string;
+  id?: JsonRpcId;
+  method?: string;
+  params?: unknown;
+};
+
+type JsonRpcResponse =
+  | { jsonrpc: '2.0'; id: JsonRpcId; result: unknown }
+  | { jsonrpc: '2.0'; id: JsonRpcId; error: { code: number; message: string } };
+
+export function handleMcpMessage(message: JsonRpcMessage): JsonRpcResponse | null {
+  if (message.jsonrpc !== '2.0' || typeof message.method !== 'string') {
+    return errorResponse(message.id ?? null, -32600, 'Invalid JSON-RPC request.');
+  }
+  // Notifications such as notifications/initialized intentionally do not receive responses.
+  if (message.id === undefined) return null;
+
+  try {
+    return successResponse(message.id, handleRequest(message.method, message.params));
+  } catch (error) {
+    if (error instanceof JsonRpcMethodNotFoundError) {
+      return errorResponse(message.id, -32601, error.message);
+    }
+    return errorResponse(
+      message.id,
+      -32602,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function handleRequest(method: string, params: unknown): unknown {
+  switch (method) {
+    case 'initialize':
+      return {
+        protocolVersion: supportedProtocolVersion(params),
+        capabilities: {
+          tools: {},
+          resources: {},
+          prompts: {},
+        },
+        serverInfo: {
+          name: MCP_SERVER_NAME,
+          version: readVersion(),
+        },
+      };
+    case 'ping':
+      return {};
+    case 'tools/list':
+      return { tools: listTools() };
+    case 'tools/call':
+      return callTool(params);
+    case 'resources/list':
+      return { resources: listResources() };
+    case 'resources/read':
+      return readMcpResource(params);
+    case 'prompts/list':
+      return { prompts: listPrompts() };
+    case 'prompts/get':
+      return readPrompt(params);
+    default:
+      throw new JsonRpcMethodNotFoundError(`Unsupported MCP method: ${method}`);
+  }
+}
+
+function callTool(params: unknown): unknown {
+  const record = asRecord(params);
+  const name = stringField(record, 'name');
+  const args = optionalRecord(record.arguments);
+  try {
+    if (name === 'status') return textToolResult(createStatusText());
+    if (name === 'install') return textToolResult(createInstallText(args));
+    if (name === 'help') return textToolResult(createHelpText(args));
+    throw new Error(`Unknown tool: ${name}`);
+  } catch (error) {
+    return textToolResult(error instanceof Error ? error.message : String(error), true);
+  }
+}
+
+function readMcpResource(params: unknown): unknown {
+  const uri = stringField(asRecord(params), 'uri');
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: uri === 'agent-device://install' ? 'text/markdown' : 'text/plain',
+        text: readResource(uri),
+      },
+    ],
+  };
+}
+
+function readPrompt(params: unknown): unknown {
+  const record = asRecord(params);
+  return getPrompt(stringField(record, 'name'), optionalStringRecord(record.arguments));
+}
+
+function supportedProtocolVersion(_params: unknown): string {
+  return SUPPORTED_PROTOCOL_VERSION;
+}
+
+function textToolResult(text: string, isError = false): unknown {
+  return {
+    isError,
+    content: [{ type: 'text', text }],
+  };
+}
+
+function successResponse(id: JsonRpcId, result: unknown): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function errorResponse(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Expected object parameters.');
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalRecord(value: unknown): Record<string, unknown> {
+  if (value === undefined) return {};
+  return asRecord(value);
+}
+
+function optionalStringRecord(value: unknown): Record<string, string> {
+  const record = optionalRecord(value);
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Expected ${key} to be a non-empty string.`);
+  }
+  return value;
+}
+
+class JsonRpcMethodNotFoundError extends Error {}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,89 @@
+import { handleMcpMessage, type JsonRpcMessage } from './router.ts';
+
+type JsonRpcResponse = NonNullable<ReturnType<typeof handleMcpMessage>>;
+type MessageSink = (message: JsonRpcMessage | JsonRpcMessage[]) => void;
+
+export async function runAgentDeviceMcpServer(): Promise<void> {
+  const decoder = new McpMessageDecoder((messageOrBatch) => {
+    const response = handleMcpPayload(messageOrBatch);
+    if (response) writeMessage(response);
+  });
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk: string) => {
+    try {
+      decoder.push(chunk);
+    } catch (error) {
+      writeMessage({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32700,
+          message: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    process.stdin.on('end', resolve);
+    process.stdin.on('close', resolve);
+    process.stdin.resume();
+  });
+}
+
+export function handleMcpPayload(
+  messageOrBatch: JsonRpcMessage | JsonRpcMessage[],
+): unknown | null {
+  if (Array.isArray(messageOrBatch)) {
+    const responses = messageOrBatch.flatMap((message) => responseArray(handleMcpMessage(message)));
+    return responses.length > 0 ? responses : null;
+  }
+  return handleMcpMessage(messageOrBatch);
+}
+
+class McpMessageDecoder {
+  private buffer = '';
+  private readonly sink: MessageSink;
+
+  constructor(sink: MessageSink) {
+    this.sink = sink;
+  }
+
+  push(chunk: string): void {
+    this.buffer += chunk;
+    for (;;) {
+      const line = this.tryReadLineMessage();
+      if (line !== undefined) {
+        this.emit(line);
+        continue;
+      }
+      break;
+    }
+  }
+
+  private tryReadLineMessage(): string | undefined {
+    const newline = this.buffer.indexOf('\n');
+    if (newline === -1) return undefined;
+    const line = this.buffer.slice(0, newline).trim();
+    this.buffer = this.buffer.slice(newline + 1);
+    return line.length > 0 ? line : undefined;
+  }
+
+  private emit(raw: string): void {
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      this.sink(parsed as JsonRpcMessage[]);
+      return;
+    }
+    this.sink(parsed as JsonRpcMessage);
+  }
+}
+
+function responseArray(response: JsonRpcResponse | null): JsonRpcResponse[] {
+  return response ? [response] : [];
+}
+
+function writeMessage(message: unknown): void {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -1470,6 +1470,14 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     ],
     skipCapabilityCheck: true,
   },
+  mcp: {
+    helpDescription:
+      'Start the official stdio MCP router for status, install guidance, version-matched CLI help, workflow prompts, and help resources. The MCP router does not expose device automation or shell execution tools.',
+    summary: 'Start MCP discovery router',
+    positionalArgs: [],
+    allowedFlags: [],
+    skipCapabilityCheck: true,
+  },
   disconnect: {
     helpDescription:
       'Disconnect remote daemon state, stop owned Metro companion, and release lease',

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -22,6 +22,14 @@ agent-device help dogfood
 
 Skills are recommended for auto-routing when your agent runtime supports them, but they are not required. The CLI help topics are the version-matched operating contract.
 
+For MCP-aware clients that need discovery instead of direct device control, run:
+
+```bash
+agent-device mcp
+```
+
+The MCP router exposes `status`, `install`, and `help` tools plus workflow prompts/resources. It does not expose device automation or generic shell execution over MCP.
+
 ## Navigation
 
 ```bash

--- a/website/docs/docs/installation.md
+++ b/website/docs/docs/installation.md
@@ -31,6 +31,43 @@ Interactive CLI runs periodically check for a newer published `agent-device` pac
 
 Set `AGENT_DEVICE_NO_UPDATE_NOTIFIER=1` to disable the notice.
 
+## MCP router
+
+`agent-device mcp` starts the official stdio MCP router for discovery-oriented clients. It exposes only `status`, `install`, and `help` tools plus workflow prompts/resources. Device automation still runs through the CLI commands returned by version-matched help.
+
+```bash
+npm install -g agent-device
+agent-device mcp
+```
+
+Generic MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "agent-device": {
+      "command": "agent-device",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+No global install variant:
+
+```json
+{
+  "mcpServers": {
+    "agent-device": {
+      "command": "npx",
+      "args": ["-y", "agent-device", "mcp"]
+    }
+  }
+}
+```
+
+Registry metadata uses MCP name `io.github.callstackincubator/agent-device`, npm package `agent-device`, stdio transport, `mcpName` package verification, `server.json`, and `smithery.yaml`.
+
 ## Without installing
 
 ```bash


### PR DESCRIPTION
## Summary

Add an official `agent-device mcp` stdio router for discovery-oriented MCP clients. It exposes only `status`, `install`, and version-matched `help` tools, plus workflow prompts/resources, while keeping device automation on the CLI.

Add MCP registry metadata (`mcpName`, `server.json`, `smithery.yaml`) and concise README/website install guidance for registry discovery. Metadata versions are kept in sync by `scripts/sync-mcp-metadata.mjs`, checked during `pnpm check:tooling` and `prepack`, and documented in `AGENTS.md` for version/metadata edits.

Touched 14 files. Scope stayed within MCP discovery/routing, CLI help, registry metadata, docs, focused tests, metadata sync tooling, and agent instructions.

## Validation

- `PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/Library/pnpm:$PATH" pnpm format`
- `PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/Library/pnpm:$PATH" pnpm exec vitest run src/mcp/__tests__/router.test.ts src/utils/__tests__/args.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/Library/pnpm:$PATH" pnpm check:mcp-metadata`
- `PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/Library/pnpm:$PATH" pnpm check:tooling`
- `PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/Library/pnpm:$PATH" pnpm check:fallow`
- `printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/Library/pnpm:$PATH" node bin/agent-device.mjs mcp`
- `printf '%s\n' '[{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]' | PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$HOME/Library/pnpm:$PATH" node bin/agent-device.mjs mcp`
- `git diff --check`

Known gap: external listings on Smithery, Cline, mcp.so, mcpservers.org, and awesome-mcp-servers still require follow-up submissions after merge/publish.