### PR TITLE
refactor: add command definition foundation

### DIFF
--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -2,6 +2,8 @@ import type { AgentDeviceClient, CommandRequestResult } from '../../client.ts';
 import { CLIENT_COMMANDS } from '../../client-command-registry.ts';
 import type { RecordOptions } from '../../client-types.ts';
 import { announceReplayTestRun } from '../../cli-test.ts';
+import { runTypeCliCommand } from '../../commands/interactions/cli.ts';
+import { typeCommandDefinition } from '../../commands/interactions/definition.ts';
 import { AppError } from '../../utils/errors.ts';
 import type { CliFlags } from '../../utils/command-schema.ts';
 import {
@@ -151,14 +153,9 @@ export const genericClientCommandHandlers = {
         y: Number(positionals[1]),
       }),
   ),
-  [CLIENT_COMMANDS.type]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.type,
-    ({ client, positionals, flags }) =>
-      client.interactions.type({
-        ...buildSelectionOptions(flags),
-        text: positionals.join(' '),
-        delayMs: flags.delayMs,
-      }),
+  [typeCommandDefinition.name]: createGenericClientCommandHandler(
+    typeCommandDefinition.name,
+    runTypeCliCommand,
   ),
   [CLIENT_COMMANDS.fill]: createGenericClientCommandHandler(
     CLIENT_COMMANDS.fill,

--- a/src/commands/command-definition.ts
+++ b/src/commands/command-definition.ts
@@ -31,9 +31,3 @@ export function commandCapabilityMap<TName extends string, TCapability>(
     definitions.map((definition) => [definition.name, definition.capability]),
   ) as Record<TName, TCapability>;
 }
-
-export function commandNames<
-  const TDefinitions extends readonly CommandDefinition<string, string, unknown, unknown>[],
->(definitions: TDefinitions): Array<TDefinitions[number]['name']> {
-  return definitions.map((definition) => definition.name) as Array<TDefinitions[number]['name']>;
-}

--- a/src/commands/command-definition.ts
+++ b/src/commands/command-definition.ts
@@ -1,0 +1,39 @@
+export type CommandDefinition<
+  TName extends string,
+  TFamily extends string,
+  TSchema,
+  TCapability,
+> = {
+  name: TName;
+  family: TFamily;
+  schema: TSchema;
+  capability: TCapability;
+};
+
+export function defineCommand<TName extends string, TFamily extends string, TSchema, TCapability>(
+  definition: CommandDefinition<TName, TFamily, TSchema, TCapability>,
+): CommandDefinition<TName, TFamily, TSchema, TCapability> {
+  return definition;
+}
+
+export function commandSchemaMap<TName extends string, TSchema>(
+  definitions: readonly CommandDefinition<TName, string, TSchema, unknown>[],
+): Record<TName, TSchema> {
+  return Object.fromEntries(
+    definitions.map((definition) => [definition.name, definition.schema]),
+  ) as Record<TName, TSchema>;
+}
+
+export function commandCapabilityMap<TName extends string, TCapability>(
+  definitions: readonly CommandDefinition<TName, string, unknown, TCapability>[],
+): Record<TName, TCapability> {
+  return Object.fromEntries(
+    definitions.map((definition) => [definition.name, definition.capability]),
+  ) as Record<TName, TCapability>;
+}
+
+export function commandNames<
+  const TDefinitions extends readonly CommandDefinition<string, string, unknown, unknown>[],
+>(definitions: TDefinitions): Array<TDefinitions[number]['name']> {
+  return definitions.map((definition) => definition.name) as Array<TDefinitions[number]['name']>;
+}

