### PR TITLE
fix: preserve iOS tab button tap centers

### DIFF
--- a/src/__tests__/runtime-interactions.test.ts
+++ b/src/__tests__/runtime-interactions.test.ts
@@ -67,6 +67,61 @@ test('runtime press resolves selector targets to the actionable node center', as
   assert.deepEqual(result.backendResult, { ok: true });
 });
 
+test('runtime click keeps distinct tab button centers when iOS reports the tab bar as hittable', async () => {
+  const calls: Point[] = [];
+  const device = createInteractionDevice(iosTabBarSnapshot(), {
+    tap: async (_context, point) => {
+      calls.push(point);
+    },
+  });
+
+  const refResult = await device.interactions.click(ref('@e4'), {
+    session: 'default',
+  });
+  const selectorResult = await device.interactions.click(selector('label=Settings'), {
+    session: 'default',
+  });
+
+  assert.deepEqual(calls, [
+    { x: 166, y: 822 },
+    { x: 257, y: 822 },
+  ]);
+  assert.equal(refResult.kind, 'ref');
+  assert.equal(refResult.node?.label, 'Library');
+  assert.equal(selectorResult.kind, 'selector');
+  assert.equal(selectorResult.node?.label, 'Settings');
+});
+
+test('runtime click keeps non-button semantic targets at their own center', async () => {
+  const calls: Point[] = [];
+  const device = createInteractionDevice(nonHittableCellSnapshot(), {
+    tap: async (_context, point) => {
+      calls.push(point);
+    },
+  });
+
+  const result = await clickRefE2(device);
+
+  assert.deepEqual(calls, [{ x: 70, y: 30 }]);
+  assert.equal(result.kind, 'ref');
+  assert.equal(result.node?.label, 'Account');
+});
+
+test('runtime click still promotes non-touchable nodes to hittable ancestors', async () => {
+  const calls: Point[] = [];
+  const device = createInteractionDevice(nonTouchableGroupSnapshot(), {
+    tap: async (_context, point) => {
+      calls.push(point);
+    },
+  });
+
+  const result = await clickRefE2(device);
+
+  assert.deepEqual(calls, [{ x: 160, y: 60 }]);
+  assert.equal(result.kind, 'ref');
+  assert.equal(result.node?.label, 'Clickable group');
+});
+
 test('runtime fill resolves refs and forwards text to the backend primitive', async () => {
   const calls: Array<{ point: Point; text: string; delayMs?: number }> = [];
   const device = createInteractionDevice(fillableSnapshot(), {
@@ -422,6 +477,107 @@ function fillableSnapshot(): SnapshotState {
   ]);
 }
 
+function iosTabBarSnapshot(): SnapshotState {
+  return makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeApplication',
+      label: 'TabRepro',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+      hittable: false,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeTabBar',
+      rect: { x: 0, y: 791, width: 402, height: 83 },
+      hittable: true,
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'XCUIElementTypeButton',
+      label: 'Home',
+      rect: { x: 30, y: 800, width: 91, height: 44 },
+      hittable: false,
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'XCUIElementTypeButton',
+      label: 'Library',
+      rect: { x: 120, y: 800, width: 92, height: 44 },
+      hittable: false,
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 1,
+      type: 'XCUIElementTypeButton',
+      label: 'Settings',
+      rect: { x: 211, y: 800, width: 91, height: 44 },
+      hittable: false,
+    },
+    {
+      index: 5,
+      depth: 2,
+      parentIndex: 1,
+      type: 'XCUIElementTypeButton',
+      label: 'Search',
+      rect: { x: 304, y: 800, width: 92, height: 44 },
+      hittable: false,
+    },
+  ]);
+}
+
+function nonHittableCellSnapshot(): SnapshotState {
+  return makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeOther',
+      label: 'Settings list',
+      rect: { x: 10, y: 20, width: 300, height: 80 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeCell',
+      label: 'Account',
+      rect: { x: 20, y: 10, width: 100, height: 40 },
+      hittable: false,
+    },
+  ]);
+}
+
+function nonTouchableGroupSnapshot(): SnapshotState {
+  return makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeOther',
+      label: 'Clickable group',
+      rect: { x: 10, y: 20, width: 300, height: 80 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeOther',
+      label: 'Decorative group',
+      rect: { x: 30, y: 40, width: 60, height: 20 },
+      hittable: false,
+    },
+  ]);
+}
+
 function snapshotWithOffscreenContent(): SnapshotState {
   return makeSnapshotState([
     {
@@ -493,5 +649,11 @@ function createInteractionDevice(
       { name: 'default', snapshot, metadata: overrides.sessionMetadata },
     ]),
     policy: localCommandPolicy(),
+  });
+}
+
+async function clickRefE2(device: ReturnType<typeof createInteractionDevice>) {
+  return await device.interactions.click(ref('@e2'), {
+    session: 'default',
   });
 }

--- a/src/commands/interaction-targeting.ts
+++ b/src/commands/interaction-targeting.ts
@@ -1,8 +1,22 @@
 import type { Rect, SnapshotNode } from '../utils/snapshot.ts';
 import { centerOfRect } from '../utils/snapshot.ts';
 import { containsPoint, pickLargestRect } from '../utils/rect-visibility.ts';
