### PR TITLE
refactor: simplify command route catalog

### DIFF
--- a/src/cli/commands/client-command.ts
+++ b/src/cli/commands/client-command.ts
@@ -6,7 +6,6 @@ import type {
   KeyboardCommandOptions,
   RotateCommandOptions,
 } from '../../client.ts';
-import { CLIENT_COMMANDS } from '../../client-command-registry.ts';
 import type { CliFlags } from '../../utils/command-schema.ts';
 import { AppError } from '../../utils/errors.ts';
 import { waitCommandCodec } from '../../command-codecs.ts';
@@ -15,49 +14,49 @@ import { buildSelectionOptions, writeCommandMessage, writeCommandOutput } from '
 import type { ClientCommandHandlerMap } from './router-types.ts';
 
 export const clientCommandMethodHandlers = {
-  [CLIENT_COMMANDS.wait]: async ({ positionals, flags, client }) => {
+  wait: async ({ positionals, flags, client }) => {
     writeCommandMessage(
       flags,
       await client.command.wait(waitCommandCodec.decode(positionals, flags)),
     );
     return true;
   },
-  [CLIENT_COMMANDS.alert]: async ({ positionals, flags, client }) => {
+  alert: async ({ positionals, flags, client }) => {
     writeCommandMessage(flags, await client.command.alert(readAlertOptions(positionals, flags)));
     return true;
   },
-  [CLIENT_COMMANDS.appState]: async ({ flags, client }) => {
+  appstate: async ({ flags, client }) => {
     const result = await client.command.appState(buildSelectionOptions(flags));
     writeCommandOutput(flags, result, () => formatAppState(result));
     return true;
   },
-  [CLIENT_COMMANDS.back]: async ({ flags, client }) => {
+  back: async ({ flags, client }) => {
     writeCommandMessage(
       flags,
       await client.command.back({ ...buildSelectionOptions(flags), mode: flags.backMode }),
     );
     return true;
   },
-  [CLIENT_COMMANDS.home]: async ({ flags, client }) => {
+  home: async ({ flags, client }) => {
     writeCommandMessage(flags, await client.command.home(buildSelectionOptions(flags)));
     return true;
   },
-  [CLIENT_COMMANDS.rotate]: async ({ positionals, flags, client }) => {
+  rotate: async ({ positionals, flags, client }) => {
     writeCommandMessage(flags, await client.command.rotate(readRotateOptions(positionals, flags)));
     return true;
   },
-  [CLIENT_COMMANDS.appSwitcher]: async ({ flags, client }) => {
+  'app-switcher': async ({ flags, client }) => {
     writeCommandMessage(flags, await client.command.appSwitcher(buildSelectionOptions(flags)));
     return true;
   },
-  [CLIENT_COMMANDS.keyboard]: async ({ positionals, flags, client }) => {
+  keyboard: async ({ positionals, flags, client }) => {
     writeCommandMessage(
       flags,
       await client.command.keyboard(readKeyboardOptions(positionals, flags)),
     );
     return true;
   },
-  [CLIENT_COMMANDS.clipboard]: async ({ positionals, flags, client }) => {
+  clipboard: async ({ positionals, flags, client }) => {
     writeClipboardOutput(
       flags,
       await client.command.clipboard(readClipboardOptions(positionals, flags)),

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -1,9 +1,7 @@
 import type { AgentDeviceClient, CommandRequestResult } from '../../client.ts';
-import { CLIENT_COMMANDS } from '../../client-command-registry.ts';
 import type { RecordOptions } from '../../client-types.ts';
 import { announceReplayTestRun } from '../../cli-test.ts';
 import { runTypeCliCommand } from '../../commands/interactions/cli.ts';
-import { typeCommandDefinition } from '../../commands/interactions/definition.ts';
 import { AppError } from '../../utils/errors.ts';
 import type { CliFlags } from '../../utils/command-schema.ts';
 import {
@@ -17,7 +15,8 @@ import {
 import { selectorSnapshotOptionsFromFlags } from '../../command-codecs/flags.ts';
 import { buildSelectionOptions } from './shared.ts';
 import { writeCommandCliOutput } from './output.ts';
-import type { ClientCommandHandler, ClientCommandHandlerMap } from './router-types.ts';
+import type { PublicCommandName } from '../../command-catalog.ts';
+import type { ClientCommandHandler } from './router-types.ts';
 
 type GenericClientCommandRunner = (params: {
   client: AgentDeviceClient;
@@ -25,242 +24,180 @@ type GenericClientCommandRunner = (params: {
   flags: CliFlags;
 }) => Promise<CommandRequestResult>;
 
-export const genericClientCommandHandlers = {
-  [CLIENT_COMMANDS.boot]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.boot,
-    ({ client, flags }) =>
-      client.devices.boot({ ...buildSelectionOptions(flags), headless: flags.headless }),
-  ),
-  [CLIENT_COMMANDS.push]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.push,
-    ({ client, positionals, flags }) =>
-      client.apps.push({
-        ...buildSelectionOptions(flags),
-        app: required(positionals[0], 'push requires bundleOrPackage'),
-        payload: required(positionals[1], 'push requires payloadOrJson'),
-      }),
-  ),
-  [CLIENT_COMMANDS.perf]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.perf,
-    ({ client, flags }) => client.observability.perf(buildSelectionOptions(flags)),
-  ),
-  [CLIENT_COMMANDS.click]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.click,
-    ({ client, positionals, flags }) =>
-      client.interactions.click({
-        ...interactionTargetCodec.decode(positionals),
-        ...selectorSnapshotOptionsFromFlags(flags),
-        ...buildSelectionOptions(flags),
-        count: flags.count,
-        intervalMs: flags.intervalMs,
-        holdMs: flags.holdMs,
-        jitterPx: flags.jitterPx,
-        doubleTap: flags.doubleTap,
-        button: flags.clickButton,
-      }),
-  ),
-  [CLIENT_COMMANDS.get]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.get,
-    ({ client, positionals, flags }) =>
-      client.interactions.get({
-        ...elementTargetCodec.decode(positionals.slice(1)),
-        ...selectorSnapshotOptionsFromFlags(flags),
-        ...buildSelectionOptions(flags),
-        format: readGetFormat(positionals[0]),
-      }),
-  ),
-  [CLIENT_COMMANDS.replay]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.replay,
-    ({ client, positionals, flags }) =>
-      client.replay.run({
-        ...buildSelectionOptions(flags),
-        path: required(positionals[0], 'replay requires path'),
-        update: flags.replayUpdate,
-        env: flags.replayEnv,
-      }),
-  ),
-  [CLIENT_COMMANDS.test]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.test,
-    ({ client, positionals, flags }) => {
-      announceReplayTestRun({ json: flags.json });
-      return client.replay.test({
-        ...buildSelectionOptions(flags),
-        paths: positionals,
-        update: flags.replayUpdate,
-        env: flags.replayEnv,
-        failFast: flags.failFast,
-        timeoutMs: flags.timeoutMs,
-        retries: flags.retries,
-        artifactsDir: flags.artifactsDir,
-        reportJunit: flags.reportJunit,
-      });
-    },
-  ),
-  [CLIENT_COMMANDS.batch]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.batch,
-    ({ client, flags }) =>
-      client.batch.run({
-        ...buildSelectionOptions(flags),
-        steps: flags.batchSteps ?? [],
-        onError: flags.batchOnError,
-        maxSteps: flags.batchMaxSteps,
-        out: flags.out,
-      }),
-  ),
-  [CLIENT_COMMANDS.press]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.press,
-    ({ client, positionals, flags }) =>
-      client.interactions.press({
-        ...interactionTargetCodec.decode(positionals),
-        ...selectorSnapshotOptionsFromFlags(flags),
-        ...buildSelectionOptions(flags),
-        count: flags.count,
-        intervalMs: flags.intervalMs,
-        holdMs: flags.holdMs,
-        jitterPx: flags.jitterPx,
-        doubleTap: flags.doubleTap,
-      }),
-  ),
-  [CLIENT_COMMANDS.longPress]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.longPress,
-    ({ client, positionals, flags }) =>
-      client.interactions.longPress({
-        ...buildSelectionOptions(flags),
-        x: Number(positionals[0]),
-        y: Number(positionals[1]),
-        durationMs: optionalNumber(positionals[2]),
-      }),
-  ),
-  [CLIENT_COMMANDS.swipe]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.swipe,
-    ({ client, positionals, flags }) =>
-      client.interactions.swipe({
-        ...buildSelectionOptions(flags),
-        from: { x: Number(positionals[0]), y: Number(positionals[1]) },
-        to: { x: Number(positionals[2]), y: Number(positionals[3]) },
-        durationMs: optionalNumber(positionals[4]),
-        count: flags.count,
-        pauseMs: flags.pauseMs,
-        pattern: flags.pattern,
-      }),
-  ),
-  [CLIENT_COMMANDS.focus]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.focus,
-    ({ client, positionals, flags }) =>
-      client.interactions.focus({
-        ...buildSelectionOptions(flags),
-        x: Number(positionals[0]),
-        y: Number(positionals[1]),
-      }),
-  ),
-  [typeCommandDefinition.name]: createGenericClientCommandHandler(
-    typeCommandDefinition.name,
-    runTypeCliCommand,
-  ),
-  [CLIENT_COMMANDS.fill]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.fill,
-    ({ client, positionals, flags }) => {
-      const decoded = fillCommandCodec.decode(positionals);
-      return client.interactions.fill({
-        ...decoded.target,
-        text: decoded.text,
-        ...selectorSnapshotOptionsFromFlags(flags),
-        ...buildSelectionOptions(flags),
-        delayMs: flags.delayMs,
-      });
-    },
-  ),
-  [CLIENT_COMMANDS.scroll]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.scroll,
-    ({ client, positionals, flags }) =>
-      client.interactions.scroll({
-        ...buildSelectionOptions(flags),
-        direction: readScrollDirection(positionals[0]),
-        amount: optionalNumber(positionals[1]),
-        pixels: flags.pixels,
-      }),
-  ),
-  [CLIENT_COMMANDS.pinch]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.pinch,
-    ({ client, positionals, flags }) =>
-      client.interactions.pinch({
-        ...buildSelectionOptions(flags),
-        scale: Number(positionals[0]),
-        x: optionalNumber(positionals[1]),
-        y: optionalNumber(positionals[2]),
-      }),
-  ),
-  [CLIENT_COMMANDS.triggerAppEvent]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.triggerAppEvent,
-    ({ client, positionals, flags }) =>
-      client.apps.triggerEvent({
-        ...buildSelectionOptions(flags),
-        event: required(positionals[0], 'trigger-app-event requires event'),
-        payload: positionals[1]
-          ? readJsonObject(positionals[1], 'trigger-app-event payload')
-          : undefined,
-      }),
-  ),
-  [CLIENT_COMMANDS.record]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.record,
-    ({ client, positionals, flags }) =>
-      client.recording.record({
-        ...buildSelectionOptions(flags),
-        action: readStartStop(positionals[0], 'record'),
-        path: positionals[1],
-        fps: flags.fps,
-        quality: flags.quality as RecordOptions['quality'],
-        hideTouches: flags.hideTouches,
-      }),
-  ),
-  [CLIENT_COMMANDS.trace]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.trace,
-    ({ client, positionals, flags }) =>
-      client.recording.trace({
-        ...buildSelectionOptions(flags),
-        action: readStartStop(positionals[0], 'trace'),
-        path: positionals[1],
-      }),
-  ),
-  [CLIENT_COMMANDS.logs]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.logs,
-    ({ client, positionals, flags }) =>
-      client.observability.logs({
-        ...buildSelectionOptions(flags),
-        action: readLogsAction(positionals[0]),
-        message: positionals.slice(1).join(' ') || undefined,
-        restart: flags.restart,
-      }),
-  ),
-  [CLIENT_COMMANDS.network]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.network,
-    ({ client, positionals, flags }) =>
-      client.observability.network({
-        ...buildSelectionOptions(flags),
-        action: readNetworkAction(positionals[0]),
-        limit: optionalNumber(positionals[1]),
-        include: flags.networkInclude ?? readNetworkInclude(positionals[2]),
-      }),
-  ),
-  [CLIENT_COMMANDS.find]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.find,
-    ({ client, positionals, flags }) =>
-      client.interactions.find(findCommandCodec.decode(positionals, flags)),
-  ),
-  [CLIENT_COMMANDS.is]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.is,
-    ({ client, positionals, flags }) =>
-      client.interactions.is(isCommandCodec.decode(positionals, flags)),
-  ),
-  [CLIENT_COMMANDS.settings]: createGenericClientCommandHandler(
-    CLIENT_COMMANDS.settings,
-    ({ client, positionals, flags }) =>
-      client.settings.update(settingsCommandCodec.decode(positionals, flags)),
-  ),
-} satisfies ClientCommandHandlerMap;
+const genericClientCommandRunners = {
+  boot: ({ client, flags }) =>
+    client.devices.boot({ ...buildSelectionOptions(flags), headless: flags.headless }),
+  push: ({ client, positionals, flags }) =>
+    client.apps.push({
+      ...buildSelectionOptions(flags),
+      app: required(positionals[0], 'push requires bundleOrPackage'),
+      payload: required(positionals[1], 'push requires payloadOrJson'),
+    }),
+  perf: ({ client, flags }) => client.observability.perf(buildSelectionOptions(flags)),
+  click: ({ client, positionals, flags }) =>
+    client.interactions.click({
+      ...interactionTargetCodec.decode(positionals),
+      ...selectorSnapshotOptionsFromFlags(flags),
+      ...buildSelectionOptions(flags),
+      count: flags.count,
+      intervalMs: flags.intervalMs,
+      holdMs: flags.holdMs,
+      jitterPx: flags.jitterPx,
+      doubleTap: flags.doubleTap,
+      button: flags.clickButton,
+    }),
+  get: ({ client, positionals, flags }) =>
+    client.interactions.get({
+      ...elementTargetCodec.decode(positionals.slice(1)),
+      ...selectorSnapshotOptionsFromFlags(flags),
+      ...buildSelectionOptions(flags),
+      format: readGetFormat(positionals[0]),
+    }),
+  replay: ({ client, positionals, flags }) =>
+    client.replay.run({
+      ...buildSelectionOptions(flags),
+      path: required(positionals[0], 'replay requires path'),
+      update: flags.replayUpdate,
+      env: flags.replayEnv,
+    }),
+  test: ({ client, positionals, flags }) => {
+    announceReplayTestRun({ json: flags.json });
+    return client.replay.test({
+      ...buildSelectionOptions(flags),
+      paths: positionals,
+      update: flags.replayUpdate,
+      env: flags.replayEnv,
+      failFast: flags.failFast,
+      timeoutMs: flags.timeoutMs,
+      retries: flags.retries,
+      artifactsDir: flags.artifactsDir,
+      reportJunit: flags.reportJunit,
+    });
+  },
+  batch: ({ client, flags }) =>
+    client.batch.run({
+      ...buildSelectionOptions(flags),
+      steps: flags.batchSteps ?? [],
+      onError: flags.batchOnError,
+      maxSteps: flags.batchMaxSteps,
+      out: flags.out,
+    }),
+  press: ({ client, positionals, flags }) =>
+    client.interactions.press({
+      ...interactionTargetCodec.decode(positionals),
+      ...selectorSnapshotOptionsFromFlags(flags),
+      ...buildSelectionOptions(flags),
+      count: flags.count,
+      intervalMs: flags.intervalMs,
+      holdMs: flags.holdMs,
+      jitterPx: flags.jitterPx,
+      doubleTap: flags.doubleTap,
+    }),
+  longpress: ({ client, positionals, flags }) =>
+    client.interactions.longPress({
+      ...buildSelectionOptions(flags),
+      x: Number(positionals[0]),
+      y: Number(positionals[1]),
+      durationMs: optionalNumber(positionals[2]),
+    }),
+  swipe: ({ client, positionals, flags }) =>
+    client.interactions.swipe({
+      ...buildSelectionOptions(flags),
+      from: { x: Number(positionals[0]), y: Number(positionals[1]) },
+      to: { x: Number(positionals[2]), y: Number(positionals[3]) },
+      durationMs: optionalNumber(positionals[4]),
+      count: flags.count,
+      pauseMs: flags.pauseMs,
+      pattern: flags.pattern,
+    }),
+  focus: ({ client, positionals, flags }) =>
+    client.interactions.focus({
+      ...buildSelectionOptions(flags),
+      x: Number(positionals[0]),
+      y: Number(positionals[1]),
+    }),
+  type: runTypeCliCommand,
+  fill: ({ client, positionals, flags }) => {
+    const decoded = fillCommandCodec.decode(positionals);
+    return client.interactions.fill({
+      ...decoded.target,
+      text: decoded.text,
+      ...selectorSnapshotOptionsFromFlags(flags),
+      ...buildSelectionOptions(flags),
+      delayMs: flags.delayMs,
+    });
+  },
+  scroll: ({ client, positionals, flags }) =>
+    client.interactions.scroll({
+      ...buildSelectionOptions(flags),
+      direction: readScrollDirection(positionals[0]),
+      amount: optionalNumber(positionals[1]),
+      pixels: flags.pixels,
+    }),
+  pinch: ({ client, positionals, flags }) =>
+    client.interactions.pinch({
+      ...buildSelectionOptions(flags),
+      scale: Number(positionals[0]),
+      x: optionalNumber(positionals[1]),
+      y: optionalNumber(positionals[2]),
+    }),
+  'trigger-app-event': ({ client, positionals, flags }) =>
+    client.apps.triggerEvent({
+      ...buildSelectionOptions(flags),
+      event: required(positionals[0], 'trigger-app-event requires event'),
+      payload: positionals[1]
+        ? readJsonObject(positionals[1], 'trigger-app-event payload')
+        : undefined,
+    }),
+  record: ({ client, positionals, flags }) =>
+    client.recording.record({
+      ...buildSelectionOptions(flags),
+      action: readStartStop(positionals[0], 'record'),
+      path: positionals[1],
+      fps: flags.fps,
+      quality: flags.quality as RecordOptions['quality'],
+      hideTouches: flags.hideTouches,
+    }),
+  trace: ({ client, positionals, flags }) =>
+    client.recording.trace({
+      ...buildSelectionOptions(flags),
+      action: readStartStop(positionals[0], 'trace'),
+      path: positionals[1],
+    }),
+  logs: ({ client, positionals, flags }) =>
+    client.observability.logs({
+      ...buildSelectionOptions(flags),
+      action: readLogsAction(positionals[0]),
+      message: positionals.slice(1).join(' ') || undefined,
+      restart: flags.restart,
+    }),
+  network: ({ client, positionals, flags }) =>
+    client.observability.network({
+      ...buildSelectionOptions(flags),
+      action: readNetworkAction(positionals[0]),
+      limit: optionalNumber(positionals[1]),
+      include: flags.networkInclude ?? readNetworkInclude(positionals[2]),
+    }),
+  find: ({ client, positionals, flags }) =>
+    client.interactions.find(findCommandCodec.decode(positionals, flags)),
+  is: ({ client, positionals, flags }) =>
+    client.interactions.is(isCommandCodec.decode(positionals, flags)),
+  settings: ({ client, positionals, flags }) =>
+    client.settings.update(settingsCommandCodec.decode(positionals, flags)),
+} satisfies Partial<Record<PublicCommandName, GenericClientCommandRunner>>;
+
+export const genericClientCommandHandlers = Object.fromEntries(
+  Object.entries(genericClientCommandRunners).map(([command, run]) => [
+    command,
+    createGenericClientCommandHandler(
+      command as PublicCommandName,
+      run as GenericClientCommandRunner,
+    ),
+  ]),
+) as { [TCommand in keyof typeof genericClientCommandRunners]: ClientCommandHandler };
 
 function createGenericClientCommandHandler(
-  command: string,
+  command: PublicCommandName,
   run: GenericClientCommandRunner,
 ): ClientCommandHandler {
   return async ({ positionals, flags, client }) => {

--- a/src/cli/commands/output.ts
+++ b/src/cli/commands/output.ts
@@ -1,5 +1,5 @@
 import type { CliFlags } from '../../utils/command-schema.ts';
-import { CLIENT_COMMANDS } from '../../client-command-registry.ts';
+import type { PublicCommandName } from '../../command-catalog.ts';
 import { readCommandMessage } from '../../utils/success-text.ts';
 import { printJson } from '../../utils/output.ts';
 import { renderReplayTestResponse } from '../../cli-test.ts';
@@ -44,7 +44,7 @@ function renderBatchStepLine(entry: unknown): string | undefined {
 }
 
 export function writeCommandCliOutput(
-  command: string,
+  command: PublicCommandName,
   positionals: string[],
   flags: CliOutputFlags,
   data: Record<string, unknown>,
@@ -53,7 +53,7 @@ export function writeCommandCliOutput(
     return writeJsonCliOutput(command, flags, data);
   }
 
-  if (command === CLIENT_COMMANDS.test) {
+  if (command === 'test') {
     return renderReplayTestResponse({
       suite: data as ReplaySuiteResult,
       verbose: flags.verbose,
@@ -74,11 +74,11 @@ export function writeCommandCliOutput(
 }
 
 function writeJsonCliOutput(
-  command: string,
+  command: PublicCommandName,
   flags: CliOutputFlags,
   data: Record<string, unknown>,
 ): number {
-  if (command === CLIENT_COMMANDS.test) {
+  if (command === 'test') {
     return renderReplayTestResponse({
       suite: data as ReplaySuiteResult,
       json: true,
@@ -89,39 +89,39 @@ function writeJsonCliOutput(
   return 0;
 }
 
-const TEXT_OUTPUT_HANDLERS: Partial<Record<string, TextOutputHandler>> = {
-  [CLIENT_COMMANDS.batch]: ({ data }) => {
+const TEXT_OUTPUT_HANDLERS: Partial<Record<PublicCommandName, TextOutputHandler>> = {
+  batch: ({ data }) => {
     renderBatchSummary(data);
     return true;
   },
-  [CLIENT_COMMANDS.get]: ({ positionals, data }) => writeGetCliOutput(positionals, data),
-  [CLIENT_COMMANDS.find]: ({ data }) => writeFindCliOutput(data),
-  [CLIENT_COMMANDS.is]: ({ data }) => {
+  get: ({ positionals, data }) => writeGetCliOutput(positionals, data),
+  find: ({ data }) => writeFindCliOutput(data),
+  is: ({ data }) => {
     process.stdout.write(`Passed: is ${data.predicate ?? 'assertion'}\n`);
     return true;
   },
-  [CLIENT_COMMANDS.boot]: ({ data }) => {
+  boot: ({ data }) => {
     const platform = data.platform ?? 'unknown';
     const device = data.device ?? data.id ?? 'unknown';
     process.stdout.write(`Boot ready: ${device} (${platform})\n`);
     return true;
   },
-  [CLIENT_COMMANDS.record]: ({ data }) => {
+  record: ({ data }) => {
     const outPath = typeof data.outPath === 'string' ? data.outPath : '';
     if (outPath) process.stdout.write(`${outPath}\n`);
     return true;
   },
-  [CLIENT_COMMANDS.logs]: ({ data, flags }) => {
+  logs: ({ data, flags }) => {
     writeLogsCliOutput(data, flags);
     return true;
   },
-  [CLIENT_COMMANDS.network]: ({ data }) => {
+  network: ({ data }) => {
     writeNetworkCliOutput(data);
     return true;
   },
-  [CLIENT_COMMANDS.click]: ({ data }) => writeTapCliOutput(data),
-  [CLIENT_COMMANDS.press]: ({ data }) => writeTapCliOutput(data),
-  [CLIENT_COMMANDS.perf]: ({ data }) => {
+  click: ({ data }) => writeTapCliOutput(data),
+  press: ({ data }) => writeTapCliOutput(data),
+  perf: ({ data }) => {
     writePerfCliOutput(data);
     return true;
   },

--- a/src/cli/commands/router-types.ts
+++ b/src/cli/commands/router-types.ts
@@ -1,5 +1,6 @@
 import type { CliFlags } from '../../utils/command-schema.ts';
 import type { AgentDeviceClient } from '../../client.ts';
+import type { CliCommandName } from '../../command-catalog.ts';
 
 export type ClientCommandParams = {
   positionals: string[];
@@ -8,4 +9,4 @@ export type ClientCommandParams = {
 };
 
 export type ClientCommandHandler = (params: ClientCommandParams) => Promise<boolean>;
-export type ClientCommandHandlerMap = Partial<Record<string, ClientCommandHandler>>;
+export type ClientCommandHandlerMap = Partial<Record<CliCommandName, ClientCommandHandler>>;

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -1,6 +1,5 @@
 import type { CliFlags } from '../../utils/command-schema.ts';
 import type { AgentDeviceClient } from '../../client.ts';
-import { CLIENT_COMMANDS, type ClientCommandName } from '../../client-command-registry.ts';
 import { sessionCommand } from './session.ts';
 import { devicesCommand } from './devices.ts';
 import { ensureSimulatorCommand } from './ensure-simulator.ts';
@@ -14,7 +13,7 @@ import { snapshotCommand } from './snapshot.ts';
 import { screenshotCommand, diffCommand } from './screenshot.ts';
 import { clientCommandMethodHandlers } from './client-command.ts';
 import { genericClientCommandHandlers } from './generic.ts';
-import type { ClientCommandHandler, ClientCommandHandlerMap } from './router-types.ts';
+import type { ClientCommandHandlerMap } from './router-types.ts';
 
 export type {
   ClientCommandHandler,
@@ -22,29 +21,28 @@ export type {
   ClientCommandParams,
 } from './router-types.ts';
 
-const dedicatedClientApiHandlers = {
+const dedicatedCliCommandHandlers = {
   session: sessionCommand,
-  [CLIENT_COMMANDS.devices]: devicesCommand,
-  [CLIENT_COMMANDS.apps]: appsCommand,
+  devices: devicesCommand,
+  apps: appsCommand,
   'ensure-simulator': ensureSimulatorCommand,
   metro: metroCommand,
-  [CLIENT_COMMANDS.install]: installCommand,
-  [CLIENT_COMMANDS.reinstall]: reinstallCommand,
-  [CLIENT_COMMANDS.installFromSource]: installFromSourceCommand,
+  install: installCommand,
+  reinstall: reinstallCommand,
+  'install-from-source': installFromSourceCommand,
   connect: connectCommand,
   disconnect: disconnectCommand,
   connection: connectionCommand,
   auth: authCommand,
-  [CLIENT_COMMANDS.open]: openCommand,
-  [CLIENT_COMMANDS.close]: closeCommand,
-  [CLIENT_COMMANDS.snapshot]: snapshotCommand,
-  [CLIENT_COMMANDS.screenshot]: screenshotCommand,
-  [CLIENT_COMMANDS.diff]: diffCommand,
+  open: openCommand,
+  close: closeCommand,
+  snapshot: snapshotCommand,
+  screenshot: screenshotCommand,
+  diff: diffCommand,
 } satisfies ClientCommandHandlerMap;
 
-const clientCommandHandlers: ClientCommandHandlerMap &
-  Record<ClientCommandName, ClientCommandHandler> = {
-  ...dedicatedClientApiHandlers,
+const clientCommandHandlers: ClientCommandHandlerMap = {
+  ...dedicatedCliCommandHandlers,
   ...clientCommandMethodHandlers,
   ...genericClientCommandHandlers,
 };
@@ -55,6 +53,6 @@ export async function tryRunClientBackedCommand(params: {
   flags: CliFlags;
   client: AgentDeviceClient;
 }): Promise<boolean> {
-  const handler = clientCommandHandlers[params.command];
+  const handler = clientCommandHandlers[params.command as keyof typeof clientCommandHandlers];
   return handler ? await handler(params) : false;
 }

--- a/src/client-command-registry.ts
+++ b/src/client-command-registry.ts
@@ -1,4 +1,0 @@
-import { PUBLIC_COMMANDS } from './command-catalog.ts';
-
-export const CLIENT_COMMANDS = PUBLIC_COMMANDS;
-export type ClientCommandName = (typeof CLIENT_COMMANDS)[keyof typeof CLIENT_COMMANDS];

--- a/src/client-commands.ts
+++ b/src/client-commands.ts
@@ -1,9 +1,9 @@
-import { CLIENT_COMMANDS } from './client-command-registry.ts';
+import { PUBLIC_COMMANDS, type PublicCommandName } from './command-catalog.ts';
 import { waitCommandCodec } from './command-codecs.ts';
 import type { AgentDeviceCommandClient, InternalRequestOptions } from './client-types.ts';
 
 export type PreparedClientCommand = {
-  command: string;
+  command: PublicCommandName;
   positionals: string[];
   options: InternalRequestOptions;
 };
@@ -28,13 +28,13 @@ export function createAgentDeviceCommandClient(
     alert: async (options = {}) => await run<'alert'>(prepareAlertCommand(options)),
     appState: async (options = {}) =>
       await run<'appState'>({
-        command: CLIENT_COMMANDS.appState,
+        command: PUBLIC_COMMANDS.appState,
         positionals: [],
         options,
       }),
     back: async (options = {}) =>
       await run<'back'>({
-        command: CLIENT_COMMANDS.back,
+        command: PUBLIC_COMMANDS.back,
         positionals: [],
         options: {
           ...options,
@@ -43,25 +43,25 @@ export function createAgentDeviceCommandClient(
       }),
     home: async (options = {}) =>
       await run<'home'>({
-        command: CLIENT_COMMANDS.home,
+        command: PUBLIC_COMMANDS.home,
         positionals: [],
         options,
       }),
     rotate: async (options) =>
       await run<'rotate'>({
-        command: CLIENT_COMMANDS.rotate,
+        command: PUBLIC_COMMANDS.rotate,
         positionals: [options.orientation],
         options,
       }),
     appSwitcher: async (options = {}) =>
       await run<'appSwitcher'>({
-        command: CLIENT_COMMANDS.appSwitcher,
+        command: PUBLIC_COMMANDS.appSwitcher,
         positionals: [],
         options,
       }),
     keyboard: async (options = {}) =>
       await run<'keyboard'>({
-        command: CLIENT_COMMANDS.keyboard,
+        command: PUBLIC_COMMANDS.keyboard,
         positionals: options.action ? [options.action] : [],
         options,
       }),
@@ -71,7 +71,7 @@ export function createAgentDeviceCommandClient(
 
 function prepareWaitCommand(options: CommandOptions<'wait'>): PreparedClientCommand {
   return {
-    command: CLIENT_COMMANDS.wait,
+    command: PUBLIC_COMMANDS.wait,
     positionals: waitCommandCodec.encode(options),
     options,
   };
@@ -80,7 +80,7 @@ function prepareWaitCommand(options: CommandOptions<'wait'>): PreparedClientComm
 function prepareAlertCommand(options: CommandOptions<'alert'>): PreparedClientCommand {
   const action = options.action ?? 'get';
   return {
-    command: CLIENT_COMMANDS.alert,
+    command: PUBLIC_COMMANDS.alert,
     positionals: [action, ...(options.timeoutMs !== undefined ? [String(options.timeoutMs)] : [])],
     options,
   };
@@ -88,10 +88,10 @@ function prepareAlertCommand(options: CommandOptions<'alert'>): PreparedClientCo
 
 function prepareClipboardCommand(options: CommandOptions<'clipboard'>): PreparedClientCommand {
   if (options.action === 'read') {
-    return { command: CLIENT_COMMANDS.clipboard, positionals: ['read'], options };
+    return { command: PUBLIC_COMMANDS.clipboard, positionals: ['read'], options };
   }
   return {
-    command: CLIENT_COMMANDS.clipboard,
+    command: PUBLIC_COMMANDS.clipboard,
     positionals: ['write', options.text],
     options,
   };

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { sendToDaemon } from './daemon-client.ts';
 import { prepareMetroRuntime, reloadMetro } from './client-metro.ts';
-import { CLIENT_COMMANDS } from './client-command-registry.ts';
+import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from './command-catalog.ts';
 import { createAgentDeviceCommandClient, type PreparedClientCommand } from './client-commands.ts';
 import {
   elementTargetCodec,
@@ -79,7 +79,7 @@ export function createAgentDeviceClient(
   };
 
   const listSessions = async (options = {}) => {
-    const data = await execute('session_list', [], options);
+    const data = await execute(INTERNAL_COMMANDS.sessionList, [], options);
     const sessions = Array.isArray(data.sessions) ? data.sessions : [];
     return sessions.map(normalizeSession);
   };
@@ -101,17 +101,17 @@ export function createAgentDeviceClient(
     command: createAgentDeviceCommandClient(executePreparedCommand),
     devices: {
       list: async (options = {}) => {
-        const data = await execute(CLIENT_COMMANDS.devices, [], options);
+        const data = await execute(PUBLIC_COMMANDS.devices, [], options);
         const devices = Array.isArray(data.devices) ? data.devices : [];
         return devices.map(normalizeDevice);
       },
-      boot: async (options = {}) => await executeCommandRequest(CLIENT_COMMANDS.boot, [], options),
+      boot: async (options = {}) => await executeCommandRequest(PUBLIC_COMMANDS.boot, [], options),
     },
     sessions: {
       list: async (options = {}) => await listSessions(options),
       close: async (options = {}) => {
         const session = resolveRequestSession(options);
-        const data = await execute('close', [], options);
+        const data = await execute(PUBLIC_COMMANDS.close, [], options);
         const shutdown = data.shutdown;
         return {
           session,
@@ -126,7 +126,7 @@ export function createAgentDeviceClient(
     simulators: {
       ensure: async (options: EnsureSimulatorOptions) => {
         const { runtime, ...rest } = options;
-        const data = await execute('ensure-simulator', [], {
+        const data = await execute(INTERNAL_COMMANDS.ensureSimulator, [], {
           ...rest,
           simulatorRuntimeId: runtime,
         });
@@ -150,17 +150,17 @@ export function createAgentDeviceClient(
     apps: {
       install: async (options: AppDeployOptions) =>
         normalizeDeployResult(
-          await execute('install', [options.app, options.appPath], options),
+          await execute(PUBLIC_COMMANDS.install, [options.app, options.appPath], options),
           resolveRequestSession(options),
         ),
       reinstall: async (options: AppDeployOptions) =>
         normalizeDeployResult(
-          await execute('reinstall', [options.app, options.appPath], options),
+          await execute(PUBLIC_COMMANDS.reinstall, [options.app, options.appPath], options),
           resolveRequestSession(options),
         ),
       installFromSource: async (options: AppInstallFromSourceOptions) =>
         normalizeInstallFromSourceResult(
-          await execute('install_source', [], {
+          await execute(INTERNAL_COMMANDS.installSource, [], {
             ...options,
             installSource: options.source,
             retainMaterializedPaths: options.retainPaths,
@@ -169,7 +169,7 @@ export function createAgentDeviceClient(
           resolveRequestSession(options),
         ),
       list: async (options: AppListOptions = {}) => {
-        const data = await execute(CLIENT_COMMANDS.apps, [], options);
+        const data = await execute(PUBLIC_COMMANDS.apps, [], options);
         return Array.isArray(data.apps)
           ? data.apps.filter((app): app is string => typeof app === 'string')
           : [];
@@ -181,7 +181,7 @@ export function createAgentDeviceClient(
             ? [options.app, options.url]
             : [options.app]
           : [];
-        const data = await execute('open', positionals, options);
+        const data = await execute(PUBLIC_COMMANDS.open, positionals, options);
         const device = normalizeOpenDevice(data);
         const appBundleId = readOptionalString(data, 'appBundleId');
         const appId = appBundleId;
@@ -206,7 +206,11 @@ export function createAgentDeviceClient(
       },
       close: async (options: AppCloseOptions = {}) => {
         const session = resolveRequestSession(options);
-        const data = await execute('close', options.app ? [options.app] : [], options);
+        const data = await execute(
+          PUBLIC_COMMANDS.close,
+          options.app ? [options.app] : [],
+          options,
+        );
         const shutdown = data.shutdown;
         return {
           session,
@@ -220,13 +224,13 @@ export function createAgentDeviceClient(
       },
       push: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.push,
+          PUBLIC_COMMANDS.push,
           [options.app, stringifyPayload(options.payload)],
           options,
         ),
       triggerEvent: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.triggerAppEvent,
+          PUBLIC_COMMANDS.triggerAppEvent,
           triggerEventPositionals(options),
           options,
         ),
@@ -234,7 +238,7 @@ export function createAgentDeviceClient(
     materializations: {
       release: async (options: MaterializationReleaseOptions) =>
         normalizeMaterializationReleaseResult(
-          await execute('release_materialized_paths', [], {
+          await execute(INTERNAL_COMMANDS.releaseMaterializedPaths, [], {
             ...options,
             materializationId: options.materializationId,
           }),
@@ -243,7 +247,7 @@ export function createAgentDeviceClient(
     leases: {
       allocate: async (options) =>
         normalizeLease(
-          await execute('lease_allocate', [], {
+          await execute(INTERNAL_COMMANDS.leaseAllocate, [], {
             ...options,
             leaseId: undefined,
             leaseTtlMs: options.ttlMs,
@@ -251,13 +255,13 @@ export function createAgentDeviceClient(
         ),
       heartbeat: async (options) =>
         normalizeLease(
-          await execute('lease_heartbeat', [], {
+          await execute(INTERNAL_COMMANDS.leaseHeartbeat, [], {
             ...options,
             leaseTtlMs: options.ttlMs,
           }),
         ),
       release: async (options) => {
-        const data = await execute('lease_release', [], options);
+        const data = await execute(INTERNAL_COMMANDS.leaseRelease, [], options);
         return { released: data.released === true };
       },
     },
@@ -295,7 +299,7 @@ export function createAgentDeviceClient(
     capture: {
       snapshot: async (options: CaptureSnapshotOptions = {}) => {
         const session = resolveRequestSession(options);
-        const data = await execute(CLIENT_COMMANDS.snapshot, [], options);
+        const data = await execute(PUBLIC_COMMANDS.snapshot, [], options);
         const appBundleId = readOptionalString(data, 'appBundleId');
         const visibility =
           typeof data.visibility === 'object' && data.visibility !== null
@@ -324,7 +328,7 @@ export function createAgentDeviceClient(
       },
       screenshot: async (options: CaptureScreenshotOptions = {}) => {
         const session = resolveRequestSession(options);
-        const data = await execute(CLIENT_COMMANDS.screenshot, options.path ? [options.path] : [], {
+        const data = await execute(PUBLIC_COMMANDS.screenshot, options.path ? [options.path] : [], {
           ...options,
           screenshotFullscreen: options.fullscreen,
           screenshotMaxSize: options.maxSize,
@@ -336,7 +340,7 @@ export function createAgentDeviceClient(
         };
       },
       diff: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.diff, [options.kind], {
+        await executeCommandRequest(PUBLIC_COMMANDS.diff, [options.kind], {
           ...options,
           interactiveOnly: options.interactiveOnly,
           compact: options.compact,
@@ -347,25 +351,25 @@ export function createAgentDeviceClient(
     },
     interactions: {
       click: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.click, interactionTargetCodec.encode(options), {
+        await executeCommandRequest(PUBLIC_COMMANDS.click, interactionTargetCodec.encode(options), {
           ...options,
           clickButton: options.button,
         }),
       press: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.press,
+          PUBLIC_COMMANDS.press,
           interactionTargetCodec.encode(options),
           options,
         ),
       longPress: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.longPress,
+          PUBLIC_COMMANDS.longPress,
           [String(options.x), String(options.y), ...optionalNumber(options.durationMs)],
           options,
         ),
       swipe: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.swipe,
+          PUBLIC_COMMANDS.swipe,
           [
             String(options.from.x),
             String(options.from.y),
@@ -377,40 +381,40 @@ export function createAgentDeviceClient(
         ),
       focus: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.focus,
+          PUBLIC_COMMANDS.focus,
           [String(options.x), String(options.y)],
           options,
         ),
       type: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.type, [options.text], options),
+        await executeCommandRequest(PUBLIC_COMMANDS.type, [options.text], options),
       fill: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.fill,
+          PUBLIC_COMMANDS.fill,
           fillCommandCodec.encode(options),
           options,
         ),
       scroll: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.scroll,
+          PUBLIC_COMMANDS.scroll,
           [options.direction, ...optionalNumber(options.amount)],
           options,
         ),
       pinch: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.pinch,
+          PUBLIC_COMMANDS.pinch,
           [String(options.scale), ...optionalNumber(options.x), ...optionalNumber(options.y)],
           options,
         ),
       get: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.get,
+          PUBLIC_COMMANDS.get,
           [options.format, ...elementTargetCodec.encode(options)],
           options,
         ),
       is: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.is, isCommandCodec.encode(options), options),
+        await executeCommandRequest(PUBLIC_COMMANDS.is, isCommandCodec.encode(options), options),
       find: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.find, findCommandCodec.encode(options), {
+        await executeCommandRequest(PUBLIC_COMMANDS.find, findCommandCodec.encode(options), {
           ...options,
           findFirst: options.first,
           findLast: options.last,
@@ -418,14 +422,14 @@ export function createAgentDeviceClient(
     },
     replay: {
       run: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.replay, [options.path], {
+        await executeCommandRequest(PUBLIC_COMMANDS.replay, [options.path], {
           ...options,
           replayUpdate: options.update,
           replayEnv: options.env,
           replayShellEnv: collectReplayClientShellEnv(process.env),
         }),
       test: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.test, options.paths, {
+        await executeCommandRequest(PUBLIC_COMMANDS.test, options.paths, {
           ...options,
           replayUpdate: options.update,
           replayEnv: options.env,
@@ -434,7 +438,7 @@ export function createAgentDeviceClient(
     },
     batch: {
       run: async (options) =>
-        await executeCommandRequest(CLIENT_COMMANDS.batch, [], {
+        await executeCommandRequest(PUBLIC_COMMANDS.batch, [], {
           ...options,
           batchSteps: options.steps,
           batchOnError: options.onError,
@@ -442,11 +446,11 @@ export function createAgentDeviceClient(
         }),
     },
     observability: {
-      perf: async (options = {}) => await executeCommandRequest(CLIENT_COMMANDS.perf, [], options),
+      perf: async (options = {}) => await executeCommandRequest(PUBLIC_COMMANDS.perf, [], options),
       logs: async (options = {}) =>
-        await executeCommandRequest(CLIENT_COMMANDS.logs, logsPositionals(options), options),
+        await executeCommandRequest(PUBLIC_COMMANDS.logs, logsPositionals(options), options),
       network: async (options = {}) =>
-        await executeCommandRequest(CLIENT_COMMANDS.network, networkPositionals(options), {
+        await executeCommandRequest(PUBLIC_COMMANDS.network, networkPositionals(options), {
           ...options,
           networkInclude: options.include,
         }),
@@ -454,13 +458,13 @@ export function createAgentDeviceClient(
     recording: {
       record: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.record,
+          PUBLIC_COMMANDS.record,
           [options.action, ...optionalString(options.path)],
           options,
         ),
       trace: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.trace,
+          PUBLIC_COMMANDS.trace,
           [options.action, ...optionalString(options.path)],
           options,
         ),
@@ -468,7 +472,7 @@ export function createAgentDeviceClient(
     settings: {
       update: async (options) =>
         await executeCommandRequest(
-          CLIENT_COMMANDS.settings,
+          PUBLIC_COMMANDS.settings,
           settingsCommandCodec.encode(options),
           options,
         ),

--- a/src/command-catalog.ts
+++ b/src/command-catalog.ts
@@ -54,6 +54,17 @@ export const INTERNAL_COMMANDS = {
   sessionList: 'session_list',
 } as const;
 
+export type PublicCommandName = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
+export type CliCommandName =
+  | PublicCommandName
+  | 'auth'
+  | 'connect'
+  | 'connection'
+  | 'disconnect'
+  | 'ensure-simulator'
+  | 'metro'
+  | 'session';
+
 export const DAEMON_COMMAND_GROUPS = {
   inventory: commandSet(
     INTERNAL_COMMANDS.sessionList,


### PR DESCRIPTION
## Summary

Drop `CLIENT_COMMANDS` as a pass-through alias and use `PUBLIC_COMMANDS` for public protocol command names.

Add a typed `CliCommandName` union from public command names plus CLI-only route literals, then type CLI handler maps against those names so route keys can be plain command strings while typos are still rejected.

Simplify generic CLI handlers so each route name is declared once; public/internal command constants are used where client code constructs daemon requests.

Touched files: 9. Net `+286/-340`. Scope stayed within command catalogs, client command preparation, and CLI routing/output.

## Validation

- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm format`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec oxfmt --write src/cli/commands/generic.ts src/cli/commands/output.ts`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec vitest run src/__tests__/command-codecs.test.ts src/__tests__/cli-client-commands.test.ts src/utils/__tests__/args.test.ts`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec fallow audit --changed-since origin/main`
- `PATH=/tmp/codex-pnpm/pnpm10-platform/package:/Users/thymikee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm check:quick`
