### PR TITLE
refactor: add capture selector command definitions

### DIFF
--- a/src/commands/capture-definition.ts
+++ b/src/commands/capture-definition.ts
@@ -1,0 +1,59 @@
+import { PUBLIC_COMMANDS } from '../command-catalog.ts';
+import {
+  ALL_DEVICE_COMMAND_CAPABILITY,
+  commandCapabilityMap,
+  commandSchemaMap,
+  defineCommand,
+} from './command-definition.ts';
+
+const SNAPSHOT_FLAGS = [
+  'snapshotInteractiveOnly',
+  'snapshotCompact',
+  'snapshotDepth',
+  'snapshotScope',
+  'snapshotRaw',
+] as const;
+
+const snapshotCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.snapshot,
+  schema: {
+    usageOverride: 'snapshot [--diff] [-i] [-c] [-d <depth>] [-s <scope>] [--raw]',
+    helpDescription: 'Capture accessibility tree or diff against the previous session baseline',
+    positionalArgs: [],
+    allowedFlags: ['snapshotDiff', ...SNAPSHOT_FLAGS],
+  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
+});
+
+const diffCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.diff,
+  schema: {
+    usageOverride:
+      'diff snapshot | diff screenshot --baseline <path> [current.png] [--out <diff.png>] [--threshold <0-1>] [--overlay-refs]',
+    helpDescription: 'Diff accessibility snapshot or compare screenshots pixel-by-pixel',
+    summary: 'Diff snapshot or screenshot',
+    positionalArgs: ['kind', 'current?'],
+    allowedFlags: [...SNAPSHOT_FLAGS, 'baseline', 'threshold', 'out', 'overlayRefs'],
+  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
+});
+
+const screenshotCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.screenshot,
+  schema: {
+    helpDescription:
+      'Capture screenshot (macOS app sessions default to the app window; use --fullscreen for full desktop, --max-size to downscale, or --overlay-refs to annotate the image with current refs)',
+    positionalArgs: ['path?'],
+    allowedFlags: ['out', 'overlayRefs', 'screenshotFullscreen', 'screenshotMaxSize'],
+  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
+});
+
+export const CAPTURE_COMMAND_DEFINITIONS = [
+  snapshotCommandDefinition,
+  diffCommandDefinition,
+  screenshotCommandDefinition,
+] as const;
+
+export const CAPTURE_COMMAND_SCHEMAS = commandSchemaMap(CAPTURE_COMMAND_DEFINITIONS);
+export const CAPTURE_COMMAND_CAPABILITIES = commandCapabilityMap(CAPTURE_COMMAND_DEFINITIONS);

--- a/src/commands/command-definition.ts
+++ b/src/commands/command-definition.ts
@@ -1,6 +1,12 @@
 import type { CommandCapability } from '../core/capabilities.ts';
 import type { CommandSchema } from '../utils/command-schema.ts';
 
