### PR TITLE
refactor: route process spawning through exec helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ A new snapshot/command flag touches up to 7 files in a fixed order. Follow this 
 Command-only flags (like `find --first`) that don't flow to the platform layer only need steps 1 and the handler file.
 
 ## Hard Rules
-- Use `runCmd`/`runCmdSync` from `src/utils/exec.ts` for process execution.
+- Use process helpers from `src/utils/exec.ts` for TypeScript process execution: `runCmd`, `runCmdStreaming`, `runCmdSync`, `runCmdBackground`, and `runCmdDetached`. Do not import raw `spawn`/`spawnSync` outside `src/utils/exec.ts`; add or extend an exec helper instead. Plain `.mjs` packaging fixtures that cannot import TypeScript helpers should keep child-process usage local and prefer `execFile`/`execFileSync` over spawn.
 - Use daemon session flow for interactions (`open` before interactions, `close` after).
 - Use `keyboard dismiss` for iOS keyboard dismissal; it may tap safe native controls such as `Done` but must not fall back to system back navigation.
 - Do not remove shared snapshot/session model behavior without full migration.

--- a/src/daemon/__tests__/app-log-android.test.ts
+++ b/src/daemon/__tests__/app-log-android.test.ts
@@ -6,12 +6,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
-vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
 vi.mock('../../utils/exec.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../utils/exec.ts')>();
   return {
     ...actual,
     runCmd: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    runCmdBackground: vi.fn(),
   };
 });
 vi.mock('../app-log-stream.ts', async (importOriginal) => {
@@ -19,12 +19,11 @@ vi.mock('../app-log-stream.ts', async (importOriginal) => {
   return { ...actual, sleep: vi.fn(async () => {}) };
 });
 
-import { spawn } from 'node:child_process';
-import { runCmd } from '../../utils/exec.ts';
+import { runCmd, runCmdBackground } from '../../utils/exec.ts';
 import { readRecentAndroidLogcatForPackage, startAndroidAppLog } from '../app-log-android.ts';
 
-const mockSpawn = vi.mocked(spawn);
 const mockRunCmd = vi.mocked(runCmd);
+const mockRunCmdBackground = vi.mocked(runCmdBackground);
 
 type MockChild = EventEmitter & {
   stdout: PassThrough;
@@ -51,6 +50,15 @@ function makeMockChild(pid?: number): MockChild {
   return child;
 }
 
+function mockBackgroundChild(child: MockChild): ReturnType<typeof runCmdBackground> {
+  return {
+    child: child as unknown as ReturnType<typeof runCmdBackground>['child'],
+    wait: new Promise((resolve) => {
+      child.once('close', (code) => resolve({ stdout: '', stderr: '', exitCode: code ?? 0 }));
+    }),
+  };
+}
+
 test('startAndroidAppLog returns to active state after a successful reattach', async () => {
   const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-android-log-'));
   const stream = fs.createWriteStream(path.join(logDir, 'app.log'));
@@ -71,25 +79,25 @@ test('startAndroidAppLog returns to active state after a successful reattach', a
     return { stdout: '', stderr: '', exitCode: 0 };
   });
 
-  mockSpawn.mockReset();
+  mockRunCmdBackground.mockReset();
   let spawnCount = 0;
-  mockSpawn.mockImplementation(() => {
+  mockRunCmdBackground.mockImplementation(() => {
     spawnCount += 1;
     if (spawnCount === 1) {
-      return firstChild as unknown as ReturnType<typeof spawn>;
+      return mockBackgroundChild(firstChild);
     }
-    return secondChild as unknown as ReturnType<typeof spawn>;
+    return mockBackgroundChild(secondChild);
   });
 
   const appLog = await startAndroidAppLog('emulator-5554', 'com.example.app', stream, []);
   await vi.waitFor(() => {
-    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockRunCmdBackground).toHaveBeenCalledTimes(1);
   });
   assert.equal(appLog.getState(), 'active');
 
   firstChild.emit('close', 1);
   await vi.waitFor(() => {
-    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockRunCmdBackground).toHaveBeenCalledTimes(2);
   });
   assert.equal(appLog.getState(), 'active');
 
@@ -110,12 +118,12 @@ test('startAndroidAppLog reports active for provider streams without host pid', 
     return { stdout: '', stderr: '', exitCode: 0 };
   });
 
-  mockSpawn.mockReset();
-  mockSpawn.mockImplementation(() => child as unknown as ReturnType<typeof spawn>);
+  mockRunCmdBackground.mockReset();
+  mockRunCmdBackground.mockImplementation(() => mockBackgroundChild(child));
 
   const appLog = await startAndroidAppLog('emulator-5554', 'com.example.app', stream, []);
   await vi.waitFor(() => {
-    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockRunCmdBackground).toHaveBeenCalledTimes(1);
   });
 
   assert.equal(appLog.getState(), 'active');

--- a/src/daemon/app-log-ios.ts
+++ b/src/daemon/app-log-ios.ts
@@ -1,7 +1,6 @@
-import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { buildSimctlArgs } from '../platforms/ios/simctl.ts';
-import { runCmd } from '../utils/exec.ts';
+import { runCmd, runCmdBackground } from '../utils/exec.ts';
 import { clearPidFile, writePidFile, type AppLogResult } from './app-log-process.ts';
 import { attachChildToStream, createLineWriter, waitForChildExit } from './app-log-stream.ts';
 
@@ -96,38 +95,14 @@ export async function startIosSimulatorAppLog(
   simulatorSetPath?: string,
   pidPath?: string,
 ): Promise<AppLogResult> {
-  let state: 'active' | 'failed' = 'active';
-  const child = spawn(
-    'xcrun',
-    buildIosSimulatorLogStreamArgs({ deviceId, appBundleId, simulatorSetPath }),
-    {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-  const writer = createLineWriter(stream, { redactionPatterns });
-  if (typeof child.pid === 'number') {
-    writePidFile(pidPath, child.pid);
-  }
-  const wait = attachChildToStream(child, stream, { endStreamOnClose: true, writer }).then(
-    (result) => {
-      if (result.exitCode !== 0) state = 'failed';
-      clearPidFile(pidPath);
-      return result;
-    },
-  );
-  return {
+  return startAppleAppLogStream({
     backend: 'ios-simulator',
-    getState: () => state,
-    startedAt: Date.now(),
-    wait,
-    stop: async () => {
-      if (!child.killed) child.kill('SIGINT');
-      await waitForChildExit(wait);
-      if (!child.killed) child.kill('SIGKILL');
-      await waitForChildExit(wait);
-      clearPidFile(pidPath);
-    },
-  };
+    cmd: 'xcrun',
+    args: buildIosSimulatorLogStreamArgs({ deviceId, appBundleId, simulatorSetPath }),
+    stream,
+    redactionPatterns,
+    pidPath,
+  });
 }
 
 export async function startMacOsAppLog(
@@ -136,38 +111,14 @@ export async function startMacOsAppLog(
   redactionPatterns: RegExp[],
   pidPath?: string,
 ): Promise<AppLogResult> {
-  let state: 'active' | 'failed' = 'active';
-  const child = spawn(
-    'log',
-    ['stream', '--style', 'compact', '--predicate', buildAppleLogPredicate(appBundleId)],
-    {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    },
-  );
-  const writer = createLineWriter(stream, { redactionPatterns });
-  if (typeof child.pid === 'number') {
-    writePidFile(pidPath, child.pid);
-  }
-  const wait = attachChildToStream(child, stream, { endStreamOnClose: true, writer }).then(
-    (result) => {
-      if (result.exitCode !== 0) state = 'failed';
-      clearPidFile(pidPath);
-      return result;
-    },
-  );
-  return {
+  return startAppleAppLogStream({
     backend: 'macos',
-    getState: () => state,
-    startedAt: Date.now(),
-    wait,
-    stop: async () => {
-      if (!child.killed) child.kill('SIGINT');
-      await waitForChildExit(wait);
-      if (!child.killed) child.kill('SIGKILL');
-      await waitForChildExit(wait);
-      clearPidFile(pidPath);
-    },
-  };
+    cmd: 'log',
+    args: ['stream', '--style', 'compact', '--predicate', buildAppleLogPredicate(appBundleId)],
+    stream,
+    redactionPatterns,
+    pidPath,
+  });
 }
 
 export async function startIosDeviceAppLog(
@@ -176,23 +127,52 @@ export async function startIosDeviceAppLog(
   redactionPatterns: RegExp[],
   pidPath?: string,
 ): Promise<AppLogResult> {
-  let state: 'active' | 'failed' = 'active';
-  const child = spawn('xcrun', buildIosDeviceLogStreamArgs(deviceId), {
-    stdio: ['ignore', 'pipe', 'pipe'],
+  return startAppleAppLogStream({
+    backend: 'ios-device',
+    cmd: 'xcrun',
+    args: buildIosDeviceLogStreamArgs(deviceId),
+    stream,
+    redactionPatterns,
+    pidPath,
   });
-  const writer = createLineWriter(stream, { redactionPatterns });
+}
+
+function startAppleAppLogStream(params: {
+  backend: AppLogResult['backend'];
+  cmd: string;
+  args: string[];
+  stream: fs.WriteStream;
+  redactionPatterns: RegExp[];
+  pidPath?: string;
+}): AppLogResult {
+  let state: 'active' | 'failed' = 'active';
+  const background = runCmdBackground(params.cmd, params.args, {
+    allowFailure: true,
+    captureOutput: false,
+  });
+  void background.wait.catch(() => {});
+  const child = background.child;
+  const writer = createLineWriter(params.stream, { redactionPatterns: params.redactionPatterns });
   if (typeof child.pid === 'number') {
-    writePidFile(pidPath, child.pid);
+    writePidFile(params.pidPath, child.pid);
   }
-  const wait = attachChildToStream(child, stream, { endStreamOnClose: true, writer }).then(
+  const wait = attachChildToStream(child, params.stream, {
+    endStreamOnClose: true,
+    writer,
+  }).then(
     (result) => {
       if (result.exitCode !== 0) state = 'failed';
-      clearPidFile(pidPath);
+      clearPidFile(params.pidPath);
       return result;
+    },
+    (error: unknown) => {
+      state = 'failed';
+      clearPidFile(params.pidPath);
+      throw error;
     },
   );
   return {
-    backend: 'ios-device',
+    backend: params.backend,
     getState: () => state,
     startedAt: Date.now(),
     wait,
@@ -201,7 +181,7 @@ export async function startIosDeviceAppLog(
       await waitForChildExit(wait);
       if (!child.killed) child.kill('SIGKILL');
       await waitForChildExit(wait);
-      clearPidFile(pidPath);
+      clearPidFile(params.pidPath);
     },
   };
 }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -12,7 +12,7 @@ export type { DaemonLockPolicy } from '../contracts.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
 import type { SessionSurface } from '../core/session-surface.ts';
 import type { DeviceInfo, Platform, PlatformSelector } from '../utils/device.ts';
-import type { ExecResult } from '../utils/exec.ts';
+import type { ExecBackgroundResult, ExecResult } from '../utils/exec.ts';
 import type { SnapshotState } from '../utils/snapshot.ts';
 import type { AppLogState } from './app-log-process.ts';
 
@@ -177,7 +177,7 @@ export type SessionState = {
   recording?:
     | (SessionRecordingBase & {
         platform: 'ios';
-        child: ReturnType<typeof import('node:child_process').spawn>;
+        child: ExecBackgroundResult['child'];
         wait: Promise<ExecResult>;
         remotePath?: string;
       })

--- a/src/platforms/android/__tests__/adb-executor.test.ts
+++ b/src/platforms/android/__tests__/adb-executor.test.ts
@@ -1,23 +1,19 @@
 import assert from 'node:assert/strict';
 import { test, vi } from 'vitest';
 
-const { spawnMock } = vi.hoisted(() => ({
-  spawnMock: vi.fn(() => ({})),
+const { runCmdBackgroundMock } = vi.hoisted(() => ({
+  runCmdBackgroundMock: vi.fn(() => ({
+    child: {},
+    wait: Promise.resolve({ stdout: '', stderr: '', exitCode: 0 }),
+  })),
 }));
-
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:child_process')>();
-  return {
-    ...actual,
-    spawn: spawnMock,
-  };
-});
 
 vi.mock('../../../utils/exec.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../utils/exec.ts')>();
   return {
     ...actual,
     runCmd: vi.fn(async () => ({ stdout: 'ok', stderr: '', exitCode: 0 })),
+    runCmdBackground: runCmdBackgroundMock,
   };
 });
 
@@ -31,9 +27,10 @@ import {
   resolveAndroidAdbProvider,
   withAndroidAdbProvider,
 } from '../adb-executor.ts';
-import { runCmd } from '../../../utils/exec.ts';
+import { runCmd, runCmdBackground } from '../../../utils/exec.ts';
 
 const mockRunCmd = vi.mocked(runCmd);
+const mockRunCmdBackground = vi.mocked(runCmdBackground);
 
 test('createDeviceAdbExecutor routes local commands through adb with the device serial', async () => {
   const adb = createDeviceAdbExecutor({
@@ -117,6 +114,7 @@ test('scoped provider only resolves for the matching device serial', async () =>
 
 test('createLocalAndroidAdbProvider exposes exec, spawn, and reverse over local adb', async () => {
   mockRunCmd.mockClear();
+  mockRunCmdBackground.mockClear();
   const provider = createLocalAndroidAdbProvider({
     platform: 'android',
     id: 'emulator-5554',
@@ -130,11 +128,11 @@ test('createLocalAndroidAdbProvider exposes exec, spawn, and reverse over local 
   await provider.reverse?.ensure({ local: 'tcp:8081', remote: 'tcp:8081', ownerId: 'session-a' });
   await provider.reverse?.removeAllOwned('session-a');
 
-  assert.deepEqual(spawnMock.mock.calls, [
+  assert.deepEqual(mockRunCmdBackground.mock.calls, [
     [
       'adb',
       ['-s', 'emulator-5554', 'logcat'],
-      { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true },
+      { stdio: ['ignore', 'pipe', 'pipe'], allowFailure: true, captureOutput: false },
     ],
   ]);
   assert.deepEqual(

--- a/src/platforms/android/__tests__/adb-provider-scope.test.ts
+++ b/src/platforms/android/__tests__/adb-provider-scope.test.ts
@@ -2,10 +2,13 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { ChildProcess } from 'node:child_process';
 import { test } from 'vitest';
 import { runCmd } from '../../../utils/exec.ts';
-import { resolveAndroidAdbProvider, withAndroidAdbProvider } from '../adb-executor.ts';
+import {
+  resolveAndroidAdbProvider,
+  withAndroidAdbProvider,
+  type AndroidAdbProcess,
+} from '../adb-executor.ts';
 
 const device = {
   platform: 'android',
@@ -66,7 +69,7 @@ test('withAndroidAdbProvider ignores adb commands for another serial', async () 
 });
 
 test('resolveAndroidAdbProvider uses the scoped provider spawner', async () => {
-  const child = { pid: 123 } as ChildProcess;
+  const child = { pid: 123 } as AndroidAdbProcess;
   const calls: string[][] = [];
 
   const result = await withAndroidAdbProvider(

--- a/src/platforms/android/adb-executor.ts
+++ b/src/platforms/android/adb-executor.ts
@@ -1,12 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { spawn, type SpawnOptions } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
 import type { DeviceInfo } from '../../utils/device.ts';
 import {
   runCmd,
+  runCmdBackground,
   withCommandExecutorOverride,
   withoutCommandExecutorOverride,
   type CommandExecutorOverride,
+  type ExecBackgroundOptions,
   type ExecOptions,
   type ExecResult,
 } from '../../utils/exec.ts';
@@ -49,7 +50,10 @@ export type AndroidAdbExecutor = (
   options?: AndroidAdbExecutorOptions,
 ) => Promise<AndroidAdbExecutorResult>;
 
-export type AndroidAdbSpawner = (args: string[], options?: SpawnOptions) => AndroidAdbProcess;
+export type AndroidAdbSpawner = (
+  args: string[],
+  options?: ExecBackgroundOptions,
+) => AndroidAdbProcess;
 
 export type AndroidPortReverseEndpoint = `tcp:${number}` | `localabstract:${string}`;
 
@@ -131,8 +135,15 @@ function createSerialAdbExecutor(serial: string): AndroidAdbExecutor {
 }
 
 function createSerialAdbSpawner(serial: string): AndroidAdbSpawner {
-  return (args, options) =>
-    spawn('adb', ['-s', serial, ...args], { ...options, windowsHide: true });
+  return (args, options) => {
+    const background = runCmdBackground('adb', ['-s', serial, ...args], {
+      ...options,
+      allowFailure: true,
+      captureOutput: false,
+    });
+    void background.wait.catch(() => {});
+    return background.child;
+  };
 }
 
 export function createLocalAndroidAdbProvider(device: DeviceInfo): AndroidAdbProvider {

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -2,11 +2,11 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import { EventEmitter } from 'node:events';
-import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { PassThrough, Writable } from 'node:stream';
+import { runCmdBackground } from '../exec.ts';
 import {
   computeDaemonCodeSignature,
   downloadRemoteArtifact,
@@ -1293,9 +1293,13 @@ test('stopDaemonProcessForTakeover terminates a matching daemon process', async 
   const daemonScriptPath = path.join(daemonDir, 'daemon.js');
   fs.mkdirSync(daemonDir, { recursive: true });
   fs.writeFileSync(daemonScriptPath, 'setInterval(() => {}, 1000);\n', 'utf8');
-  const child = spawn(process.execPath, [daemonScriptPath], {
+  const daemonProcess = runCmdBackground(process.execPath, [daemonScriptPath], {
     stdio: 'ignore',
+    allowFailure: true,
+    captureOutput: false,
   });
+  void daemonProcess.wait.catch(() => {});
+  const child = daemonProcess.child;
   const pid = child.pid;
   assert.ok(pid, 'spawned child should have a pid');
 
@@ -1322,9 +1326,13 @@ test('stopDaemonProcessForTakeover terminates a matching daemon process', async 
 });
 
 test('stopDaemonProcessForTakeover does not terminate non-daemon process', async () => {
-  const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+  const daemonProcess = runCmdBackground(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
     stdio: 'ignore',
+    allowFailure: true,
+    captureOutput: false,
   });
+  void daemonProcess.wait.catch(() => {});
+  const child = daemonProcess.child;
   const pid = child.pid;
   assert.ok(pid, 'spawned child should have a pid');
 

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -70,6 +70,41 @@ test('runCmd writes stdin through pipeline', async () => {
   assert.equal(result.stdout, String(stdin.length));
 });
 
+test('runCmdBackground can leave output streams to the caller', async () => {
+  const { child, wait } = runCmdBackground(
+    process.execPath,
+    ['-e', 'process.stdout.write("out"); process.stderr.write("err");'],
+    { captureOutput: false },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr?.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  const result = await wait;
+
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr, '');
+  assert.equal(stdout, 'out');
+  assert.equal(stderr, 'err');
+});
+
+test('runCmdBackground aborts with request cancellation details', async () => {
+  const controller = new AbortController();
+  const { wait } = runCmdBackground(process.execPath, ['-e', 'setTimeout(() => {}, 10_000)'], {
+    signal: controller.signal,
+  });
+  controller.abort();
+
+  await assertRejectsRequestCanceled(wait);
+});
+
 test('whichCmd resolves absolute executable paths without invoking a shell', async () => {
   assert.equal(await whichCmd(process.execPath), true);
 });

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -40,6 +40,15 @@ type ExecDetachedOptions = ExecOptions & {
   stdio?: StdioOptions;
 };
 
+export type ExecBackgroundOptions = ExecOptions & {
+  /**
+   * Capture stdout/stderr into the wait result when the child has piped stdio.
+   * Set false when the caller owns, ignores, or forwards the streams.
+   */
+  captureOutput?: boolean;
+  stdio?: StdioOptions;
+};
+
 const BARE_COMMAND_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
 const WINDOWS_PATH_EXTENSIONS = ['.com', '.exe', '.bat', '.cmd'];
 export type CommandExecutorOverride = (
@@ -104,7 +113,6 @@ function runSpawnedCommand(
     const stdoutChunks: Buffer[] | undefined = options.binaryStdout ? [] : undefined;
     let stderr = '';
     let didTimeout = false;
-    let didAbort = false;
     const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
     const timeoutHandle = timeoutMs
       ? setTimeout(() => {
@@ -112,21 +120,13 @@ function runSpawnedCommand(
           killProcessTree(child, options.detached);
         }, timeoutMs)
       : null;
-    const onAbort = () => {
-      didAbort = true;
-      killProcessTree(child, options.detached);
-    };
-    if (options.signal?.aborted) {
-      onAbort();
-    } else {
-      options.signal?.addEventListener('abort', onAbort, { once: true });
-    }
+    const abort = watchCommandAbort(child, options);
 
     if (!options.binaryStdout) child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
 
     void writeChildStdin(child, options.stdin).catch((err: unknown) => {
-      if (didAbort || didTimeout) return;
+      if (abort.didAbort || didTimeout) return;
       if (isEpipeError(err)) return;
       reject(createStdinError(executable, cmd, args, err));
       killProcessTree(child, options.detached);
@@ -150,9 +150,9 @@ function runSpawnedCommand(
 
     child.on('error', (err) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
-      options.signal?.removeEventListener('abort', onAbort);
+      abort.dispose();
       reject(
-        didAbort
+        abort.didAbort
           ? createCommandCanceledError(executable, cmd, args)
           : createSpawnError(executable, cmd, args, err),
       );
@@ -160,9 +160,9 @@ function runSpawnedCommand(
 
     child.on('close', (code) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
-      options.signal?.removeEventListener('abort', onAbort);
+      abort.dispose();
       const exitCode = code ?? 1;
-      if (didAbort) {
+      if (abort.didAbort) {
         reject(createCommandCanceledError(executable, cmd, args));
         return;
       }
@@ -315,13 +315,13 @@ export function runCmdDetached(
 export function runCmdBackground(
   cmd: string,
   args: string[],
-  options: ExecOptions = {},
+  options: ExecBackgroundOptions = {},
 ): ExecBackgroundResult {
   const executable = normalizeExecutableCommand(cmd);
   const child = spawn(executable, args, {
     cwd: options.cwd,
     env: options.env,
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
     detached: options.detached,
     windowsHide: true,
     shell: false,
@@ -329,23 +329,37 @@ export function runCmdBackground(
 
   let stdout = '';
   let stderr = '';
+  const captureOutput = options.captureOutput ?? true;
+  const abort = watchCommandAbort(child, options);
 
-  child.stdout.setEncoding('utf8');
-  child.stderr.setEncoding('utf8');
+  if (captureOutput) {
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
 
-  child.stdout.on('data', (chunk) => {
-    stdout += chunk;
-  });
-  child.stderr.on('data', (chunk) => {
-    stderr += chunk;
-  });
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk;
+    });
+  }
 
   const wait = new Promise<ExecResult>((resolve, reject) => {
     child.on('error', (err) => {
-      reject(createSpawnError(executable, cmd, args, err));
+      abort.dispose();
+      reject(
+        abort.didAbort
+          ? createCommandCanceledError(executable, cmd, args)
+          : createSpawnError(executable, cmd, args, err),
+      );
     });
     child.on('close', (code) => {
+      abort.dispose();
       const exitCode = code ?? 1;
+      if (abort.didAbort) {
+        reject(createCommandCanceledError(executable, cmd, args));
+        return;
+      }
       if (exitCode !== 0 && !options.allowFailure) {
         reject(createExitError(executable, cmd, args, exitCode, stdout, stderr));
         return;
@@ -520,6 +534,30 @@ function normalizeTimeoutMs(value: number | undefined): number | undefined {
   const timeout = Math.floor(value as number);
   if (timeout <= 0) return undefined;
   return timeout;
+}
+
+function watchCommandAbort(
+  child: ChildProcess,
+  options: Pick<ExecOptions, 'detached' | 'signal'>,
+): { readonly didAbort: boolean; dispose: () => void } {
+  let didAbort = false;
+  const onAbort = () => {
+    didAbort = true;
+    killProcessTree(child, options.detached);
+  };
+  if (options.signal?.aborted) {
+    onAbort();
+  } else {
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+  }
+  return {
+    get didAbort() {
+      return didAbort;
+    },
+    dispose: () => {
+      options.signal?.removeEventListener('abort', onAbort);
+    },
+  };
 }
 
 function killProcessTree(child: ChildProcess, detached: boolean | undefined): void {


### PR DESCRIPTION
## Summary

Route production Android ADB and Apple app-log process spawning through `src/utils/exec.ts`.
Add `runCmdBackground` no-capture mode for stream-owned stdout/stderr so long-running logs do not leak memory by buffering indefinitely.
Consolidate Apple app-log stream startup and mark stream setup/stream failures as failed while clearing the pid file from the shared path.
Update focused tests and `AGENTS.md` process-execution guidance.

Touched files: 10. Scope is limited to the production spawn sites, focused exec/provider tests, and agent guidance so fallow does not pull unrelated historical test duplication into this PR.

## Validation

`pnpm format`
`pnpm exec vitest run src/utils/__tests__/exec.test.ts src/platforms/android/__tests__/adb-executor.test.ts src/daemon/__tests__/app-log-android.test.ts src/daemon/__tests__/app-log.test.ts src/utils/__tests__/daemon-client.test.ts`
`pnpm check:quick`
`pnpm check:fallow`
`pnpm check:unit`