### PR TITLE
refactor: split session recording modules

### DIFF
--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -6,6 +6,14 @@ import path from 'node:path';
 import { SessionStore } from '../session-store.ts';
 import type { SessionState } from '../types.ts';
 
+type RecordActionEntry = Parameters<SessionStore['recordAction']>[1];
+
+type SessionStoreFixture = {
+  root: string;
+  store: SessionStore;
+  session: SessionState;
+};
+
 function makeSession(name: string): SessionState {
   return {
     name,
@@ -35,6 +43,50 @@ function readWrittenSessionScript(root: string): string {
   return fs.readFileSync(path.join(root, scriptFile), 'utf8');
 }
 
+function makeFixture(prefix: string, sessionsDir?: string): SessionStoreFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return {
+    root,
+    store: new SessionStore(sessionsDir ? path.join(root, sessionsDir) : root),
+    session: makeSession('default'),
+  };
+}
+
+function recordOpen(
+  store: SessionStore,
+  session: SessionState,
+  flags: RecordActionEntry['flags'] = { platform: 'ios', saveScript: true },
+  runtime?: RecordActionEntry['runtime'],
+): void {
+  store.recordAction(session, {
+    command: 'open',
+    positionals: ['Settings'],
+    flags,
+    runtime,
+    result: {},
+  });
+}
+
+function recordClose(store: SessionStore, session: SessionState): void {
+  store.recordAction(session, {
+    command: 'close',
+    positionals: [],
+    flags: { platform: 'ios' },
+    result: {},
+  });
+}
+
+function writeScript({ root, store, session }: SessionStoreFixture): string {
+  store.writeSessionLog(session);
+  return readWrittenSessionScript(root);
+}
+
+function assertScriptMatches(script: string, patterns: RegExp[]): void {
+  for (const pattern of patterns) {
+    assert.match(script, pattern);
+  }
+}
+
 test('expandHome resolves tilde, relative-with-cwd, and absolute paths', () => {
   const homePath = SessionStore.expandHome('~/flows/replay.ad');
   assert.equal(homePath.startsWith(os.homedir()), true);
@@ -54,13 +106,25 @@ test('recordAction stores normalized action entries', () => {
   store.recordAction(session, {
     command: 'snapshot',
     positionals: [],
-    flags: { platform: 'ios', snapshotInteractiveOnly: true, verbose: true },
+    flags: {
+      platform: 'ios',
+      snapshotInteractiveOnly: true,
+      verbose: true,
+      json: true,
+      unknownFlag: 'drop-me',
+    } as Parameters<SessionStore['recordAction']>[1]['flags'] & {
+      json: boolean;
+      unknownFlag: string;
+    },
     result: { nodes: 1 },
   });
   assert.equal(session.actions.length, 1);
   assert.equal(session.actions[0].command, 'snapshot');
-  assert.equal(session.actions[0].flags.platform, 'ios');
-  assert.equal(session.actions[0].flags.snapshotInteractiveOnly, true);
+  assert.deepEqual(session.actions[0].flags, {
+    platform: 'ios',
+    snapshotInteractiveOnly: true,
+    verbose: true,
+  });
 });
 
 test('recordAction skips entries marked noRecord', () => {
@@ -84,58 +148,27 @@ test('defaultTracePath sanitizes session name', () => {
 });
 
 test('writeSessionLog writes .ad only when recording is enabled', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-disabled-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios' },
-    result: {},
-  });
+  const { root, store, session } = makeFixture('agent-device-session-log-disabled-');
+  recordOpen(store, session, { platform: 'ios' });
 
   store.writeSessionLog(session);
   assert.equal(listSessionScriptFiles(root).length, 0);
 });
 
 test('saveScript flag enables .ad session log writing', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-enabled-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true },
-    result: {},
-  });
-  store.recordAction(session, {
-    command: 'close',
-    positionals: [],
-    flags: { platform: 'ios' },
-    result: {},
-  });
+  const { root, store, session } = makeFixture('agent-device-session-log-enabled-');
+  recordOpen(store, session);
+  recordClose(store, session);
 
   store.writeSessionLog(session);
   assert.equal(listSessionScriptFiles(root).length, 1);
 });
 
 test('saveScript path writes session log to custom location', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-custom-path-'));
-  const store = new SessionStore(path.join(root, 'sessions'));
-  const session = makeSession('default');
+  const { root, store, session } = makeFixture('agent-device-session-log-custom-path-', 'sessions');
   const customPath = path.join(root, 'workflows', 'my-flow.ad');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: customPath },
-    result: {},
-  });
-  store.recordAction(session, {
-    command: 'close',
-    positionals: [],
-    flags: { platform: 'ios' },
-    result: {},
-  });
+  recordOpen(store, session, { platform: 'ios', saveScript: customPath });
+  recordClose(store, session);
 
   store.writeSessionLog(session);
   assert.equal(fs.existsSync(customPath), true);
@@ -143,96 +176,58 @@ test('saveScript path writes session log to custom location', () => {
 });
 
 test('writeSessionLog persists open --relaunch in script output', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-relaunch-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true, relaunch: true },
-    result: {},
-  });
-  store.recordAction(session, {
-    command: 'close',
-    positionals: [],
-    flags: { platform: 'ios' },
-    result: {},
-  });
+  const fixture = makeFixture('agent-device-session-log-relaunch-');
+  recordOpen(fixture.store, fixture.session, { platform: 'ios', saveScript: true, relaunch: true });
+  recordClose(fixture.store, fixture.session);
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
+  const script = writeScript(fixture);
   assert.match(script, /open "Settings" --relaunch/);
 });
 
 test('writeSessionLog persists record --hide-touches flags in script output', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-record-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true },
-    result: {},
-  });
-  store.recordAction(session, {
+  const fixture = makeFixture('agent-device-session-log-record-');
+  recordOpen(fixture.store, fixture.session);
+  fixture.store.recordAction(fixture.session, {
     command: 'record',
     positionals: ['start', './capture.mp4'],
     flags: { platform: 'ios', fps: 30, quality: 8, hideTouches: true },
     result: { action: 'start', showTouches: false },
   });
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
+  const script = writeScript(fixture);
   assert.match(script, /record start "\.\/capture\.mp4" --fps 30 --quality 8 --hide-touches/);
 });
 
 test('writeSessionLog persists screenshot flags in script output', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-screenshot-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true },
