### PR TITLE
refactor: make touch target resolution policy explicit

### DIFF
--- a/src/__tests__/runtime-interactions.test.ts
+++ b/src/__tests__/runtime-interactions.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import type { AgentDeviceBackend } from '../backend.ts';
 import { commands, ref, selector } from '../commands/index.ts';
+import { resolveActionableTouchResolution } from '../commands/interaction-targeting.ts';
 import { createLocalArtifactAdapter } from '../io.ts';
 import { createAgentDevice, createMemorySessionStore, localCommandPolicy } from '../runtime.ts';
 import type { Point, SnapshotState } from '../utils/snapshot.ts';
@@ -120,6 +121,138 @@ test('runtime click still promotes non-touchable nodes to hittable ancestors', a
   assert.deepEqual(calls, [{ x: 160, y: 60 }]);
   assert.equal(result.kind, 'ref');
   assert.equal(result.node?.label, 'Clickable group');
+});
+
+test('touch resolution keeps non-hittable semantic iOS tab buttons at their own center', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeApplication',
+      label: 'TabRepro',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeTabBar',
+      rect: { x: 0, y: 791, width: 402, height: 83 },
+      hittable: true,
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'XCUIElementTypeButton',
+      label: 'Library',
+      rect: { x: 120, y: 800, width: 92, height: 44 },
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[2]!);
+
+  assert.equal(resolution.reason, 'semantic-target');
+  assert.equal(resolution.node.label, 'Library');
+});
+
+test('touch resolution promotes static text inside a hittable row to the row', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeCell',
+      label: 'Account row',
+      rect: { x: 10, y: 20, width: 300, height: 60 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeStaticText',
+      label: 'Account',
+      rect: { x: 24, y: 32, width: 80, height: 20 },
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[1]!);
+
+  assert.equal(resolution.reason, 'hittable-ancestor');
+  assert.equal(resolution.node.label, 'Account row');
+});
+
+test('touch resolution prefers same-rect hittable descendants over semantic targets', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeButton',
+      label: 'Profile',
+      rect: { x: 30, y: 40, width: 120, height: 50 },
+      hittable: false,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeImage',
+      identifier: 'profile-hit-area',
+      rect: { x: 30, y: 40, width: 120, height: 50 },
+      hittable: true,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[0]!);
+
+  assert.equal(resolution.reason, 'same-rect-descendant');
+  assert.equal(resolution.node.identifier, 'profile-hit-area');
+});
+
+test('touch resolution prevents full-screen window-like ancestors from stealing taps', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeApplication',
+      label: 'Example',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeStaticText',
+      label: 'Status',
+      rect: { x: 24, y: 72, width: 80, height: 24 },
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[1]!);
+
+  assert.equal(resolution.reason, 'overly-broad-ancestor');
+  assert.equal(resolution.node.label, 'Status');
+});
+
+test('touch resolution falls back to the original node when no usable touch target exists', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'XCUIElementTypeOther',
+      label: 'Virtual item',
+      hittable: false,
+    },
+  ]);
+
+  const resolution = resolveActionableTouchResolution(snapshot.nodes, snapshot.nodes[0]!);
+
+  assert.equal(resolution.reason, 'original');
+  assert.equal(resolution.node.label, 'Virtual item');
 });
 
 test('runtime fill resolves refs and forwards text to the backend primitive', async () => {

--- a/src/commands/interaction-targeting.ts
+++ b/src/commands/interaction-targeting.ts
@@ -18,25 +18,45 @@ const SEMANTIC_TOUCH_ROLE_FRAGMENTS = [
   'cell',
 ];
 
+type ActionableTouchResolutionReason =
+  | 'same-rect-descendant'
+  | 'semantic-target'
+  | 'hittable-ancestor'
+  | 'overly-broad-ancestor'
+  | 'original';
+
+type ActionableTouchResolution = {
+  node: SnapshotNode;
+  reason: ActionableTouchResolutionReason;
+};
+
 export function resolveActionableTouchNode(
   nodes: SnapshotNode[],
   node: SnapshotNode,
 ): SnapshotNode {
+  return resolveActionableTouchResolution(nodes, node).node;
+}
+
+/** @internal Exposed for focused policy tests; runtime callers should use resolveActionableTouchNode. */
+export function resolveActionableTouchResolution(
+  nodes: SnapshotNode[],
+  node: SnapshotNode,
+): ActionableTouchResolution {
   const descendant = findPreferredActionableDescendant(nodes, node);
   if (descendant?.rect && resolveRectCenter(descendant.rect)) {
-    return descendant;
+    return { node: descendant, reason: 'same-rect-descendant' };
   }
-  if (isSemanticallyTouchableNode(node) && node.rect && resolveRectCenter(node.rect)) {
-    return node;
+  if (isSemanticTouchTarget(node) && node.rect && resolveRectCenter(node.rect)) {
+    return { node, reason: 'semantic-target' };
   }
   const ancestor = findNearestHittableAncestor(nodes, node);
   if (ancestor?.rect && resolveRectCenter(ancestor.rect)) {
     if (isOverlyBroadAncestor(node, ancestor, nodes)) {
-      return node;
+      return { node, reason: 'overly-broad-ancestor' };
     }
-    return ancestor;
+    return { node: ancestor, reason: 'hittable-ancestor' };
   }
-  return node;
+  return { node, reason: 'original' };
 }
 
 function findPreferredActionableDescendant(
@@ -66,7 +86,7 @@ function findPreferredActionableDescendant(
   return current === node ? null : current;
 }
 
-function isSemanticallyTouchableNode(node: SnapshotNode): boolean {
+function isSemanticTouchTarget(node: SnapshotNode): boolean {
   const roles = [node.type, node.role, node.subrole].map((value) => normalizeType(value ?? ''));
   return roles.some(isSemanticTouchRole);
 }


### PR DESCRIPTION
## Summary

Make touch coordinate resolution return explicit policy reasons while preserving the existing node-returning API.

Add focused tests for semantic tab buttons, hittable row promotion, same-rect descendant promotion, and broad ancestor avoidance.

Closes #509.

Touched files: 2. Scope stayed within the interaction resolver/tests.

## Validation

- `pnpm format`
- `pnpm exec vitest run src/__tests__/runtime-interactions.test.ts`
- `pnpm check:quick`