### PR TITLE
perf: fast-path macos device resolution

### DIFF
--- a/src/core/__tests__/dispatch-resolve.test.ts
+++ b/src/core/__tests__/dispatch-resolve.test.ts
@@ -190,12 +190,45 @@ test('resolveTargetDevice uses injected device inventory without local discovery
 });
 
 test('resolveTargetDevice treats empty injected inventory as authoritative', async () => {
-  const err = await withDeviceInventoryProvider(
-    async () => [],
-    async () => await resolveTargetDevice({ platform: 'ios' }),
-  ).catch((error) => error);
+  await expectDeviceNotFound(() =>
+    withDeviceInventoryProvider(
+      async () => [],
+      async () => await resolveTargetDevice({ platform: 'ios' }),
+    ),
+  );
+
+  assert.equal(mockListAppleDevices.mock.calls.length, 0);
+});
+
+test('resolveTargetDevice fast-paths explicit macOS without Apple mobile discovery', async () => {
+  const result = await resolveTargetDevice({ platform: 'macos' });
+
+  assert.equal(result.platform, 'macos');
+  assert.equal(result.id, 'host-macos-local');
+  assert.equal(mockListAppleDevices.mock.calls.length, 0);
+});
+
+test('resolveTargetDevice fast-paths Apple desktop target without simulator-set discovery', async () => {
+  const result = await resolveTargetDevice({
+    platform: 'apple',
+    target: 'desktop',
+    iosSimulatorDeviceSet: '/tmp/simulators',
+  });
+
+  assert.equal(result.platform, 'macos');
+  assert.equal(result.target, 'desktop');
+  assert.equal(mockListAppleDevices.mock.calls.length, 0);
+});
+
+test('resolveTargetDevice fast-path preserves macOS selector validation', async () => {
+  await expectDeviceNotFound(() => resolveTargetDevice({ platform: 'macos', udid: 'other-mac' }));
+
+  assert.equal(mockListAppleDevices.mock.calls.length, 0);
+});
+
+async function expectDeviceNotFound(action: () => Promise<unknown>): Promise<void> {
+  const err = await action().catch((error) => error);
 
   assert.ok(err instanceof AppError);
   assert.equal(err.code, 'DEVICE_NOT_FOUND');
-  assert.equal(mockListAppleDevices.mock.calls.length, 0);
-});
+}

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -12,6 +12,7 @@ import { listAndroidDevices } from '../platforms/android/devices.ts';
 import { ensureAdb } from '../platforms/android/index.ts';
 import { findBootableIosSimulator, listAppleDevices } from '../platforms/ios/devices.ts';
 import { listLinuxDevices } from '../platforms/linux/devices.ts';
+import { listMacosDevices } from '../platforms/macos/devices.ts';
 import { withDiagnosticTimer } from '../utils/diagnostics.ts';
 import {
   resolveAndroidSerialAllowlist,
@@ -163,6 +164,11 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
         );
       }
 
+      if (shouldUseHostMacFastPath(selector)) {
+        const devices = await listMacosDevices();
+        return cacheResolvedTargetDevice(cacheKey, await resolveDevice(devices, selector));
+      }
+
       if (selector.platform === 'linux') {
         const devices = await listLinuxDevices();
         return cacheResolvedTargetDevice(cacheKey, await resolveDevice(devices, selector));
@@ -202,6 +208,16 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
       );
     },
     diagnosticData,
+  );
+}
+
+function shouldUseHostMacFastPath(selector: {
+  platform?: PlatformSelector;
+  target?: DeviceTarget;
+}): boolean {
+  return (
+    selector.platform === 'macos' ||
+    (selector.platform === 'apple' && selector.target === 'desktop')
   );
 }
 

--- a/src/platforms/ios/devices.ts
+++ b/src/platforms/ios/devices.ts
@@ -6,6 +6,7 @@ import { AppError } from '../../utils/errors.ts';
 import type { DeviceInfo, DeviceTarget } from '../../utils/device.ts';
 import { resolveTimeoutMs } from '../../utils/timeouts.ts';
 import { resolveIosSimulatorDeviceSetPath } from '../../utils/device-isolation.ts';
+import { buildHostMacDevice } from '../macos/devices.ts';
 import { buildSimctlArgs } from './simctl.ts';
 
 const IOS_DEVICECTL_LIST_TIMEOUT_MS = resolveTimeoutMs(
@@ -47,7 +48,6 @@ type IosDeviceDiscoveryOptions = {
   simulatorSetPath?: string;
 };
 
-const HOST_MAC_DEVICE_ID = 'host-macos-local';
 const XCTRACE_SECTION_HEADER_PATTERN = /^==\s*(.+?)\s*==$/;
 const XCTRACE_DEVICE_LINE_PATTERN = /^(?<name>.+?)\s+\[(?<id>[^[\]]+)\]\s*$/;
 
@@ -179,17 +179,6 @@ export async function findBootableIosSimulator(
   }
 
   return bestBooted ?? bestMobile ?? bestAny;
-}
-
-function buildHostMacDevice(): DeviceInfo {
-  return {
-    platform: 'macos',
-    id: HOST_MAC_DEVICE_ID,
-    name: os.hostname(),
-    kind: 'device',
-    target: 'desktop',
-    booted: true,
-  };
 }
 
 function parseSimctlAppleDevices(

--- a/src/platforms/macos/devices.ts
+++ b/src/platforms/macos/devices.ts
@@ -1,0 +1,19 @@
+import os from 'node:os';
+import type { DeviceInfo } from '../../utils/device.ts';
+
+const HOST_MAC_DEVICE_ID = 'host-macos-local';
+
+export function buildHostMacDevice(): DeviceInfo {
+  return {
+    platform: 'macos',
+    id: HOST_MAC_DEVICE_ID,
+    name: os.hostname(),
+    kind: 'device',
+    target: 'desktop',
+    booted: true,
+  };
+}
+
+export async function listMacosDevices(): Promise<DeviceInfo[]> {
+  return [buildHostMacDevice()];
+}


### PR DESCRIPTION
## Summary

Fast-path explicit macOS desktop device resolution.

Adds a macOS device-list helper, preserves selector validation on the fast path, and keeps simulator-set parity in the resolver call. Behavior note: explicit `--platform macos` / Apple desktop resolution now validates the host target directly instead of surfacing missing Apple mobile tooling errors from `xcrun` probes.

## Validation

- `pnpm exec vitest run src/core/__tests__/dispatch-resolve.test.ts`
- `pnpm check:fallow --base 6874af189dba6261efaff1f0463f6fada3372f1e`
- Stack head: `pnpm check:quick`
- Stack head: `pnpm check:unit`