-    result: {},
-  });
-  store.recordAction(session, {
+  const fixture = makeFixture('agent-device-session-log-screenshot-');
+  recordOpen(fixture.store, fixture.session);
+  fixture.store.recordAction(fixture.session, {
     command: 'screenshot',
     positionals: ['./page.png'],
     flags: { platform: 'ios', screenshotFullscreen: true, screenshotMaxSize: 1024 },
     result: {},
   });
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
+  const script = writeScript(fixture);
   assert.match(script, /screenshot "\.\/page\.png" --fullscreen --max-size 1024/);
 });
 
 test('writeSessionLog persists inline open runtime hints in script output', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-open-runtime-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true, relaunch: true },
-    runtime: {
+  const fixture = makeFixture('agent-device-session-log-open-runtime-');
+  recordOpen(
+    fixture.store,
+    fixture.session,
+    { platform: 'ios', saveScript: true, relaunch: true },
+    {
       platform: 'ios',
       metroHost: '127.0.0.1',
       metroPort: 8081,
       launchUrl: 'myapp://dev',
     },
-    result: {},
-  });
-  store.recordAction(session, {
-    command: 'close',
-    positionals: [],
-    flags: { platform: 'ios' },
-    result: {},
-  });
+  );
+  recordClose(fixture.store, fixture.session);
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
+  const script = writeScript(fixture);
   assert.match(
     script,
     /open "Settings" --relaunch --platform ios --metro-host 127\.0\.0\.1 --metro-port 8081 --launch-url myapp:\/\/dev/,
@@ -240,16 +235,9 @@ test('writeSessionLog persists inline open runtime hints in script output', () =
 });
 
 test('writeSessionLog persists runtime set hints in script output', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-runtime-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true },