-import { findNearestHittableAncestor } from '../utils/snapshot-processing.ts';
+import { findNearestHittableAncestor, normalizeType } from '../utils/snapshot-processing.ts';
 import { normalizeRect, resolveRectCenter } from '../utils/rect-center.ts';
+
+const SEMANTIC_TOUCH_ROLE_FRAGMENTS = [
+  'button',
+  'link',
+  'menuitem',
+  'tabitem',
+  'textfield',
+  'searchfield',
+  'securetextfield',
+  'checkbox',
+  'radio',
+  'switch',
+  'cell',
+];
 
 export function resolveActionableTouchNode(
   nodes: SnapshotNode[],
@@ -11,6 +25,9 @@ export function resolveActionableTouchNode(
   const descendant = findPreferredActionableDescendant(nodes, node);
   if (descendant?.rect && resolveRectCenter(descendant.rect)) {
     return descendant;
+  }
+  if (isSemanticallyTouchableNode(node) && node.rect && resolveRectCenter(node.rect)) {
+    return node;
   }
   const ancestor = findNearestHittableAncestor(nodes, node);
   if (ancestor?.rect && resolveRectCenter(ancestor.rect)) {
@@ -47,6 +64,18 @@ function findPreferredActionableDescendant(
   }
 
   return current === node ? null : current;
+}
+
+function isSemanticallyTouchableNode(node: SnapshotNode): boolean {
+  const roles = [node.type, node.role, node.subrole].map((value) => normalizeType(value ?? ''));
+  return roles.some(isSemanticTouchRole);
+}
+
+function isSemanticTouchRole(role: string): boolean {
+  // Match Tab exactly so broad roles like Table/TabBar do not become touch targets.
+  return (
+    role === 'tab' || SEMANTIC_TOUCH_ROLE_FRAGMENTS.some((fragment) => role.includes(fragment))
+  );
 }
 
 function areRectsApproximatelyEqual(left: Rect, right: Rect): boolean {


### PR DESCRIPTION
## Summary

Fixes #507 by keeping the resolved node center for non-hittable snapshot nodes that are already semantically touchable, such as iOS 26 SwiftUI `TabView` buttons. This prevents `click @ref` from promoting those tab buttons to the wider hittable tab bar container.

This is intentionally a shared resolver behavior change: non-hittable semantic controls with valid bounds can now keep their own touch center across platforms, while plain grouping nodes still promote to hittable ancestors.

Adds focused runtime regressions covering:

- iOS tab buttons with distinct frames and `hittable:false`
- a non-button semantic target (`Cell`) keeping its own center
- a non-touchable grouping node still promoting to its hittable ancestor

Touched files: 2. Scope stayed within the interaction target resolver and its runtime test.

## Before / After

Linked repro snapshot on iOS 26 exposes distinct tab button rects, all reported as `hittable:false`:

```text
@e12 [button] "Home"     rect=(25,795,100.7,54)    center=(75,822)
@e14 [button] "Library"  rect=(115.7,795,100.7,54) center=(166,822)
@e16 [button] "Settings" rect=(206.3,795,100.7,54) center=(257,822)
@e19 [button] "Search"   rect=(319,791,62,62)      center=(350,822)
```

Before this fix, each `click @ref` promoted to the hittable tab bar ancestor and collapsed to the bar center:

```text
Home     -> Tapped (201, 833)
Library  -> Tapped (201, 833)
Settings -> Tapped (201, 833)
Search   -> Tapped (201, 833)
```

After this fix, each semantic button keeps its own snapshot center:

```text
click @e12 -> Tapped @e12 (75, 822)
click @e14 -> Tapped @e14 (166, 822)
click @e16 -> Tapped @e16 (257, 822)
click @e19 -> Tapped @e19 (350, 822)
```

## Validation

- `pnpm format`
- `pnpm exec vitest run src/__tests__/runtime-interactions.test.ts`
- `pnpm check:quick`
- `pnpm test:smoke`
- `pnpm build`
- Manual linked repro on iOS 26 simulator (`iPhone 17 Pro`, UDID `C25DBB5B-9254-4293-A8D5-2785C78DE03A`): built `https://github.com/lechuckcaptain/agent-device-ios26-tabview-repro`, installed `dev.example.tabview-repro`, verified `click @e12/@e14/@e16/@e19 --json` resolves to `(75,822)`, `(166,822)`, `(257,822)`, `(350,822)`, and `click 'role=button label=<tab>' --json` resolves to the same distinct centers.

Known gaps:

- Real-device validation was blocked: the paired iPhone is visible to CoreDevice, but `agent-device apps --platform ios --device thymikee-iphone` fails mounting the developer disk image (`CoreDeviceError 12040`).
- `pnpm check:unit` did not complete because `src/__tests__/client-metro-packaged.test.ts` times out in this environment after a successful build (`result.status === null`). Rerunning the iOS archive-install failure individually passed.