### PR TITLE
refactor: extract request execution scope

### DIFF
--- a/src/daemon/__tests__/request-execution-scope.test.ts
+++ b/src/daemon/__tests__/request-execution-scope.test.ts
@@ -1,0 +1,187 @@
+import { test, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { withDiagnosticsScope } from '../../utils/diagnostics.ts';
+import {
+  makeAndroidSession,
+  makeIosSession,
+} from '../../__tests__/test-utils/session-factories.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { clearRequestCanceled, markRequestCanceled } from '../request-cancel.ts';
+import {
+  createRequestExecutionScope,
+  prepareLockedRequestScope,
+} from '../request-execution-scope.ts';
+import type { DaemonRequest } from '../types.ts';
+
+const TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-request-execution-scope-'));
+const LOG_PATH = path.join(TEST_ROOT, 'diagnostics.log');
+
+test('createRequestExecutionScope applies tenant scoping and lease admission', async () => {
+  const sessionStore = makeSessionStore('agent-device-request-scope-');
+  const leaseRegistry = new LeaseRegistry();
+  const lease = leaseRegistry.allocateLease({ tenantId: 'tenant-a', runId: 'run-1' });
+
+  const scope = await createRequestExecutionScope({
+    req: makeRequest({
+      session: 'default',
+      command: 'snapshot',
+      meta: {
+        tenantId: 'tenant-a',
+        runId: 'run-1',
+        leaseId: lease.leaseId,
+        sessionIsolation: 'tenant',
+      },
+    }),
+    sessionStore,
+    leaseRegistry,
+  });
+
+  expect(scope.req.session).toBe('tenant-a:default');
+  expect(scope.req.meta?.tenantId).toBe('tenant-a');
+  expect(scope.sessionName).toBe('tenant-a:default');
+});
+
+test('createRequestExecutionScope rejects tenant requests without an active lease', async () => {
+  await expect(
+    createRequestExecutionScope({
+      req: makeRequest({
+        session: 'default',
+        command: 'snapshot',
+        meta: {
+          tenantId: 'tenant-a',
+          runId: 'run-1',
+          leaseId: '0'.repeat(32),
+          sessionIsolation: 'tenant',
+        },
+      }),
+      sessionStore: makeSessionStore('agent-device-request-scope-'),
+      leaseRegistry: new LeaseRegistry(),
+    }),
+  ).rejects.toThrow(/Lease is not active/);
+});
+
+test('prepareLockedRequestScope preserves existing-session selector validation', async () => {
+  const sessionStore = makeSessionStore('agent-device-request-scope-');
+  sessionStore.set('default', makeAndroidSession('default'));
+  const scope = await createRequestExecutionScope({
+    req: makeRequest({
+      command: 'snapshot',
+      flags: {
+        platform: 'ios',
+      },
+    }),
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+  });
+
+  expect(() =>
+    prepareLockedRequestScope({
+      scope,
+      logPath: LOG_PATH,
+      sessionStore,
+      trackDownloadableArtifact: () => 'artifact-id',
+    }),
+  ).toThrow(/cannot be used with --platform=ios/i);
+});
+
+test('prepareLockedRequestScope blocks commands for invalidated recordings before handlers run', async () => {
+  const sessionStore = makeSessionStore('agent-device-request-scope-');
+  sessionStore.set(
+    'default',
+    makeIosSession('default', {
+      recording: {
+        platform: 'ios-device-runner',
+        outPath: '/tmp/recording.mp4',
+        remotePath: '/tmp/remote.mp4',
+        startedAt: Date.now(),
+        showTouches: true,
+        gestureEvents: [],
+        invalidatedReason: 'iOS runner session restarted during recording',
+      },
+    }),
+  );
+  const scope = await createRequestExecutionScope({
+    req: makeRequest({ command: 'snapshot' }),
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+  });
+
+  const result = await withDiagnosticsScope({ command: 'snapshot', logPath: LOG_PATH }, async () =>
+    prepareLockedRequestScope({
+      scope,
+      logPath: LOG_PATH,
+      sessionStore,
+      trackDownloadableArtifact: () => 'artifact-id',
+    }),
+  );
+
+  expect(result.type).toBe('response');
+  if (result.type === 'response') {
+    expect(result.response.ok).toBe(false);
+    if (!result.response.ok) {
+      expect(result.response.error.message).toBe('iOS runner session restarted during recording');
+    }
+  }
+});
+
+test('runLocked rejects a canceled request before executing work', async () => {
+  const requestId = 'request-scope-canceled-before-lock';
+  const scope = await createRequestExecutionScope({
+    req: makeRequest({ meta: { requestId } }),
+    sessionStore: makeSessionStore('agent-device-request-scope-'),
+    leaseRegistry: new LeaseRegistry(),
+  });
+
+  markRequestCanceled(requestId);
+  try {
+    await expect(scope.runLocked(async () => 'ran')).rejects.toThrow(/request canceled/);
+  } finally {
+    clearRequestCanceled(requestId);
+  }
+});
+
+test('runLocked rejects a request canceled while waiting for its execution lock', async () => {
+  const requestId = 'request-scope-canceled-after-lock';
+  const sessionStore = makeSessionStore('agent-device-request-scope-');
+  sessionStore.set('default', makeIosSession('default'));
+  const leaseRegistry = new LeaseRegistry();
+  const first = await createRequestExecutionScope({
+    req: makeRequest({ command: 'click' }),
+    sessionStore,
+    leaseRegistry,
+  });
+  const second = await createRequestExecutionScope({
+    req: makeRequest({ command: 'click', meta: { requestId } }),
+    sessionStore,
+    leaseRegistry,
+  });
+  let releaseLock: () => void = () => {};
+  const lockReleased = new Promise<void>((resolve) => {
+    releaseLock = resolve;
+  });
+  const firstRun = first.runLocked(async () => await lockReleased);
+  const secondRun = second.runLocked(async () => 'ran');
+  const secondExpectation = expect(secondRun).rejects.toThrow(/request canceled/);
+
+  markRequestCanceled(requestId);
+  releaseLock();
+  try {
+    await firstRun;
+    await secondExpectation;
+  } finally {
+    clearRequestCanceled(requestId);
+  }
+});
+
+function makeRequest(overrides: Partial<DaemonRequest> = {}): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'default',
+    command: 'snapshot',
+    positionals: [],
+    ...overrides,
+  };
+}