-    result: {},
-  });
-  store.recordAction(session, {
+  const fixture = makeFixture('agent-device-session-log-runtime-');
+  recordOpen(fixture.store, fixture.session);
+  fixture.store.recordAction(fixture.session, {
     command: 'runtime',
     positionals: ['set'],
     flags: {
@@ -260,15 +248,9 @@ test('writeSessionLog persists runtime set hints in script output', () => {
     },
     result: {},
   });
-  store.recordAction(session, {
-    command: 'close',
-    positionals: [],
-    flags: { platform: 'ios' },
-    result: {},
-  });
+  recordClose(fixture.store, fixture.session);
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
+  const script = writeScript(fixture);
   assert.match(
     script,
     /runtime set --platform ios --metro-host 127\.0\.0\.1 --metro-port 8081 --launch-url myapp:\/\/dev/,
@@ -276,16 +258,9 @@ test('writeSessionLog persists runtime set hints in script output', () => {
 });
 
 test('writeSessionLog preserves interaction series flags for click/press/swipe', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-series-flags-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true },
-    result: {},
-  });
-  store.recordAction(session, {
+  const fixture = makeFixture('agent-device-session-log-series-flags-');
+  recordOpen(fixture.store, fixture.session);
+  fixture.store.recordAction(fixture.session, {
     command: 'click',
     positionals: ['id="continue_button"'],
     flags: {
@@ -298,7 +273,7 @@ test('writeSessionLog preserves interaction series flags for click/press/swipe',
     },
     result: {},
   });
-  store.recordAction(session, {
+  fixture.store.recordAction(fixture.session, {
     command: 'press',
     positionals: ['201', '545'],
     flags: {
@@ -308,7 +283,7 @@ test('writeSessionLog preserves interaction series flags for click/press/swipe',
     },
     result: {},
   });
-  store.recordAction(session, {
+  fixture.store.recordAction(fixture.session, {
     command: 'swipe',
     positionals: ['10', '20', '30', '40'],
     flags: {
@@ -319,7 +294,7 @@ test('writeSessionLog preserves interaction series flags for click/press/swipe',
     },
     result: {},
   });
-  store.recordAction(session, {
+  fixture.store.recordAction(fixture.session, {
     command: 'fill',
     positionals: ['@e5', 'search'],
     flags: {
@@ -328,38 +303,54 @@ test('writeSessionLog preserves interaction series flags for click/press/swipe',
     },
     result: {},
   });
-  store.recordAction(session, {
-    command: 'close',
+  recordClose(fixture.store, fixture.session);
+
+  const script = writeScript(fixture);
+  assertScriptMatches(script, [
+    /click "id=\\"continue_button\\"" --count 5 --interval-ms 1 --hold-ms 2 --jitter-px 3 --double-tap/,
+    /press 201 545 --count 4 --interval-ms 8/,
+    /swipe 10 20 30 40 --count 3 --pause-ms 12 --pattern ping-pong/,
+    /fill @e5 "search" --delay-ms 40/,
+  ]);
+});
+
+test('writeSessionLog optimizes selector chains and scopes fallback snapshots', () => {
+  const fixture = makeFixture('agent-device-session-log-selectors-');
+  recordOpen(fixture.store, fixture.session);
+  fixture.store.recordAction(fixture.session, {
+    command: 'snapshot',
     positionals: [],
-    flags: { platform: 'ios' },
+    flags: { platform: 'ios', snapshotInteractiveOnly: true },
     result: {},
   });
+  fixture.store.recordAction(fixture.session, {
+    command: 'click',
+    positionals: ['@e1'],
+    flags: { platform: 'ios', count: 2 },
+    result: { selectorChain: ['text="Continue"', 'role=button'], refLabel: 'Continue' },
+  });
+  fixture.store.recordAction(fixture.session, {
+    command: 'fill',
+    positionals: ['@e2', 'hello world'],
+    flags: { platform: 'ios', delayMs: 5 },
+    result: { refLabel: 'Email' },
+  });
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
-  assert.match(
-    script,
-    /click "id=\\"continue_button\\"" --count 5 --interval-ms 1 --hold-ms 2 --jitter-px 3 --double-tap/,
-  );
-  assert.match(script, /press 201 545 --count 4 --interval-ms 8/);
-  assert.match(script, /swipe 10 20 30 40 --count 3 --pause-ms 12 --pattern ping-pong/);
-  assert.match(script, /fill @e5 "search" --delay-ms 40/);
+  const script = writeScript(fixture);
+  assert.doesNotMatch(script, /\nsnapshot\n/);
+  assertScriptMatches(script, [
+    /click "text=\\"Continue\\" \|\| role=button" --count 2/,
+    /snapshot -i -c -s "Email"/,
+    /fill @e2 "Email" "hello world" --delay-ms 5/,
+  ]);
 });
 
 test('writeSessionLog escapes device labels with quotes and backslashes', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-device-label-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  session.device.name = 'QA "Lab" \\ Shelf';
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true },
-    result: {},
-  });
+  const fixture = makeFixture('agent-device-session-log-device-label-');
+  fixture.session.device.name = 'QA "Lab" \\ Shelf';
+  recordOpen(fixture.store, fixture.session);
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
+  const script = writeScript(fixture);
   assert.match(
     script,
     /context platform=ios device="QA \\"Lab\\" \\\\ Shelf" kind=simulator theme=unknown/,
@@ -367,43 +358,41 @@ test('writeSessionLog escapes device labels with quotes and backslashes', () => 
 });
 
 test('writeSessionLog preserves significant whitespace and empty string arguments', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-log-whitespace-'));
-  const store = new SessionStore(root);
-  const session = makeSession('default');
-  store.recordAction(session, {
-    command: 'open',
-    positionals: ['Settings'],
-    flags: { platform: 'ios', saveScript: true },
-    runtime: {
+  const fixture = makeFixture('agent-device-session-log-whitespace-');
+  recordOpen(
+    fixture.store,
+    fixture.session,
+    { platform: 'ios', saveScript: true },
+    {
       platform: 'ios',
       metroHost: ' host\t',
       launchUrl: 'myapp://dev ',
     },
-    result: {},
-  });
-  store.recordAction(session, {
+  );
+  fixture.store.recordAction(fixture.session, {
     command: 'type',
     positionals: ['  leading\ttrailing  '],
     flags: { platform: 'ios' },
     result: {},
   });
-  store.recordAction(session, {
+  fixture.store.recordAction(fixture.session, {
     command: 'fill',
     positionals: ['@e5', ''],
     flags: { platform: 'ios' },
     result: { refLabel: 'Search field' },
   });
-  store.recordAction(session, {
+  fixture.store.recordAction(fixture.session, {
     command: 'screenshot',
     positionals: [' ./screens/final.png '],
     flags: { platform: 'ios' },
     result: {},
   });
 
-  store.writeSessionLog(session);
-  const script = readWrittenSessionScript(root);
-  assert.match(script, /type "  leading\\ttrailing  "/);
-  assert.match(script, /fill @e5 "Search field" ""/);
-  assert.match(script, /screenshot " \.\/screens\/final\.png "/);
-  assert.match(script, /--metro-host " host\\t" --launch-url "myapp:\/\/dev "/);
+  const script = writeScript(fixture);
+  assertScriptMatches(script, [
+    /type "  leading\\ttrailing  "/,
+    /fill @e5 "Search field" ""/,
+    /screenshot " \.\/screens\/final\.png "/,
+    /--metro-host " host\\t" --launch-url "myapp:\/\/dev "/,
+  ]);
 });

--- a/src/daemon/handlers/session-replay-script.ts
+++ b/src/daemon/handlers/session-replay-script.ts
@@ -1,14 +1,10 @@
 import fs from 'node:fs';
 import { AppError } from '../../utils/errors.ts';
 import type { PlatformSelector } from '../../utils/device.ts';
-import { appendOpenActionScriptArgs, parseReplayOpenFlags } from '../session-open-script.ts';
+import { parseReplayOpenFlags } from '../session-open-script.ts';
+import { formatPortableActionLine } from '../session-script-formatting.ts';
 import type { SessionAction, SessionState } from '../types.ts';
 import {
-  appendRecordActionScriptArgs,
-  appendRuntimeHintFlags,
-  appendScriptSeriesFlags,
-  formatScriptArgQuoteIfNeeded,
-  formatScriptArg,
   formatScriptStringLiteral,
   isClickLikeCommand,
   parseReplaySeriesFlags,
@@ -381,36 +377,57 @@ function tokenizeReplayLine(line: string): string[] {
   const tokens: string[] = [];
   let cursor = 0;
   while (cursor < line.length) {
-    while (cursor < line.length && /\s/.test(line[cursor])) {
-      cursor += 1;
-    }
+    cursor = skipReplayWhitespace(line, cursor);
     if (cursor >= line.length) break;
-    if (line[cursor] === '"') {
-      let end = cursor + 1;
-      let escaped = false;
-      while (end < line.length) {
-        const char = line[end];
-        if (char === '"' && !escaped) break;
-        escaped = char === '\\' && !escaped;
-        if (char !== '\\') escaped = false;
-        end += 1;
-      }
-      if (end >= line.length) {
-        throw new AppError('INVALID_ARGS', `Invalid replay script line: ${line}`);
-      }
-      const literal = line.slice(cursor, end + 1);
-      tokens.push(JSON.parse(literal) as string);
-      cursor = end + 1;
-      continue;
-    }
-    let end = cursor;
-    while (end < line.length && !/\s/.test(line[end])) {
-      end += 1;
-    }
-    tokens.push(line.slice(cursor, end));
-    cursor = end;
+    const parsed =
+      line[cursor] === '"'
+        ? readQuotedReplayToken(line, cursor)
+        : readBareReplayToken(line, cursor);
+    tokens.push(parsed.value);
+    cursor = parsed.nextCursor;
   }
   return tokens;
+}
+
+function skipReplayWhitespace(line: string, cursor: number): number {
+  let nextCursor = cursor;
+  while (nextCursor < line.length && /\s/.test(line[nextCursor])) {
+    nextCursor += 1;
+  }
+  return nextCursor;
+}
+
+function readQuotedReplayToken(
+  line: string,
+  cursor: number,
+): { value: string; nextCursor: number } {
+  const tokenStart = cursor + 1;
+  let escaped = false;
+  let end = tokenStart;
+  for (; end < line.length; end += 1) {
+    const char = line[end];
+    if (char === '"' && !escaped) break;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    escaped = char === '\\';
+  }
+  if (end >= line.length) {
+    throw new AppError('INVALID_ARGS', `Invalid replay script line: ${line}`);
+  }
+  return {
+    value: JSON.parse(line.slice(cursor, end + 1)) as string,
+    nextCursor: end + 1,
+  };
+}
+
+function readBareReplayToken(line: string, cursor: number): { value: string; nextCursor: number } {
+  let end = cursor;
+  while (end < line.length && !/\s/.test(line[end])) {
+    end += 1;
+  }
+  return { value: line.slice(cursor, end), nextCursor: end };
 }
 
 export function writeReplayScript(
@@ -438,47 +455,5 @@ export function writeReplayScript(
 }
 
 function formatReplayActionLine(action: SessionAction): string {
-  const parts: string[] = [action.command];
-  if (action.command === 'snapshot') {
-    if (action.flags?.snapshotInteractiveOnly) parts.push('-i');
-    if (action.flags?.snapshotCompact) parts.push('-c');
-    if (typeof action.flags?.snapshotDepth === 'number') {
-      parts.push('-d', String(action.flags.snapshotDepth));
-    }
-    if (action.flags?.snapshotScope) {
-      parts.push('-s', formatScriptArg(action.flags.snapshotScope));
-    }
-    if (action.flags?.snapshotRaw) parts.push('--raw');
-    return parts.join(' ');
-  }
-  if (action.command === 'open') {
-    appendOpenActionScriptArgs(parts, action);
-    return parts.join(' ');
-  }
-  if (action.command === 'runtime') {
-    for (const positional of action.positionals ?? []) {
-      parts.push(formatScriptArgQuoteIfNeeded(positional));
-    }
-    appendRuntimeHintFlags(parts, action.flags);
-    return parts.join(' ');
-  }
-  if (action.command === 'record') {
-    appendRecordActionScriptArgs(parts, action);
-    return parts.join(' ');
-  }
-  if (action.command === 'screenshot') {
-    for (const positional of action.positionals ?? []) {
-      parts.push(formatScriptArg(positional));
-    }
-    if (action.flags?.screenshotFullscreen) parts.push('--fullscreen');
-    if (typeof action.flags?.screenshotMaxSize === 'number') {
-      parts.push('--max-size', String(action.flags.screenshotMaxSize));
-    }
-    return parts.join(' ');
-  }
-  for (const positional of action.positionals ?? []) {
-    parts.push(formatScriptArg(positional));
-  }
-  appendScriptSeriesFlags(parts, action);
-  return parts.join(' ');
+  return formatPortableActionLine(action, { runtimeIncludeAllPositionals: true });
 }

--- a/src/daemon/script-utils.ts
+++ b/src/daemon/script-utils.ts
@@ -37,7 +37,7 @@ export function formatScriptStringLiteral(value: string): string {
 }
 
 // Preserve readable CLI-ish script output for ordinary tokens while still quoting whitespace.
-export function formatScriptArgQuoteIfNeeded(value: string): string {
+function formatScriptArgQuoteIfNeeded(value: string): string {
   return formatScriptToken(value, isBareScriptToken);
 }
 
@@ -136,6 +136,48 @@ export function appendRecordActionScriptArgs(parts: string[], action: SessionAct
   if (action.flags?.hideTouches) {
     parts.push('--hide-touches');
   }
+}
+
+export function appendSnapshotActionScriptArgs(parts: string[], action: SessionAction): void {
+  if (action.flags?.snapshotInteractiveOnly) parts.push('-i');
+  if (action.flags?.snapshotCompact) parts.push('-c');
+  if (typeof action.flags?.snapshotDepth === 'number') {
+    parts.push('-d', String(action.flags.snapshotDepth));
+  }
+  if (action.flags?.snapshotScope) {
+    parts.push('-s', formatScriptArg(action.flags.snapshotScope));
+  }
+  if (action.flags?.snapshotRaw) parts.push('--raw');
+}
+
+export function appendScreenshotActionScriptArgs(parts: string[], action: SessionAction): void {
+  for (const positional of action.positionals ?? []) {
+    parts.push(formatScriptArg(positional));
+  }
+  if (action.flags?.screenshotFullscreen) parts.push('--fullscreen');
+  if (typeof action.flags?.screenshotMaxSize === 'number') {
+    parts.push('--max-size', String(action.flags.screenshotMaxSize));
+  }
+}
+
+export function appendRuntimeActionScriptArgs(
+  parts: string[],
+  action: SessionAction,
+  options: { includeAllPositionals?: boolean } = {},
+): void {
+  const positionals = action.positionals ?? [];
+  const selectedPositionals = options.includeAllPositionals ? positionals : positionals.slice(0, 1);
+  for (const positional of selectedPositionals) {
+    parts.push(formatScriptArgQuoteIfNeeded(positional));
+  }
+  appendRuntimeHintFlags(parts, action.flags);
+}
+
+export function appendGenericActionScriptArgs(parts: string[], action: SessionAction): void {
+  for (const positional of action.positionals ?? []) {
+    parts.push(formatScriptArg(positional));
+  }
+  appendScriptSeriesFlags(parts, action);
 }
 
 export function parseReplaySeriesFlags(

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -1,0 +1,84 @@
+import type { CommandFlags } from '../core/dispatch.ts';
+import { emitDiagnostic } from '../utils/diagnostics.ts';
+import type { SessionAction, SessionRuntimeHints, SessionState } from './types.ts';
+import { expandSessionPath } from './session-paths.ts';
+
+export type RecordActionEntry = {
+  command: string;
+  positionals: string[];
+  flags: CommandFlags;
+  runtime?: SessionRuntimeHints;
+  result?: Record<string, unknown>;
+};
+
+export function recordActionEntry(session: SessionState, entry: RecordActionEntry): void {
+  if (entry.flags?.noRecord) return;
+  if (entry.flags?.saveScript) {
+    session.recordSession = true;
+    if (typeof entry.flags.saveScript === 'string') {
+      session.saveScriptPath = expandSessionPath(entry.flags.saveScript);
+    }
+  }
+  session.actions.push({
+    ts: Date.now(),
+    command: entry.command,
+    positionals: entry.positionals,
+    runtime: entry.runtime,
+    flags: sanitizeFlags(entry.flags),
+    result: entry.result,
+  });
+  emitDiagnostic({
+    level: 'debug',
+    phase: 'record_action',
+    data: {
+      command: entry.command,
+      session: session.name,
+    },
+  });
+}
+
+const SANITIZED_FLAG_KEYS = [
+  'platform',
+  'device',
+  'udid',
+  'serial',
+  'out',
+  'verbose',
+  'metroHost',
+  'metroPort',
+  'bundleUrl',
+  'launchUrl',
+  'snapshotInteractiveOnly',
+  'snapshotCompact',
+  'snapshotDepth',
+  'snapshotScope',
+  'snapshotRaw',
+  'screenshotFullscreen',
+  'screenshotMaxSize',
+  'relaunch',
+  'saveScript',
+  'noRecord',
+  'fps',
+  'quality',
+  'hideTouches',
+  'count',
+  'intervalMs',
+  'delayMs',
+  'holdMs',
+  'jitterPx',
+  'doubleTap',
+  'clickButton',
+  'pauseMs',
+  'pattern',
+] as const satisfies readonly (keyof CommandFlags)[];
+
+function sanitizeFlags(flags: CommandFlags | undefined): SessionAction['flags'] {
+  if (!flags) return {};
+  const result: Record<string, unknown> = {};
+  for (const key of SANITIZED_FLAG_KEYS) {
+    if (flags[key] !== undefined) {
+      result[key] = flags[key];
+    }
+  }
+  return result as SessionAction['flags'];
+}

--- a/src/daemon/session-paths.ts
+++ b/src/daemon/session-paths.ts
@@ -1,0 +1,9 @@
+import { resolveUserPath } from '../utils/path-resolution.ts';
+
+export function safeSessionName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+export function expandSessionPath(filePath: string, cwd?: string): string {
+  return resolveUserPath(filePath, { cwd });
+}

--- a/src/daemon/session-script-formatting.ts
+++ b/src/daemon/session-script-formatting.ts
@@ -1,0 +1,32 @@
+import { appendOpenActionScriptArgs } from './session-open-script.ts';
+import {
+  appendGenericActionScriptArgs,
+  appendRecordActionScriptArgs,
+  appendRuntimeActionScriptArgs,
+  appendScreenshotActionScriptArgs,
+  appendSnapshotActionScriptArgs,
+} from './script-utils.ts';
+import type { SessionAction } from './types.ts';
+
+export function formatPortableActionLine(
+  action: SessionAction,
+  options: { runtimeIncludeAllPositionals?: boolean } = {},
+): string {
+  const parts: string[] = [action.command];
+  if (action.command === 'snapshot') {
+    appendSnapshotActionScriptArgs(parts, action);
+  } else if (action.command === 'open') {
+    appendOpenActionScriptArgs(parts, action);
+  } else if (action.command === 'runtime') {
+    appendRuntimeActionScriptArgs(parts, action, {
+      includeAllPositionals: options.runtimeIncludeAllPositionals,
+    });
+  } else if (action.command === 'record') {
+    appendRecordActionScriptArgs(parts, action);
+  } else if (action.command === 'screenshot') {
+    appendScreenshotActionScriptArgs(parts, action);
+  } else {
+    appendGenericActionScriptArgs(parts, action);
+  }
+  return parts.join(' ');
+}

--- a/src/daemon/session-script-writer.ts
+++ b/src/daemon/session-script-writer.ts
@@ -1,0 +1,217 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { inferFillText } from './action-utils.ts';
+import { emitDiagnostic } from '../utils/diagnostics.ts';
+import { formatPortableActionLine } from './session-script-formatting.ts';
+import { expandSessionPath, safeSessionName } from './session-paths.ts';
+import {
+  appendScriptSeriesFlags,
+  formatScriptArg,
+  formatScriptStringLiteral,
+  isClickLikeCommand,
+} from './script-utils.ts';
+import type { SessionAction, SessionState } from './types.ts';
+
+export type SessionScriptWriteResult = { written: false } | { written: true; path: string };
+
+export class SessionScriptWriter {
+  private readonly sessionsDir: string;
+
+  constructor(sessionsDir: string) {
+    this.sessionsDir = sessionsDir;
+  }
+
+  write(session: SessionState): SessionScriptWriteResult {
+    let scriptPath: string | undefined;
+    try {
+      if (!session.recordSession) return { written: false };
+      scriptPath = this.resolveScriptPath(session);
+      const scriptDir = path.dirname(scriptPath);
+      if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
+      const script = formatSessionScript(session);
+      fs.writeFileSync(scriptPath, script);
+      return { written: true, path: scriptPath };
+    } catch (error) {
+      emitDiagnostic({
+        level: 'warn',
+        phase: 'session_script_write_failed',
+        data: {
+          session: session.name,
+          path: scriptPath,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+      return { written: false };
+    }
+  }
+
+  private resolveScriptPath(session: SessionState): string {
+    if (session.saveScriptPath) {
+      return expandSessionPath(session.saveScriptPath);
+    }
+    if (!fs.existsSync(this.sessionsDir)) fs.mkdirSync(this.sessionsDir, { recursive: true });
+    const safeName = safeSessionName(session.name);
+    const timestamp = new Date(session.createdAt).toISOString().replace(/[:.]/g, '-');
+    return path.join(this.sessionsDir, `${safeName}-${timestamp}.ad`);
+  }
+}
+
+function formatSessionScript(session: SessionState): string {
+  return formatScript(session, buildOptimizedActions(session));
+}
+
+function buildOptimizedActions(session: SessionState): SessionAction[] {
+  const optimized: SessionAction[] = [];
+  for (const action of session.actions) {
+    if (action.command === 'snapshot') continue;
+    const optimizedAction = optimizeSelectorChainAction(action);
+    if (optimizedAction) {
+      optimized.push(optimizedAction);
+      continue;
+    }
+    const scopedSnapshot = buildScopedSnapshotAction(session, action);
+    if (scopedSnapshot) optimized.push(scopedSnapshot);
+    optimized.push(action);
+  }
+  return optimized;
+}
+
+function optimizeSelectorChainAction(action: SessionAction): SessionAction | undefined {
+  const selectorExpr = readSelectorChainExpression(action);
+  if (!selectorExpr || !isSelectorTargetingCommand(action.command)) return undefined;
+  if (isClickLikeCommand(action.command)) return { ...action, positionals: [selectorExpr] };
+  if (action.command === 'fill') return optimizeFillAction(action, selectorExpr);
+  return optimizeGetAction(action, selectorExpr);
+}
+
+function readSelectorChainExpression(action: SessionAction): string | undefined {
+  const selectorChain =
+    Array.isArray(action.result?.selectorChain) &&
+    action.result.selectorChain.every((entry) => typeof entry === 'string')
+      ? (action.result.selectorChain as string[])
+      : [];
+  return selectorChain.length > 0 ? selectorChain.join(' || ') : undefined;
+}
+
+function isSelectorTargetingCommand(command: string): boolean {
+  return isClickLikeCommand(command) || command === 'fill' || command === 'get';
+}
+
+function optimizeFillAction(
+  action: SessionAction,
+  selectorExpr: string,
+): SessionAction | undefined {
+  const text = inferFillText(action);
+  return text.length > 0 ? { ...action, positionals: [selectorExpr, text] } : undefined;
+}
+
+function optimizeGetAction(action: SessionAction, selectorExpr: string): SessionAction | undefined {
+  const sub = action.positionals?.[0];
+  return sub === 'text' || sub === 'attrs'
+    ? { ...action, positionals: [sub, selectorExpr] }
+    : undefined;
+}
+
+function buildScopedSnapshotAction(
+  session: SessionState,
+  action: SessionAction,
+): SessionAction | undefined {
+  if (!isSelectorTargetingCommand(action.command)) return undefined;
+  const refLabel = action.result?.refLabel;
+  if (typeof refLabel !== 'string' || refLabel.trim().length === 0) return undefined;
+  const scope = refLabel.trim();
+  return {
+    ts: action.ts,
+    command: 'snapshot',
+    positionals: [],
+    flags: {
+      platform: session.device.platform,
+      snapshotInteractiveOnly: true,
+      snapshotCompact: true,
+      snapshotScope: scope,
+    },
+    result: { scope },
+  };
+}
+
+function formatScript(session: SessionState, actions: SessionAction[]): string {
+  const lines: string[] = [];
+  const kind = session.device.kind ? ` kind=${session.device.kind}` : '';
+  const theme = 'unknown';
+  lines.push(
+    `context platform=${session.device.platform} device=${formatScriptStringLiteral(session.device.name)}${kind} theme=${theme}`,
+  );
+  for (const action of actions) {
+    if (action.flags?.noRecord) continue;
+    lines.push(formatActionLine(action));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function formatActionLine(action: SessionAction): string {
+  const parts: string[] = [action.command];
+  const specialLine = formatSpecialActionLine(parts, action);
+  if (specialLine) return specialLine;
+  return formatPortableActionLine(action);
+}
+
+function formatSpecialActionLine(parts: string[], action: SessionAction): string | undefined {
+  if (isClickLikeCommand(action.command)) {
+    return formatClickLikeActionLine(parts, action);
+  }
+  if (action.command === 'fill') {
+    return formatFillActionLine(parts, action);
+  }
+  if (action.command === 'get') {
+    return formatGetActionLine(parts, action);
+  }
+  return undefined;
+}
+
+function formatClickLikeActionLine(parts: string[], action: SessionAction): string | undefined {
+  const first = action.positionals?.[0];
+  if (!first) return undefined;
+  if (first.startsWith('@')) {
+    parts.push(formatScriptArg(first));
+    appendRefLabel(parts, action);
+    appendScriptSeriesFlags(parts, action);
+    return parts.join(' ');
+  }
+  if (action.positionals.length === 1) {
+    parts.push(formatScriptArg(first));
+    appendScriptSeriesFlags(parts, action);
+    return parts.join(' ');
+  }
+  return undefined;
+}
+
+function formatFillActionLine(parts: string[], action: SessionAction): string | undefined {
+  const ref = action.positionals?.[0];
+  if (!ref?.startsWith('@')) return undefined;
+  parts.push(formatScriptArg(ref));
+  appendRefLabel(parts, action);
+  const text = action.positionals.slice(1).join(' ');
+  // Preserve explicit empty-string fill arguments.
+  if (action.positionals.length > 1) {
+    parts.push(formatScriptArg(text));
+  }
+  appendScriptSeriesFlags(parts, action);
+  return parts.join(' ');
+}
+
+function formatGetActionLine(parts: string[], action: SessionAction): string | undefined {
+  const sub = action.positionals?.[0];
+  const ref = action.positionals?.[1];
+  if (!sub || !ref) return undefined;
+  parts.push(formatScriptArg(sub));
+  parts.push(formatScriptArg(ref));
+  if (ref.startsWith('@')) appendRefLabel(parts, action);
+  return parts.join(' ');
+}
+
+function appendRefLabel(parts: string[], action: SessionAction): void {
+  const refLabel = action.result?.refLabel;
+  if (typeof refLabel === 'string' && refLabel.trim().length > 0) {
+    parts.push(formatScriptArg(refLabel));
+  }
+}

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -1,28 +1,19 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import type { CommandFlags } from '../core/dispatch.ts';
-import type { SessionAction, SessionRuntimeHints, SessionState } from './types.ts';
-import { inferFillText } from './action-utils.ts';
-import { resolveUserPath } from '../utils/path-resolution.ts';
-import { appendOpenActionScriptArgs } from './session-open-script.ts';
-import {
-  appendRecordActionScriptArgs,
-  appendRuntimeHintFlags,
-  appendScriptSeriesFlags,
-  formatScriptArgQuoteIfNeeded,
-  formatScriptArg,
-  formatScriptStringLiteral,
-  isClickLikeCommand,
-} from './script-utils.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
+import type { SessionRuntimeHints, SessionState } from './types.ts';
+import { recordActionEntry, type RecordActionEntry } from './session-action-recorder.ts';
+import { expandSessionPath, safeSessionName } from './session-paths.ts';
+import { SessionScriptWriter } from './session-script-writer.ts';
 
 export class SessionStore {
   private readonly sessions = new Map<string, SessionState>();
   private readonly runtimeHints = new Map<string, SessionRuntimeHints>();
   private readonly sessionsDir: string;
+  private readonly scriptWriter: SessionScriptWriter;
 
   constructor(sessionsDir: string) {
     this.sessionsDir = sessionsDir;
+    this.scriptWriter = new SessionScriptWriter(sessionsDir);
   }
 
   get(name: string): SessionState | undefined {
@@ -62,312 +53,37 @@ export class SessionStore {
     return this.runtimeHints.delete(name);
   }
 
-  recordAction(
-    session: SessionState,
-    entry: {
-      command: string;
-      positionals: string[];
-      flags: CommandFlags;
-      runtime?: SessionRuntimeHints;
-      result?: Record<string, unknown>;
-    },
-  ): void {
-    if (entry.flags?.noRecord) return;
-    if (entry.flags?.saveScript) {
-      session.recordSession = true;
-      if (typeof entry.flags.saveScript === 'string') {
-        session.saveScriptPath = SessionStore.expandHome(entry.flags.saveScript);
-      }
-    }
-    session.actions.push({
-      ts: Date.now(),
-      command: entry.command,
-      positionals: entry.positionals,
-      runtime: entry.runtime,
-      flags: sanitizeFlags(entry.flags),
-      result: entry.result,
-    });
-    emitDiagnostic({
-      level: 'debug',
-      phase: 'record_action',
-      data: {
-        command: entry.command,
-        session: session.name,
-      },
-    });
+  recordAction(session: SessionState, entry: RecordActionEntry): void {
+    recordActionEntry(session, entry);
   }
 
   writeSessionLog(session: SessionState): void {
-    try {
-      if (!session.recordSession) return;
-      const scriptPath = this.resolveScriptPath(session);
-      const scriptDir = path.dirname(scriptPath);
-      if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
-      const script = formatScript(session, this.buildOptimizedActions(session));
-      fs.writeFileSync(scriptPath, script);
-    } catch {}
+    const result = this.scriptWriter.write(session);
+    if (result.written) {
+      emitDiagnostic({
+        level: 'info',
+        phase: 'session_script_written',
+        data: { session: session.name, path: result.path },
+      });
+    }
   }
 
   defaultTracePath(session: SessionState): string {
-    const safeName = SessionStore.safeSessionName(session.name);
+    const safeName = safeSessionName(session.name);
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     return path.join(this.sessionsDir, `${safeName}-${timestamp}.trace.log`);
   }
 
   /** Path to session-scoped app log file. Agent can grep this for token-efficient debugging. */
   resolveAppLogPath(sessionName: string): string {
-    return path.join(this.sessionsDir, SessionStore.safeSessionName(sessionName), 'app.log');
+    return path.join(this.sessionsDir, safeSessionName(sessionName), 'app.log');
   }
 
   resolveAppLogPidPath(sessionName: string): string {
-    return path.join(this.sessionsDir, SessionStore.safeSessionName(sessionName), 'app-log.pid');
-  }
-
-  static safeSessionName(name: string): string {
-    return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+    return path.join(this.sessionsDir, safeSessionName(sessionName), 'app-log.pid');
   }
 
   static expandHome(filePath: string, cwd?: string): string {
-    return resolveUserPath(filePath, { cwd });
+    return expandSessionPath(filePath, cwd);
   }
-
-  private resolveScriptPath(session: SessionState): string {
-    if (session.saveScriptPath) {
-      return SessionStore.expandHome(session.saveScriptPath);
-    }
-    if (!fs.existsSync(this.sessionsDir)) fs.mkdirSync(this.sessionsDir, { recursive: true });
-    const safeName = SessionStore.safeSessionName(session.name);
-    const timestamp = new Date(session.createdAt).toISOString().replace(/[:.]/g, '-');
-    return path.join(this.sessionsDir, `${safeName}-${timestamp}.ad`);
-  }
-
-  private buildOptimizedActions(session: SessionState): SessionAction[] {
-    const optimized: SessionAction[] = [];
-    for (const action of session.actions) {
-      if (action.command === 'snapshot') {
-        continue;
-      }
-      const selectorChain =
-        Array.isArray(action.result?.selectorChain) &&
-        action.result?.selectorChain.every((entry) => typeof entry === 'string')
-          ? (action.result.selectorChain as string[])
-          : [];
-      if (
-        selectorChain.length > 0 &&
-        (isClickLikeCommand(action.command) ||
-          action.command === 'fill' ||
-          action.command === 'get')
-      ) {
-        const selectorExpr = selectorChain.join(' || ');
-        if (isClickLikeCommand(action.command)) {
-          optimized.push({
-            ...action,
-            positionals: [selectorExpr],
-          });
-          continue;
-        }
-        if (action.command === 'fill') {
-          const text = inferFillText(action);
-          if (text.length > 0) {
-            optimized.push({
-              ...action,
-              positionals: [selectorExpr, text],
-            });
-            continue;
-          }
-        }
-        if (action.command === 'get') {
-          const sub = action.positionals?.[0];
-          if (sub === 'text' || sub === 'attrs') {
-            optimized.push({
-              ...action,
-              positionals: [sub, selectorExpr],
-            });
-            continue;
-          }
-        }
-      }
-      if (
-        isClickLikeCommand(action.command) ||
-        action.command === 'fill' ||
-        action.command === 'get'
-      ) {
-        const refLabel = action.result?.refLabel;
-        if (typeof refLabel === 'string' && refLabel.trim().length > 0) {
-          optimized.push({
-            ts: action.ts,
-            command: 'snapshot',
-            positionals: [],
-            flags: {
-              platform: session.device.platform,
-              snapshotInteractiveOnly: true,
-              snapshotCompact: true,
-              snapshotScope: refLabel.trim(),
-            },
-            result: { scope: refLabel.trim() },
-          });
-        }
-      }
-      optimized.push(action);
-    }
-    return optimized;
-  }
-}
-
-const SANITIZED_FLAG_KEYS = [
-  'platform',
-  'device',
-  'udid',
-  'serial',
-  'out',
-  'verbose',
-  'metroHost',
-  'metroPort',
-  'bundleUrl',
-  'launchUrl',
-  'snapshotInteractiveOnly',
-  'snapshotCompact',
-  'snapshotDepth',
-  'snapshotScope',
-  'snapshotRaw',
-  'screenshotFullscreen',
-  'screenshotMaxSize',
-  'relaunch',
-  'saveScript',
-  'noRecord',
-  'fps',
-  'quality',
-  'hideTouches',
-  'count',
-  'intervalMs',
-  'delayMs',
-  'holdMs',
-  'jitterPx',
-  'doubleTap',
-  'clickButton',
-  'pauseMs',
-  'pattern',
-] as const;
-
-function sanitizeFlags(flags: CommandFlags | undefined): SessionAction['flags'] {
-  if (!flags) return {};
-  const result: Record<string, unknown> = {};
-  for (const key of SANITIZED_FLAG_KEYS) {
-    if (flags[key] !== undefined) {
-      result[key] = flags[key];
-    }
-  }
-  return result as SessionAction['flags'];
-}
-
-function formatScript(session: SessionState, actions: SessionAction[]): string {
-  const lines: string[] = [];
-  const kind = session.device.kind ? ` kind=${session.device.kind}` : '';
-  const theme = 'unknown';
-  lines.push(
-    `context platform=${session.device.platform} device=${formatScriptStringLiteral(session.device.name)}${kind} theme=${theme}`,
-  );
-  for (const action of actions) {
-    if (action.flags?.noRecord) continue;
-    lines.push(formatActionLine(action));
-  }
-  return `${lines.join('\n')}\n`;
-}
-
-function formatActionLine(action: SessionAction): string {
-  const parts: string[] = [action.command];
-  if (isClickLikeCommand(action.command)) {
-    const first = action.positionals?.[0];
-    if (first) {
-      if (first.startsWith('@')) {
-        parts.push(formatScriptArg(first));
-        const refLabel = action.result?.refLabel;
-        if (typeof refLabel === 'string' && refLabel.trim().length > 0) {
-          parts.push(formatScriptArg(refLabel));
-        }
-        appendScriptSeriesFlags(parts, action);
-        return parts.join(' ');
-      }
-      if (action.positionals.length === 1) {
-        parts.push(formatScriptArg(first));
-        appendScriptSeriesFlags(parts, action);
-        return parts.join(' ');
-      }
-    }
-  }
-  if (action.command === 'fill') {
-    const ref = action.positionals?.[0];
-    if (ref && ref.startsWith('@')) {
-      parts.push(formatScriptArg(ref));
-      const refLabel = action.result?.refLabel;
-      const text = action.positionals.slice(1).join(' ');
-      if (typeof refLabel === 'string' && refLabel.trim().length > 0) {
-        parts.push(formatScriptArg(refLabel));
-      }
-      // Preserve explicit empty-string fill arguments.
-      if (action.positionals.length > 1) {
-        parts.push(formatScriptArg(text));
-      }
-      appendScriptSeriesFlags(parts, action);
-      return parts.join(' ');
-    }
-  }
-  if (action.command === 'get') {
-    const sub = action.positionals?.[0];
-    const ref = action.positionals?.[1];
-    if (sub && ref) {
-      parts.push(formatScriptArg(sub));
-      parts.push(formatScriptArg(ref));
-      if (ref.startsWith('@')) {
-        const refLabel = action.result?.refLabel;
-        if (typeof refLabel === 'string' && refLabel.trim().length > 0) {
-          parts.push(formatScriptArg(refLabel));
-        }
-      }
-      return parts.join(' ');
-    }
-  }
-  if (action.command === 'snapshot') {
-    if (action.flags?.snapshotInteractiveOnly) parts.push('-i');
-    if (action.flags?.snapshotCompact) parts.push('-c');
-    if (typeof action.flags?.snapshotDepth === 'number') {
-      parts.push('-d', String(action.flags.snapshotDepth));
-    }
-    if (action.flags?.snapshotScope) {
-      parts.push('-s', formatScriptArg(action.flags.snapshotScope));
-    }
-    if (action.flags?.snapshotRaw) parts.push('--raw');
-    return parts.join(' ');
-  }
-  if (action.command === 'screenshot') {
-    for (const positional of action.positionals ?? []) {
-      parts.push(formatScriptArg(positional));
-    }
-    if (action.flags?.screenshotFullscreen) parts.push('--fullscreen');
-    if (typeof action.flags?.screenshotMaxSize === 'number') {
-      parts.push('--max-size', String(action.flags.screenshotMaxSize));
-    }
-    return parts.join(' ');
-  }
-  if (action.command === 'open') {
-    appendOpenActionScriptArgs(parts, action);
-    return parts.join(' ');
-  }
-  if (action.command === 'runtime') {
-    const subcommand = action.positionals?.[0];
-    if (subcommand) {
-      parts.push(formatScriptArgQuoteIfNeeded(subcommand));
-    }
-    appendRuntimeHintFlags(parts, action.flags);
-    return parts.join(' ');
-  }
-  if (action.command === 'record') {
-    appendRecordActionScriptArgs(parts, action);
-    return parts.join(' ');
-  }
-  for (const positional of action.positionals ?? []) {
-    parts.push(formatScriptArg(positional));
-  }
-  appendScriptSeriesFlags(parts, action);
-  return parts.join(' ');
 }


### PR DESCRIPTION
## Summary

Split session recording into hot-path recording and export-time script writing modules.

Adds diagnostics for session script write failures/successes and tightens sanitized flag key typing while preserving the existing store facade.

Folded narrow recorder/writer tests into broader `SessionStore` coverage so the test surface follows the handler-facing facade. Cleaned up fallow findings by keeping internal helpers private, reducing repeated store-test setup, and splitting replay script token parsing helpers.

## Validation

- `zsh -ilc 'export PNPM_HOME="$HOME/Library/pnpm"; export PATH="$PNPM_HOME:$PATH"; pnpm install --frozen-lockfile'`
- `zsh -ilc 'export PNPM_HOME="$HOME/Library/pnpm"; export PATH="$PNPM_HOME:$PATH"; pnpm exec vitest run src/daemon/__tests__/session-store.test.ts src/daemon/handlers/__tests__/replay-heal.test.ts'`
- `zsh -ilc 'export PNPM_HOME="$HOME/Library/pnpm"; export PATH="$PNPM_HOME:$PATH"; pnpm check:fallow --base origin/main'`
- `zsh -ilc 'export PNPM_HOME="$HOME/Library/pnpm"; export PATH="$PNPM_HOME:$PATH"; pnpm format && pnpm check:quick'`
- `zsh -ilc 'export PNPM_HOME="$HOME/Library/pnpm"; export PATH="$PNPM_HOME:$PATH"; pnpm check:unit'`