### PR TITLE
refactor: split xctestrun product resolution

### DIFF
--- a/src/platforms/ios/__tests__/runner-client.test.ts
+++ b/src/platforms/ios/__tests__/runner-client.test.ts
@@ -48,9 +48,9 @@ import {
   ensureXctestrun,
   resolveRunnerPerformanceBuildSettings,
   shouldDeleteRunnerDerivedRootEntry,
-  xctestrunReferencesExistingProducts,
   xctestrunReferencesProjectRoot,
 } from '../runner-xctestrun.ts';
+import { xctestrunReferencesExistingProducts } from '../runner-xctestrun-products.ts';
 import { parseRunnerResponse } from '../runner-session.ts';
 
 const iosSimulator: DeviceInfo = {
@@ -181,6 +181,94 @@ ${entries}
 </plist>`,
     'utf8',
   );
+}
+
+async function makeXctestrunProductsFixture(): Promise<{
+  debugDir: string;
+  xctestrunPath: string;
+}> {
+  const tmpDir = await makeTmpDir();
+  const productsDir = path.join(tmpDir, 'Build', 'Products');
+  return {
+    debugDir: path.join(productsDir, 'Debug'),
+    xctestrunPath: path.join(productsDir, 'AgentDeviceRunner.xctestrun'),
+  };
+}
+
+function writeProductReferenceXctestrun(xctestrunPath: string, entries: string[]): void {
+  fs.writeFileSync(
+    xctestrunPath,
+    ['<plist><dict>', ...entries, '</dict></plist>'].join(''),
+    'utf8',
+  );
+}
+
+async function makeBasicProductReferenceXctestrun(options: {
+  includeRunnerHostBundle: boolean;
+}): Promise<string> {
+  const { debugDir, xctestrunPath } = await makeXctestrunProductsFixture();
+  await fs.promises.mkdir(path.join(debugDir, 'AgentDeviceRunner.app'), { recursive: true });
+  if (options.includeRunnerHostBundle) {
+    await fs.promises.mkdir(
+      path.join(
+        debugDir,
+        'AgentDeviceRunnerUITests-Runner.app',
+        'Contents',
+        'PlugIns',
+        'AgentDeviceRunnerUITests.xctest',
+      ),
+      { recursive: true },
+    );
+  }
+  writeProductReferenceXctestrun(xctestrunPath, [
+    '<key>ProductPaths</key><array>',
+    '<string>__TESTROOT__/Debug/AgentDeviceRunner.app</string>',
+    '<string>__TESTROOT__/Debug/AgentDeviceRunnerUITests-Runner.app</string>',
+    '</array>',
+    '<key>TestHostPath</key><string>__TESTROOT__/Debug/AgentDeviceRunnerUITests-Runner.app</string>',
+    '<key>TestBundlePath</key><string>__TESTHOST__/Contents/PlugIns/AgentDeviceRunnerUITests.xctest</string>',
+  ]);
+  return xctestrunPath;
+}
+
+function withRunnerDerivedPathEnv(
+  derivedPath: string,
+  options: { allowOverrideClean?: boolean } = {},
+): void {
+  const previousDerivedPath = process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH;
+  const previousAllowCleanup = process.env.AGENT_DEVICE_IOS_ALLOW_OVERRIDE_DERIVED_CLEAN;
+  process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH = derivedPath;
+  if (options.allowOverrideClean) {
+    process.env.AGENT_DEVICE_IOS_ALLOW_OVERRIDE_DERIVED_CLEAN = '1';
+  }
+  onTestFinished(() => {
+    restoreEnvVar('AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH', previousDerivedPath);
+    restoreEnvVar('AGENT_DEVICE_IOS_ALLOW_OVERRIDE_DERIVED_CLEAN', previousAllowCleanup);
+  });
+}
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function makeCachedRunnerXctestrun(): Promise<{
+  derivedPath: string;
+  existingXctestrunPath: string;
+}> {
+  const tmpDir = await makeTmpDir();
+  const derivedPath = path.join(tmpDir, 'custom-derived');
+  const existingXctestrunPath = path.join(derivedPath, 'existing.xctestrun');
+  await fs.promises.mkdir(derivedPath, { recursive: true });
+  await fs.promises.mkdir(path.join(derivedPath, 'Runner.app'), { recursive: true });
+  writeXctestrunFixture(existingXctestrunPath, {
+    projectRoot: repoRoot,
+    productRelativePaths: ['Runner.app'],
+  });
+  return { derivedPath, existingXctestrunPath };
 }
 
 beforeEach(() => {
@@ -470,67 +558,23 @@ test('xctestrunReferencesProjectRoot rejects stale worktree artifacts', async ()
 });
 
 test('xctestrunReferencesExistingProducts rejects missing runner host artifacts', async () => {
-  const tmpDir = await makeTmpDir();
-  const productsDir = path.join(tmpDir, 'Build', 'Products');
-  const debugDir = path.join(productsDir, 'Debug');
-  await fs.promises.mkdir(path.join(debugDir, 'AgentDeviceRunner.app'), { recursive: true });
-  const xctestrunPath = path.join(productsDir, 'AgentDeviceRunner.xctestrun');
-  fs.writeFileSync(
-    xctestrunPath,
-    [
-      '<plist><dict>',
-      '<key>ProductPaths</key><array>',
-      '<string>__TESTROOT__/Debug/AgentDeviceRunner.app</string>',
-      '<string>__TESTROOT__/Debug/AgentDeviceRunnerUITests-Runner.app</string>',
-      '</array>',
-      '<key>TestHostPath</key><string>__TESTROOT__/Debug/AgentDeviceRunnerUITests-Runner.app</string>',
-      '<key>TestBundlePath</key><string>__TESTHOST__/Contents/PlugIns/AgentDeviceRunnerUITests.xctest</string>',
-      '</dict></plist>',
-    ].join(''),
-    'utf8',
-  );
+  const xctestrunPath = await makeBasicProductReferenceXctestrun({
+    includeRunnerHostBundle: false,
+  });
 
   assert.equal(xctestrunReferencesExistingProducts(xctestrunPath), false);
 });
 
 test('xctestrunReferencesExistingProducts accepts xctestruns when referenced products exist', async () => {
-  const tmpDir = await makeTmpDir();
-  const productsDir = path.join(tmpDir, 'Build', 'Products');
-  const debugDir = path.join(productsDir, 'Debug');
-  await fs.promises.mkdir(path.join(debugDir, 'AgentDeviceRunner.app'), { recursive: true });
-  await fs.promises.mkdir(
-    path.join(
-      debugDir,
-      'AgentDeviceRunnerUITests-Runner.app',
-      'Contents',
-      'PlugIns',
-      'AgentDeviceRunnerUITests.xctest',
-    ),
-    { recursive: true },
-  );
-  const xctestrunPath = path.join(productsDir, 'AgentDeviceRunner.xctestrun');
-  fs.writeFileSync(
-    xctestrunPath,
-    [
-      '<plist><dict>',
-      '<key>ProductPaths</key><array>',
-      '<string>__TESTROOT__/Debug/AgentDeviceRunner.app</string>',
-      '<string>__TESTROOT__/Debug/AgentDeviceRunnerUITests-Runner.app</string>',
-      '</array>',
-      '<key>TestHostPath</key><string>__TESTROOT__/Debug/AgentDeviceRunnerUITests-Runner.app</string>',
-      '<key>TestBundlePath</key><string>__TESTHOST__/Contents/PlugIns/AgentDeviceRunnerUITests.xctest</string>',
-      '</dict></plist>',
-    ].join(''),
-    'utf8',
-  );
+  const xctestrunPath = await makeBasicProductReferenceXctestrun({
+    includeRunnerHostBundle: true,
+  });
 
   assert.equal(xctestrunReferencesExistingProducts(xctestrunPath), true);
 });
 
 test('xctestrunReferencesExistingProducts parses nested plist fallback values from XML', async () => {
-  const tmpDir = await makeTmpDir();
-  const productsDir = path.join(tmpDir, 'Build', 'Products');
-  const debugDir = path.join(productsDir, 'Debug');
+  const { debugDir, xctestrunPath } = await makeXctestrunProductsFixture();
   await fs.promises.mkdir(path.join(debugDir, 'AgentDeviceRunner.app'), { recursive: true });
   await fs.promises.mkdir(path.join(debugDir, 'Target.app'), { recursive: true });
   await fs.promises.mkdir(path.join(debugDir, 'Frameworks', 'Helper.framework'), {
@@ -546,32 +590,25 @@ test('xctestrunReferencesExistingProducts parses nested plist fallback values fr
     ),
     { recursive: true },
   );
-  const xctestrunPath = path.join(productsDir, 'AgentDeviceRunner.xctestrun');
-  fs.writeFileSync(
-    xctestrunPath,
-    [
-      '<plist><dict>',
-      '<key>TestConfigurations</key><array>',
-      '<dict>',
-      '<key>TestTargets</key><array>',
-      '<dict>',
-      '<key>ProductPaths</key><array>',
-      '<string>__TESTROOT__/Debug/AgentDeviceRunner.app</string>',
-      '</array>',
-      '<key>DependentProductPaths</key><array>',
-      '<string>__TESTROOT__/Debug/Frameworks/Helper.framework</string>',
-      '</array>',
-      '<key>TestHostPath</key><string>__TESTROOT__/Debug/AgentDeviceRunner.app</string>',
-      '<key>TestBundlePath</key><string>__TESTHOST__/Contents/PlugIns/AgentDeviceRunnerUITests.xctest</string>',
-      '<key>UITargetAppPath</key><string>__TESTROOT__/Debug/Target.app</string>',
-      '</dict>',
-      '</array>',
-      '</dict>',
-      '</array>',
-      '</dict></plist>',
-    ].join(''),
-    'utf8',
-  );
+  writeProductReferenceXctestrun(xctestrunPath, [
+    '<key>TestConfigurations</key><array>',
+    '<dict>',
+    '<key>TestTargets</key><array>',
+    '<dict>',
+    '<key>ProductPaths</key><array>',
+    '<string>__TESTROOT__/Debug/AgentDeviceRunner.app</string>',
+    '</array>',
+    '<key>DependentProductPaths</key><array>',
+    '<string>__TESTROOT__/Debug/Frameworks/Helper.framework</string>',
+    '</array>',
+    '<key>TestHostPath</key><string>__TESTROOT__/Debug/AgentDeviceRunner.app</string>',
+    '<key>TestBundlePath</key><string>__TESTHOST__/Contents/PlugIns/AgentDeviceRunnerUITests.xctest</string>',
+    '<key>UITargetAppPath</key><string>__TESTROOT__/Debug/Target.app</string>',
+    '</dict>',
+    '</array>',
+    '</dict>',
+    '</array>',
+  ]);
 
   assert.equal(xctestrunReferencesExistingProducts(xctestrunPath), true);
 });
@@ -579,9 +616,8 @@ test('xctestrunReferencesExistingProducts parses nested plist fallback values fr
 test('ensureXctestrun rebuilds after cached macOS runner repair failure', async () => {
   // Cached runner artifacts can look reusable until ad-hoc repair fails; ensure we clean once,
   // rebuild, and return the repaired rebuilt xctestrun instead of looping on stale cache state.
-  const tmpDir = await makeTmpDir();
   const projectRoot = repoRoot;
-  const derivedPath = path.join(tmpDir, 'custom-derived');
+  const { derivedPath, existingXctestrunPath } = await makeCachedRunnerXctestrun();
   const projectPath = path.join(
     projectRoot,
     'ios-runner',
@@ -589,31 +625,9 @@ test('ensureXctestrun rebuilds after cached macOS runner repair failure', async 
     'AgentDeviceRunner.xcodeproj',
   );
 
-  const existingXctestrunPath = path.join(derivedPath, 'existing.xctestrun');
   const rebuiltXctestrunPath = path.join(derivedPath, 'rebuilt', 'rebuilt.xctestrun');
-  await fs.promises.mkdir(derivedPath, { recursive: true });
-  await fs.promises.mkdir(path.join(derivedPath, 'Runner.app'), { recursive: true });
-  writeXctestrunFixture(existingXctestrunPath, {
-    projectRoot,
-    productRelativePaths: ['Runner.app'],
-  });
 
-  const previousDerivedPath = process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH;
-  const previousAllowCleanup = process.env.AGENT_DEVICE_IOS_ALLOW_OVERRIDE_DERIVED_CLEAN;
-  process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH = derivedPath;
-  process.env.AGENT_DEVICE_IOS_ALLOW_OVERRIDE_DERIVED_CLEAN = '1';
-  onTestFinished(() => {
-    if (previousDerivedPath === undefined) {
-      delete process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH;
-    } else {
-      process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH = previousDerivedPath;
-    }
-    if (previousAllowCleanup === undefined) {
-      delete process.env.AGENT_DEVICE_IOS_ALLOW_OVERRIDE_DERIVED_CLEAN;
-      return;
-    }
-    process.env.AGENT_DEVICE_IOS_ALLOW_OVERRIDE_DERIVED_CLEAN = previousAllowCleanup;
-  });
+  withRunnerDerivedPathEnv(derivedPath, { allowOverrideClean: true });
 
   const repairedPaths: string[] = [];
 
@@ -648,26 +662,9 @@ test('ensureXctestrun rebuilds after cached macOS runner repair failure', async 
 });
 
 test('ensureXctestrun rethrows unexpected cached macOS runner repair errors', async () => {
-  const tmpDir = await makeTmpDir();
-  const projectRoot = repoRoot;
-  const derivedPath = path.join(tmpDir, 'custom-derived');
-  const existingXctestrunPath = path.join(derivedPath, 'existing.xctestrun');
-  await fs.promises.mkdir(derivedPath, { recursive: true });
-  await fs.promises.mkdir(path.join(derivedPath, 'Runner.app'), { recursive: true });
-  writeXctestrunFixture(existingXctestrunPath, {
-    projectRoot,
-    productRelativePaths: ['Runner.app'],
-  });
+  const { derivedPath, existingXctestrunPath } = await makeCachedRunnerXctestrun();
 
-  const previousDerivedPath = process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH;
-  process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH = derivedPath;
-  onTestFinished(() => {
-    if (previousDerivedPath === undefined) {
-      delete process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH;
-      return;
-    }
-    process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH = previousDerivedPath;
-  });
+  withRunnerDerivedPathEnv(derivedPath);
 
   mockRepairMacOsRunnerProductsIfNeeded.mockRejectedValue(new Error('permission denied'));
 

--- a/src/platforms/ios/runner-xctestrun-products.ts
+++ b/src/platforms/ios/runner-xctestrun-products.ts
@@ -26,39 +26,70 @@ export function resolveExistingXctestrunProductPaths(xctestrunPath: string): str
   }
   const testRoot = path.dirname(xctestrunPath);
   const resolvedPaths = new Set<string>();
+  const hostProducts = collectResolvedTestHostProducts(values, testRoot);
+
+  for (const resolvedPath of hostProducts.testRootPaths) {
+    if (!fs.existsSync(resolvedPath)) {
+      return null;
+    }
+    resolvedPaths.add(resolvedPath);
+  }
+
+  for (const resolvedPath of resolveTestHostRelativePaths(hostProducts)) {
+    if (!resolvedPath) {
+      return null;
+    }
+    resolvedPaths.add(resolvedPath);
+  }
+
+  return Array.from(resolvedPaths);
+}
+
+function collectResolvedTestHostProducts(
+  values: readonly string[],
+  testRoot: string,
+): {
+  testRootPaths: string[];
+  hostRoots: string[];
+  hostRelativePaths: string[];
+} {
+  const testRootPaths: string[] = [];
   const hostRoots = new Set<string>();
   const hostRelativePaths: string[] = [];
 
   for (const value of values) {
-    if (value.startsWith('__TESTROOT__/')) {
-      const relativePath = value.slice('__TESTROOT__/'.length);
-      const resolvedPath = path.join(testRoot, relativePath);
-      if (!fs.existsSync(resolvedPath)) {
-        return null;
-      }
-      resolvedPaths.add(resolvedPath);
-      const appBundleRoot = extractAppBundleRoot(relativePath);
-      if (appBundleRoot) {
-        hostRoots.add(path.join(testRoot, appBundleRoot));
-      }
-      continue;
-    }
     if (value.startsWith('__TESTHOST__/')) {
       hostRelativePaths.push(value.slice('__TESTHOST__/'.length));
+      continue;
+    }
+    if (!value.startsWith('__TESTROOT__/')) {
+      continue;
+    }
+    const relativePath = value.slice('__TESTROOT__/'.length);
+    testRootPaths.push(path.join(testRoot, relativePath));
+    const appBundleRoot = extractAppBundleRoot(relativePath);
+    if (appBundleRoot) {
+      hostRoots.add(path.join(testRoot, appBundleRoot));
     }
   }
 
-  for (const relativePath of hostRelativePaths) {
-    const resolvedHostRoot = Array.from(hostRoots).find((hostRoot) =>
+  return {
+    testRootPaths,
+    hostRoots: Array.from(hostRoots),
+    hostRelativePaths,
+  };
+}
+
+function resolveTestHostRelativePaths(products: {
+  hostRoots: readonly string[];
+  hostRelativePaths: readonly string[];
+}): (string | null)[] {
+  return products.hostRelativePaths.map((relativePath) => {
+    const resolvedHostRoot = products.hostRoots.find((hostRoot) =>
       fs.existsSync(path.join(hostRoot, relativePath)),
     );
-    if (!resolvedHostRoot) {
-      return null;
-    }
-    resolvedPaths.add(path.join(resolvedHostRoot, relativePath));
-  }
-
-  return Array.from(resolvedPaths);
+    return resolvedHostRoot ? path.join(resolvedHostRoot, relativePath) : null;
+  });
 }
 
 function resolveXctestrunProductReferences(xctestrunPath: string): string[] | null {
@@ -96,43 +127,49 @@ function readXctestrunJson(xctestrunPath: string): Record<string, unknown> | nul
 
 function resolveXctestrunProductReferencesFromJson(parsed: Record<string, unknown>): string[] {
   const values = new Set<string>();
-  const addTargetValues = (target: unknown) => {
-    if (!target || typeof target !== 'object') {
-      return;
-    }
-    for (const value of collectXctestrunProductReferenceValuesFromTarget(
-      target as Record<string, unknown>,
-    )) {
+
+  for (const target of collectXctestrunProductReferenceTargets(parsed)) {
+    for (const value of collectXctestrunProductReferenceValuesFromTarget(target)) {
       values.add(value);
     }
-  };
-
-  addTargetValues(parsed);
-
-  const testConfigurations = parsed.TestConfigurations;
-  if (Array.isArray(testConfigurations)) {
-    for (const config of testConfigurations) {
-      if (!config || typeof config !== 'object') {
-        continue;
-      }
-      const testTargets = (config as Record<string, unknown>).TestTargets;
-      if (!Array.isArray(testTargets)) {
-        continue;
-      }
-      for (const target of testTargets) {
-        addTargetValues(target);
-      }
-    }
-  }
-
-  for (const value of Object.values(parsed)) {
-    if (!value || typeof value !== 'object' || !('TestBundlePath' in value)) {
-      continue;
-    }
-    addTargetValues(value);
   }
 
   return Array.from(values);
+}
+
+function collectXctestrunProductReferenceTargets(
+  parsed: Record<string, unknown>,
+): Record<string, unknown>[] {
+  return [parsed, ...collectConfiguredTestTargets(parsed), ...collectLegacyTestTargets(parsed)];
+}
+
+function collectConfiguredTestTargets(parsed: Record<string, unknown>): Record<string, unknown>[] {
+  const testConfigurations = parsed.TestConfigurations;
+  if (!Array.isArray(testConfigurations)) {
+    return [];
+  }
+
+  const targets: Record<string, unknown>[] = [];
+  for (const config of testConfigurations) {
+    if (!isRecord(config)) {
+      continue;
+    }
+    const testTargets = config.TestTargets;
+    if (Array.isArray(testTargets)) {
+      targets.push(...testTargets.filter(isRecord));
+    }
+  }
+  return targets;
+}
+
+function collectLegacyTestTargets(parsed: Record<string, unknown>): Record<string, unknown>[] {
+  return Object.values(parsed).filter(
+    (value): value is Record<string, unknown> => isRecord(value) && 'TestBundlePath' in value,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
 }
 
 function collectXctestrunProductReferenceValuesFromTarget(

--- a/src/platforms/ios/runner-xctestrun-products.ts
+++ b/src/platforms/ios/runner-xctestrun-products.ts
@@ -1,0 +1,194 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { runCmdSync } from '../../utils/exec.ts';
+import { parseXmlDocumentSync, visitXmlPlistEntries, type XmlNode } from './xml.ts';
+
+const XCTESTRUN_PRODUCT_REFERENCE_KEYS = new Set([
+  'ProductPaths',
+  'DependentProductPaths',
+  'TestHostPath',
+  'TestBundlePath',
+  'UITargetAppPath',
+]);
+
+export function xctestrunReferencesExistingProducts(xctestrunPath: string): boolean {
+  try {
+    return resolveExistingXctestrunProductPaths(xctestrunPath) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveExistingXctestrunProductPaths(xctestrunPath: string): string[] | null {
+  const values = resolveXctestrunProductReferences(xctestrunPath);
+  if (!values || values.length === 0) {
+    return null;
+  }
+  const testRoot = path.dirname(xctestrunPath);
+  const resolvedPaths = new Set<string>();
+  const hostRoots = new Set<string>();
+  const hostRelativePaths: string[] = [];
+
+  for (const value of values) {
+    if (value.startsWith('__TESTROOT__/')) {
+      const relativePath = value.slice('__TESTROOT__/'.length);
+      const resolvedPath = path.join(testRoot, relativePath);
+      if (!fs.existsSync(resolvedPath)) {
+        return null;
+      }
+      resolvedPaths.add(resolvedPath);
+      const appBundleRoot = extractAppBundleRoot(relativePath);
+      if (appBundleRoot) {
+        hostRoots.add(path.join(testRoot, appBundleRoot));
+      }
+      continue;
+    }
+    if (value.startsWith('__TESTHOST__/')) {
+      hostRelativePaths.push(value.slice('__TESTHOST__/'.length));
+    }
+  }
+
+  for (const relativePath of hostRelativePaths) {
+    const resolvedHostRoot = Array.from(hostRoots).find((hostRoot) =>
+      fs.existsSync(path.join(hostRoot, relativePath)),
+    );
+    if (!resolvedHostRoot) {
+      return null;
+    }
+    resolvedPaths.add(path.join(resolvedHostRoot, relativePath));
+  }
+
+  return Array.from(resolvedPaths);
+}
+
+function resolveXctestrunProductReferences(xctestrunPath: string): string[] | null {
+  const parsed = readXctestrunJson(xctestrunPath);
+  if (parsed) {
+    return resolveXctestrunProductReferencesFromJson(parsed);
+  }
+  if (process.platform === 'darwin') {
+    // On real macOS runner builds, plutil should always be available. If it cannot parse the
+    // file here, treat the xctestrun as unusable instead of masking a corrupt plist with a
+    // best-effort regex fallback.
+    return null;
+  }
+  try {
+    // Keep a simple XML fallback only for non-macOS test environments where plutil is absent.
+    return resolveXctestrunProductReferencesFromXml(fs.readFileSync(xctestrunPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readXctestrunJson(xctestrunPath: string): Record<string, unknown> | null {
+  try {
+    const result = runCmdSync('plutil', ['-convert', 'json', '-o', '-', xctestrunPath], {
+      allowFailure: true,
+    });
+    if (result.exitCode !== 0 || !result.stdout.trim()) {
+      return null;
+    }
+    return JSON.parse(result.stdout) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function resolveXctestrunProductReferencesFromJson(parsed: Record<string, unknown>): string[] {
+  const values = new Set<string>();
+  const addTargetValues = (target: unknown) => {
+    if (!target || typeof target !== 'object') {
+      return;
+    }
+    for (const value of collectXctestrunProductReferenceValuesFromTarget(
+      target as Record<string, unknown>,
+    )) {
+      values.add(value);
+    }
+  };
+
+  addTargetValues(parsed);
+
+  const testConfigurations = parsed.TestConfigurations;
+  if (Array.isArray(testConfigurations)) {
+    for (const config of testConfigurations) {
+      if (!config || typeof config !== 'object') {
+        continue;
+      }
+      const testTargets = (config as Record<string, unknown>).TestTargets;
+      if (!Array.isArray(testTargets)) {
+        continue;
+      }
+      for (const target of testTargets) {
+        addTargetValues(target);
+      }
+    }
+  }
+
+  for (const value of Object.values(parsed)) {
+    if (!value || typeof value !== 'object' || !('TestBundlePath' in value)) {
+      continue;
+    }
+    addTargetValues(value);
+  }
+
+  return Array.from(values);
+}
+
+function collectXctestrunProductReferenceValuesFromTarget(
+  target: Record<string, unknown>,
+): string[] {
+  const values = new Set<string>();
+  for (const [key, value] of Object.entries(target)) {
+    if (!XCTESTRUN_PRODUCT_REFERENCE_KEYS.has(key)) {
+      continue;
+    }
+    if (typeof value === 'string') {
+      values.add(value);
+      continue;
+    }
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    for (const item of value) {
+      if (typeof item === 'string') {
+        values.add(item);
+      }
+    }
+  }
+  return Array.from(values);
+}
+
+function resolveXctestrunProductReferencesFromXml(contents: string): string[] {
+  return collectXctestrunXmlProductReferenceValues(parseXmlDocumentSync(contents));
+}
+
+function collectXctestrunXmlProductReferenceValues(nodes: XmlNode[]): string[] {
+  const values = new Set<string>();
+  visitXmlPlistEntries(nodes, (key, valueNode) => {
+    if (!XCTESTRUN_PRODUCT_REFERENCE_KEYS.has(key)) {
+      return;
+    }
+    if (valueNode.name === 'string' && valueNode.text) {
+      values.add(valueNode.text);
+      return;
+    }
+    if (valueNode.name !== 'array') {
+      return;
+    }
+    for (const child of valueNode.children) {
+      if (child.name === 'string' && child.text) {
+        values.add(child.text);
+      }
+    }
+  });
+  return Array.from(values);
+}
+
+function extractAppBundleRoot(relativePath: string): string | null {
+  const match = /\.app(?:\/|$)/.exec(relativePath);
+  if (!match || match.index === undefined) {
+    return null;
+  }
+  return relativePath.slice(0, match.index + '.app'.length);
+}

--- a/src/platforms/ios/runner-xctestrun.ts
+++ b/src/platforms/ios/runner-xctestrun.ts
@@ -4,12 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { AppError } from '../../utils/errors.ts';
 import { sleep } from '../../utils/timeouts.ts';
-import {
-  runCmd,
-  runCmdSync,
-  runCmdStreaming,
-  type ExecBackgroundResult,
-} from '../../utils/exec.ts';
+import { runCmd, runCmdStreaming, type ExecBackgroundResult } from '../../utils/exec.ts';
 import { resolveIosSimulatorDeviceSetPath } from '../../utils/device-isolation.ts';
 import { isProcessAlive, readProcessStartTime } from '../../utils/process-identity.ts';
 import { isEnvTruthy } from '../../utils/retry.ts';
@@ -22,7 +17,8 @@ import {
   repairMacOsRunnerProductsIfNeeded,
   isExpectedRunnerRepairFailure,
 } from './runner-macos-products.ts';
-import { parseXmlDocumentSync, visitXmlPlistEntries, type XmlNode } from './xml.ts';
+import { resolveExistingXctestrunProductPaths } from './runner-xctestrun-products.ts';
+export { xctestrunReferencesExistingProducts } from './runner-xctestrun-products.ts';
 
 const DEFAULT_IOS_RUNNER_APP_BUNDLE_ID = 'com.callstack.agentdevice.runner';
 const XCTEST_DEVICE_SET_BASE_NAME = 'XCTestDevices';
@@ -33,13 +29,6 @@ const RUNNER_DERIVED_ROOT = path.join(os.homedir(), '.agent-device', 'ios-runner
 const XCTEST_DEVICE_SET_LOCK_TIMEOUT_MS = 30_000;
 const XCTEST_DEVICE_SET_LOCK_POLL_MS = 100;
 const XCTEST_DEVICE_SET_LOCK_OWNER_GRACE_MS = 5_000;
-const XCTESTRUN_PRODUCT_REFERENCE_KEYS = new Set([
-  'ProductPaths',
-  'DependentProductPaths',
-  'TestHostPath',
-  'TestBundlePath',
-  'UITargetAppPath',
-]);
 
 const runnerXctestrunBuildLocks = new Map<string, Promise<unknown>>();
 export const runnerPrepProcesses = new Set<ExecBackgroundResult['child']>();
@@ -1018,195 +1007,4 @@ function emitRunnerXctestrunDecision(
       ...data,
     },
   });
-}
-
-// --- xctestrun product resolution (merged from runner-xctestrun-products.ts) ---
-
-export function xctestrunReferencesExistingProducts(xctestrunPath: string): boolean {
-  try {
-    return resolveExistingXctestrunProductPaths(xctestrunPath) !== null;
-  } catch {
-    return false;
-  }
-}
-
-function resolveExistingXctestrunProductPaths(xctestrunPath: string): string[] | null {
-  const values = resolveXctestrunProductReferences(xctestrunPath);
-  if (!values || values.length === 0) {
-    return null;
-  }
-  const testRoot = path.dirname(xctestrunPath);
-  const resolvedPaths = new Set<string>();
-  const hostRoots = new Set<string>();
-  const hostRelativePaths: string[] = [];
-
-  for (const value of values) {
-    if (value.startsWith('__TESTROOT__/')) {
-      const relativePath = value.slice('__TESTROOT__/'.length);
-      const resolvedPath = path.join(testRoot, relativePath);
-      if (!fs.existsSync(resolvedPath)) {
-        return null;
-      }
-      resolvedPaths.add(resolvedPath);
-      const appBundleRoot = extractAppBundleRoot(relativePath);
-      if (appBundleRoot) {
-        hostRoots.add(path.join(testRoot, appBundleRoot));
-      }
-      continue;
-    }
-    if (value.startsWith('__TESTHOST__/')) {
-      hostRelativePaths.push(value.slice('__TESTHOST__/'.length));
-    }
-  }
-
-  for (const relativePath of hostRelativePaths) {
-    const resolvedHostRoot = Array.from(hostRoots).find((hostRoot) =>
-      fs.existsSync(path.join(hostRoot, relativePath)),
-    );
-    if (!resolvedHostRoot) {
-      return null;
-    }
-    resolvedPaths.add(path.join(resolvedHostRoot, relativePath));
-  }
-
-  return Array.from(resolvedPaths);
-}
-
-function resolveXctestrunProductReferences(xctestrunPath: string): string[] | null {
-  const parsed = readXctestrunJson(xctestrunPath);
-  if (parsed) {
-    return resolveXctestrunProductReferencesFromJson(parsed);
-  }
-  if (process.platform === 'darwin') {
-    // On real macOS runner builds, plutil should always be available. If it cannot parse the
-    // file here, treat the xctestrun as unusable instead of masking a corrupt plist with a
-    // best-effort regex fallback.
-    return null;
-  }
-  try {
-    // Keep a simple XML fallback only for non-macOS test environments where plutil is absent.
-    return resolveXctestrunProductReferencesFromXml(fs.readFileSync(xctestrunPath, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
-function readXctestrunJson(xctestrunPath: string): Record<string, unknown> | null {
-  try {
-    const result = runCmdSync('plutil', ['-convert', 'json', '-o', '-', xctestrunPath], {
-      allowFailure: true,
-    });
-    if (result.exitCode !== 0 || !result.stdout.trim()) {
-      return null;
-    }
-    return JSON.parse(result.stdout) as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
-function resolveXctestrunProductReferencesFromJson(parsed: Record<string, unknown>): string[] {
-  const values = new Set<string>();
-  const addTargetValues = (target: unknown) => {
-    if (!target || typeof target !== 'object') {
-      return;
-    }
-    for (const value of collectXctestrunProductReferenceValuesFromTarget(
-      target as Record<string, unknown>,
-    )) {
-      values.add(value);
-    }
-  };
-
-  addTargetValues(parsed);
-
-  const testConfigurations = parsed.TestConfigurations;
-  if (Array.isArray(testConfigurations)) {
-    for (const config of testConfigurations) {
-      if (!config || typeof config !== 'object') {
-        continue;
-      }
-      const testTargets = (config as Record<string, unknown>).TestTargets;
-      if (!Array.isArray(testTargets)) {
-        continue;
-      }
-      for (const target of testTargets) {
-        addTargetValues(target);
-      }
-    }
-  }
-
-  for (const value of Object.values(parsed)) {
-    if (!value || typeof value !== 'object' || !('TestBundlePath' in value)) {
-      continue;
-    }
-    addTargetValues(value);
-  }
-
-  return Array.from(values);
-}
-
-function collectXctestrunProductReferenceValuesFromTarget(
-  target: Record<string, unknown>,
-): string[] {
-  const productPathKeys = new Set([
-    'ProductPaths',
-    'DependentProductPaths',
-    'TestHostPath',
-    'TestBundlePath',
-    'UITargetAppPath',
-  ]);
-  const values = new Set<string>();
-  for (const [key, value] of Object.entries(target)) {
-    if (!productPathKeys.has(key)) {
-      continue;
-    }
-    if (typeof value === 'string') {
-      values.add(value);
-      continue;
-    }
-    if (!Array.isArray(value)) {
-      continue;
-    }
-    for (const item of value) {
-      if (typeof item === 'string') {
-        values.add(item);
-      }
-    }
-  }
-  return Array.from(values);
-}
-
-function resolveXctestrunProductReferencesFromXml(contents: string): string[] {
-  return collectXctestrunXmlProductReferenceValues(parseXmlDocumentSync(contents));
-}
-
-function collectXctestrunXmlProductReferenceValues(nodes: XmlNode[]): string[] {
-  const values = new Set<string>();
-  visitXmlPlistEntries(nodes, (key, valueNode) => {
-    if (!XCTESTRUN_PRODUCT_REFERENCE_KEYS.has(key)) {
-      return;
-    }
-    if (valueNode.name === 'string' && valueNode.text) {
-      values.add(valueNode.text);
-      return;
-    }
-    if (valueNode.name !== 'array') {
-      return;
-    }
-    for (const child of valueNode.children) {
-      if (child.name === 'string' && child.text) {
-        values.add(child.text);
-      }
-    }
-  });
-  return Array.from(values);
-}
-
-function extractAppBundleRoot(relativePath: string): string | null {
-  const match = /\.app(?:\/|$)/.exec(relativePath);
-  if (!match || match.index === undefined) {
-    return null;
-  }
-  return relativePath.slice(0, match.index + '.app'.length);
 }

--- a/src/platforms/ios/runner-xctestrun.ts
+++ b/src/platforms/ios/runner-xctestrun.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { AppError } from '../../utils/errors.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import { runCmd, runCmdStreaming, type ExecBackgroundResult } from '../../utils/exec.ts';
@@ -11,6 +10,7 @@ import { isEnvTruthy } from '../../utils/retry.ts';
 import { resolveApplePlatformName, type DeviceInfo } from '../../utils/device.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { findProjectRoot } from '../../utils/version.ts';
 import { resolveSigningFailureHint } from './runner-contract.ts';
 import { logChunk } from './runner-transport.ts';
 import {
@@ -18,7 +18,6 @@ import {
   isExpectedRunnerRepairFailure,
 } from './runner-macos-products.ts';
 import { resolveExistingXctestrunProductPaths } from './runner-xctestrun-products.ts';
-export { xctestrunReferencesExistingProducts } from './runner-xctestrun-products.ts';
 
 const DEFAULT_IOS_RUNNER_APP_BUNDLE_ID = 'com.callstack.agentdevice.runner';
 const XCTEST_DEVICE_SET_BASE_NAME = 'XCTestDevices';
@@ -631,17 +630,6 @@ export function xctestrunReferencesProjectRoot(
   } catch {
     return false;
   }
-}
-
-function findProjectRoot(): string {
-  const start = path.dirname(fileURLToPath(import.meta.url));
-  let current = start;
-  for (let i = 0; i < 6; i += 1) {
-    const pkgPath = path.join(current, 'package.json');
-    if (fs.existsSync(pkgPath)) return current;
-    current = path.dirname(current);
-  }
-  return start;
 }
 
 export async function prepareXctestrunWithEnv(


### PR DESCRIPTION
## Summary

Extract xctestrun product-reference validation from runner-xctestrun into a focused Apple-family module.

Use the shared project-root resolver from `src/utils/version.ts`, and require callers/tests to import product helpers from their owning module directly instead of through a compatibility re-export.

Fallow follow-up: flatten product-reference collection and deduplicate repeated runner-client test fixture/env setup.

Touched-file count: 3. Scope stayed within `src/platforms/ios` and related iOS tests.

## Validation

- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm format`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec fallow audit --changed-since origin/main`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec vitest run src/platforms/ios/__tests__/runner-xctestrun.test.ts src/platforms/ios/__tests__/runner-client.test.ts`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm check:quick`

Notes: `gh` is not installed in this local environment, so the Fallow failure was reproduced locally with the PR-scoped audit instead of inspecting Actions logs through `gh`.