### PR TITLE
refactor: split request handler chain

### DIFF
--- a/src/daemon/request-handler-chain.ts
+++ b/src/daemon/request-handler-chain.ts
@@ -1,0 +1,87 @@
+import type { CommandFlags } from '../core/dispatch.ts';
+import type { AndroidAdbExecutor } from '../platforms/android/adb-executor.ts';
+import type { DaemonCommandContext } from './context.ts';
+import { handleFindCommands } from './handlers/find.ts';
+import { handleInteractionCommands } from './handlers/interaction.ts';
+import { handleLeaseCommands } from './handlers/lease.ts';
+import { handleRecordTraceCommands } from './handlers/record-trace.ts';
+import { handleSessionCommands } from './handlers/session.ts';
+import { handleSnapshotCommands } from './handlers/snapshot.ts';
+import type { LeaseRegistry } from './lease-registry.ts';
+import { SessionStore } from './session-store.ts';
+import type { DaemonRequest, DaemonResponse } from './types.ts';
+
+export async function runRequestHandlerChain(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  leaseRegistry: LeaseRegistry;
+  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  androidAdbExecutor?: AndroidAdbExecutor;
+  contextFromFlags: (
+    flags: CommandFlags | undefined,
+    appBundleId?: string,
+    traceLogPath?: string,
+  ) => DaemonCommandContext;
+}): Promise<DaemonResponse | null> {
+  const {
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    leaseRegistry,
+    invoke,
+    androidAdbExecutor,
+    contextFromFlags,
+  } = params;
+
+  const leaseResponse = await handleLeaseCommands({ req, leaseRegistry });
+  if (leaseResponse) return leaseResponse;
+
+  const sessionResponse = await handleSessionCommands({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+    androidAdbExecutor,
+  });
+  if (sessionResponse) return sessionResponse;
+
+  const snapshotResponse = await handleSnapshotCommands({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+  });
+  if (snapshotResponse) return snapshotResponse;
+
+  const recordTraceResponse = await handleRecordTraceCommands({
+    req,
+    sessionName,
+    sessionStore,
+    logPath,
+  });
+  if (recordTraceResponse) return recordTraceResponse;
+
+  const findResponse = await handleFindCommands({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    invoke,
+  });
+  if (findResponse) return findResponse;
+
+  const interactionResponse = await handleInteractionCommands({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    contextFromFlags,
+  });
+  if (interactionResponse) return interactionResponse;
+
+  return null;
+}

--- a/src/daemon/request-handler-chain.ts
+++ b/src/daemon/request-handler-chain.ts
@@ -8,7 +8,7 @@ import { handleRecordTraceCommands } from './handlers/record-trace.ts';
 import { handleSessionCommands } from './handlers/session.ts';
 import { handleSnapshotCommands } from './handlers/snapshot.ts';
 import type { LeaseRegistry } from './lease-registry.ts';
-import { SessionStore } from './session-store.ts';
+import type { SessionStore } from './session-store.ts';
 import type { DaemonRequest, DaemonResponse } from './types.ts';
 
 export async function runRequestHandlerChain(params: {

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -1,7 +1,4 @@
-import {
-  withAndroidAdbProvider,
-  type AndroidAdbExecutor,
-} from '../platforms/android/adb-executor.ts';
+import { withAndroidAdbProvider } from '../platforms/android/adb-executor.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
 import {
   type DeviceInventoryProvider,
@@ -14,12 +11,6 @@ import {
   contextFromFlags as contextFromFlagsWithLog,
   type DaemonCommandContext,
 } from './context.ts';
-import { handleSessionCommands } from './handlers/session.ts';
-import { handleSnapshotCommands } from './handlers/snapshot.ts';
-import { handleFindCommands } from './handlers/find.ts';
-import { handleRecordTraceCommands } from './handlers/record-trace.ts';
-import { handleInteractionCommands } from './handlers/interaction.ts';
-import { handleLeaseCommands } from './handlers/lease.ts';
 import { assertSessionSelectorMatches } from './session-selector.ts';
 import { applyRequestLockPolicy } from './request-lock-policy.ts';
 import { resolveEffectiveSessionName } from './session-routing.ts';
@@ -49,6 +40,7 @@ import {
   refreshRecordingHealth,
   shouldBlockForInvalidRecording,
 } from './request-recording-health.ts';
+import { runRequestHandlerChain } from './request-handler-chain.ts';
 
 const sessionExecutionLocks = new Map<string, Promise<unknown>>();
 
@@ -73,85 +65,6 @@ function contextFromFlags(
     ...contextFromFlagsWithLog(logPath, flags, appBundleId, traceLogPath, requestId),
     requestId,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Specialized handler chain
-// ---------------------------------------------------------------------------
-
-async function runHandlerChain(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath: string;
-  sessionStore: SessionStore;
-  leaseRegistry: LeaseRegistry;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
-  androidAdbExecutor?: AndroidAdbExecutor;
-  contextFromFlags: (
-    flags: CommandFlags | undefined,
-    appBundleId?: string,
-    traceLogPath?: string,
-  ) => DaemonCommandContext;
-}): Promise<DaemonResponse | null> {
-  const {
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-    leaseRegistry,
-    invoke,
-    androidAdbExecutor,
-    contextFromFlags,
-  } = params;
-
-  const leaseResponse = await handleLeaseCommands({ req, leaseRegistry });
-  if (leaseResponse) return leaseResponse;
-
-  const sessionResponse = await handleSessionCommands({
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-    invoke,
-    androidAdbExecutor,
-  });
-  if (sessionResponse) return sessionResponse;
-
-  const snapshotResponse = await handleSnapshotCommands({
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-  });
-  if (snapshotResponse) return snapshotResponse;
-
-  const recordTraceResponse = await handleRecordTraceCommands({
-    req,
-    sessionName,
-    sessionStore,
-    logPath,
-  });
-  if (recordTraceResponse) return recordTraceResponse;
-
-  const findResponse = await handleFindCommands({
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-    invoke,
-  });
-  if (findResponse) return findResponse;
-
-  const interactionResponse = await handleInteractionCommands({
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-    contextFromFlags,
-  });
-  if (interactionResponse) return interactionResponse;
-
-  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -260,7 +173,7 @@ export function createRequestHandler(
                   // The ADB provider is scoped to this single locked request; handlers may re-read
                   // the session state, but all device-scoped adb calls in this request share it.
                   // Phase 1: Try specialized handler chain
-                  const handlerResponse = await runHandlerChain({
+                  const handlerResponse = await runRequestHandlerChain({
                     req: lockedReq,
                     sessionName,
                     logPath,


### PR DESCRIPTION
## Summary

Extract the specialized daemon request handler chain into `src/daemon/request-handler-chain.ts`.
Keep `request-router.ts` focused on request lifecycle orchestration: auth, diagnostics, admission, locking, ADB scoping, finalization, and fallback dispatch.

Touched files: 2. Scope stayed within `src/daemon/request-router.ts` and `src/daemon/request-*.ts`.

## Validation

- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$HOME/Library/pnpm:$PATH" pnpm format`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$HOME/Library/pnpm:$PATH" pnpm exec vitest run src/daemon/__tests__/request-router-*.test.ts`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$HOME/Library/pnpm:$PATH" pnpm check:quick`