### PR TITLE
fix: hide adb console windows on Windows

### DIFF
--- a/src/platforms/android/__tests__/adb-executor.test.ts
+++ b/src/platforms/android/__tests__/adb-executor.test.ts
@@ -1,6 +1,18 @@
 import assert from 'node:assert/strict';
 import { test, vi } from 'vitest';
 
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(() => ({})),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
 vi.mock('../../../utils/exec.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../utils/exec.ts')>();
   return {
@@ -114,9 +126,17 @@ test('createLocalAndroidAdbProvider exposes exec, spawn, and reverse over local 
   });
 
   await provider.exec(['shell', 'echo', 'ok']);
+  provider.spawn?.(['logcat'], { stdio: ['ignore', 'pipe', 'pipe'] });
   await provider.reverse?.ensure({ local: 'tcp:8081', remote: 'tcp:8081', ownerId: 'session-a' });
   await provider.reverse?.removeAllOwned('session-a');
 
+  assert.deepEqual(spawnMock.mock.calls, [
+    [
+      'adb',
+      ['-s', 'emulator-5554', 'logcat'],
+      { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true },
+    ],
+  ]);
   assert.deepEqual(
     mockRunCmd.mock.calls.map((call) => call[1]),
     [

--- a/src/platforms/android/adb-executor.ts
+++ b/src/platforms/android/adb-executor.ts
@@ -131,7 +131,8 @@ function createSerialAdbExecutor(serial: string): AndroidAdbExecutor {
 }
 
 function createSerialAdbSpawner(serial: string): AndroidAdbSpawner {
-  return (args, options) => spawn('adb', ['-s', serial, ...args], options ?? {});
+  return (args, options) =>
+    spawn('adb', ['-s', serial, ...args], { ...options, windowsHide: true });
 }
 
 export function createLocalAndroidAdbProvider(device: DeviceInfo): AndroidAdbProvider {

--- a/src/utils/__tests__/exec-windows-hide.test.ts
+++ b/src/utils/__tests__/exec-windows-hide.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { beforeEach, test, vi } from 'vitest';
+
+type MockChildProcess = EventEmitter & {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+  unref: ReturnType<typeof vi.fn>;
+};
+
+const { spawnMock, spawnSyncMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+  spawnSync: spawnSyncMock,
+}));
+
+import { runCmd, runCmdBackground, runCmdDetached, runCmdSync } from '../exec.ts';
+
+beforeEach(() => {
+  spawnMock.mockReset();
+  spawnSyncMock.mockReset();
+});
+
+test('process helpers hide Windows console windows for spawned commands', async () => {
+  spawnMock.mockImplementation(() => makeMockChild());
+  spawnSyncMock.mockReturnValue({ stdout: '', stderr: '', status: 0 });
+
+  await runCmd('node', ['--version']);
+  runCmdSync('node', ['--version']);
+  runCmdDetached('node', ['--version']);
+  runCmdBackground('node', ['--version']);
+
+  for (const call of spawnMock.mock.calls) {
+    assert.equal(call[2]?.windowsHide, true);
+  }
+  assert.equal(spawnSyncMock.mock.calls[0]?.[2]?.windowsHide, true);
+});
+
+function makeMockChild(): ReturnType<typeof import('node:child_process').spawn> {
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn(() => true);
+  child.unref = vi.fn();
+
+  queueMicrotask(() => {
+    child.stdout?.end();
+    child.stderr?.end();
+    child.emit('close', 0, null);
+  });
+
+  return child as unknown as ReturnType<typeof import('node:child_process').spawn>;
+}

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -95,6 +95,7 @@ function runSpawnedCommand(
       env: options.env,
       stdio: ['pipe', 'pipe', 'pipe'],
       detached: options.detached,
+      windowsHide: true,
       shell: false,
     });
     options.onSpawn?.(child);
@@ -248,6 +249,7 @@ export function runCmdSync(cmd: string, args: string[], options: ExecOptions = {
     encoding: options.binaryStdout ? undefined : 'utf8',
     input: options.stdin,
     timeout: normalizeTimeoutMs(options.timeoutMs),
+    windowsHide: true,
     shell: false,
   });
 
@@ -303,6 +305,7 @@ export function runCmdDetached(
     env: options.env,
     stdio: options.stdio ?? 'ignore',
     detached: true,
+    windowsHide: true,
     shell: false,
   });
   child.unref();
@@ -320,6 +323,7 @@ export function runCmdBackground(
     env: options.env,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: options.detached,
+    windowsHide: true,
     shell: false,
   });
 


### PR DESCRIPTION
## Summary

- Set `windowsHide: true` on shared process helpers so Windows subprocesses do not flash console windows.
- Apply the same hidden-window option to the direct local ADB streaming spawner.
- Add regression coverage for both shared process helpers and the local ADB provider spawner.

Closes #502

Touched files: 4. Scope stayed within shared process execution, Android ADB provider code, and focused tests.

## Validation

- `pnpm exec vitest run src/utils/__tests__/exec-windows-hide.test.ts src/platforms/android/__tests__/adb-executor.test.ts`
- `pnpm format`
- `pnpm check:quick`
- Android test-app manual check on Pixel 9 Pro XL emulator: `pnpm test-app:install`, `pnpm test-app:android`, `agent-device snapshot -i --platform android --json`; verified the Agent Device Tester UI loaded and snapshot returned Android nodes.

Known gap: `pnpm check:unit` was attempted. The full suite hit environment/test harness failures unrelated to this change: two failing tests passed when rerun in isolation, and `src/__tests__/client-metro-packaged.test.ts` cannot complete in this shell because no `npm` binary is available and its cleanup path kills PID 0 after that setup failure.