### PR TITLE
fix: improve RN agent-device stability guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you install skills separately, keep the CLI on `agent-device >= 0.14.0`. Olde
 ### AI Agent Entry Points
 
 - **Agent + terminal**: in Cursor, Codex, Claude Code, Windsurf, and similar clients, run `agent-device` in the integrated terminal. Start planning with `agent-device help workflow`; CLI help is authoritative.
-- **Skills or rules**: install the skill with `npx skills add callstackincubator/agent-device`, use the bundled [agent-device skill](skills/agent-device/SKILL.md), or mirror it as a thin project rule, so the agent checks the installed version and reads `agent-device help workflow` before acting.
+- **Skills or rules**: install the skill with `npx skills add callstackincubator/agent-device`, use the bundled [agent-device skill](skills/agent-device/SKILL.md), or mirror it as a thin project rule, so the agent checks the installed version and reads `agent-device help workflow` before acting. Use `agent-device help react-native` for React Native apps, overlays, Metro/Fast Refresh blockers, and routing to React DevTools or debugging evidence.
 - **MCP router**: use `agent-device mcp` when an MCP-aware client needs install, status, and version-matched help discovery. MCP is intentionally a thin router; device automation still runs through CLI commands.
 
 For client-specific setup, see [AI Agent Setup](https://incubator.callstack.com/agent-device/docs/agent-setup). For agent-readable docs, use [llms-full.txt](https://incubator.callstack.com/agent-device/llms-full.txt).

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -31,6 +31,7 @@ Escalate only when relevant:
 
 ```bash
 agent-device help debugging
+agent-device help react-native
 agent-device help react-devtools
 agent-device help remote
 agent-device help macos

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -506,7 +506,7 @@ test('client capture.snapshot preserves visibility metadata from daemon response
     data: {
       nodes: [],
       truncated: false,
-      appBundleId: 'com.expensify.chat.dev',
+      appBundleId: 'com.agentdevice.tester',
       visibility: {
         partial: true,
         visibleNodeCount: 64,

--- a/src/__tests__/runtime-snapshot.test.ts
+++ b/src/__tests__/runtime-snapshot.test.ts
@@ -86,22 +86,14 @@ test('runtime diff snapshot initializes baseline when no previous snapshot exist
 });
 
 test('runtime snapshot emits filtered Android guidance from backend analysis', async () => {
-  const device = createAgentDevice({
-    backend: createSnapshotBackend(() => ({
-      nodes: [],
-      truncated: false,
-      backend: 'android',
-      analysis: {
-        rawNodeCount: 42,
-        maxDepth: 6,
-      },
-    })),
-    artifacts: createLocalArtifactAdapter(),
-    sessions: {
-      get: () => undefined,
-      set: () => {},
+  const device = createSnapshotOnlyDevice({
+    nodes: [],
+    truncated: false,
+    backend: 'android',
+    analysis: {
+      rawNodeCount: 42,
+      maxDepth: 6,
     },
-    policy: localCommandPolicy(),
   });
 
   const result = await device.capture.snapshot({
@@ -114,6 +106,99 @@ test('runtime snapshot emits filtered Android guidance from backend analysis', a
     'Interactive snapshot is empty after filtering 42 raw Android nodes. Likely causes: depth too low, transient route change, or collector filtering.',
     'Interactive output is empty at depth 3; retry without -d.',
   ]);
+});
+
+test('runtime snapshot warns when Android hierarchy looks like a React Native overlay', async () => {
+  const device = createSnapshotOnlyDevice({
+    nodes: [
+      { ref: 'e1', index: 0, depth: 0, type: 'Text', label: 'LogBox' },
+      { ref: 'e2', index: 1, depth: 1, type: 'Text', label: 'Warnings' },
+      { ref: 'e3', index: 2, depth: 1, type: 'Button', label: 'Dismiss' },
+    ],
+    truncated: false,
+    backend: 'android',
+  });
+
+  const result = await device.capture.snapshot({ session: 'default', interactiveOnly: true });
+
+  assertReactNativeOverlayWarning(result.warnings);
+});
+
+test('runtime snapshot warns on collapsed Android React Native warning banners', async () => {
+  const device = createSnapshotOnlyDevice({
+    nodes: [
+      {
+        ref: 'e1',
+        index: 0,
+        depth: 0,
+        type: 'android.view.ViewGroup',
+        label: '!, Open debugger to view warnings.',
+      },
+      {
+        ref: 'e2',
+        index: 1,
+        depth: 1,
+        type: 'android.widget.TextView',
+        label: 'Open debugger to view warnings.',
+      },
+    ],
+    truncated: false,
+    backend: 'android',
+  });
+
+  const result = await device.capture.snapshot({ session: 'default', interactiveOnly: true });
+
+  assertReactNativeOverlayWarning(result.warnings);
+});
+
+test('runtime snapshot warns when iOS hierarchy looks like a React Native overlay', async () => {
+  const device = createSnapshotOnlyDevice({
+    nodes: [
+      {
+        ref: 'e1',
+        index: 0,
+        depth: 0,
+        type: 'XCUIElementTypeOther',
+        label: 'React Native RedBox',
+      },
+      {
+        ref: 'e2',
+        index: 1,
+        depth: 1,
+        type: 'XCUIElementTypeStaticText',
+        value: 'Runtime Error',
+      },
+      {
+        ref: 'e3',
+        index: 2,
+        depth: 1,
+        type: 'XCUIElementTypeButton',
+        identifier: 'Reload JS',
+      },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const result = await device.capture.snapshot({ session: 'default', interactiveOnly: true });
+
+  assertReactNativeOverlayWarning(result.warnings);
+});
+
+test('runtime snapshot does not warn for ordinary Android validation errors', async () => {
+  const device = createSnapshotOnlyDevice({
+    nodes: [
+      { ref: 'e1', index: 0, depth: 0, type: 'Text', label: 'Validation errors' },
+      { ref: 'e2', index: 1, depth: 1, type: 'Text', label: 'Required' },
+      { ref: 'e3', index: 2, depth: 1, type: 'Button', label: 'Submit order' },
+    ],
+    truncated: false,
+    backend: 'android',
+  });
+
+  const result = await device.capture.snapshot({ session: 'default', interactiveOnly: true });
+
+  assert.equal(result.warnings, undefined);
 });
 
 test('runtime snapshot stale-drop warning uses the runtime clock', async () => {
@@ -256,4 +341,21 @@ function createSnapshotBackend(
     platform: 'ios',
     captureSnapshot: async () => await captureSnapshot(),
   };
+}
+
+function createSnapshotOnlyDevice(result: BackendSnapshotResult) {
+  return createAgentDevice({
+    backend: createSnapshotBackend(() => result),
+    artifacts: createLocalArtifactAdapter(),
+    sessions: {
+      get: () => undefined,
+      set: () => {},
+    },
+    policy: localCommandPolicy(),
+  });
+}
+
+function assertReactNativeOverlayWarning(warnings: string[] | undefined) {
+  assert.equal(warnings?.length, 1);
+  assert.match(warnings[0] ?? '', /Possible React Native warning\/error overlay/);
 }

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -216,6 +216,12 @@ function buildSnapshotWarnings(params: {
     }
   }
 
+  if (hasReactNativeOverlay(params.snapshot.nodes)) {
+    warnings.push(
+      'Possible React Native warning/error overlay detected. Capture screenshot --overlay-refs, check react-devtools errors if connected, dismiss Dismiss/Close only if unrelated, re-snapshot, and report it.',
+    );
+  }
+
   const previousSnapshot = params.session?.snapshot;
   const isRecentSnapshot = previousSnapshot
     ? [params.capturedAt, params.runtimeNow].some((timestamp) => {
@@ -253,4 +259,17 @@ function buildSnapshotWarnings(params: {
 function isLikelyStaleSnapshotDrop(previousCount: number, currentCount: number): boolean {
   if (previousCount < 12) return false;
   return currentCount <= Math.floor(previousCount * 0.2);
+}
+
+function hasReactNativeOverlay(nodes: SnapshotNode[]): boolean {
+  const text = nodes
+    .map((node) =>
+      [node.label, node.value, node.identifier, node.type, node.role].filter(Boolean).join(' '),
+    )
+    .join('\n')
+    .toLowerCase();
+
+  return /\b(logbox|redbox|reload js|copy stack|component stack|call stack|runtime error|open debugger to view warnings)\b/.test(
+    text,
+  );
 }

--- a/src/core/__tests__/dispatch-type.test.ts
+++ b/src/core/__tests__/dispatch-type.test.ts
@@ -6,7 +6,7 @@ import { ANDROID_EMULATOR } from '../../__tests__/test-utils/device-fixtures.ts'
 
 test('dispatch type rejects ref-shaped first positional with a repair hint', async () => {
   await assert.rejects(
-    () => dispatchCommand(ANDROID_EMULATOR, 'type', ['@ref42', 'filed', 'the', 'expense']),
+    () => dispatchCommand(ANDROID_EMULATOR, 'type', ['@ref42', 'sent', 'the', 'update']),
     (error: unknown) =>
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&

--- a/src/daemon/__tests__/network-log.test.ts
+++ b/src/daemon/__tests__/network-log.test.ts
@@ -48,7 +48,7 @@ test('readRecentNetworkTraffic enriches Android GIBSDK URL lines with timing met
     [
       '03-31 17:43:32.564 V/GIBSDK  (17434): [NetworkAgent]: packet id 23911610 added, queue size: 1',
       '03-31 17:43:33.031 D/GIBSDK  (17434): [NetworkAgent] packet id 23911610 total elapsed request/response time, ms: 377; response code: 200;',
-      '03-31 17:43:33.031 D/GIBSDK  (17434): URL: https://www.expensify.com/api/fl?as=2.0.2816300925',
+      '03-31 17:43:33.031 D/GIBSDK  (17434): URL: https://api.example.com/v1/fixture?as=2.0.2816300925',
       '03-31 17:43:33.032 V/GIBSDK  (17434): [NetworkAgent]: packet id 23911610 sent successfully, 0 left in queue',
     ].join('\n'),
     'utf8',
@@ -64,7 +64,7 @@ test('readRecentNetworkTraffic enriches Android GIBSDK URL lines with timing met
 
   assert.equal(dump.exists, true);
   assert.equal(dump.entries.length, 1);
-  assert.equal(dump.entries[0]?.url, 'https://www.expensify.com/api/fl?as=2.0.2816300925');
+  assert.equal(dump.entries[0]?.url, 'https://api.example.com/v1/fixture?as=2.0.2816300925');
   assert.equal(dump.entries[0]?.timestamp, '03-31 17:43:33.031');
   assert.equal(dump.entries[0]?.status, 200);
   assert.equal(dump.entries[0]?.durationMs, 377);
@@ -83,7 +83,7 @@ test('readRecentNetworkTraffic tolerates interleaved Android lines within the pa
       '03-31 17:43:32.900 V/OtherTag (17434): unrelated line 3',
       '03-31 17:43:33.000 V/OtherTag (17434): unrelated line 4',
       '03-31 17:43:33.031 D/GIBSDK  (17434): [NetworkAgent] packet id 23911610 total elapsed request/response time, ms: 377; response code: 200;',
-      '03-31 17:43:33.032 D/GIBSDK  (17434): URL: https://www.expensify.com/api/fl?as=2.0.2816300925',
+      '03-31 17:43:33.032 D/GIBSDK  (17434): URL: https://api.example.com/v1/fixture?as=2.0.2816300925',
     ].join('\n'),
     'utf8',
   );
@@ -109,7 +109,7 @@ test('readRecentNetworkTraffic keeps Android packet enrichment disabled for Appl
     logPath,
     [
       '2026-03-31 17:43:33.031 response code: 200',
-      '2026-03-31 17:43:33.032 URL: https://www.expensify.com/api/fl?as=2.0.2816300925',
+      '2026-03-31 17:43:33.032 URL: https://api.example.com/v1/fixture?as=2.0.2816300925',
     ].join('\n'),
     'utf8',
   );
@@ -123,7 +123,7 @@ test('readRecentNetworkTraffic keeps Android packet enrichment disabled for Appl
   });
 
   assert.equal(dump.entries.length, 1);
-  assert.equal(dump.entries[0]?.url, 'https://www.expensify.com/api/fl?as=2.0.2816300925');
+  assert.equal(dump.entries[0]?.url, 'https://api.example.com/v1/fixture?as=2.0.2816300925');
   assert.equal(dump.entries[0]?.timestamp, '2026-03-31 17:43:33.032');
   assert.equal(dump.entries[0]?.status, undefined);
   assert.equal(dump.entries[0]?.durationMs, undefined);
@@ -134,7 +134,7 @@ test('readRecentNetworkTraffic ignores plain documentation URLs in non-network l
   const logPath = path.join(tempDir, 'app.log');
   fs.writeFileSync(
     logPath,
-    '2026-04-02 08:14:44.371 E New Expensify Dev[32193:8c7e18d] Airship config warning. See https://docs.airship.com/platform/mobile/setup/sdk/ios/#url-allow-list for more information.\n',
+    '2026-04-02 08:14:44.371 E Agent Device Tester[32193:8c7e18d] Airship config warning. See https://docs.airship.com/platform/mobile/setup/sdk/ios/#url-allow-list for more information.\n',
     'utf8',
   );
 

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -315,7 +315,7 @@ test('handleFindCommands wait bypasses snapshot cache while Android freshness re
     })
     .mockResolvedValueOnce({
       nodes: [
-        { index: 0, depth: 0, type: 'android.widget.TextView', label: 'Create expense' },
+        { index: 0, depth: 0, type: 'android.widget.TextView', label: 'Create document' },
         { index: 1, depth: 0, type: 'android.widget.Button', label: 'Submit', hittable: true },
       ],
       truncated: false,
@@ -324,7 +324,7 @@ test('handleFindCommands wait bypasses snapshot cache while Android freshness re
     });
 
   const { response } = await runFindClickScenario({
-    positionals: ['text', 'Create expense', 'wait', '700'],
+    positionals: ['text', 'Create document', 'wait', '700'],
     session,
   });
 

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -1024,7 +1024,7 @@ test('press @ref fails when Android tap escapes to Settings', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'android-settings-escape';
   const session = makeAndroidSession(sessionName);
-  session.appBundleId = 'com.expensify.chat.dev';
+  session.appBundleId = 'com.agentdevice.tester';
   session.snapshot = {
     nodes: attachRefs([
       {

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -3743,6 +3743,8 @@ test('open on in-use device returns DEVICE_IN_USE before readiness checks', asyn
   expect(response?.ok).toBe(false);
   if (response && !response.ok) {
     expect(response.error.code).toBe('DEVICE_IN_USE');
+    expect(response.error.details?.hint).toContain('agent-device session list');
+    expect(response.error.details?.hint).toContain('--session busy-session');
   }
   expect(mockEnsureDeviceReady).not.toHaveBeenCalled();
 });
@@ -4733,7 +4735,7 @@ test('network dump recovers Android entries from adb logcat when the session str
       return {
         stdout:
           '04-01 10:00:14.500 I/ActivityManager( 9999): Start proc 4321:com.example.app/u0a123 for top-activity\n' +
-          '04-01 10:00:15.000 D/GIBSDK  (4321): POST https://api.example.com/v1/expenses status=200 duration=15032\n',
+          '04-01 10:00:15.000 D/GIBSDK  (4321): POST https://api.example.com/v1/documents status=200 duration=15032\n',
         stderr: '',
         exitCode: 0,
       };
@@ -4763,7 +4765,7 @@ test('network dump recovers Android entries from adb logcat when the session str
     expect(entries.length).toBe(1);
     const latest = entries[0] as Record<string, unknown>;
     expect(latest.method).toBe('POST');
-    expect(latest.url).toBe('https://api.example.com/v1/expenses');
+    expect(latest.url).toBe('https://api.example.com/v1/documents');
     expect(latest.status).toBe(200);
     expect(response.data?.notes).toContain(
       'Session app log stream was inactive. Recovered recent Android HTTP entries from adb logcat for PID set 4321.',
@@ -4996,7 +4998,7 @@ test('network dump recovers iOS simulator entries from simctl log show when the 
   fs.mkdirSync(path.dirname(appLogPath), { recursive: true });
   fs.writeFileSync(
     appLogPath,
-    'Filtering the log data using "subsystem == \\"com.expensify.chat.dev\\""\n',
+    'Filtering the log data using "subsystem == \\"com.agentdevice.tester\\""\n',
     'utf8',
   );
   sessionStore.set(sessionName, {
@@ -5007,7 +5009,7 @@ test('network dump recovers iOS simulator entries from simctl log show when the 
       kind: 'simulator',
       booted: true,
     }),
-    appBundleId: 'com.expensify.chat.dev',
+    appBundleId: 'com.agentdevice.tester',
     appLog: {
       platform: 'ios',
       backend: 'ios-simulator',
@@ -5030,7 +5032,7 @@ test('network dump recovers iOS simulator entries from simctl log show when the 
       return {
         stdout:
           'Timestamp               Ty Process[PID:TID]\n' +
-          '2026-04-02 08:08:50.665 I New Expensify Dev[32193:8c7411e] POST https://api.example.com/v1/search statusCode=200 duration=42\n',
+          '2026-04-02 08:08:50.665 I Agent Device Tester[32193:8c7411e] POST https://api.example.com/v1/search statusCode=200 duration=42\n',
         stderr: '',
         exitCode: 0,
       };
@@ -5073,7 +5075,7 @@ test('network dump explains when iOS simulator recovery found app logs but no HT
   fs.mkdirSync(path.dirname(appLogPath), { recursive: true });
   fs.writeFileSync(
     appLogPath,
-    'Filtering the log data using "subsystem == \\"com.expensify.chat.dev\\""\n',
+    'Filtering the log data using "subsystem == \\"com.agentdevice.tester\\""\n',
     'utf8',
   );
   sessionStore.set(sessionName, {
@@ -5084,7 +5086,7 @@ test('network dump explains when iOS simulator recovery found app logs but no HT
       kind: 'simulator',
       booted: true,
     }),
-    appBundleId: 'com.expensify.chat.dev',
+    appBundleId: 'com.agentdevice.tester',
     appLog: {
       platform: 'ios',
       backend: 'ios-simulator',
@@ -5107,7 +5109,7 @@ test('network dump explains when iOS simulator recovery found app logs but no HT
       return {
         stdout:
           'Timestamp               Ty Process[PID:TID]\n' +
-          '2026-04-02 08:08:50.665 E New Expensify Dev[32193:8c7411e] Airship config warning\n',
+          '2026-04-02 08:08:50.665 E Agent Device Tester[32193:8c7411e] Airship config warning\n',
         stderr: '',
         exitCode: 0,
       };

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -243,7 +243,7 @@ test('snapshot automatically retries stale Android trees after recent navigation
     })
     .mockResolvedValueOnce({
       nodes: [
-        { index: 0, depth: 0, type: 'android.widget.TextView', label: 'Create expense' },
+        { index: 0, depth: 0, type: 'android.widget.TextView', label: 'Create document' },
         { index: 1, depth: 0, type: 'android.widget.Button', label: 'Submit', hittable: true },
       ],
       truncated: false,
@@ -268,7 +268,7 @@ test('snapshot automatically retries stale Android trees after recent navigation
   if (response?.ok) {
     expect(response.data?.warnings).toBeUndefined();
     expect(response.data?.nodes).toEqual(
-      expect.arrayContaining([expect.objectContaining({ label: 'Create expense' })]),
+      expect.arrayContaining([expect.objectContaining({ label: 'Create document' })]),
     );
   }
   expect(mockDispatch).toHaveBeenCalledTimes(2);
@@ -543,7 +543,7 @@ test('wait text on Android uses freshness-aware capture instead of one-shot snap
     })
     .mockResolvedValueOnce({
       nodes: [
-        { index: 0, depth: 0, type: 'android.widget.TextView', label: 'Create expense' },
+        { index: 0, depth: 0, type: 'android.widget.TextView', label: 'Create document' },
         { index: 1, depth: 0, type: 'android.widget.TextView', label: 'Done' },
       ],
       truncated: false,
@@ -556,7 +556,7 @@ test('wait text on Android uses freshness-aware capture instead of one-shot snap
       token: 't',
       session: sessionName,
       command: 'wait',
-      positionals: ['Create expense', '50'],
+      positionals: ['Create document', '50'],
       flags: {},
     },
     sessionName,
@@ -566,11 +566,11 @@ test('wait text on Android uses freshness-aware capture instead of one-shot snap
 
   expect(response?.ok).toBe(true);
   if (response?.ok) {
-    expect(response.data?.text).toBe('Create expense');
+    expect(response.data?.text).toBe('Create document');
   }
   expect(mockDispatch).toHaveBeenCalledTimes(2);
   expect(sessionStore.get(sessionName)?.snapshot?.nodes).toEqual(
-    expect.arrayContaining([expect.objectContaining({ label: 'Create expense' })]),
+    expect.arrayContaining([expect.objectContaining({ label: 'Create document' })]),
   );
 });
 

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -314,7 +314,12 @@ export async function handleOpenCommand(params: {
       return errorResponse(
         'DEVICE_IN_USE',
         `Device is already in use by session "${inUse.name}".`,
-        { session: inUse.name, deviceId: device.id, deviceName: device.name },
+        {
+          session: inUse.name,
+          deviceId: device.id,
+          deviceName: device.name,
+          hint: `Run agent-device session list and reuse --session ${inUse.name}, or close that session before opening a new one on this device.`,
+        },
       );
     }
 

--- a/src/mcp/__tests__/router.test.ts
+++ b/src/mcp/__tests__/router.test.ts
@@ -67,6 +67,7 @@ test('MCP exposes help resources and workflow prompts', () => {
     (resource) => resource.uri,
   );
   assert.ok(resourceUris.includes('agent-device://help/workflow'));
+  assert.ok(resourceUris.includes('agent-device://help/react-native'));
 
   const prompt = handleMcpMessage({
     jsonrpc: '2.0',
@@ -81,6 +82,21 @@ test('MCP exposes help resources and workflow prompts', () => {
   const result = prompt.result as { messages: Array<{ content: { text: string } }> };
   assert.match(result.messages[0]?.content.text ?? '', /dogfood/);
   assert.match(result.messages[0]?.content.text ?? '', /SampleApp on iOS/);
+});
+
+test('MCP React Native prompt routes to RN workflow guidance', () => {
+  const prompt = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 6,
+    method: 'prompts/get',
+    params: {
+      name: 'agent-device-react-native',
+    },
+  });
+
+  assert.ok(prompt && 'result' in prompt);
+  const result = prompt.result as { messages: Array<{ content: { text: string } }> };
+  assert.match(result.messages[0]?.content.text ?? '', /react-native/);
 });
 
 test('MCP initialize returns supported protocol version and unknown methods use JSON-RPC code', () => {

--- a/src/mcp/catalog.ts
+++ b/src/mcp/catalog.ts
@@ -1,19 +1,13 @@
-import { buildCommandUsageText, buildUsageText } from '../utils/command-schema.ts';
+import {
+  buildCommandUsageText,
+  buildUsageText,
+  HELP_TOPIC_NAMES,
+  type HelpTopicName,
+} from '../utils/command-schema.ts';
 import { readVersion } from '../utils/version.ts';
 
 export const MCP_SERVER_NAME = 'agent-device';
 const MCP_REGISTRY_NAME = 'io.github.callstackincubator/agent-device';
-
-const HELP_TOPICS = [
-  'workflow',
-  'debugging',
-  'react-devtools',
-  'remote',
-  'macos',
-  'dogfood',
-] as const;
-
-type HelpTopic = (typeof HELP_TOPICS)[number];
 
 type InstallArgs = {
   client?: string;
@@ -71,7 +65,7 @@ export function createHelpText(args: { topic?: string; command?: string } = {}):
   if (!target) return buildUsageText();
   if (args.topic && !isHelpTopic(args.topic)) {
     throw new Error(
-      `Unknown help topic: ${args.topic}. Expected one of: ${HELP_TOPICS.join(', ')}`,
+      `Unknown help topic: ${args.topic}. Expected one of: ${HELP_TOPIC_NAMES.join(', ')}`,
     );
   }
   const help = buildCommandUsageText(target);
@@ -116,7 +110,7 @@ export function listTools(): unknown[] {
         properties: {
           topic: {
             type: 'string',
-            enum: HELP_TOPICS,
+            enum: HELP_TOPIC_NAMES,
             description: 'Agent workflow topic.',
           },
           command: {
@@ -149,7 +143,7 @@ export function listResources(): Array<{
       description: 'Version-matched command list and global flags.',
       mimeType: 'text/plain',
     },
-    ...HELP_TOPICS.map((topic) => ({
+    ...HELP_TOPIC_NAMES.map((topic) => ({
       uri: `agent-device://help/${topic}`,
       name: `agent-device help ${topic}`,
       description: `Version-matched ${topic} workflow guidance.`,
@@ -177,19 +171,19 @@ export function listPrompts(): Array<{ name: string; description: string; argume
       'Run exploratory QA with reproducible evidence.',
     ),
     createPromptDescriptor(
-      'agent-device-react-native-performance',
-      'Inspect React Native renders.',
+      'agent-device-react-native',
+      'Plan React Native app automation with overlay and DevTools routing.',
     ),
     createPromptDescriptor('agent-device-macos', 'Inspect a macOS app or surface.'),
   ];
 }
 
 export function getPrompt(name: string, args: Record<string, string> = {}): unknown {
-  const topicByPrompt: Record<string, HelpTopic> = {
+  const topicByPrompt: Record<string, HelpTopicName> = {
     'agent-device-workflow': 'workflow',
     'agent-device-debugging': 'debugging',
     'agent-device-dogfood': 'dogfood',
-    'agent-device-react-native-performance': 'react-devtools',
+    'agent-device-react-native': 'react-native',
     'agent-device-macos': 'macos',
   };
   const topic = topicByPrompt[name];
@@ -230,6 +224,6 @@ function createPromptDescriptor(
   };
 }
 
-function isHelpTopic(value: string): value is HelpTopic {
-  return (HELP_TOPICS as readonly string[]).includes(value);
+function isHelpTopic(value: string): value is HelpTopicName {
+  return (HELP_TOPIC_NAMES as readonly string[]).includes(value);
 }

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -1510,7 +1510,7 @@ test('fillAndroid tolerates delayed React Native text verification', async () =>
       '  count=$((count + 1))',
       '  printf "%s" "$count" > "$DUMP_COUNT_FILE"',
       '  if [ "$count" -eq 1 ]; then',
-      '    text="filed the expens"',
+      '    text="sent the updat"',
       '  else',
       '    text="$(cat "$STATE_FILE" 2>/dev/null)"',
       '  fi',
@@ -1522,7 +1522,7 @@ test('fillAndroid tolerates delayed React Native text verification', async () =>
       '',
     ].join('\n'),
     async ({ device }) => {
-      await fillAndroid(device, 10, 10, 'filed the expense');
+      await fillAndroid(device, 10, 10, 'sent the update');
     },
   );
 });