--- a/src/commands/command-definition.ts
+++ b/src/commands/command-definition.ts
@@ -1,33 +1,30 @@
-export type CommandDefinition<
-  TName extends string,
-  TFamily extends string,
-  TSchema,
-  TCapability,
-> = {
+import type { CommandCapability } from '../core/capabilities.ts';
+import type { CommandSchema } from '../utils/command-schema.ts';
+
+export type CommandDefinition<TName extends string = string> = {
   name: TName;
-  family: TFamily;
-  schema: TSchema;
-  capability: TCapability;
+  schema: CommandSchema;
+  capability: CommandCapability;
 };
 
-export function defineCommand<TName extends string, TFamily extends string, TSchema, TCapability>(
-  definition: CommandDefinition<TName, TFamily, TSchema, TCapability>,
-): CommandDefinition<TName, TFamily, TSchema, TCapability> {
+export function defineCommand<const TDefinition extends CommandDefinition>(
+  definition: TDefinition,
+): TDefinition {
   return definition;
 }
 
-export function commandSchemaMap<TName extends string, TSchema>(
-  definitions: readonly CommandDefinition<TName, string, TSchema, unknown>[],
-): Record<TName, TSchema> {
+export function commandSchemaMap<TName extends string>(
+  definitions: readonly CommandDefinition<TName>[],
+): Record<TName, CommandSchema> {
   return Object.fromEntries(
     definitions.map((definition) => [definition.name, definition.schema]),
-  ) as Record<TName, TSchema>;
+  ) as Record<TName, CommandSchema>;
 }
 
-export function commandCapabilityMap<TName extends string, TCapability>(
-  definitions: readonly CommandDefinition<TName, string, unknown, TCapability>[],
-): Record<TName, TCapability> {
+export function commandCapabilityMap<TName extends string>(
+  definitions: readonly CommandDefinition<TName>[],
+): Record<TName, CommandCapability> {
   return Object.fromEntries(
     definitions.map((definition) => [definition.name, definition.capability]),
-  ) as Record<TName, TCapability>;
+  ) as Record<TName, CommandCapability>;
 }

--- a/src/commands/interactions/__tests__/definition.test.ts
+++ b/src/commands/interactions/__tests__/definition.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { getCommandCapability } from '../../../core/capabilities.ts';
+import { getCommandSchema } from '../../../utils/command-schema.ts';
+import { INTERACTION_COMMAND_DEFINITIONS } from '../definition.ts';
+
+test('interaction command definitions feed schema and capability registries', () => {
+  for (const definition of INTERACTION_COMMAND_DEFINITIONS) {
+    assert.deepEqual(getCommandSchema(definition.name), definition.schema);
+    assert.deepEqual(getCommandCapability(definition.name), definition.capability);
+  }
+});

--- a/src/commands/interactions/cli.ts
+++ b/src/commands/interactions/cli.ts
@@ -1,0 +1,21 @@
+import type { AgentDeviceClient, CommandRequestResult } from '../../client.ts';
+import type { CliFlags } from '../../utils/command-schema.ts';
+import { buildSelectionOptions } from '../../cli/commands/shared.ts';
+
+export type InteractionCliCommandParams = {
+  client: AgentDeviceClient;
+  positionals: string[];
+  flags: CliFlags;
+};
+
+export async function runTypeCliCommand({
+  client,
+  positionals,
+  flags,
+}: InteractionCliCommandParams): Promise<CommandRequestResult> {
+  return await client.interactions.type({
+    ...buildSelectionOptions(flags),
+    text: positionals.join(' '),
+    delayMs: flags.delayMs,
+  });
+}

--- a/src/commands/interactions/definition.ts
+++ b/src/commands/interactions/definition.ts
@@ -1,13 +1,8 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
-import type { CommandCapability } from '../../core/capabilities.ts';
-import type { CommandSchema } from '../../utils/command-schema.ts';
 import { commandCapabilityMap, commandSchemaMap, defineCommand } from '../command-definition.ts';
-
-const INTERACTION_COMMAND_FAMILY = 'interactions';
 
 export const typeCommandDefinition = defineCommand({
   name: PUBLIC_COMMANDS.type,
-  family: INTERACTION_COMMAND_FAMILY,
   schema: {
     helpDescription: 'Type text in focused field',
     positionalArgs: ['text'],
@@ -19,11 +14,6 @@ export const typeCommandDefinition = defineCommand({
     android: { emulator: true, device: true, unknown: true },
     linux: { device: true },
   },
-} satisfies {
-  name: typeof PUBLIC_COMMANDS.type;
-  family: typeof INTERACTION_COMMAND_FAMILY;
-  schema: CommandSchema;
-  capability: CommandCapability;
 });
 
 export const INTERACTION_COMMAND_DEFINITIONS = [typeCommandDefinition] as const;

--- a/src/commands/interactions/definition.ts
+++ b/src/commands/interactions/definition.ts
@@ -1,14 +1,9 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { CommandCapability } from '../../core/capabilities.ts';
 import type { CommandSchema } from '../../utils/command-schema.ts';
-import {
-  commandCapabilityMap,
-  commandNames,
-  commandSchemaMap,
-  defineCommand,
-} from '../command-definition.ts';
+import { commandCapabilityMap, commandSchemaMap, defineCommand } from '../command-definition.ts';
 
-export const INTERACTION_COMMAND_FAMILY = 'interactions';
+const INTERACTION_COMMAND_FAMILY = 'interactions';
 
 export const typeCommandDefinition = defineCommand({
   name: PUBLIC_COMMANDS.type,
@@ -37,4 +32,3 @@ export const INTERACTION_COMMAND_SCHEMAS = commandSchemaMap(INTERACTION_COMMAND_
 export const INTERACTION_COMMAND_CAPABILITIES = commandCapabilityMap(
   INTERACTION_COMMAND_DEFINITIONS,
 );
-export const INTERACTION_COMMAND_NAMES = commandNames(INTERACTION_COMMAND_DEFINITIONS);

--- a/src/commands/interactions/definition.ts
+++ b/src/commands/interactions/definition.ts
@@ -1,0 +1,40 @@
+import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
+import type { CommandCapability } from '../../core/capabilities.ts';
+import type { CommandSchema } from '../../utils/command-schema.ts';
+import {
+  commandCapabilityMap,
+  commandNames,
+  commandSchemaMap,
+  defineCommand,
+} from '../command-definition.ts';
+
+export const INTERACTION_COMMAND_FAMILY = 'interactions';
+
+export const typeCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.type,
+  family: INTERACTION_COMMAND_FAMILY,
+  schema: {
+    helpDescription: 'Type text in focused field',
+    positionalArgs: ['text'],
+    allowsExtraPositionals: true,
+    allowedFlags: ['delayMs'],
+  },
+  capability: {
+    apple: { simulator: true, device: true },
+    android: { emulator: true, device: true, unknown: true },
+    linux: { device: true },
+  },
+} satisfies {
+  name: typeof PUBLIC_COMMANDS.type;
+  family: typeof INTERACTION_COMMAND_FAMILY;
+  schema: CommandSchema;
+  capability: CommandCapability;
+});
+
+export const INTERACTION_COMMAND_DEFINITIONS = [typeCommandDefinition] as const;
+
+export const INTERACTION_COMMAND_SCHEMAS = commandSchemaMap(INTERACTION_COMMAND_DEFINITIONS);
+export const INTERACTION_COMMAND_CAPABILITIES = commandCapabilityMap(
+  INTERACTION_COMMAND_DEFINITIONS,
+);
+export const INTERACTION_COMMAND_NAMES = commandNames(INTERACTION_COMMAND_DEFINITIONS);

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -1,4 +1,5 @@
 import { isApplePlatform, type DeviceInfo } from '../utils/device.ts';
+import { INTERACTION_COMMAND_CAPABILITIES } from '../commands/interactions/definition.ts';
 
 type KindMatrix = {
   simulator?: boolean;
@@ -7,7 +8,7 @@ type KindMatrix = {
   unknown?: boolean;
 };
 
-type CommandCapability = {
+export type CommandCapability = {
   apple?: KindMatrix;
   android?: KindMatrix;
   linux?: KindMatrix;
@@ -227,11 +228,7 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
   },
-  type: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
+  ...INTERACTION_COMMAND_CAPABILITIES,
   wait: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
@@ -251,6 +248,10 @@ export function isCommandSupportedOnDevice(command: string, device: DeviceInfo):
   if (capability.supports && !capability.supports(device)) return false;
   const kind = (device.kind ?? 'unknown') as keyof KindMatrix;
   return byPlatform[kind] === true;
+}
+
+export function getCommandCapability(command: string): CommandCapability | undefined {
+  return COMMAND_CAPABILITY_MATRIX[command];
 }
 
 export function listCapabilityCommands(): string[] {

--- a/src/daemon/handlers/interaction.ts
+++ b/src/daemon/handlers/interaction.ts
@@ -8,6 +8,7 @@ import { createInteractionRuntime } from './interaction-runtime.ts';
 import { finalizeTouchInteraction } from './interaction-common.ts';
 import { errorResponse } from './response.ts';
 import { isCommandSupportedOnDevice } from '../../core/capabilities.ts';
+import { typeCommandDefinition } from '../../commands/interactions/definition.ts';
 import { normalizeError } from '../../utils/errors.ts';
 import { successText } from '../../utils/success-text.ts';
 import { recoverAndroidBlockingSystemDialog } from '../android-system-dialog.ts';
@@ -27,7 +28,7 @@ export async function handleInteractionCommands(
   }
 
   switch (params.req.command) {
-    case 'type':
+    case typeCommandDefinition.name:
       return await dispatchTypeViaRuntime({
         ...params,
         captureSnapshotForSession,
@@ -49,7 +50,7 @@ async function dispatchTypeViaRuntime(
   const { req, sessionName, sessionStore } = params;
   const session = sessionStore.get(sessionName);
   if (!session) return errorResponse('SESSION_NOT_FOUND', 'No active session. Run open first.');
-  if (!isCommandSupportedOnDevice('type', session.device)) {
+  if (!isCommandSupportedOnDevice(typeCommandDefinition.name, session.device)) {
     return errorResponse('UNSUPPORTED_OPERATION', 'type is not supported on this device');
   }
   if (session.device.platform === 'android' && session.recording) {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -2,13 +2,8 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { parseArgs, usage, usageForCommand } from '../args.ts';
 import { AppError } from '../errors.ts';
-import {
-  getCliCommandNames,
-  getCommandSchema,
-  getSchemaCapabilityKeys,
-} from '../command-schema.ts';
-import { getCommandCapability, listCapabilityCommands } from '../../core/capabilities.ts';
-import { INTERACTION_COMMAND_DEFINITIONS } from '../../commands/interactions/definition.ts';
+import { getCliCommandNames, getSchemaCapabilityKeys } from '../command-schema.ts';
+import { listCapabilityCommands } from '../../core/capabilities.ts';
 
 test('parseArgs recognizes command-specific flag combinations', async () => {
   const scenarios: Array<{
@@ -981,13 +976,6 @@ test('every capability command has a parser schema entry', () => {
 
 test('schema capability mappings match capability source-of-truth', () => {
   assert.deepEqual(getSchemaCapabilityKeys(), listCapabilityCommands());
-});
-
-test('interaction command definitions feed schema and capability registries', () => {
-  for (const definition of INTERACTION_COMMAND_DEFINITIONS) {
-    assert.deepEqual(getCommandSchema(definition.name), definition.schema);
-    assert.deepEqual(getCommandCapability(definition.name), definition.capability);
-  }
 });
 
 test('compat mode warns and strips unsupported command flags', () => {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -2,8 +2,13 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { parseArgs, usage, usageForCommand } from '../args.ts';
 import { AppError } from '../errors.ts';
-import { getCliCommandNames, getSchemaCapabilityKeys } from '../command-schema.ts';
-import { listCapabilityCommands } from '../../core/capabilities.ts';
+import {
+  getCliCommandNames,
+  getCommandSchema,
+  getSchemaCapabilityKeys,
+} from '../command-schema.ts';
+import { getCommandCapability, listCapabilityCommands } from '../../core/capabilities.ts';
+import { INTERACTION_COMMAND_DEFINITIONS } from '../../commands/interactions/definition.ts';
 
 test('parseArgs recognizes command-specific flag combinations', async () => {
   const scenarios: Array<{
@@ -976,6 +981,13 @@ test('every capability command has a parser schema entry', () => {
 
 test('schema capability mappings match capability source-of-truth', () => {
   assert.deepEqual(getSchemaCapabilityKeys(), listCapabilityCommands());
+});
+
+test('interaction command definitions feed schema and capability registries', () => {
+  for (const definition of INTERACTION_COMMAND_DEFINITIONS) {
+    assert.deepEqual(getCommandSchema(definition.name), definition.schema);
+    assert.deepEqual(getCommandCapability(definition.name), definition.capability);
+  }
 });
 
 test('compat mode warns and strips unsupported command flags', () => {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -1,6 +1,7 @@
 import { SETTINGS_USAGE_OVERRIDE } from '../core/settings-contract.ts';
 import { SESSION_SURFACES } from '../core/session-surface.ts';
 import type { DaemonInstallSource } from '../contracts.ts';
+import { INTERACTION_COMMAND_SCHEMAS } from '../commands/interactions/definition.ts';
 
 export type CliFlags = {
   json: boolean;
@@ -130,7 +131,7 @@ export type FlagDefinition = {
   usageDescription?: string;
 };
 
-type CommandSchema = {
+export type CommandSchema = {
   helpDescription: string;
   summary?: string;
   positionalArgs: readonly string[];
@@ -1779,12 +1780,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     positionalArgs: ['x', 'y'],
     allowedFlags: [],
   },
-  type: {
-    helpDescription: 'Type text in focused field',
-    positionalArgs: ['text'],
-    allowsExtraPositionals: true,
-    allowedFlags: ['delayMs'],
-  },
+  ...INTERACTION_COMMAND_SCHEMAS,
   fill: {
     usageOverride: 'fill <x> <y> <text> | fill <@ref|selector> <text>',
     helpDescription: 'Tap then type',


### PR DESCRIPTION
## Summary

Add a small command-definition foundation for collocating command schema and capability metadata.

Pilot the interaction `type` command through the new definition by wiring its schema, capability metadata, CLI mapping, and daemon command-name routing from the interaction command module.

Tighten `defineCommand` around the shared schema/capability types and remove unused `family` metadata so stacked command-definition PRs do not need tautological `satisfies` blocks.

Touched files: 8. Scope stayed within the command-definition foundation plus one interaction pilot.

## Validation

PATH=/Users/thymikee/.nvm/versions/node/v24.13.0/bin:$PATH pnpm format
PATH=/Users/thymikee/.nvm/versions/node/v24.13.0/bin:$PATH pnpm exec vitest run src/commands/interactions/__tests__/definition.test.ts src/utils/__tests__/args.test.ts
PATH=/Users/thymikee/.nvm/versions/node/v24.13.0/bin:$PATH pnpm check:fallow
PATH=/Users/thymikee/.nvm/versions/node/v24.13.0/bin:$PATH pnpm check:quick