+export const ALL_DEVICE_COMMAND_CAPABILITY = {
+  apple: { simulator: true, device: true },
+  android: { emulator: true, device: true, unknown: true },
+  linux: { device: true },
+} as const satisfies CommandCapability;
+
 export type CommandDefinition<TName extends string = string> = {
   name: TName;
   schema: CommandSchema;

--- a/src/commands/interactions/__tests__/definition.test.ts
+++ b/src/commands/interactions/__tests__/definition.test.ts
@@ -2,10 +2,16 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { getCommandCapability } from '../../../core/capabilities.ts';
 import { getCommandSchema } from '../../../utils/command-schema.ts';
+import { CAPTURE_COMMAND_DEFINITIONS } from '../../capture-definition.ts';
+import { SELECTOR_COMMAND_DEFINITIONS } from '../../selectors-definition.ts';
 import { INTERACTION_COMMAND_DEFINITIONS } from '../definition.ts';
 
-test('interaction command definitions feed schema and capability registries', () => {
-  for (const definition of INTERACTION_COMMAND_DEFINITIONS) {
+test('command definitions feed schema and capability registries', () => {
+  for (const definition of [
+    ...INTERACTION_COMMAND_DEFINITIONS,
+    ...CAPTURE_COMMAND_DEFINITIONS,
+    ...SELECTOR_COMMAND_DEFINITIONS,
+  ]) {
     assert.deepEqual(getCommandSchema(definition.name), definition.schema);
     assert.deepEqual(getCommandCapability(definition.name), definition.capability);
   }

--- a/src/commands/interactions/definition.ts
+++ b/src/commands/interactions/definition.ts
@@ -1,5 +1,10 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
-import { commandCapabilityMap, commandSchemaMap, defineCommand } from '../command-definition.ts';
+import {
+  ALL_DEVICE_COMMAND_CAPABILITY,
+  commandCapabilityMap,
+  commandSchemaMap,
+  defineCommand,
+} from '../command-definition.ts';
 
 export const typeCommandDefinition = defineCommand({
   name: PUBLIC_COMMANDS.type,
@@ -9,11 +14,7 @@ export const typeCommandDefinition = defineCommand({
     allowsExtraPositionals: true,
     allowedFlags: ['delayMs'],
   },
-  capability: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: { device: true },
-  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
 });
 
 export const INTERACTION_COMMAND_DEFINITIONS = [typeCommandDefinition] as const;

--- a/src/commands/selectors-definition.ts
+++ b/src/commands/selectors-definition.ts
@@ -1,0 +1,75 @@
+import { PUBLIC_COMMANDS } from '../command-catalog.ts';
+import type { FlagKey } from '../utils/command-schema.ts';
+import {
+  ALL_DEVICE_COMMAND_CAPABILITY,
+  commandCapabilityMap,
+  commandSchemaMap,
+  defineCommand,
+} from './command-definition.ts';
+
+export const SELECTOR_SNAPSHOT_FLAGS = [
+  'snapshotDepth',
+  'snapshotScope',
+  'snapshotRaw',
+] as const satisfies readonly FlagKey[];
+
+const waitCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.wait,
+  schema: {
+    usageOverride: 'wait <ms>|text <text>|@ref|<selector> [timeoutMs]',
+    helpDescription: 'Wait for duration, text, ref, or selector to appear',
+    summary: 'Wait for time, text, ref, or selector',
+    positionalArgs: ['durationOrSelector', 'timeoutMs?'],
+    allowsExtraPositionals: true,
+    allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS],
+  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
+});
+
+const getCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.get,
+  schema: {
+    usageOverride: 'get text|attrs <@ref|selector>',
+    helpDescription:
+      'Return exposed element text/attributes by ref or selector; use snapshot -s @ref for truncated previews',
+    summary: 'Get exposed text or attrs by ref or selector',
+    positionalArgs: ['subcommand', 'target'],
+    allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS],
+  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
+});
+
+const findCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.find,
+  schema: {
+    usageOverride: 'find <locator|text> <action> [value] [--first|--last]',
+    helpDescription: 'Find by text/label/value/role/id and run action',
+    summary: 'Find an element and act',
+    positionalArgs: ['query', 'action', 'value?'],
+    allowsExtraPositionals: true,
+    allowedFlags: ['snapshotDepth', 'snapshotRaw', 'findFirst', 'findLast'],
+  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
+});
+
+const isCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.is,
+  schema: {
+    helpDescription: 'Assert UI state (visible|hidden|exists|editable|selected|text)',
+    summary: 'Assert UI state',
+    positionalArgs: ['predicate', 'selector', 'value?'],
+    allowsExtraPositionals: true,
+    allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS],
+  },
+  capability: ALL_DEVICE_COMMAND_CAPABILITY,
+});
+
+export const SELECTOR_COMMAND_DEFINITIONS = [
+  waitCommandDefinition,
+  getCommandDefinition,
+  findCommandDefinition,
+  isCommandDefinition,
+] as const;
+
+export const SELECTOR_COMMAND_SCHEMAS = commandSchemaMap(SELECTOR_COMMAND_DEFINITIONS);
+export const SELECTOR_COMMAND_CAPABILITIES = commandCapabilityMap(SELECTOR_COMMAND_DEFINITIONS);

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -1,5 +1,7 @@
 import { isApplePlatform, type DeviceInfo } from '../utils/device.ts';
+import { CAPTURE_COMMAND_CAPABILITIES } from '../commands/capture-definition.ts';
 import { INTERACTION_COMMAND_CAPABILITIES } from '../commands/interactions/definition.ts';
+import { SELECTOR_COMMAND_CAPABILITIES } from '../commands/selectors-definition.ts';
 
 type KindMatrix = {
   simulator?: boolean;
@@ -99,27 +101,9 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
   },
-  diff: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  find: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
+  ...CAPTURE_COMMAND_CAPABILITIES,
+  ...SELECTOR_COMMAND_CAPABILITIES,
   focus: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  get: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  is: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
@@ -196,11 +180,6 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     supports: (device) =>
       device.platform === 'android' || (device.platform === 'ios' && device.target !== 'tv'),
   },
-  screenshot: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
   scroll: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
@@ -218,22 +197,12 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     supports: (device) =>
       device.platform === 'android' || device.platform === 'macos' || device.kind === 'simulator',
   },
-  snapshot: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
   'trigger-app-event': {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
   },
   ...INTERACTION_COMMAND_CAPABILITIES,