--- a/src/platforms/android/__tests__/input-actions-fill.test.ts
+++ b/src/platforms/android/__tests__/input-actions-fill.test.ts
@@ -61,6 +61,39 @@ test('verifyAndroidFilledTextInHierarchy accepts matching-length masked password
   assert.equal(verification.masked, true);
 });
 
+test('verifyAndroidFilledTextInHierarchy accepts Android sentence autocapitalization', () => {
+  const verification = verifyAndroidFilledTextInHierarchy(
+    androidInputXml({ text: 'Sent the update' }),
+    10,
+    10,
+    'sent the update',
+  );
+
+  assert.equal(verification.ok, true);
+});
+
+test('verifyAndroidFilledTextInHierarchy rejects reverse sentence autocapitalization mismatch', () => {
+  const verification = verifyAndroidFilledTextInHierarchy(
+    androidInputXml({ text: 'john' }),
+    10,
+    10,
+    'John',
+  );
+
+  assert.equal(verification.ok, false);
+});
+
+test('verifyAndroidFilledTextInHierarchy does not ignore broader case mismatches', () => {
+  const verification = verifyAndroidFilledTextInHierarchy(
+    androidInputXml({ text: 'SENT THE UPDATE' }),
+    10,
+    10,
+    'sent the update',
+  );
+
+  assert.equal(verification.ok, false);
+});
+
 test('fillAndroid accepts matching-length masked password verification', async () => {
   let typed = '';
   await withFillAdb(
@@ -149,6 +182,10 @@ function imeCaptureHierarchy(imeText: string): string {
 
 function passwordHierarchy(mask: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.EditText" text="${mask}" password="true" focused="true" bounds="[0,0][200,100]"/></hierarchy>`;
+}
+
+function androidInputXml(options: { text: string }): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><hierarchy><node package="com.example" class="android.widget.EditText" text="${options.text}" focused="true" bounds="[0,0][200,100]"/></hierarchy>`;
 }
 
 function focusedEditHierarchy(): string {

--- a/src/platforms/android/fill-verification.ts
+++ b/src/platforms/android/fill-verification.ts
@@ -213,6 +213,9 @@ function isAcceptableAndroidFillMatch(actual: string | null, expected: string): 
   if (normalizedActual === normalizedExpected) {
     return true;
   }
+  if (isSentenceAutocapitalizeMatch(normalizedActual, normalizedExpected)) {
+    return true;
+  }
   if (normalizedActual.includes(normalizedExpected)) {
     return true;
   }
@@ -224,6 +227,17 @@ function isAcceptableAndroidFillMatch(actual: string | null, expected: string): 
 
 function normalizeFillVerificationText(value: string | null): string {
   return (value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function isSentenceAutocapitalizeMatch(actual: string, expected: string): boolean {
+  if (actual.length !== expected.length || actual.length === 0) return false;
+  if (actual.slice(1) !== expected.slice(1)) return false;
+  const actualFirst = actual[0];
+  const expectedFirst = expected[0];
+  if (!actualFirst || !expectedFirst) return false;
+  return (
+    expectedFirst.toLowerCase() === expectedFirst && actualFirst === expectedFirst.toUpperCase()
+  );
 }
 
 function androidFillCandidateFromNode(

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -794,7 +794,7 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /Use selectors or refs as positional targets/);
   assert.match(usageText, /Plain snapshot reads state; snapshot -i is required/);
   assert.match(usageText, /Truncated text\/input preview: expand first with snapshot -s @e12/);
-  assert.match(usageText, /RN warning\/error overlays can block taps: snapshot -i/);
+  assert.match(usageText, /React Native apps: read help react-native/);
   assert.match(usageText, /Expo Go\/dev clients: use the provided URL when given/);
   assert.match(usageText, /on iOS prefer open "Expo Go" <url>/);
   assert.match(usageText, /Install flows: install\/install-from-source first/);
@@ -802,6 +802,7 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /do not use fill <target> ""/);
   assert.match(usageText, /Android IME capture: if fill says input was captured/);
   assert.match(usageText, /Run mutating commands serially against one session/);
+  assert.match(usageText, /run session list and reuse the active session name/);
   assert.match(usageText, /After mutation: diff snapshot -i/);
   assert.match(usageText, /app-owned back uses back/);
   assert.match(usageText, /logs clear --restart\/mark\/path/);
@@ -815,6 +816,10 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(
     usageText,
     /help react-devtools\s+React Native performance, profiling, component tree, and renders/,
+  );
+  assert.match(
+    usageText,
+    /help react-native\s+React Native app automation hazards, overlays, Metro, and routing/,
   );
   assert.match(usageText, /Configuration:/);
   assert.match(
@@ -857,7 +862,9 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /agent-device get attrs @e4/);
   assert.match(help, /Ambiguous find: add --first or --last/);
   assert.match(help, /report that gap instead of typing\/searching\/navigating/);
-  assert.match(help, /If snapshot -i shows one, dismiss\/close its visible control/);
+  assert.match(help, /App-owned action sheets, menus, and camera\/scan screens are normal UI/);
+  assert.match(help, /wait for a concrete result before returning to chat\/form state/);
+  assert.match(help, /use help react-native for Metro\/Fast Refresh/);
   assert.match(help, /iOS Allow Paste prompt cannot be exercised under XCUITest/);
   assert.match(help, /Empty replacement is not a supported clear-field command/);
   assert.match(help, /do not plan fill <target> ""/);
@@ -872,18 +879,21 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /Android Gboard handwriting\/stylus UI can capture text/);
   assert.match(help, /targetInput\/actualInput details/);
   assert.match(help, /Do not keep retrying fill\/type against the same field/);
+  assert.match(help, /do not switch to clipboard or paste for non-ASCII field entry/);
   assert.match(help, /trusted ADB keyboard IME/);
   assert.match(help, /if no URL is provided but a target\/app name is provided, open that target/);
   assert.match(help, /do not split clear\/restart/);
   assert.match(help, /do not write network log headers/);
   assert.match(help, /agent-device open exp:\/\/127\.0\.0\.1:8081 --platform ios/);
   assert.match(help, /agent-device open "Expo Go" exp:\/\/127\.0\.0\.1:8081 --platform ios/);
+  assert.match(help, /There is no open-url command/);
   assert.match(help, /direct URL open can report success while leaving the runner\/shell focused/);
   assert.match(help, /verify with snapshot -i after opening/);
   assert.match(help, /agent-device open exp:\/\/127\.0\.0\.1:8081 --platform android/);
   assert.match(help, /apps lookup misses the project but shows Expo Go\/dev-client/);
   assert.match(help, /metro prepare --kind expo/);
   assert.match(help, /help react-devtools/);
+  assert.match(help, /help react-native/);
 });
 
 test('workflow help keeps common copyable command forms', () => {
@@ -896,6 +906,15 @@ test('workflow help keeps common copyable command forms', () => {
   assert.match(help, /screenshot --overlay-refs/);
   assert.match(help, /snapshot -s @e7/);
   assert.match(help, /clipboard write "some text"/);
+});
+
+test('usageForCommand resolves debugging help topic', () => {
+  const help = usageForCommand('debugging');
+  if (help === null) throw new Error('Expected debugging help text');
+  assert.match(help, /agent-device help debugging/);
+  assert.match(help, /agent-device alert wait 3000/);
+  assert.match(help, /Do not use alert wait for them/);
+  assert.match(help, /do not use settings permission to answer a dialog already on screen/);
 });
 
 test('usageForCommand resolves remote help topic', () => {
@@ -955,6 +974,26 @@ test('usageForCommand resolves react-devtools help topic', () => {
   assert.match(help, /isolated --state-dir/);
   assert.match(help, /local service tunnel/);
   assert.match(help, /Remote iOS apps attempt the legacy React DevTools websocket/);
+});
+
+test('usageForCommand resolves react-native help topic', () => {
+  const help = usageForCommand('react-native');
+  if (help === null) throw new Error('Expected react-native help text');
+  assert.match(help, /agent-device help react-native/);
+  assert.match(help, /React Native-specific automation hazards/);
+  assert.match(help, /Choose the next help topic/);
+  assert.match(help, /help workflow/);
+  assert.match(help, /help debugging/);
+  assert.match(help, /help react-devtools/);
+  assert.match(help, /Help workflow owns the full Expo URL command shapes/);
+  assert.match(help, /Keep the agent-device react-devtools prefix/);
+  assert.match(help, /Use help react-devtools for status\/wait/);
+  assert.match(help, /logs clear --restart/);
+  assert.match(help, /network dump --include headers/);
+  assert.match(help, /React Native warning\/error overlays belong to the app run/);
+  assert.match(help, /Android runtime permission dialogs are visible UI/);
+  assert.match(help, /snapshot times out because the UI never becomes idle/);
+  assert.match(help, /Report React render offenders separately/);
 });
 
 test('apps defaults to --all filter and allows overrides', () => {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -162,6 +162,10 @@ const AGENT_WORKFLOWS = [
   { label: 'help workflow', description: 'Normal bootstrap, exploration, and validation loop' },
   { label: 'help debugging', description: 'Logs, network, alerts, diagnostics, and traces' },
   {
+    label: 'help react-native',
+    description: 'React Native app automation hazards, overlays, Metro, and routing',
+  },
+  {
     label: 'help react-devtools',
     description: 'React Native performance, profiling, component tree, and renders',
   },
@@ -179,13 +183,14 @@ const AGENT_QUICKSTART_LINES = [
   'Plain snapshot reads state; snapshot -i is required to refresh interactive refs.',
   'Read-only visible/state question: use snapshot/get/is/find; use snapshot -i only when refs are needed.',
   'Truncated text/input preview: expand first with snapshot -s @e12, not get text.',
-  'RN warning/error overlays can block taps: snapshot -i, dismiss/close, then diff snapshot -i.',
+  'React Native apps: read help react-native for Metro, LogBox/RedBox overlays, DevTools routing, and RN-specific blockers.',
   'Expo Go/dev clients: use the provided URL when given; on iOS prefer open "Expo Go" <url>; Android URL opens infer the foreground package for logs/perf when possible.',
   'Install flows: install/install-from-source first, then open the installed id with --relaunch.',
   'Text: fill \'id="field-email"\' "qa@example.com" replaces; type appends after press.',
   'Clearing text: do not use fill <target> ""; use a visible clear/reset control or report that clearing is unsupported.',
   'Android IME capture: if fill says input was captured by the keyboard/IME, inspect keyboard state and switch/disable handwriting before retrying; do not loop fill/type.',
   'Run mutating commands serially against one session; parallelize only read-only commands or separate sessions.',
+  'Before taking over a shared device, run session list and reuse the active session name when one already owns the device.',
   'Clipboard limits: iOS Allow Paste cannot be automated through XCUITest; prefill with clipboard write. Android non-ASCII should use fill/type, not raw adb input.',
   'After mutation: diff snapshot -i. Off-screen hints: scroll, then snapshot -i.',
   'Raw coordinates are fallback-only: use snapshot -i -c --json rects when iOS refs no-op or child refs are missing.',
@@ -293,7 +298,7 @@ Text entry:
   Search-as-you-type fields on iOS can drop characters when driven too fast; use --delay-ms on fill/type before trying clipboard paste.
   iOS Allow Paste prompt cannot be exercised under XCUITest. To test paste-driven app behavior, prefill first with agent-device clipboard write "some text"; test the system prompt manually.
   Android Gboard handwriting/stylus UI can capture text in an IME-owned input instead of the app field. If fill reports that input was captured by the keyboard/IME, use the diagnostic targetInput/actualInput details, inspect with keyboard status/get if needed, and switch or disable handwriting/trusted ADB keyboard outside the command plan before retrying. Do not keep retrying fill/type against the same field while the IME owns focus.
-  Android non-ASCII can fail on some system images. Try fill/type normally; agent-device uses safer fallbacks. If the shell reports unsupported non-ASCII input, configure a trusted ADB keyboard IME outside the command plan and restore the previous IME afterward.
+  Android non-ASCII can fail on some system images. Use fill/type and let agent-device own the safer fallback path; do not switch to clipboard or paste for non-ASCII field entry. If the shell reports unsupported non-ASCII input, configure a trusted ADB keyboard IME outside the command plan and restore the previous IME afterward.
 
 Session ordering:
   Stateful commands against one --session must run serially. Do not run open/press/fill/type/scroll/back/alert/replay/batch/close commands in parallel against the same session.
@@ -315,6 +320,7 @@ Read-only and waits:
 Navigation and gestures:
   Use scroll for lists; swipe for coordinate gestures/carousels.
   If app-owned back is ambiguous or has just misrouted, prefer a visible nav/back button ref, tab-bar ref, or deep link over repeated back/system back.
+  App-owned action sheets, menus, and camera/scan screens are normal UI. After opening one, run snapshot -i or wait for the option, press by label/ref, handle visible permission sheets through UI or platform-supported native alerts, then wait for a concrete result before returning to chat/form state.
   Keep count/pause/pattern on one swipe; flags are --count, --pause-ms, --pattern ping-pong.
   longpress duration and pinch scale/center are positional:
     agent-device longpress 300 500 800
@@ -344,10 +350,11 @@ React Native dev loop:
     agent-device metro reload
     agent-device find "Home"
   Do not use agent-device reload. Use open --relaunch for native startup reset.
-  Warning/error overlays can obscure UI and intercept taps. If snapshot -i shows one, dismiss/close its visible control (for example Dismiss or Close) if it is not the task target, then diff snapshot -i or snapshot -i before tapping the real UI.
+  React Native apps: use help react-native for Metro/Fast Refresh, LogBox/RedBox overlays, DevTools routing, and RN-specific blockers.
   Expo Go is a host shell. Use a provided project URL instead of inventing a bundle id; if no URL is provided but a target/app name is provided, open that target and do not inspect project files to find one. On iOS, prefer host + URL when the host shell is known because direct URL open can report success while leaving the runner/shell focused; verify with snapshot -i after opening:
     agent-device open "Expo Go" exp://127.0.0.1:8081 --platform ios
     agent-device snapshot -i --platform ios
+  There is no open-url command; use open with the URL target or host + URL form.
   Direct iOS URL open remains valid when no host shell is known, but verify that the app UI loaded:
     agent-device open exp://127.0.0.1:8081 --platform ios
   Android uses the URL target directly; do not write open <app> <url> there:
@@ -369,6 +376,7 @@ React DevTools minimum loop:
 Escalate:
   help debugging       logs, network, alerts, traces, flaky runtime failures
   help react-devtools  React Native performance, profiling, props/state/hooks, slow renders, rerenders
+  help react-native   React Native app automation hazards, overlays, Metro, and routing
   help remote          remote/cloud config, tenant, lease, local service tunnels
   help macos           desktop, frontmost-app, menu bar surfaces
   help dogfood         exploratory QA report workflow`,
@@ -403,6 +411,7 @@ Alerts:
   If alert accept says no alert but a permission sheet is visibly on screen, treat it as normal UI:
     agent-device snapshot -i
     agent-device press 'label="Allow"'
+  Android runtime permission prompts are visible UI. Do not use alert wait for them, and do not use settings permission to answer a dialog already on screen. Reserve settings permission for setup/resetting permission state before a flow.
 
 Diagnostics and traces:
   Use --debug for CLI/daemon diagnostic ids and log paths.
@@ -476,6 +485,44 @@ Example:
   agent-device react-devtools profile report @c5
 
 Use snapshot, screenshot, logs, network, and perf for device/app runtime evidence. Use react-devtools only when component internals or React rendering behavior matters.`,
+  },
+  'react-native': {
+    summary: 'React Native app automation hazards and routing',
+    body: `agent-device help react-native
+
+Use this when the target app is React Native, Expo, or a React Native dev client.
+This topic covers React Native-specific automation hazards and routes deeper
+questions to the owning help topic.
+
+Choose the next help topic:
+  Generic navigation, selectors, refs, verification, serial commands: help workflow.
+  Logs, network, diagnostics, traces, permission dialogs, or runtime failures: help debugging.
+  Component tree, props/state/hooks, slow renders, rerenders, or render causes: help react-devtools.
+  Remote/cloud config, leases, and local service tunnels: help remote.
+
+React Native dev loop:
+  JS-only change with Metro connected:
+    agent-device metro reload
+    agent-device find "Home"
+  Do not use agent-device reload. Use open --relaunch for native startup reset.
+  Expo Go/dev clients are host shells. Use provided project URLs, verify with snapshot -i after opening, and ask instead of inventing app ids or URLs. Help workflow owns the full Expo URL command shapes.
+
+Overlays and busy RN UIs:
+  React Native warning/error overlays belong to the app run. Treat them as findings or blockers: capture screenshot --overlay-refs, run react-devtools errors when connected, dismiss visible Dismiss/Close only if unrelated, re-snapshot, and report the overlay.
+  If snapshot times out because the UI never becomes idle, use screenshot as visual truth, try settings animations off for Android, or wait briefly and retry; report the busy UI as the blocker if it persists.
+  Android runtime permission dialogs are visible UI: inspect snapshot -i and press Allow/Deny by visible label/ref. Use alert wait/accept/dismiss only where the platform supports native alerts.
+
+React DevTools routing:
+  Keep the agent-device react-devtools prefix on every React DevTools command.
+  Use help react-devtools for status/wait, component trees, props/state/hooks, profile windows, slow renders, rerenders, and remote bridge rules.
+  If React DevTools cannot connect, report status and continue with logs, network, perf, screenshot, and trace evidence instead of blocking the whole flow.
+
+Slow-flow investigation:
+  Keep one named session, start with session list, open, and snapshot -i.
+  Use help react-devtools for the narrow React profile window.
+  Use help debugging for logs clear --restart, logs mark, network dump --include headers, perf --json, traces, and runtime failure evidence.
+  For 15-20s async work, use wait with the exact expected text or selector instead of repeated snapshots.
+  Report React render offenders separately from network/backend waits and device frame/CPU/memory findings.`,
   },
   remote: {
     summary: 'Remote config, tenant, lease, and remote host flow',
@@ -601,6 +648,9 @@ Rules:
   Escalate to help debugging or help react-devtools when runtime symptoms require those tools.`,
   },
 } as const satisfies Record<string, { summary: string; body: string }>;
+
+export type HelpTopicName = keyof typeof HELP_TOPICS;
+export const HELP_TOPIC_NAMES = Object.keys(HELP_TOPICS) as readonly HelpTopicName[];
 
 const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
   {

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -9,10 +9,11 @@ interface PlannedCommandMatcher {
   matchers: CommandMatcher[];
 }
 
-const APP_SOURCE = /(?:^|\/)examples\/test-app\//;
-const REPO_SOURCE = /(?:^|\/)src\//;
-const COMMAND_DOCS = /website\/docs\/docs\/commands\.md$/;
-const SUITE_FILE = /test\/skillgym\/suites\/agent-device-smoke-suite\.ts$/;
+const WORKSPACE_ROOT = process.cwd().replaceAll('\\', '/');
+const APP_SOURCE = workspacePathPattern('examples/test-app', 'directory');
+const REPO_SOURCE = workspacePathPattern('src', 'directory');
+const COMMAND_DOCS = workspacePathPattern('website/docs/docs/commands.md', 'file');
+const SUITE_FILE = workspacePathPattern('test/skillgym/suites/agent-device-smoke-suite.ts', 'file');
 
 const BASE_INSTRUCTIONS = `
 You are benchmarking agent-device command planning for a known fixture app.
@@ -24,6 +25,18 @@ Use only this prompt plus local CLI help as private reference.
 For local CLI help in this repo, use node bin/agent-device.mjs help or --help; final commands still use agent-device.
 Final output: only agent-device commands, one per line. Any prose or Markdown fails.
 `.trim();
+
+function workspacePathPattern(relativePath: string, kind: 'directory' | 'file') {
+  const normalizedPath = relativePath.replaceAll('\\', '/').replace(/^\.\//, '');
+  const escapedRoot = escapeRegExp(WORKSPACE_ROOT);
+  const escapedRelativePath = escapeRegExp(normalizedPath);
+  const boundary = kind === 'directory' ? '(?:/|$)' : '$';
+  return new RegExp(`^(?:${escapedRelativePath}|${escapedRoot}/${escapedRelativePath})${boundary}`);
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 function buildPrompt(options: { contract: string[]; task: string }) {
   const contractLines = options.contract.map((line) => `- ${line}`).join('\n');
@@ -682,10 +695,18 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       'Field selector: id="field-name"',
       'Desired value: Café ☕ 🎉',
       'Some Android system images fail with direct platform-shell text injection',
+      'agent-device fill owns the non-ASCII fallback; do not use clipboard or paste',
     ],
     task: 'Plan only the robust agent-device command to fill the field with the provided non-ASCII value.',
     outputs: [plannedCommand('fill'), /id=(?:["']field-name["']|field-name)/i, /Café ☕ 🎉/i],
-    forbiddenOutputs: [/\badb\b/i, /shell input text/i, /\bime\b/i, /ADBKeyBoard/i],
+    forbiddenOutputs: [
+      plannedCommand('adb'),
+      plannedCommand('clipboard'),
+      /shell input text/i,
+      /\bpaste\b/i,
+      /\bime\b/i,
+      /ADBKeyBoard/i,
+    ],
   }),
   makeCase({
     id: 'offscreen-target-scroll-resnapshot',
@@ -713,8 +734,8 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     ],
     task: 'Plan commands to handle the missing child refs by inspecting raw compact rects, tapping the Bakery center, and verifying the selected filter changed.',
     outputs: [
-      COMPACT_RECT_SNAPSHOT,
-      /(?:^|\n)(?:agent-device\s+)?(?:press|click)\s+84\s+220\b/i,
+      /(?:snapshot\b(?=[^\n]*(?:-c\b|--compact\b))(?=[^\n]*(?:--json|--raw))|snapshot\b.*-i)/i,
+      /(?:^|\n)(?:agent-device\s+(?:--platform\s+ios\s+)?)?(?:press|click)\s+84\s+220\b/i,
       /(?:diff snapshot -i|snapshot\b.*(?:-i\b.*--diff|--diff\b.*-i\b)|snapshot\b.*-i|Berry Tart|Bakery)/i,
     ],
     forbiddenOutputs: [
@@ -741,8 +762,9 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       'App name: Agent Device Tester',
       'Current screen: product detail',
       'Goal: return to the Catalog tab through normal app navigation',
+      'No visible Catalog tab selector or nav-back selector is currently exposed',
     ],
-    task: 'Plan the command to go back to Catalog using app-owned navigation semantics.',
+    task: 'Plan the command to go back to Catalog using the app-owned back command.',
     outputs: [plannedCommand('back')],
     forbiddenOutputs: [/back\s+--system/i],
   }),
@@ -828,7 +850,6 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     task: 'Plan the minimal read-only command to inspect exposed UI without typing, navigating, or mutating the app to reveal hidden information.',
     outputs: [plannedCommand('snapshot')],
     forbiddenOutputs: [
-      /snapshot -i/i,
       plannedCommand('press'),
       plannedCommand('click'),
       plannedCommand('fill'),
@@ -862,7 +883,7 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     ],
     task: 'Plan commands to identify the warning overlay in snapshot -i, dismiss it, verify the overlay is gone with diff snapshot -i or a fresh snapshot -i, then press the submit target.',
     outputs: [
-      /snapshot -i[\s\S]*(?:press|click)\b[^\n]*(?:Dismiss|Close|warning)[\s\S]*(?:diff snapshot -i|snapshot\b.*-i)/i,
+      /snapshot -i[\s\S]*(?:(?:press|click)\b[^\n]*(?:Dismiss|Close|warning)|find\b[^\n]*(?:Dismiss|Close|warning)[^\n]*(?:press|click))[\s\S]*(?:diff snapshot -i|snapshot\b.*-i)/i,
       /submit-order/i,
     ],
     forbiddenOutputs: [
@@ -871,6 +892,29 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       /(?:^|\n)(?:agent-device\s+)?(?:press|click)\b[^\n]*submit-order[\s\S]*(?:Dismiss|Close)/i,
       /alert accept/i,
     ],
+  }),
+  makeCase({
+    id: 'rn-error-overlay-human-flag',
+    contract: [
+      'App name: Agent Device Tester',
+      'Platform: Android',
+      'Fresh interactive snapshot shows a React Native error overlay',
+      'Overlay controls include Dismiss and Reload JS',
+      'React DevTools is connected',
+      'The overlay is unrelated to the requested checkout task but should be reported',
+      'Checkout target selector after dismissing overlay: id="submit-order"',
+      'Need overlay screenshot evidence with refs before dismissing it',
+    ],
+    task: 'Plan commands to capture the error overlay using screenshot --overlay-refs, inspect React DevTools errors, dismiss only the unrelated overlay, re-snapshot, then continue to id="submit-order".',
+    outputs: [
+      /snapshot(?:\s+-i)?/i,
+      /screenshot\b[^\n]*--overlay-refs/i,
+      plannedCommand('react-devtools errors'),
+      /(?:(?:press|click)\b[^\n]*(?:Dismiss|Close)|find\b[^\n]*(?:Dismiss|Close)[^\n]*(?:press|click))/i,
+      /(?:diff snapshot -i|snapshot(?:\s+-i)?)/i,
+      /submit-order/i,
+    ],
+    forbiddenOutputs: [RAW_COORDINATE_TARGET, /alert accept/i, /ignore/i],
   }),
   makeCase({
     id: 'expo-go-ios-project-url',
@@ -920,6 +964,7 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     task: 'Plan the next command to launch the project after the app-id lookup miss without inventing a native bundle id.',
     outputs: [IOS_EXPO_GO_OPEN],
     forbiddenOutputs: [
+      /open-url/i,
       /open\s+Agent Device Tester/i,
       /com\.(?:callstack|example|agent)/i,
       /host\.exp\.Exponent/i,
@@ -966,10 +1011,53 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     outputs: [
       /load-diagnostics/i,
       plannedCommand('network'),
-      /dump/i,
-      /(?:--include\s+headers|\bheaders\b)/i,
+      /(?:dump|log)/i,
+      /(?:--include\s+headers|\bheaders\b|network dump\b[^\n]*\ball\b)/i,
     ],
     forbiddenOutputs: [/logs path/i, /cat .*log/i],
+  }),
+  makeCase({
+    id: 'android-open-verify-ui',
+    contract: [
+      'App name: Agent Device Tester',
+      'Platform: Android',
+      'Package id: com.agentdevice.tester',
+      'Expected loaded text: Agent Device Tester',
+      'Need to verify the UI loaded after relaunch',
+    ],
+    task: 'Plan commands to open the Android package with a relaunch and verify the app UI loaded. Do not rely on screenshot-only verification.',
+    outputs: [
+      plannedCommand('open'),
+      /com\.agentdevice\.tester/i,
+      /--relaunch/i,
+      /(?:wait(?:\s+text)?|is visible|find)\b[^\n]*Agent Device Tester/i,
+    ],
+    forbiddenOutputs: [plannedCommand('screenshot')],
+  }),
+  makeCase({
+    id: 'android-action-sheet-document-scan-wait',
+    contract: [
+      'App name: Document Fixture',
+      'Platform: Android',
+      'Current screen: chat composer',
+      'Action sheet trigger selector: id="composer-actions"',
+      'Scan option text: Scan document',
+      'Expected result text after upload: Document uploaded',
+      'Android camera permission may appear as visible UI',
+    ],
+    task: 'Plan commands to open the composer action sheet, choose Scan document, handle any visible permission prompt, and wait for the upload result.',
+    outputs: [
+      /composer-actions/i,
+      /Scan document/i,
+      /Allow|snapshot -i/i,
+      /wait\b[^\n]*Document uploaded/i,
+    ],
+    forbiddenOutputs: [
+      RAW_COORDINATE_TARGET,
+      PSEUDO_ASSERTION_COMMAND,
+      /alert wait/i,
+      /settings permission/i,
+    ],
   }),
   makeCase({
     id: 'evidence-screenshot-overlay-refs',
@@ -992,7 +1080,7 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     ],
     task: 'Plan the commands to open the app first if needed, then collect session performance metrics as JSON.',
     outputs: [plannedCommand('open'), plannedCommandAlternatives(['perf', 'metrics']), /--json/i],
-    forbiddenOutputs: [plannedCommand('logs'), plannedCommand('network')],
+    forbiddenOutputs: [plannedCommand('network')],
   }),
   makeCase({
     id: 'react-devtools-profile-search',
@@ -1005,7 +1093,7 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     ],
     task: 'Plan the commands to verify React DevTools is connected, profile the Catalog search interaction, then list slow components and rerenders.',
     outputs: [
-      plannedCommand('react-devtools status'),
+      plannedCommandAlternatives(['react-devtools status', 'react-devtools start']),
       plannedCommand('react-devtools wait'),
       plannedCommand('react-devtools profile start'),
       /catalog-search/i,
@@ -1048,6 +1136,41 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       plannedCommand('react-devtools profile slow'),
       plannedCommand('react-devtools profile rerenders'),
     ],
+  }),
+  makeCase({
+    id: 'react-native-diagnostics-flow',
+    contract: [
+      'App name: Agent Device Tester',
+      'Platform: Android',
+      'Current screen: Settings tab',
+      'Slow interaction: load diagnostics from the Settings screen',
+      'Diagnostics trigger selector: id="load-diagnostics"',
+      'Expected async result selector: id="diagnostics-error"',
+      'The diagnostics request can take 5-10 seconds',
+      'Need React component offenders and network evidence',
+      'Before beginning the shared-device flow, run session list to discover/reuse any active session',
+      'Open Agent Device Tester on Android and take snapshot -i before interacting',
+    ],
+    task: 'Plan commands for a focused React Native performance run around the Settings diagnostics load flow, including debug markers, async verification, slow/rerender output, and network headers.',
+    outputs: [
+      plannedCommand('session list'),
+      plannedCommand('open'),
+      /snapshot -i/i,
+      /logs (?:clear --restart|start)/i,
+      /logs mark\b[^\n]*(?:before|start|begin)/i,
+      plannedCommand('react-devtools status'),
+      plannedCommand('react-devtools wait'),
+      plannedCommand('react-devtools profile start'),
+      /load-diagnostics/i,
+      /wait\b[^\n]*(?:diagnostics-error|Diagnostics error)/i,
+      /(?:5000|10000|12000|15000|20000)/i,
+      /logs mark\b[^\n]*(?:after|end|verified|diagnostics|loaded)/i,
+      plannedCommand('react-devtools profile stop'),
+      plannedCommand('react-devtools profile slow'),
+      plannedCommand('react-devtools profile rerenders'),
+      /network dump\b[^\n]*(?:--include headers|\bheaders\b|\ball\b)/i,
+    ],
+    forbiddenOutputs: [RAW_COORDINATE_TARGET, /cat .*log/i, /alert wait/i, /agent-devtools/i],
   }),
   makeCase({
     id: 'gesture-swipe-carousel',
@@ -1160,7 +1283,7 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       'Question: is the keyboard visible and what input type is active?',
     ],
     task: 'Plan the read-only command to inspect Android keyboard visibility and input type.',
-    outputs: [/(?:^|\n)(?:agent-device\s+)?keyboard\s+(?:status|get)(?:\s|$)/i],
+    outputs: [/(?:^|\n)(?:agent-device\s+)?keyboard(?:\s+(?:status|get))?(?:\s|$)/i],
     forbiddenOutputs: [plannedCommand('fill'), plannedCommand('type'), /keyboard dismiss/i],
   }),
   makeCase({
@@ -1176,7 +1299,7 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     ],
     task: 'Plan the next diagnostic step. Do not retry fill or type until the IME handwriting/stylus state has been corrected.',
     outputs: [
-      /(?:^|\n)(?:agent-device\s+)?keyboard\s+(?:status|get)(?:\s|$)/i,
+      /(?:^|\n)(?:agent-device\s+)?keyboard(?:\s+(?:status|get))?(?:\s|$)/i,
       /(?:IME|keyboard|Gboard|handwriting|stylus)/i,
     ],
     forbiddenOutputs: [
@@ -1253,8 +1376,9 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       'App name: Agent Device Tester Menu',
       'The app lives entirely as a menu bar extra',
       'Normal app snapshots can be sparse or empty',
+      'Required flags: --platform macos --surface menubar',
     ],
-    task: 'Plan the commands to inspect the menu bar app surface and capture interactive refs with snapshot -i.',
+    task: 'Plan the commands to inspect the menu bar app surface with --platform macos --surface menubar and capture interactive refs with snapshot -i.',
     outputs: [/--platform macos/i, /--surface menubar/i, /snapshot\b.*(?:-i\b|\s-i\b)/i],
     forbiddenOutputs: [/--surface app/i, /snapshot --raw/i],
   }),
