### PR TITLE
refactor: split platform interactors

### DIFF
--- a/src/core/__tests__/dispatch-interactions.test.ts
+++ b/src/core/__tests__/dispatch-interactions.test.ts
@@ -1,7 +1,7 @@
 import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import { handlePressCommand } from '../dispatch-interactions.ts';
-import type { Interactor } from '../interactors.ts';
+import type { Interactor } from '../interactor-types.ts';
 import { MACOS_DEVICE } from '../../__tests__/test-utils/device-fixtures.ts';
 
 vi.mock('../../platforms/ios/macos-helper.ts', async (importOriginal) => {
@@ -31,6 +31,7 @@ function makeUnusedInteractor(): Interactor {
     fill: fail,
     scroll: fail,
     screenshot: fail,
+    snapshot: fail,
     back: fail,
     home: fail,
     rotate: fail,
@@ -45,16 +46,10 @@ test('handlePressCommand routes macOS menubar press through the helper', async (
   const mockRunMacOsPressAction = vi.mocked(runMacOsPressAction);
   mockRunMacOsPressAction.mockClear();
 
-  const result = await handlePressCommand(
-    MACOS_DEVICE,
-    makeUnusedInteractor(),
-    ['100', '200'],
-    {
-      surface: 'menubar',
-      appBundleId: 'com.example.menubarapp',
-    },
-    {},
-  );
+  const result = await handlePressCommand(MACOS_DEVICE, makeUnusedInteractor(), ['100', '200'], {
+    surface: 'menubar',
+    appBundleId: 'com.example.menubarapp',
+  });
 
   assert.deepEqual(result, {
     x: 100,

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -21,7 +21,7 @@ import {
   runRepeatedSeries,
 } from './dispatch-series.ts';
 import type { DispatchContext } from './dispatch-context.ts';
-import type { Interactor, RunnerContext } from './interactors.ts';
+import type { Interactor } from './interactor-types.ts';
 
 export async function handleLongPressCommand(
   interactor: Interactor,
@@ -92,7 +92,6 @@ export async function handlePressCommand(
   interactor: Interactor,
   positionals: string[],
   context: DispatchContext | undefined,
-  _runnerCtx: RunnerContext,
 ): Promise<Record<string, unknown>> {
   const { x, y } = readPoint(positionals, 'press requires x y');
 
@@ -338,7 +337,6 @@ export async function handleSwipeCommand(
   interactor: Interactor,
   positionals: string[],
   context: DispatchContext | undefined,
-  _runnerCtx: RunnerContext,
 ): Promise<Record<string, unknown>> {
   const x1 = Number(positionals[0]);
   const y1 = Number(positionals[1]);
@@ -459,7 +457,6 @@ export async function handlePinchCommand(
   device: DeviceInfo,
   positionals: string[],
   context: DispatchContext | undefined,
-  _runnerCtx: RunnerContext,
 ): Promise<Record<string, unknown>> {
   if (device.platform === 'android') {
     throw new AppError(
@@ -499,7 +496,6 @@ export async function handleReadCommand(
   device: DeviceInfo,
   positionals: string[],
   context: DispatchContext | undefined,
-  _runnerCtx: RunnerContext,
 ): Promise<Record<string, unknown>> {
   const [x, y] = positionals.map(Number);
   if (Number.isNaN(x) || Number.isNaN(y)) {

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -6,20 +6,17 @@ import {
   dismissAndroidKeyboard,
   getAndroidKeyboardState,
   pushAndroidNotification,
-  snapshotAndroid,
 } from '../platforms/android/index.ts';
-import { getInteractor, type Interactor, type RunnerContext } from './interactors.ts';
+import { getInteractor } from './interactors.ts';
+import type { Interactor, RunnerContext } from './interactor-types.ts';
 import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
 import { pushIosNotification } from '../platforms/ios/index.ts';
-import { snapshotLinux } from '../platforms/linux/snapshot.ts';
 import { isDeepLinkTarget } from './open-target.ts';
 import { parseTriggerAppEventArgs, resolveAppEventUrl } from './app-events.ts';
-import type { RawSnapshotNode } from '../utils/snapshot.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../utils/diagnostics.ts';
 import { readLocationCoordinate } from '../utils/location-coordinates.ts';
 import { successText, withSuccessText } from '../utils/success-text.ts';
 import type { DispatchContext } from './dispatch-context.ts';
-import { shouldUseIosTapSeries, shouldUseIosDragSeries } from './dispatch-series.ts';
 import {
   handleFillCommand,
   handleFocusCommand,
@@ -35,7 +32,6 @@ import { readNotificationPayload } from './dispatch-payload.ts';
 import { parseDeviceRotation } from './device-rotation.ts';
 
 export { resolveTargetDevice } from './dispatch-resolve.ts';
-export { shouldUseIosTapSeries, shouldUseIosDragSeries };
 export type { BatchStep, CommandFlags, DispatchContext } from './dispatch-context.ts';
 
 export async function dispatchCommand(
@@ -77,9 +73,9 @@ export async function dispatchCommand(
           return { app, ...successText(`Closed: ${app}`) };
         }
         case 'press':
-          return handlePressCommand(device, interactor, positionals, context, runnerCtx);
+          return handlePressCommand(device, interactor, positionals, context);
         case 'swipe':
-          return handleSwipeCommand(device, interactor, positionals, context, runnerCtx);
+          return handleSwipeCommand(device, interactor, positionals, context);
         case 'longpress':
           return handleLongPressCommand(interactor, positionals);
         case 'focus':
@@ -91,7 +87,7 @@ export async function dispatchCommand(
         case 'scroll':
           return handleScrollCommand(interactor, positionals, context);
         case 'pinch':
-          return handlePinchCommand(device, positionals, context, runnerCtx);
+          return handlePinchCommand(device, positionals, context);
         case 'trigger-app-event': {
           const { eventName, payload } = parseTriggerAppEventArgs(positionals);
           const eventUrl = resolveAppEventUrl(device.platform, eventName, payload);
@@ -135,15 +131,15 @@ export async function dispatchCommand(
         case 'clipboard':
           return handleClipboardCommand(interactor, positionals);
         case 'keyboard':
-          return handleKeyboardCommand(device, interactor, positionals, context, runnerCtx);
+          return handleKeyboardCommand(device, positionals, context, runnerCtx);
         case 'settings':
           return handleSettingsCommand(device, interactor, positionals, context);
         case 'push':
           return handlePushCommand(device, positionals, context);
         case 'snapshot':
-          return handleSnapshotCommand(device, positionals, context, runnerCtx);
+          return await handleSnapshotCommand(interactor, context);
         case 'read':
-          return handleReadCommand(device, positionals, context, runnerCtx);
+          return handleReadCommand(device, positionals, context);
         default:
           throw new AppError('INVALID_ARGS', `Unknown command: ${command}`);
       }
@@ -230,7 +226,6 @@ async function handleClipboardCommand(
 
 async function handleKeyboardCommand(
   device: DeviceInfo,
-  _interactor: Interactor,
   positionals: string[],
   context: DispatchContext | undefined,
   runnerCtx: RunnerContext,
@@ -367,76 +362,18 @@ async function handlePushCommand(
 }
 
 async function handleSnapshotCommand(
-  device: DeviceInfo,
-  _positionals: string[],
+  interactor: Interactor,
   context: DispatchContext | undefined,
-  _runnerCtx: RunnerContext,
 ): Promise<Record<string, unknown>> {
-  if (device.platform === 'linux') {
-    const linuxResult = await withDiagnosticTimer(
-      'snapshot_capture',
-      async () => await snapshotLinux(context?.surface),
-      { backend: 'linux-atspi' },
-    );
-    return {
-      nodes: linuxResult.nodes ?? [],
-      truncated: linuxResult.truncated ?? false,
-      backend: 'linux-atspi',
-    };
-  }
-  if (device.platform !== 'android') {
-    const result = (await withDiagnosticTimer(
-      'snapshot_capture',
-      async () =>
-        await runIosRunnerCommand(
-          device,
-          {
-            command: 'snapshot',
-            appBundleId: context?.appBundleId,
-            interactiveOnly: context?.snapshotInteractiveOnly,
-            compact: context?.snapshotCompact,
-            depth: context?.snapshotDepth,
-            scope: context?.snapshotScope,
-            raw: context?.snapshotRaw,
-          },
-          {
-            verbose: context?.verbose,
-            logPath: context?.logPath,
-            traceLogPath: context?.traceLogPath,
-            requestId: context?.requestId,
-          },
-        ),
-      {
-        backend: 'xctest',
-      },
-    )) as { nodes?: RawSnapshotNode[]; truncated?: boolean };
-    const nodes = result.nodes ?? [];
-    if (nodes.length === 0 && device.kind === 'simulator') {
-      throw new AppError('COMMAND_FAILED', 'XCTest snapshot returned 0 nodes on iOS simulator.');
-    }
-    return { nodes, truncated: result.truncated ?? false, backend: 'xctest' };
-  }
-  const androidResult = await withDiagnosticTimer(
-    'snapshot_capture',
-    async () =>
-      await snapshotAndroid(device, {
-        interactiveOnly: context?.snapshotInteractiveOnly,
-        compact: context?.snapshotCompact,
-        depth: context?.snapshotDepth,
-        scope: context?.snapshotScope,
-        raw: context?.snapshotRaw,
-      }),
-    {
-      backend: 'android',
-    },
-  );
-  return {
-    nodes: androidResult.nodes ?? [],
-    truncated: androidResult.truncated ?? false,
-    backend: 'android',
-    analysis: androidResult.analysis,
-    androidSnapshot: androidResult.androidSnapshot,
-  };
+  return await interactor.snapshot({
+    appBundleId: context?.appBundleId,
+    interactiveOnly: context?.snapshotInteractiveOnly,
+    compact: context?.snapshotCompact,
+    depth: context?.snapshotDepth,
+    scope: context?.snapshotScope,
+    raw: context?.snapshotRaw,
+    surface: context?.surface,
+  });
 }
 
 function readResultMessage(result: Record<string, unknown>): string | undefined {

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -2,6 +2,12 @@ import type { DeviceRotation } from './device-rotation.ts';
 import type { ScrollDirection } from './scroll-gesture.ts';
 import type { SettingOptions } from '../platforms/permission-utils.ts';
 import type { SessionSurface } from './session-surface.ts';
+import type { BackendSnapshotResult } from '../backend.ts';
+import type {
+  RawSnapshotNode,
+  SnapshotBackend,
+  SnapshotOptions as BaseSnapshotOptions,
+} from '../utils/snapshot.ts';
 
 export type RunnerContext = {
   requestId?: string;
@@ -17,6 +23,16 @@ export type ScreenshotOptions = {
   appBundleId?: string;
   fullscreen?: boolean;
   surface?: SessionSurface;
+};
+
+export type SnapshotOptions = BaseSnapshotOptions & {
+  appBundleId?: string;
+  surface?: SessionSurface;
+};
+
+export type SnapshotResult = Omit<BackendSnapshotResult, 'backend' | 'nodes'> & {
+  nodes?: RawSnapshotNode[];
+  backend: Extract<SnapshotBackend, 'android' | 'xctest' | 'linux-atspi'>;
 };
 
 export type Interactor = {
@@ -49,6 +65,7 @@ export type Interactor = {
     options?: { amount?: number; pixels?: number },
   ): Promise<Record<string, unknown> | void>;
   screenshot(outPath: string, options?: ScreenshotOptions): Promise<void>;
+  snapshot(options?: SnapshotOptions): Promise<SnapshotResult>;
   back(mode?: BackMode): Promise<void>;
   home(): Promise<void>;
   rotate(orientation: DeviceRotation): Promise<void>;

--- a/src/core/interactors.ts
+++ b/src/core/interactors.ts
@@ -1,191 +1,19 @@
-import { AppError } from '../utils/errors.ts';
 import type { DeviceInfo } from '../utils/device.ts';
-import {
-  appSwitcherAndroid,
-  backAndroid,
-  closeAndroidApp,
-  fillAndroid,
-  focusAndroid,
-  homeAndroid,
-  longPressAndroid,
-  openAndroidApp,
-  openAndroidDevice,
-  pressAndroid,
-  readAndroidClipboardText,
-  rotateAndroid,
-  swipeAndroid,
-  scrollAndroid,
-  screenshotAndroid,
-  setAndroidSetting,
-  typeAndroid,
-  writeAndroidClipboardText,
-} from '../platforms/android/index.ts';
-import {
-  closeIosApp,
-  openIosApp,
-  openIosDevice,
-  readIosClipboardText,
-  screenshotIos,
-  setIosSetting,
-  writeIosClipboardText,
-} from '../platforms/ios/index.ts';
-import { runMacOsScreenshotAction } from '../platforms/ios/macos-helper.ts';
-import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
-import {
-  appleRemotePressCommand,
-  iosRunnerOverrides,
-  resolveAppleBackRunnerCommand,
-} from '../platforms/ios/interactions.ts';
-import {
-  pressLinux,
-  doubleClickLinux,
-  swipeLinux,
-  longPressLinux,
-  focusLinux,
-  typeLinux,
-  fillLinux,
-  scrollLinux,
-} from '../platforms/linux/input-actions.ts';
-import { screenshotLinux } from '../platforms/linux/screenshot.ts';
-import {
-  openLinuxApp,
-  closeLinuxApp,
-  backLinux,
-  homeLinux,
-} from '../platforms/linux/app-lifecycle.ts';
-import { readLinuxClipboard, writeLinuxClipboard } from '../platforms/linux/clipboard.ts';
+import { AppError } from '../utils/errors.ts';
 import type { Interactor, RunnerContext } from './interactor-types.ts';
-
-export type { BackMode, Interactor, RunnerContext, ScreenshotOptions } from './interactor-types.ts';
+import { createAndroidInteractor } from './interactors/android.ts';
+import { createAppleInteractor } from './interactors/apple.ts';
+import { createLinuxInteractor } from './interactors/linux.ts';
 
 export function getInteractor(device: DeviceInfo, runnerContext: RunnerContext): Interactor {
   switch (device.platform) {
     case 'android':
-      return {
-        open: (app, options) => openAndroidApp(device, app, options?.activity),
-        openDevice: () => openAndroidDevice(device),
-        close: (app) => closeAndroidApp(device, app),
-        tap: (x, y) => pressAndroid(device, x, y),
-        doubleTap: async (x, y) => {
-          await pressAndroid(device, x, y);
-          await pressAndroid(device, x, y);
-        },
-        swipe: (x1, y1, x2, y2, durationMs) => swipeAndroid(device, x1, y1, x2, y2, durationMs),
-        longPress: (x, y, durationMs) => longPressAndroid(device, x, y, durationMs),
-        focus: (x, y) => focusAndroid(device, x, y),
-        type: (text, delayMs) => typeAndroid(device, text, delayMs),
-        fill: (x, y, text, delayMs) => fillAndroid(device, x, y, text, delayMs),
-        scroll: (direction, options) => scrollAndroid(device, direction, options),
-        screenshot: (outPath) => screenshotAndroid(device, outPath),
-        back: (_mode) => backAndroid(device),
-        home: () => homeAndroid(device),
-        rotate: (orientation) => rotateAndroid(device, orientation),
-        appSwitcher: () => appSwitcherAndroid(device),
-        readClipboard: () => readAndroidClipboardText(device),
-        writeClipboard: (text) => writeAndroidClipboardText(device, text),
-        setSetting: (setting, state, appId, options) =>
-          setAndroidSetting(device, setting, state, appId, options),
-      };
+      return createAndroidInteractor(device);
     case 'linux':
-      return {
-        open: (app) => openLinuxApp(app),
-        openDevice: () => Promise.resolve(),
-        close: (app) => closeLinuxApp(app),
-        tap: (x, y) => pressLinux(x, y),
-        doubleTap: (x, y) => doubleClickLinux(x, y),
-        swipe: (x1, y1, x2, y2, durationMs) => swipeLinux(x1, y1, x2, y2, durationMs),
-        longPress: (x, y, durationMs) => longPressLinux(x, y, durationMs),
-        focus: (x, y) => focusLinux(x, y),
-        type: (text, delayMs) => typeLinux(text, delayMs),
-        fill: (x, y, text, delayMs) => fillLinux(x, y, text, delayMs),
-        scroll: (direction, options) => scrollLinux(direction, options),
-        screenshot: (outPath) => screenshotLinux(outPath),
-        back: () => backLinux(),
-        home: () => homeLinux(),
-        rotate: () => {
-          throw new AppError('UNSUPPORTED_OPERATION', 'rotate not supported on Linux');
-        },
-        appSwitcher: () => {
-          throw new AppError('UNSUPPORTED_OPERATION', 'appSwitcher not yet supported on Linux');
-        },
-        readClipboard: () => readLinuxClipboard(),
-        writeClipboard: (text) => writeLinuxClipboard(text),
-        setSetting: () => {
-          throw new AppError('UNSUPPORTED_OPERATION', 'setSetting not supported on Linux');
-        },
-      };
+      return createLinuxInteractor();
     case 'ios':
-    case 'macos': {
-      const { overrides, runnerOpts } = iosRunnerOverrides(device, runnerContext);
-      return {
-        open: (app, options) =>
-          openIosApp(device, app, { appBundleId: options?.appBundleId, url: options?.url }),
-        openDevice: () => openIosDevice(device),
-        close: (app) => closeIosApp(device, app),
-        screenshot: async (outPath, options) => {
-          if (device.platform === 'macos' && options?.surface && options.surface !== 'app') {
-            await runMacOsScreenshotAction(outPath, {
-              surface: options.surface,
-              fullscreen: options.fullscreen,
-            });
-            return;
-          }
-          await screenshotIos(device, outPath, options?.appBundleId, options?.fullscreen);
-        },
-        back: async (mode) => {
-          if (device.target === 'tv') {
-            await runIosRunnerCommand(
-              device,
-              appleRemotePressCommand('menu', runnerContext.appBundleId),
-              runnerOpts,
-            );
-            return;
-          }
-          await runIosRunnerCommand(
-            device,
-            {
-              command: resolveAppleBackRunnerCommand(mode),
-              appBundleId: runnerContext.appBundleId,
-            },
-            runnerOpts,
-          );
-        },
-        home: async () => {
-          if (device.target === 'tv') {
-            await runIosRunnerCommand(
-              device,
-              appleRemotePressCommand('home', runnerContext.appBundleId),
-              runnerOpts,
-            );
-            return;
-          }
-          await runIosRunnerCommand(
-            device,
-            { command: 'home', appBundleId: runnerContext.appBundleId },
-            runnerOpts,
-          );
-        },
-        rotate: async (orientation) => {
-          await runIosRunnerCommand(
-            device,
-            { command: 'rotate', orientation, appBundleId: runnerContext.appBundleId },
-            runnerOpts,
-          );
-        },
-        appSwitcher: async () => {
-          await runIosRunnerCommand(
-            device,
-            { command: 'appSwitcher', appBundleId: runnerContext.appBundleId },
-            runnerOpts,
-          );
-        },
-        readClipboard: () => readIosClipboardText(device),
-        writeClipboard: (text) => writeIosClipboardText(device, text),
-        setSetting: (setting, state, appId, options) =>
-          setIosSetting(device, setting, state, appId, options),
-        ...overrides,
-      };
-    }
+    case 'macos':
+      return createAppleInteractor(device, runnerContext);
     default:
       throw new AppError('UNSUPPORTED_PLATFORM', `Unsupported platform: ${device.platform}`);
   }

--- a/src/core/interactors/android.ts
+++ b/src/core/interactors/android.ts
@@ -1,0 +1,73 @@
+import {
+  appSwitcherAndroid,
+  backAndroid,
+  closeAndroidApp,
+  fillAndroid,
+  focusAndroid,
+  homeAndroid,
+  longPressAndroid,
+  openAndroidApp,
+  openAndroidDevice,
+  pressAndroid,
+  readAndroidClipboardText,
+  rotateAndroid,
+  scrollAndroid,
+  screenshotAndroid,
+  setAndroidSetting,
+  snapshotAndroid,
+  swipeAndroid,
+  typeAndroid,
+  writeAndroidClipboardText,
+} from '../../platforms/android/index.ts';
+import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import type { Interactor } from '../interactor-types.ts';
+
+export function createAndroidInteractor(device: DeviceInfo): Interactor {
+  return {
+    open: (app, options) => openAndroidApp(device, app, options?.activity),
+    openDevice: () => openAndroidDevice(device),
+    close: (app) => closeAndroidApp(device, app),
+    tap: (x, y) => pressAndroid(device, x, y),
+    doubleTap: async (x, y) => {
+      await pressAndroid(device, x, y);
+      await pressAndroid(device, x, y);
+    },
+    swipe: (x1, y1, x2, y2, durationMs) => swipeAndroid(device, x1, y1, x2, y2, durationMs),
+    longPress: (x, y, durationMs) => longPressAndroid(device, x, y, durationMs),
+    focus: (x, y) => focusAndroid(device, x, y),
+    type: (text, delayMs) => typeAndroid(device, text, delayMs),
+    fill: (x, y, text, delayMs) => fillAndroid(device, x, y, text, delayMs),
+    scroll: (direction, options) => scrollAndroid(device, direction, options),
+    screenshot: (outPath) => screenshotAndroid(device, outPath),
+    snapshot: async (options) => {
+      const result = await withDiagnosticTimer(
+        'snapshot_capture',
+        async () =>
+          await snapshotAndroid(device, {
+            interactiveOnly: options?.interactiveOnly,
+            compact: options?.compact,
+            depth: options?.depth,
+            scope: options?.scope,
+            raw: options?.raw,
+          }),
+        { backend: 'android' },
+      );
+      return {
+        nodes: result.nodes ?? [],
+        truncated: result.truncated ?? false,
+        backend: 'android',
+        analysis: result.analysis,
+        androidSnapshot: result.androidSnapshot,
+      };
+    },
+    back: (_mode) => backAndroid(device),
+    home: () => homeAndroid(device),
+    rotate: (orientation) => rotateAndroid(device, orientation),
+    appSwitcher: () => appSwitcherAndroid(device),
+    readClipboard: () => readAndroidClipboardText(device),
+    writeClipboard: (text) => writeAndroidClipboardText(device, text),
+    setSetting: (setting, state, appId, options) =>
+      setAndroidSetting(device, setting, state, appId, options),
+  };
+}

--- a/src/core/interactors/apple.ts
+++ b/src/core/interactors/apple.ts
@@ -1,0 +1,132 @@
+import {
+  closeIosApp,
+  openIosApp,
+  openIosDevice,
+  readIosClipboardText,
+  screenshotIos,
+  setIosSetting,
+  writeIosClipboardText,
+} from '../../platforms/ios/index.ts';
+import {
+  appleRemotePressCommand,
+  iosRunnerOverrides,
+  resolveAppleBackRunnerCommand,
+} from '../../platforms/ios/interactions.ts';
+import { runMacOsScreenshotAction } from '../../platforms/ios/macos-helper.ts';
+import { runIosRunnerCommand } from '../../platforms/ios/runner-client.ts';
+import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import type { RawSnapshotNode } from '../../utils/snapshot.ts';
+import type { Interactor, RunnerContext, SnapshotResult } from '../interactor-types.ts';
+
+export function createAppleInteractor(
+  device: DeviceInfo,
+  runnerContext: RunnerContext,
+): Interactor {
+  const { overrides, runnerOpts } = iosRunnerOverrides(device, runnerContext);
+  return {
+    open: (app, options) =>
+      openIosApp(device, app, { appBundleId: options?.appBundleId, url: options?.url }),
+    openDevice: () => openIosDevice(device),
+    close: (app) => closeIosApp(device, app),
+    screenshot: async (outPath, options) => {
+      if (device.platform === 'macos' && options?.surface && options.surface !== 'app') {
+        await runMacOsScreenshotAction(outPath, {
+          surface: options.surface,
+          fullscreen: options.fullscreen,
+        });
+        return;
+      }
+      await screenshotIos(device, outPath, options?.appBundleId, options?.fullscreen);
+    },
+    snapshot: async (options) => {
+      const result = readAppleSnapshotResult(
+        await withDiagnosticTimer(
+          'snapshot_capture',
+          async () =>
+            await runIosRunnerCommand(
+              device,
+              {
+                command: 'snapshot',
+                appBundleId: options?.appBundleId,
+                interactiveOnly: options?.interactiveOnly,
+                compact: options?.compact,
+                depth: options?.depth,
+                scope: options?.scope,
+                raw: options?.raw,
+              },
+              runnerOpts,
+            ),
+          { backend: 'xctest' },
+        ),
+      );
+      const nodes = result.nodes ?? [];
+      if (nodes.length === 0 && device.kind === 'simulator') {
+        throw new AppError('COMMAND_FAILED', 'XCTest snapshot returned 0 nodes on iOS simulator.');
+      }
+      return { nodes, truncated: result.truncated ?? false, backend: 'xctest' };
+    },
+    back: async (mode) => {
+      if (device.target === 'tv') {
+        await runIosRunnerCommand(
+          device,
+          appleRemotePressCommand('menu', runnerContext.appBundleId),
+          runnerOpts,
+        );
+        return;
+      }
+      await runIosRunnerCommand(
+        device,
+        {
+          command: resolveAppleBackRunnerCommand(mode),
+          appBundleId: runnerContext.appBundleId,
+        },
+        runnerOpts,
+      );
+    },
+    home: async () => {
+      if (device.target === 'tv') {
+        await runIosRunnerCommand(
+          device,
+          appleRemotePressCommand('home', runnerContext.appBundleId),
+          runnerOpts,
+        );
+        return;
+      }
+      await runIosRunnerCommand(
+        device,
+        { command: 'home', appBundleId: runnerContext.appBundleId },
+        runnerOpts,
+      );
+    },
+    rotate: async (orientation) => {
+      await runIosRunnerCommand(
+        device,
+        { command: 'rotate', orientation, appBundleId: runnerContext.appBundleId },
+        runnerOpts,
+      );
+    },
+    appSwitcher: async () => {
+      await runIosRunnerCommand(
+        device,
+        { command: 'appSwitcher', appBundleId: runnerContext.appBundleId },
+        runnerOpts,
+      );
+    },
+    readClipboard: () => readIosClipboardText(device),
+    writeClipboard: (text) => writeIosClipboardText(device, text),
+    setSetting: (setting, state, appId, options) =>
+      setIosSetting(device, setting, state, appId, options),
+    ...overrides,
+  };
+}
+
+function readAppleSnapshotResult(
+  result: Record<string, unknown>,
+): Pick<SnapshotResult, 'nodes' | 'truncated'> {
+  return {
+    nodes: Array.isArray(result.nodes) ? (result.nodes as RawSnapshotNode[]) : undefined,
+    truncated: typeof result.truncated === 'boolean' ? result.truncated : undefined,
+  };
+}

--- a/src/core/interactors/linux.ts
+++ b/src/core/interactors/linux.ts
@@ -1,0 +1,64 @@
+import { AppError } from '../../utils/errors.ts';
+import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
+import {
+  backLinux,
+  closeLinuxApp,
+  homeLinux,
+  openLinuxApp,
+} from '../../platforms/linux/app-lifecycle.ts';
+import { readLinuxClipboard, writeLinuxClipboard } from '../../platforms/linux/clipboard.ts';
+import {
+  doubleClickLinux,
+  fillLinux,
+  focusLinux,
+  longPressLinux,
+  pressLinux,
+  scrollLinux,
+  swipeLinux,
+  typeLinux,
+} from '../../platforms/linux/input-actions.ts';
+import { screenshotLinux } from '../../platforms/linux/screenshot.ts';
+import { snapshotLinux } from '../../platforms/linux/snapshot.ts';
+import type { Interactor } from '../interactor-types.ts';
+
+export function createLinuxInteractor(): Interactor {
+  return {
+    open: (app) => openLinuxApp(app),
+    openDevice: () => Promise.resolve(),
+    close: (app) => closeLinuxApp(app),
+    tap: (x, y) => pressLinux(x, y),
+    doubleTap: (x, y) => doubleClickLinux(x, y),
+    swipe: (x1, y1, x2, y2, durationMs) => swipeLinux(x1, y1, x2, y2, durationMs),
+    longPress: (x, y, durationMs) => longPressLinux(x, y, durationMs),
+    focus: (x, y) => focusLinux(x, y),
+    type: (text, delayMs) => typeLinux(text, delayMs),
+    fill: (x, y, text, delayMs) => fillLinux(x, y, text, delayMs),
+    scroll: (direction, options) => scrollLinux(direction, options),
+    screenshot: (outPath) => screenshotLinux(outPath),
+    snapshot: async (options) => {
+      const result = await withDiagnosticTimer(
+        'snapshot_capture',
+        async () => await snapshotLinux(options?.surface),
+        { backend: 'linux-atspi' },
+      );
+      return {
+        nodes: result.nodes ?? [],
+        truncated: result.truncated ?? false,
+        backend: 'linux-atspi',
+      };
+    },
+    back: () => backLinux(),
+    home: () => homeLinux(),
+    rotate: () => {
+      throw new AppError('UNSUPPORTED_OPERATION', 'rotate not supported on Linux');
+    },
+    appSwitcher: () => {
+      throw new AppError('UNSUPPORTED_OPERATION', 'appSwitcher not yet supported on Linux');
+    },
+    readClipboard: () => readLinuxClipboard(),
+    writeClipboard: (text) => writeLinuxClipboard(text),
+    setSetting: () => {
+      throw new AppError('UNSUPPORTED_OPERATION', 'setSetting not supported on Linux');
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Split platform interactors and route snapshots through the interactor contract.

Reuses backend snapshot option/result types, narrows snapshot backend names, and parses Apple snapshot runner output at the platform boundary.

## Validation

- `pnpm exec vitest run src/core/__tests__/dispatch-resolve.test.ts`
- `pnpm check:fallow --base 87b66d3896016cb773b7ab985bbd1d7ee7efa4d6`
- Stack head: `pnpm check:quick`
- Stack head: `pnpm check:unit`