-  wait: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
 };
 
 export function isCommandSupportedOnDevice(command: string, device: DeviceInfo): boolean {

--- a/src/remote-config-schema.ts
+++ b/src/remote-config-schema.ts
@@ -1,6 +1,22 @@
 import { buildPrimaryEnvVarName } from './utils/source-value.ts';
 
-export type RemoteConfigProfile = {
+export type RemoteConfigMetroOptions = {
+  metroProjectRoot?: string;
+  metroKind?: 'auto' | 'react-native' | 'expo';
+  metroPublicBaseUrl?: string;
+  metroProxyBaseUrl?: string;
+  metroBearerToken?: string;
+  metroPreparePort?: number;
+  metroListenHost?: string;
+  metroStatusHost?: string;
+  metroStartupTimeoutMs?: number;
+  metroProbeTimeoutMs?: number;
+  metroRuntimeFile?: string;
+  metroNoReuseExisting?: boolean;
+  metroNoInstallDeps?: boolean;
+};
+
+export type RemoteConfigProfile = RemoteConfigMetroOptions & {
   stateDir?: string;
   daemonBaseUrl?: string;
   daemonAuthToken?: string;
@@ -19,19 +35,6 @@ export type RemoteConfigProfile = {
   iosSimulatorDeviceSet?: string;
   androidDeviceAllowlist?: string;
   session?: string;
-  metroProjectRoot?: string;
-  metroKind?: 'auto' | 'react-native' | 'expo';
-  metroPublicBaseUrl?: string;
-  metroProxyBaseUrl?: string;
-  metroBearerToken?: string;
-  metroPreparePort?: number;
-  metroListenHost?: string;
-  metroStatusHost?: string;
-  metroStartupTimeoutMs?: number;
-  metroProbeTimeoutMs?: number;
-  metroRuntimeFile?: string;
-  metroNoReuseExisting?: boolean;
-  metroNoInstallDeps?: boolean;
 };
 
 export type RemoteConfigProfileOptions = {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -1,9 +1,15 @@
 import { SETTINGS_USAGE_OVERRIDE } from '../core/settings-contract.ts';
 import { SESSION_SURFACES } from '../core/session-surface.ts';
 import type { DaemonInstallSource } from '../contracts.ts';
+import type { RemoteConfigMetroOptions } from '../remote-config-schema.ts';
+import { CAPTURE_COMMAND_SCHEMAS } from '../commands/capture-definition.ts';
 import { INTERACTION_COMMAND_SCHEMAS } from '../commands/interactions/definition.ts';
+import {
+  SELECTOR_COMMAND_SCHEMAS,
+  SELECTOR_SNAPSHOT_FLAGS,
+} from '../commands/selectors-definition.ts';
 
-export type CliFlags = {
+export type CliFlags = RemoteConfigMetroOptions & {
   json: boolean;
   config?: string;
   remoteConfig?: string;
@@ -34,19 +40,6 @@ export type CliFlags = {
   runtime?: string;
   metroHost?: string;
   metroPort?: number;
-  metroProjectRoot?: string;
-  metroKind?: 'auto' | 'react-native' | 'expo';
-  metroPublicBaseUrl?: string;
-  metroProxyBaseUrl?: string;
-  metroBearerToken?: string;
-  metroPreparePort?: number;
-  metroListenHost?: string;
-  metroStatusHost?: string;
-  metroStartupTimeoutMs?: number;
-  metroProbeTimeoutMs?: number;
-  metroRuntimeFile?: string;
-  metroNoReuseExisting?: boolean;
-  metroNoInstallDeps?: boolean;
   bundleUrl?: string;
   launchUrl?: string;
   boot?: boolean;
@@ -142,22 +135,6 @@ export type CommandSchema = {
   usageOverride?: string;
   listUsageOverride?: string;
 };
-
-const SNAPSHOT_FLAGS = [
-  'snapshotInteractiveOnly',
-  'snapshotCompact',
-  'snapshotDepth',
-  'snapshotScope',
-  'snapshotRaw',
-] as const satisfies readonly FlagKey[];
-
-const SELECTOR_SNAPSHOT_FLAGS = [
-  'snapshotDepth',
-  'snapshotScope',
-  'snapshotRaw',
-] as const satisfies readonly FlagKey[];
-
-const FIND_SNAPSHOT_FLAGS = ['snapshotDepth', 'snapshotRaw'] as const satisfies readonly FlagKey[];
 
 const AGENT_WORKFLOWS = [
   { label: 'help workflow', description: 'Normal bootstrap, exploration, and validation loop' },
@@ -1547,20 +1524,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     positionalArgs: ['bundleOrPackage', 'payloadOrJson'],
     allowedFlags: [],
   },
-  snapshot: {
-    usageOverride: 'snapshot [--diff] [-i] [-c] [-d <depth>] [-s <scope>] [--raw]',
-    helpDescription: 'Capture accessibility tree or diff against the previous session baseline',
-    positionalArgs: [],
-    allowedFlags: ['snapshotDiff', ...SNAPSHOT_FLAGS],
-  },
-  diff: {
-    usageOverride:
-      'diff snapshot | diff screenshot --baseline <path> [current.png] [--out <diff.png>] [--threshold <0-1>] [--overlay-refs]',
-    helpDescription: 'Diff accessibility snapshot or compare screenshots pixel-by-pixel',
-    summary: 'Diff snapshot or screenshot',
-    positionalArgs: ['kind', 'current?'],
-    allowedFlags: [...SNAPSHOT_FLAGS, 'baseline', 'threshold', 'out', 'overlayRefs'],
-  },
+  ...CAPTURE_COMMAND_SCHEMAS,
   'ensure-simulator': {
     helpDescription: 'Ensure an iOS simulator exists in a device set (create if missing)',
     summary: 'Ensure iOS simulator exists',
@@ -1675,14 +1639,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     positionalArgs: [],
     allowedFlags: [],
   },
-  wait: {
-    usageOverride: 'wait <ms>|text <text>|@ref|<selector> [timeoutMs]',
-    helpDescription: 'Wait for duration, text, ref, or selector to appear',
-    summary: 'Wait for time, text, ref, or selector',
-    positionalArgs: ['durationOrSelector', 'timeoutMs?'],
-    allowsExtraPositionals: true,
-    allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS],
-  },
+  ...SELECTOR_COMMAND_SCHEMAS,
   alert: {
     usageOverride: 'alert [get|accept|dismiss|wait] [timeout]',
     helpDescription: 'Inspect or handle alert (iOS simulator and macOS desktop)',
@@ -1705,14 +1662,6 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
       'clickButton',
       ...SELECTOR_SNAPSHOT_FLAGS,
     ],
-  },
-  get: {
-    usageOverride: 'get text|attrs <@ref|selector>',
-    helpDescription:
-      'Return exposed element text/attributes by ref or selector; use snapshot -s @ref for truncated previews',
-    summary: 'Get exposed text or attrs by ref or selector',
-    positionalArgs: ['subcommand', 'target'],
-    allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS],
   },
   replay: {
     helpDescription: 'Replay a recorded session',
@@ -1800,12 +1749,6 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     positionalArgs: ['scale', 'x?', 'y?'],
     allowedFlags: [],
   },
-  screenshot: {
-    helpDescription:
-      'Capture screenshot (macOS app sessions default to the app window; use --fullscreen for full desktop, --max-size to downscale, or --overlay-refs to annotate the image with current refs)',
-    positionalArgs: ['path?'],
-    allowedFlags: ['out', 'overlayRefs', 'screenshotFullscreen', 'screenshotMaxSize'],
-  },
   'trigger-app-event': {
     usageOverride: 'trigger-app-event <event> [payloadJson]',
     helpDescription: 'Trigger app-defined event hook via deep link template',
@@ -1848,21 +1791,6 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     summary: 'Show recent HTTP traffic',
     positionalArgs: ['dump|log', 'limit?', 'include?'],
     allowedFlags: ['networkInclude'],
-  },
-  find: {
-    usageOverride: 'find <locator|text> <action> [value] [--first|--last]',
-    helpDescription: 'Find by text/label/value/role/id and run action',
-    summary: 'Find an element and act',
-    positionalArgs: ['query', 'action', 'value?'],
-    allowsExtraPositionals: true,
-    allowedFlags: [...FIND_SNAPSHOT_FLAGS, 'findFirst', 'findLast'],
-  },
-  is: {
-    helpDescription: 'Assert UI state (visible|hidden|exists|editable|selected|text)',
-    summary: 'Assert UI state',
-    positionalArgs: ['predicate', 'selector', 'value?'],
-    allowsExtraPositionals: true,
-    allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS],
   },
   settings: {
     usageOverride: SETTINGS_USAGE_OVERRIDE,


### PR DESCRIPTION
## Summary

Collocate capture command schemas/capabilities for snapshot, diff, and screenshot.

Collocate selector read schemas/capabilities for wait, get, find, and is, and keep selector snapshot flags shared from that family definition.

Follow the #513 command-definition foundation now merged into `main`: no command `family` metadata, no unused command-name exports, and no tautological definition `satisfies` blocks.

Touched-file count: 8. Scope remains command definition/schema/capability glue; `remote-config-schema.ts` changed only to share the Metro option type and keep Fallow duplication clean.

## Validation

- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm format`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec vitest run src/commands/interactions/__tests__/definition.test.ts src/utils/__tests__/args.test.ts src/__tests__/command-codecs.test.ts src/core/__tests__/capabilities.test.ts`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec fallow audit --changed-since origin/main`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm check:quick`
