### PR TITLE
docs: clarify agent-device shell resolution

### DIFF
--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -11,13 +11,7 @@ Router only. Private setup before using this skill:
 agent-device --version
 ```
 
-If that fails but the user installed `agent-device` globally, try the user's login shell before using `npx`:
-
-```bash
-zsh -lic 'command -v agent-device'
-```
-
-If it prints a path, run that absolute path instead of `agent-device`. For non-zsh shells, use the equivalent login-shell command.
+If that fails but the user may have installed `agent-device` globally, check the user's configured login/interactive shell and environment before using `npx`. Resolve the command the same way the user would from a normal terminal session, then run the absolute binary path if found. This may require inspecting shell startup behavior or package-manager/global bin locations; do not assume the Codex process `PATH` is the user's `PATH`.
 
 Require `agent-device >= 0.14.0`; older CLIs lack these help topics. If older, stop and tell the user to upgrade the trusted install or approve an exact-version npm command. Do not run `npm install -g agent-device@latest` or `npx -y agent-device@latest` autonomously, and do not include version/upgrade commands in final plans.
 

--- a/website/docs/docs/agent-setup.md
+++ b/website/docs/docs/agent-setup.md
@@ -49,7 +49,7 @@ Add this as a project rule, custom instruction, or skill equivalent when your ag
 ```text
 Use agent-device only for app/device automation tasks. Before planning commands, run `agent-device --version` and read `agent-device help workflow`. For exploratory QA, read `agent-device help dogfood`. For logs, network, traces, or runtime failures, read `agent-device help debugging`. For React Native component trees, props/state/hooks, slow renders, or rerenders, read `agent-device help react-devtools`.
 
-Use the CLI in the integrated terminal. If `agent-device` is not on PATH but the user installed it globally in another shell, ask the user's login shell for the absolute path and run that path instead. For macOS zsh users, use `zsh -lic 'command -v agent-device'`; for other shells, use the equivalent login-shell lookup. Do not silently fall back to `npx -y agent-device@latest`; ask or use an exact version. MCP is only a discovery/help router and does not expose device automation tools. Prefer `open -> snapshot -i -> act -> re-snapshot -> verify -> close`. Use current refs such as `@e3` for exploration and selectors for durable replay. Keep mutating commands against one session serial. Capture screenshots, logs, network, perf, traces, recordings, and `.ad` replay scripts only when they add evidence.
+Use the CLI in the integrated terminal. If `agent-device` is not on PATH but the user installed it globally in another shell, resolve the command the same way the user would from a normal terminal session and run that absolute path instead. This may require inspecting shell startup behavior or package-manager/global bin locations; do not assume the agent process `PATH` is the user's `PATH`. Do not silently fall back to `npx -y agent-device@latest`; ask or use an exact version. MCP is only a discovery/help router and does not expose device automation tools. Prefer `open -> snapshot -i -> act -> re-snapshot -> verify -> close`. Use current refs such as `@e3` for exploration and selectors for durable replay. Keep mutating commands against one session serial. Capture screenshots, logs, network, perf, traces, recordings, and `.ad` replay scripts only when they add evidence.
 ```
 
 ## MCP router
@@ -108,15 +108,7 @@ agent-device open <app-or-url> --platform ios
 agent-device snapshot -i
 ```
 
-Some agent clients run commands in an environment that differs from the user's normal install shell. If the user installed `agent-device` globally but the agent cannot find it, have the agent ask the user's login shell for the absolute path.
-
-For macOS zsh users:
-
-```bash
-zsh -lic 'command -v agent-device'
-```
-
-For other shells, use the equivalent login-shell lookup. Then use the printed path for `--version`, `help workflow`, and subsequent commands.
+Some agent clients run commands in an environment that differs from the user's normal install shell. If the user installed `agent-device` globally but the agent cannot find it, resolve the command the same way the user would from a normal terminal session, then use the absolute binary path for `--version`, `help workflow`, and subsequent commands. This may require inspecting shell startup behavior or package-manager/global bin locations; do not assume the agent process `PATH` is the user's `PATH`.
 
 For reviews or planning-only tasks, tell the agent not to run devices unless explicitly requested.
 

--- a/website/docs/docs/installation.md
+++ b/website/docs/docs/installation.md
@@ -23,15 +23,7 @@ agent-device help debugging
 agent-device help react-devtools
 ```
 
-Some agent clients run commands in an environment that differs from the user's normal install shell. If `agent-device` is missing in the agent terminal but was installed globally elsewhere, ask the user's login shell for the absolute path.
-
-For macOS zsh users:
-
-```bash
-zsh -lic 'command -v agent-device'
-```
-
-For other shells, use the equivalent login-shell lookup. Then use the printed path for agent commands.
+Some agent clients run commands in an environment that differs from the user's normal install shell. If `agent-device` is missing in the agent terminal but was installed globally elsewhere, resolve the command the same way the user would from a normal terminal session, then use the absolute binary path for agent commands. This may require inspecting shell startup behavior or package-manager/global bin locations; do not assume the agent process `PATH` is the user's `PATH`.
 
 For Cursor, Codex, Claude Code, Windsurf, Cline, Goose, skills, project rules, and MCP configuration, see [AI Agent Setup](/docs/agent-setup). For the first app automation commands, see [Quick Start](/docs/quick-start).
 


### PR DESCRIPTION
## Summary

Clarify the agent-device fallback so agents resolve globally installed binaries through the user's normal shell/environment instead of relying on brittle hardcoded zsh probes.

Touched files: 3. Scope stayed within agent-facing installation/setup guidance.

## Validation

- `rg -n "zsh -lic|command -v agent-device|login shell before using npx|equivalent login-shell command" . || true`
- `git diff --check`

Notes: `pnpm` was not available in the current shell or the user's login shell, so `pnpm format` could not be run for the docs/skills change.