### PR TITLE
fix: keep MCP registry description valid

### DIFF
--- a/scripts/sync-mcp-metadata.mjs
+++ b/scripts/sync-mcp-metadata.mjs
@@ -11,12 +11,16 @@ const pkg = readJson(packagePath);
 const server = readJson(serverPath);
 const expectedName = pkg.mcpName;
 const expectedVersion = pkg.version;
+const registryDescriptionMaxLength = 100;
 
 if (typeof expectedName !== 'string' || expectedName.length === 0) {
   fail('package.json must define mcpName.');
 }
 if (typeof expectedVersion !== 'string' || expectedVersion.length === 0) {
   fail('package.json must define version.');
+}
+if (typeof server.description === 'string' && server.description.length > registryDescriptionMaxLength) {
+  fail(`server.json description must be ${registryDescriptionMaxLength} characters or fewer.`);
 }
 
 server.name = expectedName;

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.callstackincubator/agent-device",
   "title": "agent-device",
-  "description": "Official MCP discovery router for the agent-device CLI. It exposes status, install guidance, version-matched CLI help, prompts, and resources without exposing device automation over MCP.",
+  "description": "Discovery router for the agent-device CLI with status, install, help, prompts, and resources.",
   "repository": {
     "url": "https://github.com/callstackincubator/agent-device",
     "source": "github"


### PR DESCRIPTION
## Summary

Shorten the MCP registry description to satisfy the live registry 100-character limit.

Add the same limit to the metadata sync check so future releases fail locally before publishing.

Touched files: 2. Scope stayed within MCP registry metadata.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:tooling`
- `pnpm check:fallow`
- `mcp-publisher validate server.json`