### PR TITLE
refactor: share daemon runtime collaborators

### DIFF
--- a/src/daemon/__tests__/request-execution-scope.test.ts
+++ b/src/daemon/__tests__/request-execution-scope.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { afterAll, test, expect } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -18,6 +18,10 @@ import type { DaemonRequest } from '../types.ts';
 
 const TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-request-execution-scope-'));
 const LOG_PATH = path.join(TEST_ROOT, 'diagnostics.log');
+
+afterAll(() => {
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
 
 test('createRequestExecutionScope applies tenant scoping and lease admission', async () => {
   const sessionStore = makeSessionStore('agent-device-request-scope-');

--- a/src/daemon/__tests__/runtime-policy.test.ts
+++ b/src/daemon/__tests__/runtime-policy.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest';
+import { createDaemonRuntimePolicy } from '../runtime-policy.ts';
+
+test('createDaemonRuntimePolicy uses local policy and unsupported artifacts', async () => {
+  const runtimePolicy = createDaemonRuntimePolicy('snapshot');
+
+  expect(runtimePolicy.policy).toBeDefined();
+  if (!runtimePolicy.policy) {
+    throw new Error('Expected daemon runtime policy');
+  }
+  expect(runtimePolicy.policy.allowLocalInputPaths).toBe(true);
+  expect(runtimePolicy.policy.allowLocalOutputPaths).toBe(true);
+  await expect(
+    runtimePolicy.artifacts.createTempFile({ prefix: 'snapshot', ext: '.png' }),
+  ).rejects.toThrow(/snapshot does not create temporary files/);
+});

--- a/src/daemon/__tests__/runtime-session.test.ts
+++ b/src/daemon/__tests__/runtime-session.test.ts
@@ -1,0 +1,82 @@
+import { test, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { makeIosSession } from '../../__tests__/test-utils/session-factories.ts';
+import { flushDiagnosticsToSessionFile, withDiagnosticsScope } from '../../utils/diagnostics.ts';
+import { createDaemonRuntimeSessionStore, toRuntimeSessionRecord } from '../runtime-session.ts';
+import type { CommandSessionRecord } from '../../runtime-contract.ts';
+
+test('toRuntimeSessionRecord projects daemon session state for runtime commands', () => {
+  const session = makeIosSession('qa-ios', {
+    appBundleId: 'com.example.app',
+    appName: 'Example',
+    surface: 'app',
+    snapshot: {
+      nodes: [],
+      createdAt: 123,
+    },
+  });
+
+  expect(toRuntimeSessionRecord(session, 'runtime-session', { includeSnapshot: true })).toEqual({
+    name: 'runtime-session',
+    appBundleId: 'com.example.app',
+    appName: 'Example',
+    snapshot: {
+      nodes: [],
+      createdAt: 123,
+    },
+    metadata: {
+      surface: 'app',
+    },
+  });
+});
+
+test('createDaemonRuntimeSessionStore hides non-matching sessions and scopes writes', async () => {
+  const previousHome = process.env.HOME;
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runtime-session-home-'));
+  const session = makeIosSession('qa-ios');
+  const writes: CommandSessionRecord[] = [];
+  const store = createDaemonRuntimeSessionStore({
+    sessionName: 'qa-ios',
+    getSession: () => session,
+    recordOptions: { includeSnapshot: true },
+    setRecord: (record) => {
+      writes.push(record);
+    },
+  });
+
+  process.env.HOME = tempHome;
+  try {
+    expect(await store.get('other')).toBeUndefined();
+    expect(await store.get('qa-ios')).toMatchObject({ name: 'qa-ios' });
+
+    const record = { name: 'qa-ios', appBundleId: 'com.example.app' };
+    await store.set(record);
+    const diagnosticsPath = await withDiagnosticsScope(
+      { session: 'qa-ios', command: 'snapshot' },
+      async () => {
+        await store.set({ name: 'other', appBundleId: 'com.example.other' });
+        return flushDiagnosticsToSessionFile({ force: true });
+      },
+    );
+
+    expect(writes).toEqual([record]);
+    expect(diagnosticsPath).toEqual(expect.any(String));
+    const rows = fs
+      .readFileSync(diagnosticsPath as string, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        level: 'warn',
+        phase: 'runtime_session_write_skipped',
+        data: { expected: 'qa-ios', received: 'other' },
+      }),
+    );
+  } finally {
+    process.env.HOME = previousHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});

--- a/src/daemon/handlers/interaction-runtime.ts
+++ b/src/daemon/handlers/interaction-runtime.ts
@@ -4,13 +4,14 @@ import type {
   BackendActionResult,
   BackendSnapshotResult,
 } from '../../backend.ts';
-import { createAgentDevice, localCommandPolicy } from '../../runtime.ts';
+import { createAgentDevice } from '../../runtime.ts';
 import { AppError } from '../../utils/errors.ts';
 import type { SessionState } from '../types.ts';
-import { createUnsupportedArtifactAdapter } from '../runtime-artifacts.ts';
 import { setSessionSnapshot } from '../session-snapshot.ts';
 import type { InteractionHandlerParams } from './interaction-common.ts';
 import type { CaptureSnapshotForSession } from './interaction-snapshot.ts';
+import { createDaemonRuntimePolicy } from '../runtime-policy.ts';
+import { createDaemonRuntimeSessionStore } from '../runtime-session.ts';
 
 export function createInteractionRuntime(
   params: InteractionHandlerParams & {
@@ -21,25 +22,17 @@ export function createInteractionRuntime(
   if (!session) throw new AppError('SESSION_NOT_FOUND', 'No active session. Run open first.');
   return createAgentDevice({
     backend: createInteractionBackend({ ...params, session }),
-    artifacts: createUnsupportedArtifactAdapter('interaction commands', { plural: true }),
-    sessions: {
-      get: (name) =>
-        name === params.sessionName
-          ? {
-              name: params.sessionName,
-              appBundleId: session.appBundleId,
-              appName: session.appName,
-              snapshot: session.snapshot,
-              metadata: { surface: session.surface },
-            }
-          : undefined,
-      set: (record) => {
+    ...createDaemonRuntimePolicy('interaction commands', { plural: true }),
+    sessions: createDaemonRuntimeSessionStore({
+      sessionName: params.sessionName,
+      getSession: () => session,
+      recordOptions: { includeSnapshot: true },
+      setRecord: (record) => {
         if (!record.snapshot) return;
         setSessionSnapshot(session, record.snapshot);
         params.sessionStore.set(params.sessionName, session);
       },
-    },
-    policy: localCommandPolicy(),
+    }),
   });
 }
 

--- a/src/daemon/request-android-adb.ts
+++ b/src/daemon/request-android-adb.ts
@@ -43,7 +43,7 @@ export async function withRequestAndroidAdbScope<T>(
     existingSession: SessionState | undefined;
     androidAdbProvider?: AndroidAdbProviderResolver;
   },
-  task: (adb: { executor?: AndroidAdbExecutor }) => Promise<T>,
+  task: (executor?: AndroidAdbExecutor) => Promise<T>,
 ): Promise<T> {
   const requestAdb = await resolveScopedAndroidAdbProvider({
     req: params.req,
@@ -53,7 +53,7 @@ export async function withRequestAndroidAdbScope<T>(
   return await withAndroidAdbProvider(
     requestAdb.provider,
     { serial: requestAdb.serial ?? '' },
-    async () => await task({ executor: requestAdb.executor }),
+    async () => await task(requestAdb.executor),
   );
 }
 

--- a/src/daemon/request-execution-scope.ts
+++ b/src/daemon/request-execution-scope.ts
@@ -23,6 +23,8 @@ import type { LeaseRegistry } from './lease-registry.ts';
 import type { SessionStore } from './session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 
+// Production daemon wiring owns one LeaseRegistry per process; scoping locks by registry keeps
+// test and embedded routers isolated without changing process-level serialization there.
 const leaseRegistryExecutionLocks = new WeakMap<LeaseRegistry, Map<string, Promise<unknown>>>();
 
 export type RequestExecutionScope = {
@@ -112,6 +114,7 @@ export function prepareLockedRequestScope(params: {
   scope.throwIfCanceled();
   const existingSession = sessionStore.get(scope.sessionName);
   if (existingSession) {
+    // Called under runLocked: refreshRecordingHealth may mutate session recording state.
     refreshRecordingHealth(existingSession);
     sessionStore.set(scope.sessionName, existingSession);
   }
@@ -160,6 +163,7 @@ export function prepareLockedRequestScope(params: {
       handlerContextFromFlags: (flags, appBundleId, traceLogPath) =>
         ({
           ...contextFromFlags(flags, appBundleId, traceLogPath),
+          // Handlers may update surface during the request, so read the current session state.
           surface: sessionStore.get(scope.sessionName)?.surface,
         }) satisfies DaemonCommandContext,
     },

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -88,7 +88,7 @@ export function createRequestHandler(
                   existingSession: lockedScope.existingSession,
                   androidAdbProvider,
                 },
-                async ({ executor }) => {
+                async (executor) => {
                   // The ADB provider is scoped to this single locked request; handlers may re-read
                   // the session state, but all device-scoped adb calls in this request share it.
                   // Phase 1: Try specialized handler chain

--- a/src/daemon/runtime-policy.ts
+++ b/src/daemon/runtime-policy.ts
@@ -1,0 +1,13 @@
+import type { AgentDeviceRuntimeConfig } from '../runtime-contract.ts';
+import { localCommandPolicy } from '../runtime.ts';
+import { createUnsupportedArtifactAdapter } from './runtime-artifacts.ts';
+
+export function createDaemonRuntimePolicy(
+  unsupportedArtifactLabel: string,
+  options: { plural?: boolean } = {},
+): Pick<AgentDeviceRuntimeConfig, 'artifacts' | 'policy'> {
+  return {
+    artifacts: createUnsupportedArtifactAdapter(unsupportedArtifactLabel, options),
+    policy: localCommandPolicy(),
+  };
+}

--- a/src/daemon/runtime-session.ts
+++ b/src/daemon/runtime-session.ts
@@ -1,0 +1,51 @@
+import type { CommandSessionRecord, CommandSessionStore } from '../runtime-contract.ts';
+import { emitDiagnostic } from '../utils/diagnostics.ts';
+import type { SessionState } from './types.ts';
+
+export type RuntimeSessionRecordOptions = {
+  includeSnapshot?: boolean;
+  metadata?: Record<string, unknown>;
+};
+
+export function toRuntimeSessionRecord(
+  session: SessionState | undefined,
+  name: string,
+  options: RuntimeSessionRecordOptions = {},
+): CommandSessionRecord | undefined {
+  if (!session) return undefined;
+  return {
+    name,
+    appBundleId: session.appBundleId,
+    appName: session.appName,
+    ...(options.includeSnapshot === true ? { snapshot: session.snapshot } : {}),
+    metadata: {
+      surface: session.surface,
+      ...(options.metadata ?? {}),
+    },
+  };
+}
+
+export function createDaemonRuntimeSessionStore(params: {
+  sessionName: string;
+  getSession: () => SessionState | undefined;
+  recordOptions?: RuntimeSessionRecordOptions;
+  setRecord: (record: CommandSessionRecord) => void;
+}): CommandSessionStore {
+  return {
+    get: (name) =>
+      name === params.sessionName
+        ? toRuntimeSessionRecord(params.getSession(), params.sessionName, params.recordOptions)
+        : undefined,
+    set: (record) => {
+      if (record.name !== params.sessionName) {
+        emitDiagnostic({
+          level: 'warn',
+          phase: 'runtime_session_write_skipped',
+          data: { expected: params.sessionName, received: record.name },
+        });
+        return;
+      }
+      params.setRecord(record);
+    },
+  };
+}

--- a/src/daemon/screenshot-runtime.ts
+++ b/src/daemon/screenshot-runtime.ts
@@ -8,6 +8,7 @@ import { dispatchCommand } from '../core/dispatch.ts';
 import { AppError } from '../utils/errors.ts';
 import type { DaemonCommandContext } from './context.ts';
 import type { SessionState } from './types.ts';
+import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
 
 export type ScreenshotOutputPlacement = 'positional' | 'out' | 'default';
 
@@ -22,17 +23,12 @@ export async function dispatchScreenshotViaRuntime(params: {
   const runtime = createAgentDevice({
     backend: createDispatchScreenshotBackend({ session, outputPlacement, dispatchContext }),
     artifacts: createDaemonScreenshotArtifactAdapter(),
-    sessions: {
-      get: (name) =>
-        name === sessionName
-          ? {
-              name: sessionName,
-              appBundleId: session.appBundleId,
-              metadata: { surface: session.surface },
-            }
-          : undefined,
-      set: () => {},
-    },
+    sessions: createDaemonRuntimeSessionStore({
+      sessionName,
+      getSession: () => session,
+      recordOptions: { includeSnapshot: false },
+      setRecord: () => {},
+    }),
     policy: localCommandPolicy(),
   });
 

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -3,7 +3,7 @@ import type {
   BackendSnapshotOptions,
   BackendSnapshotResult,
 } from '../backend.ts';
-import { createAgentDevice, localCommandPolicy } from '../runtime.ts';
+import { createAgentDevice } from '../runtime.ts';
 import { parseWaitPositionals, type WaitParsed } from '../command-codecs/wait.ts';
 import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
 import { resolveTargetDevice, type CommandFlags } from '../core/dispatch.ts';
@@ -26,7 +26,6 @@ import { refSnapshotFlagGuardResponse } from './handlers/interaction-flags.ts';
 import type { IsCommandOptions } from '../commands/selector-read.ts';
 import { isSupportedPredicate } from './is-predicates.ts';
 import type { ContextFromFlags } from './handlers/interaction-common.ts';
-import { createUnsupportedArtifactAdapter } from './runtime-artifacts.ts';
 import { setSessionSnapshot } from './session-snapshot.ts';
 import { getActiveAndroidSnapshotFreshness } from './android-snapshot-freshness.ts';
 import {
@@ -42,6 +41,8 @@ import {
   toDaemonGetData,
   toDaemonWaitData,
 } from './selector-recording.ts';
+import { createDaemonRuntimePolicy } from './runtime-policy.ts';
+import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
 
 type SelectorRuntimeParams = {
   req: DaemonRequest;
@@ -224,16 +225,17 @@ function createSelectorRuntimeForDevice(params: {
 }) {
   return createAgentDevice({
     backend: createSelectorBackend(params),
-    artifacts: createUnsupportedArtifactAdapter('selector commands', { plural: true }),
-    sessions: {
-      get: (name) => (name === params.sessionName ? toCommandSession(params.session) : undefined),
-      set: (record) => {
+    ...createDaemonRuntimePolicy('selector commands', { plural: true }),
+    sessions: createDaemonRuntimeSessionStore({
+      sessionName: params.sessionName,
+      getSession: () => params.session,
+      recordOptions: { includeSnapshot: true },
+      setRecord: (record) => {
         if (!params.session || !record.snapshot) return;
         setSessionSnapshot(params.session, record.snapshot);
         params.sessionStore.set(params.sessionName, params.session);
       },
-    },
-    policy: localCommandPolicy(),
+    }),
   });
 }
 
@@ -492,17 +494,6 @@ async function maybeAndroidForegroundBlockerResponse(
       originalMessage: response.error.message,
     },
   );
-}
-
-function toCommandSession(session: SessionState | undefined) {
-  if (!session) return undefined;
-  return {
-    name: session.name,
-    appName: session.appName,
-    appBundleId: session.appBundleId,
-    snapshot: session.snapshot,
-    metadata: { surface: session.surface },
-  };
 }
 
 function isReadOnlyFindAction(

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -1,18 +1,20 @@
 import type { AgentDeviceBackend, BackendSnapshotResult } from '../backend.ts';
 import type { CommandSessionRecord } from '../runtime.ts';
-import { createAgentDevice, localCommandPolicy } from '../runtime.ts';
+import { createAgentDevice } from '../runtime.ts';
 import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
 import { AppError } from '../utils/errors.ts';
-import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
+import type { SnapshotDiffSummary } from '../utils/snapshot-diff.ts';
+import type { DaemonRequest, DaemonResponse, DaemonResponseData, SessionState } from './types.ts';
 import { SessionStore } from './session-store.ts';
 import { errorResponse } from './handlers/response.ts';
-import { createUnsupportedArtifactAdapter } from './runtime-artifacts.ts';
 import { captureSnapshot, resolveSnapshotScope } from './handlers/snapshot-capture.ts';
 import {
   buildSnapshotSession,
   resolveSessionDevice,
   withSessionlessRunnerCleanup,
 } from './handlers/snapshot-session.ts';
+import { createDaemonRuntimePolicy } from './runtime-policy.ts';
+import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
 
 export async function dispatchSnapshotViaRuntime(params: {
   req: DaemonRequest;
@@ -20,45 +22,28 @@ export async function dispatchSnapshotViaRuntime(params: {
   logPath: string;
   sessionStore: SessionStore;
 }): Promise<DaemonResponse> {
-  const { req, sessionName, logPath, sessionStore } = params;
-  const { session, device } = await resolveSessionDevice(sessionStore, sessionName, req.flags);
-  if (!isCommandSupportedOnDevice('snapshot', device)) {
-    return errorResponse('UNSUPPORTED_OPERATION', 'snapshot is not supported on this device');
-  }
-  const resolvedScope = resolveSnapshotScope(req.flags?.snapshotScope, session);
-  if (!resolvedScope.ok) return resolvedScope;
-
-  return await withSessionlessRunnerCleanup(session, device, async () => {
-    const runtime = createSnapshotRuntime({
-      req,
-      sessionName,
-      logPath,
-      sessionStore,
-      session,
-      device,
-      snapshotScope: resolvedScope.scope,
-    });
-    const result = await runtime.capture.snapshot({
-      session: sessionName,
-      interactiveOnly: req.flags?.snapshotInteractiveOnly,
-      compact: req.flags?.snapshotCompact,
-      depth: req.flags?.snapshotDepth,
-      scope: resolvedScope.scope,
-      raw: req.flags?.snapshotRaw,
-    });
-    recordSnapshotRuntimeAction({
-      req,
-      sessionName,
-      sessionStore,
-      result: {
-        nodes: result.nodes.length,
-        truncated: result.truncated,
-      },
-    });
-    return {
-      ok: true,
-      data: result,
-    };
+  return await dispatchSnapshotRuntimeCommand({
+    ...params,
+    command: 'snapshot',
+    unsupportedMessage: 'snapshot is not supported on this device',
+    execute: async ({ runtime, sessionName, req, snapshotScope }) => {
+      const result = await runtime.capture.snapshot({
+        session: sessionName,
+        interactiveOnly: req.flags?.snapshotInteractiveOnly,
+        compact: req.flags?.snapshotCompact,
+        depth: req.flags?.snapshotDepth,
+        scope: snapshotScope,
+        raw: req.flags?.snapshotRaw,
+      });
+      return {
+        data: result,
+        record: {
+          kind: 'snapshot',
+          nodes: result.nodes.length,
+          truncated: result.truncated,
+        },
+      };
+    },
   });
 }
 
@@ -68,10 +53,63 @@ export async function dispatchSnapshotDiffViaRuntime(params: {
   logPath: string;
   sessionStore: SessionStore;
 }): Promise<DaemonResponse> {
+  return await dispatchSnapshotRuntimeCommand({
+    ...params,
+    command: 'diff',
+    unsupportedMessage: 'diff is not supported on this device',
+    execute: async ({ runtime, sessionName, req, snapshotScope }) => {
+      const result = await runtime.capture.diffSnapshot({
+        session: sessionName,
+        interactiveOnly: req.flags?.snapshotInteractiveOnly,
+        compact: req.flags?.snapshotCompact,
+        depth: req.flags?.snapshotDepth,
+        scope: snapshotScope,
+        raw: req.flags?.snapshotRaw,
+      });
+      return {
+        data: result,
+        record: {
+          kind: 'diff',
+          mode: 'snapshot',
+          baselineInitialized: result.baselineInitialized,
+          summary: result.summary,
+        },
+      };
+    },
+  });
+}
+
+type SnapshotRuntimeCommandParams = {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  command: 'snapshot' | 'diff';
+  unsupportedMessage: string;
+  execute(params: {
+    runtime: ReturnType<typeof createSnapshotRuntime>;
+    sessionName: string;
+    req: DaemonRequest;
+    snapshotScope: string | undefined;
+  }): Promise<{ data: DaemonResponseData; record: SnapshotRuntimeRecord }>;
+};
+
+type SnapshotRuntimeRecord =
+  | { kind: 'snapshot'; nodes: number; truncated: boolean | undefined }
+  | {
+      kind: 'diff';
+      mode: 'snapshot';
+      baselineInitialized: boolean;
+      summary: SnapshotDiffSummary;
+    };
+
+async function dispatchSnapshotRuntimeCommand(
+  params: SnapshotRuntimeCommandParams,
+): Promise<DaemonResponse> {
   const { req, sessionName, logPath, sessionStore } = params;
   const { session, device } = await resolveSessionDevice(sessionStore, sessionName, req.flags);
-  if (!isCommandSupportedOnDevice('diff', device)) {
-    return errorResponse('UNSUPPORTED_OPERATION', 'diff is not supported on this device');
+  if (!isCommandSupportedOnDevice(params.command, device)) {
+    return errorResponse('UNSUPPORTED_OPERATION', params.unsupportedMessage);
   }
   const resolvedScope = resolveSnapshotScope(req.flags?.snapshotScope, session);
   if (!resolvedScope.ok) return resolvedScope;
@@ -86,27 +124,21 @@ export async function dispatchSnapshotDiffViaRuntime(params: {
       device,
       snapshotScope: resolvedScope.scope,
     });
-    const result = await runtime.capture.diffSnapshot({
-      session: sessionName,
-      interactiveOnly: req.flags?.snapshotInteractiveOnly,
-      compact: req.flags?.snapshotCompact,
-      depth: req.flags?.snapshotDepth,
-      scope: resolvedScope.scope,
-      raw: req.flags?.snapshotRaw,
+    const result = await params.execute({
+      runtime,
+      sessionName,
+      req,
+      snapshotScope: resolvedScope.scope,
     });
     recordSnapshotRuntimeAction({
       req,
       sessionName,
       sessionStore,
-      result: {
-        mode: 'snapshot',
-        baselineInitialized: result.baselineInitialized,
-        summary: result.summary,
-      },
+      result: result.record,
     });
     return {
       ok: true,
-      data: result,
+      data: result.data,
     };
   });
 }
@@ -129,14 +161,13 @@ function createSnapshotRuntime(params: {
       device,
       snapshotScope,
     }),
-    artifacts: createUnsupportedArtifactAdapter('snapshot'),
-    sessions: {
-      get: (name) =>
-        name === sessionName ? toCommandSessionRecord(sessionStore.get(sessionName)) : undefined,
-      set: (record) => {
-        if (!record.snapshot) {
-          throw new AppError('UNKNOWN', 'snapshot runtime did not produce session state');
-        }
+    ...createDaemonRuntimePolicy('snapshot'),
+    sessions: createDaemonRuntimeSessionStore({
+      sessionName,
+      getSession: () => sessionStore.get(sessionName),
+      recordOptions: { includeSnapshot: true },
+      setRecord: (record) => {
+        const snapshotRecord = assertSnapshotSessionRecord(record);
         const current = sessionStore.get(sessionName);
         sessionStore.set(
           sessionName,
@@ -144,13 +175,12 @@ function createSnapshotRuntime(params: {
             current,
             sessionName,
             device,
-            record,
+            record: snapshotRecord,
             refScopedSnapshot: isRefScopedSnapshot(req),
           }),
         );
       },
-    },
-    policy: localCommandPolicy(),
+    }),
   });
 }
 
@@ -158,13 +188,10 @@ function buildNextSnapshotSession(params: {
   current: SessionState | undefined;
   sessionName: string;
   device: SessionState['device'];
-  record: CommandSessionRecord;
+  record: CommandSessionRecord & { snapshot: NonNullable<CommandSessionRecord['snapshot']> };
   refScopedSnapshot: boolean;
 }): SessionState {
   const { current, sessionName, device, record, refScopedSnapshot } = params;
-  if (!record.snapshot) {
-    throw new AppError('UNKNOWN', 'snapshot runtime did not produce session state');
-  }
   const keepCurrentSnapshot = shouldKeepCurrentSnapshot(current, record, refScopedSnapshot);
   const snapshot = keepCurrentSnapshot ? current.snapshot : record.snapshot;
   const nextSession = buildSnapshotSession({
@@ -239,26 +266,11 @@ function createDaemonSnapshotBackend(params: {
   };
 }
 
-function toCommandSessionRecord(
-  session: SessionState | undefined,
-): CommandSessionRecord | undefined {
-  if (!session) return undefined;
-  return {
-    name: session.name,
-    appBundleId: session.appBundleId,
-    appName: session.appName,
-    snapshot: session.snapshot,
-    metadata: {
-      surface: session.surface,
-    },
-  };
-}
-
 function recordSnapshotRuntimeAction(params: {
   req: DaemonRequest;
   sessionName: string;
   sessionStore: SessionStore;
-  result: Record<string, unknown>;
+  result: SnapshotRuntimeRecord;
 }): void {
   const session = params.sessionStore.get(params.sessionName);
   if (!session) return;
@@ -266,6 +278,28 @@ function recordSnapshotRuntimeAction(params: {
     command: params.req.command,
     positionals: params.req.positionals ?? [],
     flags: params.req.flags ?? {},
-    result: params.result,
+    result: toRecordedSnapshotRuntimeResult(params.result),
   });
+}
+
+function assertSnapshotSessionRecord(
+  record: CommandSessionRecord,
+): CommandSessionRecord & { snapshot: NonNullable<CommandSessionRecord['snapshot']> } {
+  if (!record.snapshot) {
+    throw new AppError('UNKNOWN', 'snapshot runtime did not produce session state');
+  }
+  return record as CommandSessionRecord & {
+    snapshot: NonNullable<CommandSessionRecord['snapshot']>;
+  };
+}
+
+function toRecordedSnapshotRuntimeResult(record: SnapshotRuntimeRecord): Record<string, unknown> {
+  if (record.kind === 'snapshot') {
+    return { nodes: record.nodes, truncated: record.truncated };
+  }
+  return {
+    mode: record.mode,
+    baselineInitialized: record.baselineInitialized,
+    summary: record.summary,
+  };
 }


### PR DESCRIPTION
## Summary

Share daemon runtime collaborators for policy, session projection, and snapshot runtime dispatch.

Makes runtime session snapshots opt-in, keeps selector/snapshot call sites explicit, adds warn diagnostics for skipped runtime writes, and covers runtime policy/write-skip behavior. Also carries review cleanup now that #523 is on main: comments for request lock/prepare invariants, request temp-dir cleanup, and direct ADB executor scoping.

## Validation

- `pnpm exec vitest run src/daemon/__tests__/request-execution-scope.test.ts src/daemon/__tests__/runtime-session.test.ts src/daemon/__tests__/runtime-policy.test.ts`
- `pnpm check:fallow --base origin/main`
- Stack head: `pnpm check:quick`
- Stack head: `pnpm check:unit`