--- a/src/daemon/request-android-adb.ts
+++ b/src/daemon/request-android-adb.ts
@@ -1,6 +1,7 @@
 import {
   type AndroidAdbExecutor,
   type AndroidAdbProvider,
+  withAndroidAdbProvider,
 } from '../platforms/android/adb-executor.ts';
 import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
 import type { DeviceInfo } from '../utils/device.ts';
@@ -18,7 +19,7 @@ export type AndroidAdbProviderResolver = (params: {
   session?: AndroidAdbProviderRequestSession;
 }) => AndroidAdbProvider | AndroidAdbExecutor | undefined;
 
-export async function resolveScopedAndroidAdbProvider(params: {
+async function resolveScopedAndroidAdbProvider(params: {
   req: DaemonRequest;
   existingSession: SessionState | undefined;
   androidAdbProvider?: AndroidAdbProviderResolver;
@@ -34,6 +35,26 @@ export async function resolveScopedAndroidAdbProvider(params: {
   const provider = androidAdbProvider({ req, device, session: existingSession });
   const executor = typeof provider === 'function' ? provider : provider?.exec;
   return { provider, executor, serial: device.id };
+}
+
+export async function withRequestAndroidAdbScope<T>(
+  params: {
+    req: DaemonRequest;
+    existingSession: SessionState | undefined;
+    androidAdbProvider?: AndroidAdbProviderResolver;
+  },
+  task: (adb: { executor?: AndroidAdbExecutor }) => Promise<T>,
+): Promise<T> {
+  const requestAdb = await resolveScopedAndroidAdbProvider({
+    req: params.req,
+    existingSession: params.existingSession,
+    androidAdbProvider: params.androidAdbProvider,
+  });
+  return await withAndroidAdbProvider(
+    requestAdb.provider,
+    { serial: requestAdb.serial ?? '' },
+    async () => await task({ executor: requestAdb.executor }),
+  );
 }
 
 async function resolveAndroidAdbProviderDevice(

--- a/src/daemon/request-cancel.ts
+++ b/src/daemon/request-cancel.ts
@@ -87,6 +87,12 @@ export function createRequestCanceledError(): AppError {
   });
 }
 
+export function throwIfRequestCanceled(requestId: string | undefined): void {
+  if (isRequestCanceled(requestId)) {
+    throw createRequestCanceledError();
+  }
+}
+
 export function isRequestCanceledError(error: unknown): boolean {
   if (!(error instanceof AppError)) return false;
   if (error.code !== 'COMMAND_FAILED') return false;

--- a/src/daemon/request-execution-scope.ts
+++ b/src/daemon/request-execution-scope.ts
@@ -1,0 +1,191 @@
+import type { CommandFlags } from '../core/dispatch.ts';
+import { withKeyedLock } from '../utils/keyed-lock.ts';
+import { emitDiagnostic, getDiagnosticsMeta } from '../utils/diagnostics.ts';
+import type { DaemonCommandContext } from './context.ts';
+import { contextFromFlags as contextFromFlagsWithLog } from './context.ts';
+import { assertSessionSelectorMatches } from './session-selector.ts';
+import { applyRequestLockPolicy } from './request-lock-policy.ts';
+import { resolveEffectiveSessionName } from './session-routing.ts';
+import {
+  assertRequestLeaseAdmission,
+  resolveExecutionLockKey,
+  scopeRequestSession,
+  shouldLockSessionExecution,
+  shouldValidateSessionSelector,
+} from './request-admission.ts';
+import { throwIfRequestCanceled } from './request-cancel.ts';
+import { finalizeDaemonResponse } from './request-finalization.ts';
+import {
+  refreshRecordingHealth,
+  shouldBlockForInvalidRecording,
+} from './request-recording-health.ts';
+import type { LeaseRegistry } from './lease-registry.ts';
+import type { SessionStore } from './session-store.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
+
+const leaseRegistryExecutionLocks = new WeakMap<LeaseRegistry, Map<string, Promise<unknown>>>();
+
+export type RequestExecutionScope = {
+  req: DaemonRequest;
+  command: string;
+  sessionName: string;
+  runLocked<T>(task: () => Promise<T>): Promise<T>;
+  throwIfCanceled(): void;
+};
+
+export type LockedRequestScope = {
+  req: DaemonRequest;
+  sessionName: string;
+  existingSession: SessionState | undefined;
+  finalize(response: DaemonResponse): DaemonResponse;
+  contextFromFlags(
+    flags: CommandFlags | undefined,
+    appBundleId?: string,
+    traceLogPath?: string,
+  ): DaemonCommandContext;
+  handlerContextFromFlags(
+    flags: CommandFlags | undefined,
+    appBundleId?: string,
+    traceLogPath?: string,
+  ): DaemonCommandContext;
+};
+
+export type LockedRequestScopeResult =
+  | { type: 'scope'; scope: LockedRequestScope }
+  | { type: 'response'; response: DaemonResponse };
+
+export async function createRequestExecutionScope(params: {
+  req: DaemonRequest;
+  sessionStore: SessionStore;
+  leaseRegistry: LeaseRegistry;
+}): Promise<RequestExecutionScope> {
+  const { sessionStore, leaseRegistry } = params;
+  const scopedReq = scopeRequestSession(params.req);
+  emitDiagnostic({
+    level: 'info',
+    phase: 'request_start',
+    data: {
+      session: scopedReq.session,
+      command: scopedReq.command,
+      tenant: scopedReq.meta?.tenantId,
+      isolation: scopedReq.meta?.sessionIsolation,
+    },
+  });
+
+  const command = scopedReq.command;
+  assertRequestLeaseAdmission(scopedReq, leaseRegistry);
+
+  const sessionName = resolveEffectiveSessionName(scopedReq, sessionStore);
+  const executionLockKey = shouldLockSessionExecution(command)
+    ? await resolveExecutionLockKey({ req: scopedReq, sessionName, sessionStore })
+    : null;
+  const executionLocks = getLeaseRegistryExecutionLocks(leaseRegistry);
+
+  const scope: RequestExecutionScope = {
+    req: scopedReq,
+    command,
+    sessionName,
+    throwIfCanceled: () => throwIfRequestCanceled(scopedReq.meta?.requestId),
+    runLocked: async (task) => {
+      throwIfRequestCanceled(scopedReq.meta?.requestId);
+      if (!executionLockKey) return await task();
+      return await withKeyedLock(executionLocks, executionLockKey, async () => {
+        throwIfRequestCanceled(scopedReq.meta?.requestId);
+        return await task();
+      });
+    },
+  };
+  return scope;
+}
+
+export function prepareLockedRequestScope(params: {
+  scope: RequestExecutionScope;
+  logPath: string;
+  sessionStore: SessionStore;
+  trackDownloadableArtifact: (opts: {
+    artifactPath: string;
+    tenantId?: string;
+    fileName?: string;
+  }) => string;
+}): LockedRequestScopeResult {
+  const { scope, logPath, sessionStore, trackDownloadableArtifact } = params;
+  scope.throwIfCanceled();
+  const existingSession = sessionStore.get(scope.sessionName);
+  if (existingSession) {
+    refreshRecordingHealth(existingSession);
+    sessionStore.set(scope.sessionName, existingSession);
+  }
+  const lockedReq = applyRequestLockPolicy(scope.req, existingSession);
+  const finalize = (response: DaemonResponse): DaemonResponse =>
+    finalizeDaemonResponse(lockedReq, response, trackDownloadableArtifact);
+
+  if (
+    existingSession?.recording?.invalidatedReason &&
+    shouldBlockForInvalidRecording(scope.command)
+  ) {
+    return {
+      type: 'response',
+      response: finalize({
+        ok: false,
+        error: {
+          code: 'COMMAND_FAILED',
+          message: existingSession.recording.invalidatedReason,
+        },
+      }),
+    };
+  }
+
+  if (
+    existingSession &&
+    !lockedReq.meta?.lockPolicy &&
+    shouldValidateSessionSelector(scope.command)
+  ) {
+    assertSessionSelectorMatches(existingSession, lockedReq.flags);
+  }
+
+  const contextFromFlags = (
+    flags: CommandFlags | undefined,
+    appBundleId?: string,
+    traceLogPath?: string,
+  ): DaemonCommandContext => contextFromRequestFlags(logPath, flags, appBundleId, traceLogPath);
+
+  return {
+    type: 'scope',
+    scope: {
+      req: lockedReq,
+      sessionName: scope.sessionName,
+      existingSession,
+      finalize,
+      contextFromFlags,
+      handlerContextFromFlags: (flags, appBundleId, traceLogPath) =>
+        ({
+          ...contextFromFlags(flags, appBundleId, traceLogPath),
+          surface: sessionStore.get(scope.sessionName)?.surface,
+        }) satisfies DaemonCommandContext,
+    },
+  };
+}
+
+function contextFromRequestFlags(
+  logPath: string,
+  flags: CommandFlags | undefined,
+  appBundleId?: string,
+  traceLogPath?: string,
+): DaemonCommandContext {
+  const requestId = getDiagnosticsMeta().requestId;
+  return {
+    ...contextFromFlagsWithLog(logPath, flags, appBundleId, traceLogPath, requestId),
+    requestId,
+  };
+}
+
+function getLeaseRegistryExecutionLocks(
+  leaseRegistry: LeaseRegistry,
+): Map<string, Promise<unknown>> {
+  let locks = leaseRegistryExecutionLocks.get(leaseRegistry);
+  if (!locks) {
+    locks = new Map();
+    leaseRegistryExecutionLocks.set(leaseRegistry, locks);
+  }
+  return locks;
+}

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -1,5 +1,3 @@
-import { withAndroidAdbProvider } from '../platforms/android/adb-executor.ts';
-import type { CommandFlags } from '../core/dispatch.ts';
 import {
   type DeviceInventoryProvider,
   withTargetDeviceResolutionScope,
@@ -8,23 +6,9 @@ import { AppError, normalizeError } from '../utils/errors.ts';
 import type { DaemonRequest, DaemonResponse } from './types.ts';
 import { SessionStore } from './session-store.ts';
 import {
-  contextFromFlags as contextFromFlagsWithLog,
-  type DaemonCommandContext,
-} from './context.ts';
-import { assertSessionSelectorMatches } from './session-selector.ts';
-import { applyRequestLockPolicy } from './request-lock-policy.ts';
-import { resolveEffectiveSessionName } from './session-routing.ts';
-import {
   type AndroidAdbProviderResolver,
-  resolveScopedAndroidAdbProvider,
+  withRequestAndroidAdbScope,
 } from './request-android-adb.ts';
-import {
-  assertRequestLeaseAdmission,
-  resolveExecutionLockKey,
-  scopeRequestSession,
-  shouldLockSessionExecution,
-  shouldValidateSessionSelector,
-} from './request-admission.ts';
 import {
   emitDiagnostic,
   flushDiagnosticsToSessionFile,
@@ -32,40 +16,12 @@ import {
   withDiagnosticsScope,
 } from '../utils/diagnostics.ts';
 import type { LeaseRegistry } from './lease-registry.ts';
-import { createRequestCanceledError, isRequestCanceled } from './request-cancel.ts';
-import { withKeyedLock } from '../utils/keyed-lock.ts';
-import { finalizeDaemonResponse } from './request-finalization.ts';
 import { dispatchGenericCommand } from './request-generic-dispatch.ts';
-import {
-  refreshRecordingHealth,
-  shouldBlockForInvalidRecording,
-} from './request-recording-health.ts';
 import { runRequestHandlerChain } from './request-handler-chain.ts';
-
-const sessionExecutionLocks = new Map<string, Promise<unknown>>();
-
-// ---------------------------------------------------------------------------
-// Request preparation helpers
-// ---------------------------------------------------------------------------
-
-function throwIfRequestCanceled(req: DaemonRequest): void {
-  if (isRequestCanceled(req.meta?.requestId)) {
-    throw createRequestCanceledError();
-  }
-}
-
-function contextFromFlags(
-  logPath: string,
-  flags: CommandFlags | undefined,
-  appBundleId?: string,
-  traceLogPath?: string,
-): DaemonCommandContext {
-  const requestId = getDiagnosticsMeta().requestId;
-  return {
-    ...contextFromFlagsWithLog(logPath, flags, appBundleId, traceLogPath, requestId),
-    requestId,
-  };
-}
+import {
+  createRequestExecutionScope,
+  prepareLockedRequestScope,
+} from './request-execution-scope.ts';
 
 // ---------------------------------------------------------------------------
 // Request handler API
@@ -110,89 +66,48 @@ export function createRequestHandler(
 
         try {
           return await withTargetDeviceResolutionScope(deviceInventoryProvider, async () => {
-            const scopedReq = scopeRequestSession(req);
-            emitDiagnostic({
-              level: 'info',
-              phase: 'request_start',
-              data: {
-                session: scopedReq.session,
-                command: scopedReq.command,
-                tenant: scopedReq.meta?.tenantId,
-                isolation: scopedReq.meta?.sessionIsolation,
-              },
+            const scope = await createRequestExecutionScope({
+              req,
+              sessionStore,
+              leaseRegistry,
             });
 
-            const command = scopedReq.command;
-            assertRequestLeaseAdmission(scopedReq, leaseRegistry);
-
-            const sessionName = resolveEffectiveSessionName(scopedReq, sessionStore);
-            const executionLockKey = shouldLockSessionExecution(command)
-              ? await resolveExecutionLockKey({ req: scopedReq, sessionName, sessionStore })
-              : null;
-
-            const executeSessionRequest = async (): Promise<DaemonResponse> => {
-              throwIfRequestCanceled(scopedReq);
-              const existingSession = sessionStore.get(sessionName);
-              if (existingSession) {
-                refreshRecordingHealth(existingSession);
-                sessionStore.set(sessionName, existingSession);
-              }
-              const lockedReq = applyRequestLockPolicy(scopedReq, existingSession);
-              const finalize = (response: DaemonResponse): DaemonResponse =>
-                finalizeDaemonResponse(lockedReq, response, trackDownloadableArtifact);
-
-              if (
-                existingSession?.recording?.invalidatedReason &&
-                shouldBlockForInvalidRecording(command)
-              ) {
-                return finalize({
-                  ok: false,
-                  error: {
-                    code: 'COMMAND_FAILED',
-                    message: existingSession.recording.invalidatedReason,
-                  },
-                });
-              }
-              if (
-                existingSession &&
-                !lockedReq.meta?.lockPolicy &&
-                shouldValidateSessionSelector(command)
-              ) {
-                assertSessionSelectorMatches(existingSession, lockedReq.flags);
-              }
-
-              const requestAdb = await resolveScopedAndroidAdbProvider({
-                req: lockedReq,
-                existingSession,
-                androidAdbProvider,
+            return await scope.runLocked(async () => {
+              const locked = prepareLockedRequestScope({
+                scope,
+                logPath,
+                sessionStore,
+                trackDownloadableArtifact,
               });
-              return await withAndroidAdbProvider(
-                requestAdb.provider,
-                { serial: requestAdb.serial ?? '' },
-                async () => {
+              if (locked.type === 'response') return locked.response;
+              const lockedScope = locked.scope;
+
+              return await withRequestAndroidAdbScope(
+                {
+                  req: lockedScope.req,
+                  existingSession: lockedScope.existingSession,
+                  androidAdbProvider,
+                },
+                async ({ executor }) => {
                   // The ADB provider is scoped to this single locked request; handlers may re-read
                   // the session state, but all device-scoped adb calls in this request share it.
                   // Phase 1: Try specialized handler chain
                   const handlerResponse = await runRequestHandlerChain({
-                    req: lockedReq,
-                    sessionName,
+                    req: lockedScope.req,
+                    sessionName: lockedScope.sessionName,
                     logPath,
                     sessionStore,
                     leaseRegistry,
                     invoke: handleRequest,
-                    androidAdbExecutor: requestAdb.executor,
-                    contextFromFlags: (flags, appBundleId, traceLogPath) =>
-                      ({
-                        ...contextFromFlags(logPath, flags, appBundleId, traceLogPath),
-                        surface: sessionStore.get(sessionName)?.surface,
-                      }) satisfies DaemonCommandContext,
+                    androidAdbExecutor: executor,
+                    contextFromFlags: lockedScope.handlerContextFromFlags,
                   });
-                  if (handlerResponse) return finalize(handlerResponse);
+                  if (handlerResponse) return lockedScope.finalize(handlerResponse);
 
                   // Phase 2: Require active session for generic dispatch
-                  const session = sessionStore.get(sessionName);
+                  const session = sessionStore.get(lockedScope.sessionName);
                   if (!session) {
-                    return finalize({
+                    return lockedScope.finalize({
                       ok: false,
                       error: {
                         code: 'SESSION_NOT_FOUND',
@@ -203,29 +118,17 @@ export function createRequestHandler(
 
                   // Phase 3: Dispatch command directly to device
                   const dispatchResponse = await dispatchGenericCommand({
-                    req: lockedReq,
+                    req: lockedScope.req,
                     session,
-                    sessionName,
+                    sessionName: lockedScope.sessionName,
                     logPath,
                     sessionStore,
-                    contextFromFlags: (flags, appBundleId, traceLogPath) =>
-                      contextFromFlags(logPath, flags, appBundleId, traceLogPath),
+                    contextFromFlags: lockedScope.contextFromFlags,
                   });
-                  return finalize(dispatchResponse);
+                  return lockedScope.finalize(dispatchResponse);
                 },
               );
-            };
-
-            if (!executionLockKey) {
-              throwIfRequestCanceled(scopedReq);
-              return await executeSessionRequest();
-            }
-            throwIfRequestCanceled(scopedReq);
-            return await withKeyedLock(
-              sessionExecutionLocks,
-              executionLockKey,
-              executeSessionRequest,
-            );
+            });
           });
         } catch (error) {
           emitDiagnostic({


### PR DESCRIPTION
## Summary

Extract request execution scope out of the daemon router.

Adds a shared request-cancel helper, scopes session execution locks per `LeaseRegistry`, and covers cancellation/temp-file isolation behavior in tests.

## Validation

- `pnpm exec vitest run src/daemon/__tests__/request-execution-scope.test.ts`
- `pnpm check:fallow --base origin/main`
- Stack head: `pnpm check:quick`
- Stack head: `pnpm check:unit`