### PR TITLE
fix: improve android fill verification diagnostics

### DIFF
--- a/examples/test-app/src/lab-state.tsx
+++ b/examples/test-app/src/lab-state.tsx
@@ -7,6 +7,7 @@ const initialFormState: CheckoutFormState = {
   name: '',
   email: '',
   phone: '',
+  imeCaptureTarget: '',
   notes: '',
   shipping: 'Delivery',
   payment: 'Card',

--- a/examples/test-app/src/screens/FormScreen.tsx
+++ b/examples/test-app/src/screens/FormScreen.tsx
@@ -14,6 +14,7 @@ export interface CheckoutFormState {
   name: string;
   email: string;
   phone: string;
+  imeCaptureTarget: string;
   notes: string;
   shipping: 'Delivery' | 'Pickup';
   payment: 'Card' | 'Cash';
@@ -133,6 +134,32 @@ export function FormScreen(props: FormScreenProps) {
       </SectionCard>
 
       <SectionCard
+        subtitle="A fixture for Android cases where Gboard handwriting owns the focused input."
+        title="Android IME capture"
+        testID="android-ime-capture-fixture"
+      >
+        {/* SkillGym fixture: static diagnostic copy, not live state. */}
+        <TextField
+          accessibilityLabel="Android IME target field"
+          autoCapitalize="none"
+          label="Android IME target field"
+          onChangeText={(value) => props.onChange('imeCaptureTarget', value)}
+          placeholder="Search term"
+          testID="field-ime-capture-target"
+          value={props.form.imeCaptureTarget}
+        />
+        <View style={styles.diagnosticBlock} testID="ime-capture-diagnostic">
+          <Text style={styles.diagnosticText}>
+            Android fill input was captured by the active keyboard instead of the app field
+          </Text>
+          <Text style={styles.diagnosticMeta}>targetInput id="field-ime-capture-target"</Text>
+          <Text style={styles.diagnosticMeta}>
+            actualInput packageName="com.google.android.inputmethod.latin" inputMethodOwned=true
+          </Text>
+        </View>
+      </SectionCard>
+
+      <SectionCard
         subtitle="These button groups are stable selector targets."
         title="Delivery choices"
       >
@@ -230,6 +257,25 @@ function createStyles(colors: AppColors) {
       flexDirection: 'row',
       flexWrap: 'wrap',
       gap: 8,
+    },
+    diagnosticBlock: {
+      backgroundColor: colors.cardStrong,
+      borderColor: colors.line,
+      borderRadius: 8,
+      borderWidth: StyleSheet.hairlineWidth,
+      gap: 6,
+      padding: 12,
+    },
+    diagnosticMeta: {
+      color: colors.textSoft,
+      fontFamily: 'monospace',
+      fontSize: 12,
+      lineHeight: 18,
+    },
+    diagnosticText: {
+      color: colors.text,
+      fontSize: 14,
+      lineHeight: 20,
     },
     checkboxRow: {
       alignItems: 'center',

--- a/src/platforms/__tests__/fill-diagnostics.test.ts
+++ b/src/platforms/__tests__/fill-diagnostics.test.ts
@@ -1,0 +1,79 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { buildFillFailureDetails } from '../fill-diagnostics.ts';
+
+test('buildFillFailureDetails redacts masked expected and node text', () => {
+  const details = buildFillFailureDetails('Secret123', {
+    ok: false,
+    actual: 'secret-value',
+    reason: 'masked_unverified',
+    masked: true,
+    targetInput: {
+      text: 'secret-value',
+      password: true,
+      focused: true,
+    },
+    actualInput: {
+      text: '••••••',
+      focused: true,
+    },
+  });
+
+  assert.equal(details.expected, undefined);
+  assert.equal(details.expectedLength, 9);
+  assert.equal(details.actual, null);
+  assert.equal(details.actualLength, 12);
+  assert.equal(details.targetInput?.text, null);
+  assert.equal(details.targetInput?.textRedacted, true);
+  assert.equal(details.actualInput?.text, null);
+  assert.equal(details.actualInput?.textRedacted, true);
+  assert.doesNotMatch(JSON.stringify(details), /Secret123|secret-value|••••••/);
+});
+
+test('buildFillFailureDetails keeps non-masked text diagnostics visible', () => {
+  const details = buildFillFailureDetails('search term', {
+    ok: false,
+    actual: 'search',
+    reason: 'text_mismatch',
+    targetInput: { text: 'Search Products', focused: false },
+    actualInput: { text: 'search', focused: true },
+  });
+
+  assert.equal(details.expected, 'search term');
+  assert.equal(details.actual, 'search');
+  assert.equal(details.targetInput?.text, 'Search Products');
+  assert.equal(details.actualInput?.text, 'search');
+});
+
+test('buildFillFailureDetails infers sensitivity from password nodes', () => {
+  const details = buildFillFailureDetails('Secret123', {
+    ok: false,
+    actual: 'secret-value',
+    reason: 'text_mismatch',
+    targetInput: { text: 'secret-value', password: true },
+    actualInput: { text: 'secret-value', password: true },
+  });
+
+  assert.equal(details.expected, undefined);
+  assert.equal(details.expectedLength, 9);
+  assert.equal(details.actual, null);
+  assert.equal(details.actualInput?.textRedacted, true);
+  assert.doesNotMatch(JSON.stringify(details), /Secret123|secret-value/);
+});
+
+test('buildFillFailureDetails redacts common masked field glyphs', () => {
+  for (const actual of ['••••', '****', '●●●']) {
+    const details = buildFillFailureDetails('Secret123', {
+      ok: false,
+      actual,
+      reason: 'masked_unverified',
+      targetInput: { text: 'Search Products' },
+      actualInput: { text: actual, focused: true },
+    });
+
+    assert.equal(details.expected, undefined);
+    assert.equal(details.actual, null);
+    assert.equal(details.actualInput?.textRedacted, true);
+    assert.doesNotMatch(JSON.stringify(details), /Secret123|\*|•|●/);
+  }
+});

--- a/src/platforms/android/__tests__/input-actions-fill.test.ts
+++ b/src/platforms/android/__tests__/input-actions-fill.test.ts
@@ -1,0 +1,165 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { ANDROID_EMULATOR } from '../../../__tests__/test-utils/index.ts';
+import { AppError } from '../../../utils/errors.ts';
+import { fillAndroid } from '../index.ts';
+import { withAndroidAdbProvider, type AndroidAdbExecutor } from '../adb-executor.ts';
+import {
+  androidFillFailureDetails,
+  androidFillFailureMessage,
+  readAndroidTextAtPointInHierarchy,
+  verifyAndroidFilledTextInHierarchy,
+} from '../fill-verification.ts';
+
+test('fillAndroid reports when the IME captures input instead of the app field', async () => {
+  const calls: string[][] = [];
+  let imeText = '';
+  await withFillAdb(
+    async (args) => {
+      calls.push(args);
+      if (isTextInput(args)) imeText = args[3] ?? '';
+      return adbResult(args[0] === 'exec-out' ? imeCaptureHierarchy(imeText) : '');
+    },
+    async () => {
+      await assert.rejects(
+        () => fillAndroid(ANDROID_EMULATOR, 10, 10, 'chips'),
+        (error: unknown) => {
+          assert.ok(error instanceof AppError);
+          assert.equal(error.code, 'COMMAND_FAILED');
+          assert.match(error.message, /captured by the active keyboard/i);
+          assert.equal(error.details?.failureReason, 'ime_capture');
+          assert.equal(inputDetails(error, 'actualInput')?.resourceId, IME_RESOURCE_ID);
+          assert.equal(
+            inputDetails(error, 'targetInput')?.resourceId,
+            'com.example.shop:id/search',
+          );
+          return true;
+        },
+      );
+    },
+  );
+
+  assert.equal(
+    calls.some((args) => args.join('\n') === 'shell\ncmd\nclipboard\nset\ntext'),
+    false,
+  );
+  assert.equal(
+    calls.some((args) => args.join('\n') === 'shell\ninput\nkeyevent\nKEYCODE_PASTE'),
+    false,
+  );
+});
+
+test('verifyAndroidFilledTextInHierarchy accepts matching-length masked password verification', () => {
+  const verification = verifyAndroidFilledTextInHierarchy(
+    passwordHierarchy(maskBullets('Test@123')),
+    10,
+    10,
+    'Test@123',
+  );
+
+  assert.equal(verification.ok, true);
+  assert.equal(verification.masked, true);
+});
+
+test('fillAndroid accepts matching-length masked password verification', async () => {
+  let typed = '';
+  await withFillAdb(
+    async (args) => {
+      if (isDeleteKey(args)) typed = '';
+      if (isTextInput(args)) typed = args[3] ?? '';
+      return adbResult(args[0] === 'exec-out' ? passwordHierarchy(maskBullets(typed)) : '');
+    },
+    async () => {
+      await fillAndroid(ANDROID_EMULATOR, 10, 10, 'Test@123');
+    },
+  );
+});
+
+test('verifyAndroidFilledTextInHierarchy redacts masked password values on wrong-length failure', () => {
+  const exposedPasswordValue = 'secret-value';
+  const verification = verifyAndroidFilledTextInHierarchy(
+    passwordHierarchy(exposedPasswordValue),
+    10,
+    10,
+    'Test@123',
+  );
+
+  assert.equal(verification.ok, false);
+  assertMaskedPasswordFailure(
+    androidFillFailureMessage(verification),
+    androidFillFailureDetails('Test@123', verification),
+    exposedPasswordValue,
+  );
+});
+
+test('readAndroidTextAtPointInHierarchy prefers focused edit text over point fallback', () => {
+  assert.equal(readAndroidTextAtPointInHierarchy(focusedEditHierarchy(), 10, 10), 'focused value');
+});
+
+const IME_RESOURCE_ID = 'com.google.android.inputmethod.latin:id/0_resource_name_obfuscated';
+
+async function withFillAdb(exec: AndroidAdbExecutor, fn: () => Promise<void>): Promise<void> {
+  await withAndroidAdbProvider({ exec }, { serial: ANDROID_EMULATOR.id }, fn);
+}
+
+function adbResult(stdout: string) {
+  return { stdout, stderr: '', exitCode: 0 };
+}
+
+function isTextInput(args: string[]): boolean {
+  return args[0] === 'shell' && args[1] === 'input' && args[2] === 'text';
+}
+
+function isDeleteKey(args: string[]): boolean {
+  return args.join('\n') === 'shell\ninput\nkeyevent\nKEYCODE_DEL';
+}
+
+function inputDetails(error: AppError, key: 'actualInput' | 'targetInput') {
+  return error.details?.[key] as Record<string, unknown> | null | undefined;
+}
+
+function assertMaskedPasswordFailure(
+  message: string,
+  details: Record<string, unknown>,
+  exposedPasswordValue: string,
+): void {
+  assert.match(message, /could not confirm masked text value/i);
+  assert.equal(details.failureReason, 'masked_unverified');
+  assert.equal(details.masked, true);
+  assert.equal(details.expected, undefined);
+  assert.equal(details.expectedLength, 8);
+  assert.equal(details.actual, null);
+  assert.equal(details.actualLength, exposedPasswordValue.length);
+  assert.equal(detailsInput(details, 'actualInput')?.text, null);
+  assert.equal(detailsInput(details, 'actualInput')?.textRedacted, true);
+  assert.equal(detailsInput(details, 'targetInput')?.text, null);
+  assert.doesNotMatch(JSON.stringify(details), /Test@123|secret-value/);
+}
+
+function detailsInput(details: Record<string, unknown>, key: 'actualInput' | 'targetInput') {
+  return details[key] as Record<string, unknown> | null | undefined;
+}
+
+function imeCaptureHierarchy(imeText: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><hierarchy>
+<node package="com.example.shop" class="android.widget.EditText" text="Search Products" resource-id="com.example.shop:id/search" focused="false" bounds="[0,0][300,100]"/>
+<node package="com.google.android.inputmethod.latin" class="android.widget.EditText" text="${imeText}" resource-id="${IME_RESOURCE_ID}" focused="true" bounds="[0,700][300,800]"/>
+</hierarchy>`;
+}
+
+function passwordHierarchy(mask: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.EditText" text="${mask}" password="true" focused="true" bounds="[0,0][200,100]"/></hierarchy>`;
+}
+
+function focusedEditHierarchy(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><hierarchy>
+<node package="com.example" class="android.widget.TextView" text="point fallback" focused="false" bounds="[0,0][200,100]"/>
+<node package="com.example" class="android.widget.EditText" text="focused value" focused="true" bounds="[300,300][500,400]"/>
+</hierarchy>`;
+}
+
+function maskBullets(value: string): string {
+  return Array.from(value)
+    .map(() => '&#8226;')
+    .join('');
+}

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -1,0 +1,308 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import type { Rect } from '../../utils/snapshot.ts';
+import {
+  buildFillFailureDetails,
+  type FillFailureDetails,
+  type FillDiagnosticNode,
+  type FillVerification,
+  isSensitiveFillDiagnosticNode,
+} from '../fill-diagnostics.ts';
+import { sleep } from './adb.ts';
+import { dumpUiHierarchy } from './snapshot.ts';
+import { parseBounds, readNodeAttributes } from './ui-hierarchy.ts';
+
+export type AndroidFillVerificationNode = FillDiagnosticNode & {
+  className: string | null;
+  resourceId: string | null;
+  packageName: string | null;
+  rect: Rect;
+  focused: boolean;
+  password: boolean;
+  inputMethodOwned: boolean;
+  area: number;
+};
+
+export type AndroidFillVerification = FillVerification<AndroidFillVerificationNode>;
+
+type AndroidFillVerificationCandidate = AndroidFillVerificationNode & {
+  editText: boolean;
+};
+
+type AndroidTextAtPointInspection = {
+  targetInput: AndroidFillVerificationNode | null;
+  actualInput: AndroidFillVerificationNode | null;
+};
+
+type AndroidTextAtPointScan = {
+  focusedEdit: AndroidFillVerificationCandidate | null;
+  editAtPoint: AndroidFillVerificationCandidate | null;
+  anyAtPoint: AndroidFillVerificationCandidate | null;
+};
+
+export async function verifyAndroidFilledText(
+  device: DeviceInfo,
+  x: number,
+  y: number,
+  expected: string,
+): Promise<AndroidFillVerification> {
+  const verificationDelaysMs = [0, 150, 350];
+  let lastVerification: AndroidFillVerification | null = null;
+
+  for (const delayMs of verificationDelaysMs) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+    const verification = await inspectAndroidFilledText(device, x, y, expected);
+    lastVerification = verification;
+    if (verification.ok) {
+      return verification;
+    }
+  }
+
+  return (
+    lastVerification ?? {
+      ok: false,
+      actual: null,
+      reason: 'text_mismatch',
+      targetInput: null,
+      actualInput: null,
+    }
+  );
+}
+
+export async function readAndroidTextAtPoint(
+  device: DeviceInfo,
+  x: number,
+  y: number,
+): Promise<string | null> {
+  return readAndroidTextAtPointInHierarchy(await dumpUiHierarchy(device), x, y);
+}
+
+export function verifyAndroidFilledTextInHierarchy(
+  xml: string,
+  x: number,
+  y: number,
+  expected: string,
+): AndroidFillVerification {
+  const inspection = inspectAndroidTextAtPointInHierarchy(xml, x, y);
+  if (isAndroidImeCapture(inspection)) {
+    return {
+      ok: false,
+      actual: inspection.actualInput?.text ?? null,
+      reason: 'ime_capture',
+      targetInput: inspection.targetInput,
+      actualInput: inspection.actualInput,
+    };
+  }
+
+  return (
+    maskedAndroidFillVerification(inspection, expected) ??
+    textAndroidFillVerification(inspection, expected)
+  );
+}
+
+export function readAndroidTextAtPointInHierarchy(
+  xml: string,
+  x: number,
+  y: number,
+): string | null {
+  return inspectAndroidTextAtPointInHierarchy(xml, x, y).actualInput?.text ?? null;
+}
+
+export function androidFillFailureMessage(verification: AndroidFillVerification | null): string {
+  if (verification?.reason === 'ime_capture') {
+    return 'Android fill input was captured by the active keyboard instead of the app field';
+  }
+  if (verification?.reason === 'masked_unverified') {
+    return 'Android fill verification could not confirm masked text value';
+  }
+  return 'Android fill verification failed';
+}
+
+export function androidFillFailureDetails(
+  expected: string,
+  verification: AndroidFillVerification | null,
+): FillFailureDetails<AndroidFillVerificationNode> {
+  const details = buildFillFailureDetails(expected, verification);
+  if (verification?.reason === 'ime_capture') {
+    details.hint =
+      'The focused input belongs to the Android keyboard/IME, not the app field. Disable handwriting/stylus input or switch to a standard IME, then retry fill.';
+  }
+  return details;
+}
+
+async function inspectAndroidFilledText(
+  device: DeviceInfo,
+  x: number,
+  y: number,
+  expected: string,
+): Promise<AndroidFillVerification> {
+  return verifyAndroidFilledTextInHierarchy(await dumpUiHierarchy(device), x, y, expected);
+}
+
+function inspectAndroidTextAtPointInHierarchy(
+  xml: string,
+  x: number,
+  y: number,
+): AndroidTextAtPointInspection {
+  const nodeRegex = /<node\b[^>]*>/g;
+  let match: RegExpExecArray | null;
+  const scan: AndroidTextAtPointScan = {
+    focusedEdit: null,
+    editAtPoint: null,
+    anyAtPoint: null,
+  };
+
+  while ((match = nodeRegex.exec(xml)) !== null) {
+    const candidate = androidFillCandidateFromNode(match[0]);
+    if (candidate) updateAndroidTextAtPointScan(scan, candidate, x, y);
+  }
+
+  return androidTextAtPointInspection(scan);
+}
+
+function isAndroidImeCapture(inspection: AndroidTextAtPointInspection): boolean {
+  const { targetInput, actualInput } = inspection;
+  if (!targetInput || !actualInput) return false;
+  if (actualInput === targetInput) return false;
+  return actualInput.inputMethodOwned && !targetInput.inputMethodOwned;
+}
+
+function maskedAndroidFillVerification(
+  inspection: AndroidTextAtPointInspection,
+  expected: string,
+): AndroidFillVerification | null {
+  const actualInput = inspection.actualInput;
+  if (!actualInput || !isMaskedAndroidInput(actualInput)) return null;
+  const actual = actualInput.text ?? null;
+  const actualLength = Array.from(actual ?? '').length;
+  const expectedLength = Array.from(expected).length;
+  const matched =
+    actual !== null && actualLength > 0 && expectedLength > 0 && actualLength === expectedLength;
+  return {
+    ok: matched,
+    actual,
+    reason: matched ? undefined : 'masked_unverified',
+    masked: true,
+    targetInput: inspection.targetInput,
+    actualInput,
+  };
+}
+
+function textAndroidFillVerification(
+  inspection: AndroidTextAtPointInspection,
+  expected: string,
+): AndroidFillVerification {
+  const actual = inspection.actualInput?.text ?? null;
+  return {
+    ok: isAcceptableAndroidFillMatch(actual, expected),
+    actual,
+    reason: 'text_mismatch',
+    targetInput: inspection.targetInput,
+    actualInput: inspection.actualInput,
+  };
+}
+
+function isAcceptableAndroidFillMatch(actual: string | null, expected: string): boolean {
+  if (actual === expected) {
+    return true;
+  }
+  const normalizedActual = normalizeFillVerificationText(actual);
+  const normalizedExpected = normalizeFillVerificationText(expected);
+  if (!normalizedActual || !normalizedExpected) {
+    return false;
+  }
+  if (normalizedActual === normalizedExpected) {
+    return true;
+  }
+  if (normalizedActual.includes(normalizedExpected)) {
+    return true;
+  }
+  return (
+    normalizedExpected.includes(normalizedActual) &&
+    normalizedActual.length >= Math.max(4, Math.floor(normalizedExpected.length * 0.8))
+  );
+}
+
+function normalizeFillVerificationText(value: string | null): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function androidFillCandidateFromNode(node: string): AndroidFillVerificationCandidate | null {
+  const attrs = readNodeAttributes(node);
+  const rect = parseBounds(attrs.bounds);
+  if (!rect) return null;
+  const text = attrs.text ?? '';
+  const area = Math.max(1, rect.width * rect.height);
+  return {
+    text: text || null,
+    className: attrs.className,
+    resourceId: attrs.resourceId,
+    packageName: attrs.packageName,
+    rect,
+    focused: attrs.focused ?? false,
+    password: attrs.password === true,
+    inputMethodOwned: isInputMethodOwnedAndroidNode(attrs.packageName, attrs.resourceId),
+    area,
+    editText: isEditTextClass(attrs.className ?? ''),
+  };
+}
+
+function updateAndroidTextAtPointScan(
+  scan: AndroidTextAtPointScan,
+  candidate: AndroidFillVerificationCandidate,
+  x: number,
+  y: number,
+): void {
+  const containsPoint = containsAndroidPoint(candidate.rect, x, y);
+  if (containsPoint && candidate.editText) {
+    scan.editAtPoint = smallerAndroidFillCandidate(scan.editAtPoint, candidate);
+  }
+  if (candidate.focused && candidate.editText) {
+    scan.focusedEdit = smallerAndroidFillCandidate(scan.focusedEdit, candidate);
+    return;
+  }
+  if (containsPoint && candidate.text) {
+    scan.anyAtPoint = smallerAndroidFillCandidate(scan.anyAtPoint, candidate);
+  }
+}
+
+function containsAndroidPoint(rect: Rect, x: number, y: number): boolean {
+  return x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
+}
+
+function smallerAndroidFillCandidate<T extends AndroidFillVerificationCandidate>(
+  current: T | null,
+  next: T,
+): T {
+  return current && current.area < next.area ? current : next;
+}
+
+function androidTextAtPointInspection(scan: AndroidTextAtPointScan): AndroidTextAtPointInspection {
+  const targetInput = scan.editAtPoint ?? scan.anyAtPoint;
+  const focusedInput = scan.focusedEdit?.text ? scan.focusedEdit : null;
+  return {
+    targetInput,
+    actualInput: focusedInput ?? targetInput,
+  };
+}
+
+function isEditTextClass(className: string): boolean {
+  const lower = className.toLowerCase();
+  return lower.includes('edittext') || lower.includes('textfield');
+}
+
+function isInputMethodOwnedAndroidNode(
+  packageName: string | null,
+  resourceId: string | null,
+): boolean {
+  const normalizedPackageName = (packageName ?? '').toLowerCase();
+  const normalizedResourceId = (resourceId ?? '').toLowerCase();
+  if (normalizedPackageName.includes('inputmethod')) return true;
+  if (normalizedPackageName === 'com.google.android.inputmethod.latin') return true;
+  return normalizedResourceId.startsWith('com.google.android.inputmethod.latin:id/');
+}
+
+function isMaskedAndroidInput(node: AndroidFillVerificationNode): boolean {
+  return isSensitiveFillDiagnosticNode(node);
+}

--- a/src/platforms/android/input-actions.ts
+++ b/src/platforms/android/input-actions.ts
@@ -2,9 +2,15 @@ import { AppError } from '../../utils/errors.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import type { DeviceRotation } from '../../core/device-rotation.ts';
 import { buildScrollGesturePlan, type ScrollDirection } from '../../core/scroll-gesture.ts';
-import { parseBounds, readNodeAttributes } from './ui-hierarchy.ts';
-import { dumpUiHierarchy } from './snapshot.ts';
 import { isClipboardShellUnsupported, runAndroidAdb, sleep } from './adb.ts';
+import {
+  androidFillFailureDetails,
+  androidFillFailureMessage,
+  verifyAndroidFilledText,
+  type AndroidFillVerification,
+} from './fill-verification.ts';
+
+export { readAndroidTextAtPoint } from './fill-verification.ts';
 
 export async function pressAndroid(device: DeviceInfo, x: number, y: number): Promise<void> {
   await runAndroidAdb(device, ['shell', 'input', 'tap', String(x), String(y)]);
@@ -140,7 +146,7 @@ export async function fillAndroid(
     attempts.push({ strategy: 'chunked_input', clearPadding: 24, minClear: 16, maxClear: 96 });
   }
 
-  let lastActual: string | null = null;
+  let lastVerification: AndroidFillVerification | null = null;
 
   for (const attempt of attempts) {
     await focusAndroid(device, x, y);
@@ -161,61 +167,25 @@ export async function fillAndroid(
       await typeAndroidChunked(device, text, 1, delayMs > 0 ? delayMs : 15);
     }
     const verification = await verifyAndroidFilledText(device, x, y, text);
-    lastActual = verification.actual;
+    lastVerification = verification;
     if (verification.ok) return;
+    if (verification.reason === 'ime_capture') {
+      throwAndroidFillFailure(text, verification);
+    }
   }
 
-  throw new AppError('COMMAND_FAILED', 'Android fill verification failed', {
-    expected: text,
-    actual: lastActual ?? null,
-  });
+  throwAndroidFillFailure(text, lastVerification);
 }
 
-async function verifyAndroidFilledText(
-  device: DeviceInfo,
-  x: number,
-  y: number,
+function throwAndroidFillFailure(
   expected: string,
-): Promise<{ ok: boolean; actual: string | null }> {
-  const verificationDelaysMs = [0, 150, 350];
-  let lastActual: string | null = null;
-
-  for (const delayMs of verificationDelaysMs) {
-    if (delayMs > 0) {
-      await sleep(delayMs);
-    }
-    lastActual = await readAndroidTextAtPoint(device, x, y);
-    if (isAcceptableAndroidFillMatch(lastActual, expected)) {
-      return { ok: true, actual: lastActual };
-    }
-  }
-
-  return { ok: false, actual: lastActual };
-}
-
-function isAcceptableAndroidFillMatch(actual: string | null, expected: string): boolean {
-  if (actual === expected) {
-    return true;
-  }
-  const normalizedActual = normalizeFillVerificationText(actual);
-  const normalizedExpected = normalizeFillVerificationText(expected);
-  if (!normalizedActual || !normalizedExpected) {
-    return false;
-  }
-  if (normalizedActual === normalizedExpected) {
-    return true;
-  }
-  if (normalizedActual.includes(normalizedExpected)) {
-    return true;
-  }
-  return (
-    normalizedExpected.includes(normalizedActual) &&
-    normalizedActual.length >= Math.max(4, Math.floor(normalizedExpected.length * 0.8))
+  verification: AndroidFillVerification | null,
+): never {
+  throw new AppError(
+    'COMMAND_FAILED',
+    androidFillFailureMessage(verification),
+    androidFillFailureDetails(expected, verification),
   );
-}
-
-function normalizeFillVerificationText(value: string | null): string {
-  return (value ?? '').replace(/\s+/g, ' ').trim();
 }
 
 export async function scrollAndroid(
@@ -351,67 +321,6 @@ async function clearFocusedText(device: DeviceInfo, count: number): Promise<void
       },
     );
   }
-}
-
-export async function readAndroidTextAtPoint(
-  device: DeviceInfo,
-  x: number,
-  y: number,
-): Promise<string | null> {
-  const xml = await dumpUiHierarchy(device);
-  const nodeRegex = /<node\b[^>]*>/g;
-  let match: RegExpExecArray | null;
-  let focusedEdit: { text: string; area: number } | null = null;
-  let editAtPoint: { text: string; area: number } | null = null;
-  let anyAtPoint: { text: string; area: number } | null = null;
-
-  while ((match = nodeRegex.exec(xml)) !== null) {
-    const node = match[0];
-    const attrs = readNodeAttributes(node);
-    const rect = parseBounds(attrs.bounds);
-    if (!rect) continue;
-    const className = attrs.className ?? '';
-    const text = decodeXmlEntities(attrs.text ?? '');
-    const focused = attrs.focused ?? false;
-    if (!text) continue;
-    const area = Math.max(1, rect.width * rect.height);
-    const containsPoint =
-      x >= rect.x && x <= rect.x + rect.width && y >= rect.y && y <= rect.y + rect.height;
-
-    if (focused && isEditTextClass(className)) {
-      if (!focusedEdit || area <= focusedEdit.area) {
-        focusedEdit = { text, area };
-      }
-      continue;
-    }
-    if (containsPoint && isEditTextClass(className)) {
-      if (!editAtPoint || area <= editAtPoint.area) {
-        editAtPoint = { text, area };
-      }
-      continue;
-    }
-    if (containsPoint) {
-      if (!anyAtPoint || area <= anyAtPoint.area) {
-        anyAtPoint = { text, area };
-      }
-    }
-  }
-
-  return focusedEdit?.text ?? editAtPoint?.text ?? anyAtPoint?.text ?? null;
-}
-
-function isEditTextClass(className: string): boolean {
-  const lower = className.toLowerCase();
-  return lower.includes('edittext') || lower.includes('textfield');
-}
-
-function decodeXmlEntities(value: string): string {
-  return value
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&');
 }
 
 function clampCount(value: number, min: number, max: number): number {

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -176,12 +176,14 @@ export function readNodeAttributes(node: string): {
   text: string | null;
   desc: string | null;
   resourceId: string | null;
+  packageName: string | null;
   className: string | null;
   bounds: string | null;
   clickable?: boolean;
   enabled?: boolean;
   focusable?: boolean;
   focused?: boolean;
+  password?: boolean;
 } {
   const attrs = parseXmlNodeAttributes(node);
   const getAttr = (name: string): string | null => readXmlAttr(attrs, name);
@@ -194,12 +196,14 @@ export function readNodeAttributes(node: string): {
     text: getAttr('text'),
     desc: getAttr('content-desc'),
     resourceId: getAttr('resource-id'),
+    packageName: getAttr('package'),
     className: getAttr('class'),
     bounds: getAttr('bounds'),
     clickable: boolAttr('clickable'),
     enabled: boolAttr('enabled'),
     focusable: boolAttr('focusable'),
     focused: boolAttr('focused'),
+    password: boolAttr('password'),
   };
 }
 

--- a/src/platforms/fill-diagnostics.ts
+++ b/src/platforms/fill-diagnostics.ts
@@ -1,0 +1,138 @@
+import type { Rect } from '../utils/snapshot.ts';
+
+/**
+ * Cross-platform metadata for fill verification diagnostics.
+ *
+ * Platform backends should populate whichever native identity fields they have:
+ * iOS/macOS usually use `identifier`, Android uses `resourceId` and `packageName`.
+ */
+export type FillDiagnosticNode = {
+  text: string | null;
+  className?: string | null;
+  identifier?: string | null;
+  resourceId?: string | null;
+  packageName?: string | null;
+  rect?: Rect | null;
+  focused?: boolean;
+  password?: boolean;
+  inputMethodOwned?: boolean;
+};
+
+export type FillFailureReason = 'ime_capture' | 'masked_unverified' | 'text_mismatch';
+
+export type FillVerification<TNode extends FillDiagnosticNode = FillDiagnosticNode> = {
+  ok: boolean;
+  actual: string | null;
+  reason?: FillFailureReason;
+  masked?: boolean;
+  targetInput: TNode | null;
+  actualInput: TNode | null;
+};
+
+export type FillDiagnosticDetailsNode<TNode extends FillDiagnosticNode = FillDiagnosticNode> = Omit<
+  TNode,
+  'text'
+> & {
+  text: string | null;
+  textRedacted?: true;
+};
+
+type FillFailureDetailsBase<TNode extends FillDiagnosticNode> = {
+  failureReason: FillFailureReason;
+  targetInput: FillDiagnosticDetailsNode<TNode> | null;
+  actualInput: FillDiagnosticDetailsNode<TNode> | null;
+  hint?: string;
+};
+
+type UnmaskedFillFailureDetails<TNode extends FillDiagnosticNode> =
+  FillFailureDetailsBase<TNode> & {
+    expected: string;
+    expectedLength?: never;
+    actual: string | null;
+    masked?: never;
+    actualLength?: never;
+  };
+
+type MaskedFillFailureDetails<TNode extends FillDiagnosticNode> = FillFailureDetailsBase<TNode> & {
+  expected?: never;
+  expectedLength: number;
+  actual: null;
+  masked: true;
+  actualLength: number;
+};
+
+export type FillFailureDetails<TNode extends FillDiagnosticNode = FillDiagnosticNode> =
+  | UnmaskedFillFailureDetails<TNode>
+  | MaskedFillFailureDetails<TNode>;
+
+export function buildFillFailureDetails<TNode extends FillDiagnosticNode>(
+  expected: string,
+  verification: FillVerification<TNode> | null,
+): FillFailureDetails<TNode> {
+  if (!verification) {
+    return {
+      expected,
+      actual: null,
+      failureReason: 'text_mismatch',
+      targetInput: null,
+      actualInput: null,
+    };
+  }
+
+  const sensitive = isSensitiveFillVerification(verification);
+  const common = {
+    failureReason: verification.reason ?? 'text_mismatch',
+    targetInput: toFillDiagnosticNode(verification.targetInput),
+    actualInput: toFillDiagnosticNode(verification.actualInput),
+  };
+  if (sensitive) {
+    return {
+      ...common,
+      expectedLength: Array.from(expected).length,
+      actual: null,
+      masked: true,
+      actualLength: Array.from(verification.actual ?? '').length,
+    };
+  }
+  return {
+    ...common,
+    expected,
+    actual: verification.actual,
+  };
+}
+
+export function isSensitiveFillDiagnosticNode(node: FillDiagnosticNode | null): boolean {
+  if (!node) return false;
+  if (node.password) return true;
+  return isMaskedFillText(node.text);
+}
+
+function isMaskedFillText(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return Array.from(text).every(isMaskCharacter);
+}
+
+function toFillDiagnosticNode<TNode extends FillDiagnosticNode>(
+  node: TNode | null,
+): FillDiagnosticDetailsNode<TNode> | null {
+  if (!node) return null;
+  const textRedacted = isSensitiveFillDiagnosticNode(node);
+  return {
+    ...node,
+    text: textRedacted ? null : node.text,
+    ...(textRedacted ? { textRedacted: true } : {}),
+  };
+}
+
+function isMaskCharacter(char: string): boolean {
+  // Deliberately conservative: expand this allowlist only for observed platform masks.
+  return char === '\u2022' || char === '*' || char === '\u25cf';
+}
+
+function isSensitiveFillVerification(verification: FillVerification): boolean {
+  return (
+    verification.masked === true ||
+    isSensitiveFillDiagnosticNode(verification.targetInput) ||
+    isSensitiveFillDiagnosticNode(verification.actualInput)
+  );
+}

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -800,6 +800,7 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /Install flows: install\/install-from-source first/);
   assert.match(usageText, /fill 'id="field-email"' "qa@example\.com" replaces/);
   assert.match(usageText, /do not use fill <target> ""/);
+  assert.match(usageText, /Android IME capture: if fill says input was captured/);
   assert.match(usageText, /Run mutating commands serially against one session/);
   assert.match(usageText, /After mutation: diff snapshot -i/);
   assert.match(usageText, /app-owned back uses back/);
@@ -868,6 +869,9 @@ test('usageForCommand resolves workflow help topic', () => {
     /Do not run open\/press\/fill\/type\/scroll\/back\/alert\/replay\/batch\/close commands in parallel/,
   );
   assert.match(help, /agent-device clipboard write "some text"/);
+  assert.match(help, /Android Gboard handwriting\/stylus UI can capture text/);
+  assert.match(help, /targetInput\/actualInput details/);
+  assert.match(help, /Do not keep retrying fill\/type against the same field/);
   assert.match(help, /trusted ADB keyboard IME/);
   assert.match(help, /if no URL is provided but a target\/app name is provided, open that target/);
   assert.match(help, /do not split clear\/restart/);

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -184,6 +184,7 @@ const AGENT_QUICKSTART_LINES = [
   'Install flows: install/install-from-source first, then open the installed id with --relaunch.',
   'Text: fill \'id="field-email"\' "qa@example.com" replaces; type appends after press.',
   'Clearing text: do not use fill <target> ""; use a visible clear/reset control or report that clearing is unsupported.',
+  'Android IME capture: if fill says input was captured by the keyboard/IME, inspect keyboard state and switch/disable handwriting before retrying; do not loop fill/type.',
   'Run mutating commands serially against one session; parallelize only read-only commands or separate sessions.',
   'Clipboard limits: iOS Allow Paste cannot be automated through XCUITest; prefill with clipboard write. Android non-ASCII should use fill/type, not raw adb input.',
   'After mutation: diff snapshot -i. Off-screen hints: scroll, then snapshot -i.',
@@ -290,6 +291,7 @@ Text entry:
   On iOS, prefer keyboard dismiss before manually pressing visible Done; the runner can use safe native keyboard controls and still reports unsupported layouts explicitly. If it returns UNSUPPORTED_OPERATION, prefer a visible app dismiss control, or use back --system only when system navigation is an acceptable side effect.
   Search-as-you-type fields on iOS can drop characters when driven too fast; use --delay-ms on fill/type before trying clipboard paste.
   iOS Allow Paste prompt cannot be exercised under XCUITest. To test paste-driven app behavior, prefill first with agent-device clipboard write "some text"; test the system prompt manually.
+  Android Gboard handwriting/stylus UI can capture text in an IME-owned input instead of the app field. If fill reports that input was captured by the keyboard/IME, use the diagnostic targetInput/actualInput details, inspect with keyboard status/get if needed, and switch or disable handwriting/trusted ADB keyboard outside the command plan before retrying. Do not keep retrying fill/type against the same field while the IME owns focus.
   Android non-ASCII can fail on some system images. Try fill/type normally; agent-device uses safer fallbacks. If the shell reports unsupported non-ASCII input, configure a trusted ADB keyboard IME outside the command plan and restore the previous IME afterward.
 
 Session ordering:

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -1156,6 +1156,29 @@ const SKILL_GUIDANCE_CASES: TestCase[] = [
     forbiddenOutputs: [plannedCommand('fill'), plannedCommand('type'), /keyboard dismiss/i],
   }),
   makeCase({
+    id: 'android-fill-ime-capture-stop-retry-loop',
+    contract: [
+      'Platform: Android',
+      'App name: Agent Device Tester',
+      'Current screen: Checkout form tab',
+      'The Android IME capture fixture is visible: id="android-ime-capture-fixture"',
+      'The app field is still visible as targetInput id="field-ime-capture-target"',
+      'The last fill failed: Android fill input was captured by the active keyboard instead of the app field',
+      'Diagnostic details show actualInput packageName="com.google.android.inputmethod.latin" inputMethodOwned=true',
+    ],
+    task: 'Plan the next diagnostic step. Do not retry fill or type until the IME handwriting/stylus state has been corrected.',
+    outputs: [
+      /(?:^|\n)(?:agent-device\s+)?keyboard\s+(?:status|get)(?:\s|$)/i,
+      /(?:IME|keyboard|Gboard|handwriting|stylus)/i,
+    ],
+    forbiddenOutputs: [
+      plannedCommand('fill'),
+      plannedCommand('type'),
+      RAW_COORDINATE_TARGET,
+      /adb shell/i,
+    ],
+  }),
+  makeCase({
     id: 'remote-cloud-connect-flow',
     contract: [
       'Cloud control plane owns the connection profile',


### PR DESCRIPTION
## Summary

Improve Android `fill` verification diagnostics for IME-captured input and masked password fields.

Details:
- Detect when typed text lands in a keyboard/IME-owned input instead of the target app field and report target/actual input metadata.
- Fail fast once verification shows IME capture instead of trying alternate text injection strategies against the wrong focused field.
- Treat matching-length masked/password values as successful verification, with a defensive non-empty expected/actual guard.
- Add a shared fill diagnostics helper for `targetInput`/`actualInput`, masked redaction, inferred password-node sensitivity, and expected/actual length metadata so other platforms can adopt the same contract.
- Redact masked/password expected and node text from failure diagnostics while reporting lengths and `textRedacted` metadata.
- Parse Android hierarchy `package` and `password` attributes for fill diagnostics, and tighten Android IME ownership detection to input-method package/resource prefixes.
- Extract Android fill verification into a focused module so `input-actions` remains the action orchestrator.
- Add versioned help and SkillGym guidance so agents stop retrying `fill`/`type` when diagnostics show Gboard handwriting/stylus capture.
- Add an Agent Device Tester fixture on the Checkout form with stable `android-ime-capture-fixture` and `field-ime-capture-target` IDs, and point the SkillGym case at that fixture.

Touched files: 11. Scope stayed within Android input verification, shared fill diagnostics, CLI help guidance, Agent Device Tester fixture coverage, and focused tests.

## Validation

- `pnpm format`
- `pnpm exec oxfmt --write examples/test-app/src/lab-state.tsx examples/test-app/src/screens/FormScreen.tsx`
- `pnpm exec vitest run src/platforms/android/__tests__/index.test.ts`
- `pnpm exec vitest run src/platforms/__tests__/fill-diagnostics.test.ts src/platforms/android/__tests__/input-actions-fill.test.ts src/platforms/android/__tests__/index.test.ts`
- `pnpm exec vitest run src/utils/__tests__/args.test.ts`
- `pnpm check:fallow --base origin/main`
- `pnpm build`
- `pnpm check:quick`
- `pnpm test-app:install`
- `pnpm --dir examples/test-app typecheck`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case android-fill-ime-capture-stop-retry-loop --runner codex-mini`

Known gap: full all-runner SkillGym invocation could not run here because the configured `claude` runner binary is missing from PATH (`spawn claude ENOENT`).