@@ -1265,8 +1389,9 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       'Current surface: app',
       'Target row current ref: @e66',
       'Need to open its native context menu and inspect menu item refs',
+      'Required platform flag: --platform macos',
     ],
-    task: 'Plan commands to open the context menu for @e66 and then refresh interactive refs for the menu items.',
+    task: 'Plan commands with --platform macos to open the context menu for @e66 and then refresh interactive refs for the menu items.',
     outputs: [
       plannedCommand('click'),
       /@e66/i,

--- a/website/docs/docs/agent-setup.md
+++ b/website/docs/docs/agent-setup.md
@@ -47,7 +47,7 @@ The bundled [agent-device skill](https://github.com/callstackincubator/agent-dev
 Add this as a project rule, custom instruction, or skill equivalent when your agent client supports it:
 
 ```text
-Use agent-device only for app/device automation tasks. Before planning commands, run `agent-device --version` and read `agent-device help workflow`. For exploratory QA, read `agent-device help dogfood`. For logs, network, traces, or runtime failures, read `agent-device help debugging`. For React Native component trees, props/state/hooks, slow renders, or rerenders, read `agent-device help react-devtools`.
+Use agent-device only for app/device automation tasks. Before planning commands, run `agent-device --version` and read `agent-device help workflow`. For exploratory QA, read `agent-device help dogfood`. For logs, network, traces, or runtime failures, read `agent-device help debugging`. For React Native component trees, props/state/hooks, slow renders, or rerenders, read `agent-device help react-devtools`. For React Native apps, overlays, Metro/Fast Refresh blockers, and routing to React DevTools or debugging evidence, read `agent-device help react-native`.
 
 Use the CLI in the integrated terminal. If `agent-device` is not on PATH but the user installed it globally in another shell, ask the user's login shell for the absolute path and run that path instead. For macOS zsh users, use `zsh -lic 'command -v agent-device'`; for other shells, use the equivalent login-shell lookup. Do not silently fall back to `npx -y agent-device@latest`; ask or use an exact version. MCP is only a discovery/help router and does not expose device automation tools. Prefer `open -> snapshot -i -> act -> re-snapshot -> verify -> close`. Use current refs such as `@e3` for exploration and selectors for durable replay. Keep mutating commands against one session serial. Capture screenshots, logs, network, perf, traces, recordings, and `.ad` replay scripts only when they add evidence.
 ```
@@ -128,6 +128,7 @@ Use the bundled skill when your Claude setup supports skills. Otherwise put the 
 agent-device --version
 agent-device help workflow
 agent-device help dogfood
+agent-device help react-native
 ```
 
 If you configure MCP, keep using CLI commands for automation. The MCP router gives Claude install/status/help context only.

--- a/website/docs/docs/batching.md
+++ b/website/docs/docs/batching.md
@@ -112,14 +112,14 @@ Open app -> open thread -> type -> send
   { "command": "open", "positionals": ["com.example.chat"], "flags": { "platform": "android" } },
   { "command": "wait", "positionals": ["text", "Inbox", "3000"], "flags": {} },
   { "command": "press", "positionals": ["label=\"Inbox\" role=button"], "flags": {} },
-  { "command": "press", "positionals": ["label=\"Adam Horodyski\""], "flags": {} },
+  { "command": "press", "positionals": ["label=\"Morgan Lee\""], "flags": {} },
   {
     "command": "fill",
-    "positionals": ["label=\"Message\" role=text-field", "filed the expense"],
+    "positionals": ["label=\"Message\" role=text-field", "sent the update"],
     "flags": {}
   },
   { "command": "press", "positionals": ["label=\"Send\" role=button"], "flags": {} },
-  { "command": "wait", "positionals": ["text", "filed the expense", "3000"], "flags": {} }
+  { "command": "wait", "positionals": ["text", "sent the update", "3000"], "flags": {} }
 ]
 ```
 
@@ -130,10 +130,10 @@ Open app -> open action menu -> choose option -> verify
   { "command": "open", "positionals": ["com.example.app"], "flags": { "platform": "android" } },
   { "command": "wait", "positionals": ["text", "Home", "3000"], "flags": {} },
   { "command": "press", "positionals": ["label=\"More actions\" role=button"], "flags": {} },
-  { "command": "wait", "positionals": ["text", "Camera scan", "2000"], "flags": {} },
-  { "command": "press", "positionals": ["label=\"Camera scan\""], "flags": {} },
-  { "command": "wait", "positionals": ["text", "Expense created", "15000"], "flags": {} },
-  { "command": "is", "positionals": ["visible", "label=\"Expense created\""], "flags": {} }
+  { "command": "wait", "positionals": ["text", "Scan document", "2000"], "flags": {} },
+  { "command": "press", "positionals": ["label=\"Scan document\""], "flags": {} },
+  { "command": "wait", "positionals": ["text", "Document uploaded", "15000"], "flags": {} },
+  { "command": "is", "positionals": ["visible", "label=\"Document uploaded\""], "flags": {} }
 ]
 ```
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -14,6 +14,7 @@ For agent workflow guidance that is matched to the installed CLI, run:
 agent-device help
 agent-device help workflow
 agent-device help debugging
+agent-device help react-native
 agent-device help react-devtools
 agent-device help remote
 agent-device help macos
@@ -280,7 +281,7 @@ agent-device pinch 0.5 200 400 # zoom out at coordinates (Apple simulator or mac
 Use `--delay-ms` on `type` or `fill` for debounced search fields and search-as-you-type inputs that miss characters when text is injected too quickly.
 Delayed typing prefers paced character entry over clipboard-style fallbacks so the target field still receives incremental updates.
 On Android, `fill` also verifies text and performs one clear-and-retry pass on mismatch.
-Some Android images cannot enter non-ASCII text over shell input; in that case use a trusted ADB keyboard IME and verify APK checksum/signature before install.
+Some Android images cannot enter non-ASCII text over shell input. Use `fill`/`type` and let `agent-device` own the safer fallback path; do not switch to clipboard or paste for non-ASCII field entry. If the shell still reports unsupported non-ASCII input, use a trusted ADB keyboard IME and verify APK checksum/signature before install.
 `click --button secondary` is the desktop context-menu flow on macOS.
 `click --button middle` is reserved for future runner support and currently returns an explicit unsupported-operation error on macOS.
 `swipe` accepts an optional `durationMs` argument (default `250ms`, range `16..10000`).
@@ -599,6 +600,8 @@ agent-device react-devtools profile rerenders --limit 5
 - `agent-device` global flags work before or after `react-devtools`. Use `--` before downstream flags only when they intentionally share an `agent-device` global flag name.
 - Use it when a React Native workflow needs component hierarchy, props, state, hooks, render causes, slow components, or re-render counts.
 - Keep using `snapshot`, `press`, `fill`, `logs`, `network`, and `perf` for device/app runtime evidence. Use `react-devtools` for React internals.
+- For React Native apps, overlays, Metro/Fast Refresh blockers, and routing to React DevTools or debugging evidence, start with `agent-device help react-native`.
+- On Android, permission prompts are visible UI; use `snapshot -i` and press visible `Allow`/`Deny` controls instead of `alert wait`. Do not use `settings permission` to answer a dialog already on screen; reserve it for setup or resetting permission state before a flow.
 - React Native development builds can connect to the DevTools daemon on port 8097. For Android emulators or physical devices, run `adb reverse tcp:8097 tcp:8097` if the app cannot reach the host. If Metro is local, also run `adb reverse tcp:8081 tcp:8081`.
 - For Android and iOS sessions connected through a remote bridge profile, `react-devtools` registers a lease-scoped companion tunnel to the sandbox-local DevTools daemon at `127.0.0.1:8097`. Android bridge profiles use the bridge-owned remote `adb reverse` mapping; iOS bridge profiles use the bridge-owned wildcard Metro host tunnel. The CLI keeps the companion alive until `agent-device react-devtools stop` or `agent-device disconnect`.
 - For remote iOS bridge sessions, open the app once to create the bridge session, run `agent-device react-devtools start`, then relaunch the same bundle id with `agent-device open <bundle-id> --platform ios --relaunch` before `wait --connected`. React Native attempts the legacy DevTools websocket during JavaScript startup, so starting DevTools after the first launch can miss that connection attempt.

--- a/website/docs/docs/debugging-profiling.md
+++ b/website/docs/docs/debugging-profiling.md
@@ -19,20 +19,31 @@ If the task needs the React Native component tree, props, state, hooks, or rende
 
 ```bash
 agent-device react-devtools status
+agent-device react-devtools wait --connected
 agent-device react-devtools get tree --depth 3
 agent-device react-devtools get component @c5
 agent-device react-devtools profile start
 agent-device react-devtools profile stop
 agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+agent-device react-devtools profile report @c5
 ```
 
 `agent-device` remains centered on the device and app runtime layer. The `react-devtools` command dynamically runs pinned `agent-react-devtools` commands for React internals.
+
+For React Native apps, overlays, Metro/Fast Refresh blockers, and routing to React DevTools or debugging evidence, start with `agent-device help react-native`. For slow-flow investigations, combine `help react-devtools` for the narrow React profile window with `help debugging` for log markers, network evidence, traces, and perf samples.
+
+React Native warning/error overlays belong to the app run. Treat them as findings or blockers: capture them, check `react-devtools errors` when connected, dismiss visible `Dismiss`/`Close` controls only when unrelated, then re-snapshot and report the overlay.
+
+On Android, runtime permission dialogs are visible UI for `snapshot -i` plus visible `Allow`/`Deny` refs or labels. Do not use `alert wait` for Android permission prompts, and do not use `settings permission` to answer a dialog already on screen. Reserve `settings permission` for setup or resetting permission state before a flow.
 
 ## Fast path
 
 ```bash
 agent-device open MyApp --platform ios
 agent-device logs clear --restart
+agent-device logs mark "before repro"
+agent-device press 'id="submit"'
 agent-device network dump 25 --include headers
 agent-device perf --json
 agent-device logs path

--- a/website/docs/docs/quick-start.md
+++ b/website/docs/docs/quick-start.md
@@ -94,7 +94,7 @@ Example batch payload for a known chat flow:
   { "command": "open", "positionals": ["ChatApp"], "flags": { "platform": "android" } },
   { "command": "click", "positionals": ["label=\"Travel chat\""], "flags": {} },
   { "command": "wait", "positionals": ["label=\"Message\"", "3000"], "flags": {} },
-  { "command": "fill", "positionals": ["label=\"Message\"", "Filed the expense"], "flags": {} },
+  { "command": "fill", "positionals": ["label=\"Message\"", "Sent the update"], "flags": {} },
   { "command": "press", "positionals": ["label=\"Send\""], "flags": {} }
 ]
 ```


### PR DESCRIPTION
## Summary

Improve RN agent-device stability guidance and runtime hints.

- Adds platform-neutral React Native overlay warnings with Android and iOS-shaped snapshot coverage.
- Replaces the unshipped `react-native-performance` help/API route with `react-native`, keeping RN hazards/routing separate from `react-devtools` internals and `debugging` evidence.
- Tightens Android fill verification so sentence autocap only accepts lowercase expected text being uppercased, with a reverse-case regression test.
- Keeps PR #490 React DevTools remote companion/relaunch guidance under `help react-devtools`.
- Updates MCP prompt routing, docs, the thin skill router, and SkillGym command-planning coverage.
- Adds Expo Go guidance against invented `open-url`; agents should use `open` with URL target or host + URL form.
- Generalizes Android runtime permission guidance: visible prompts are UI, not `alert wait`; `settings permission` is for setup/reset, not answering an active dialog.
- Removes SkillGym-only teaching hints for logs/React DevTools command sequencing so the cases verify shipped CLI help behavior instead.

Touched files: 25. Scope remains agent guidance, diagnostics, Android fill verification, and tests/docs.

## Validation

- `pnpm format`
- `pnpm exec vitest run src/platforms/android/__tests__/input-actions-fill.test.ts src/utils/__tests__/args.test.ts src/mcp/__tests__/router.test.ts src/__tests__/cli-help.test.ts src/__tests__/cli-react-devtools.test.ts src/__tests__/cli-react-devtools-session.test.ts`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case react-native-diagnostics-flow --repeat-failure 1`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case expo-go-ios-after-app-id-miss --repeat-failure 1`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case android-action-sheet-document-scan-wait --repeat-failure 1`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case rn-error-overlay-human-flag --repeat-failure 1`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case ios-composite-horizontal-tabs-coordinate-fallback --repeat-failure 1`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case react-devtools-render-cause-report --repeat-failure 1`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case catalog-scroll-footer --repeat-failure 1`
- `pnpm check:quick`
- `pnpm exec vitest run --maxWorkers=1`
- `pnpm test:smoke`

Notes: broad `pnpm test:skillgym` was run multiple times. The latest full run reached 74/76 cases and 150/152 executions; the two failures were `catalog-scroll-footer` reading the suite file and `rn-error-overlay-human-flag` missing re-snapshot on one `claude-haiku` execution. Both failed cases passed 2/2 on direct rerun. Earlier broad-run failures in `ios-composite-horizontal-tabs-coordinate-fallback`, `react-devtools-render-cause-report`, and `expo-go-ios-after-app-id-miss` also passed 2/2 on direct rerun; the Expo miss exposed and fixed the `open-url` guidance gap. Default parallel `pnpm check` still shows unrelated mocked platform test timeouts/exits; the failed files pass directly and the full unit suite passes with one worker.