### PR TITLE
fix: improve Android helper snapshot stability

### DIFF
--- a/src/__tests__/runtime-snapshot.test.ts
+++ b/src/__tests__/runtime-snapshot.test.ts
@@ -108,6 +108,24 @@ test('runtime snapshot emits filtered Android guidance from backend analysis', a
   ]);
 });
 
+test('runtime snapshot warns when Android helper falls back to stock UIAutomator', async () => {
+  const device = createSnapshotOnlyDevice({
+    nodes: [{ ref: 'e1', index: 0, depth: 0, type: 'Window', label: 'Home' }],
+    truncated: false,
+    backend: 'android',
+    androidSnapshot: {
+      backend: 'uiautomator-dump',
+      fallbackReason: 'helper artifact missing',
+    },
+  });
+
+  const result = await device.capture.snapshot({ session: 'default', interactiveOnly: true });
+
+  assert.deepEqual(result.warnings, [
+    'Android snapshot helper unavailable; using stock UIAutomator dump, which can time out on busy React Native UIs. Reason: helper artifact missing',
+  ]);
+});
+
 test('runtime snapshot warns when Android hierarchy looks like a React Native overlay', async () => {
   const device = createSnapshotOnlyDevice({
     nodes: [

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -194,6 +194,7 @@ function buildSnapshotWarnings(params: {
   const warnings = [...(params.result.warnings ?? [])];
   const interactiveOnly = params.options.interactiveOnly === true;
   const analysis = params.result.analysis;
+  const androidSnapshot = params.result.androidSnapshot;
 
   if (
     params.snapshot.backend === 'android' &&
@@ -214,6 +215,15 @@ function buildSnapshotWarnings(params: {
         `Interactive output is empty at depth ${params.options.depth}; retry without -d.`,
       );
     }
+  }
+
+  if (androidSnapshot?.backend === 'uiautomator-dump') {
+    const reason = androidSnapshot.fallbackReason
+      ? ` Reason: ${androidSnapshot.fallbackReason}`
+      : '';
+    warnings.push(
+      `Android snapshot helper unavailable; using stock UIAutomator dump, which can time out on busy React Native UIs.${reason}`,
+    );
   }
 
   if (hasReactNativeOverlay(params.snapshot.nodes)) {

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -260,7 +260,7 @@ test('snapshotAndroid uses injected helper artifact before stock uiautomator', a
   assert.equal(result.androidSnapshot.installReason, 'current');
   assert.equal(result.androidSnapshot.captureMode, 'interactive-windows');
   assert.equal(result.androidSnapshot.windowCount, 1);
-  assert.deepEqual(timeouts, [30000, 13000]);
+  assert.deepEqual(timeouts, [30000, 30000]);
   assert.equal(mockRunCmd.mock.calls.length, 0);
 });
 
@@ -345,6 +345,45 @@ test('snapshotAndroid falls back to stock uiautomator when helper fails', async 
     ['shell', 'shell', 'exec-out'],
   );
   assert.equal(mockRunCmd.mock.calls.length, 0);
+});
+
+test('snapshotAndroid preserves helper failure reason when stock fallback fails', async () => {
+  const helperAdb: AndroidAdbExecutor = async (args) => {
+    if (args.includes('--show-versioncode')) {
+      return {
+        exitCode: 0,
+        stdout: 'package:com.callstack.agentdevice.snapshothelper versionCode:13003',
+        stderr: '',
+      };
+    }
+    if (args.includes('exec-out')) {
+      throw new AppError('COMMAND_FAILED', 'stock dump timed out', { hint: 'stock hint' });
+    }
+    return { exitCode: 1, stdout: '', stderr: 'instrumentation failed' };
+  };
+
+  await assert.rejects(
+    () =>
+      snapshotAndroid(device, {
+        helperAdb,
+        helperArtifact: {
+          apkPath: '/tmp/helper.apk',
+          manifest: helperManifest,
+        },
+      }),
+    (error) => {
+      assert.ok(error instanceof AppError);
+      assert.match(error.message, /stock dump timed out/);
+      assert.match(error.message, /Android snapshot helper failed before stock fallback/);
+      assert.match(error.message, /failed before returning parseable output/);
+      assert.equal(
+        error.details?.androidSnapshotHelperFallbackReason,
+        'Android snapshot helper failed before returning parseable output',
+      );
+      assert.equal(error.details?.hint, 'stock hint');
+      return true;
+    },
+  );
 });
 
 test('snapshotAndroid re-probes helper install after helper capture failure', async () => {

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { withRetry } from '../../utils/retry.ts';
-import { AppError, normalizeError } from '../../utils/errors.ts';
+import { AppError, normalizeError, toAppErrorCode } from '../../utils/errors.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { findProjectRoot, readVersion } from '../../utils/version.ts';
 import {
@@ -39,7 +39,9 @@ import {
 
 const UI_HIERARCHY_DUMP_TIMEOUT_MS = 8_000;
 const HELPER_INSTALL_TIMEOUT_MS = 30_000;
-const HELPER_COMMAND_TIMEOUT_MS = UI_HIERARCHY_DUMP_TIMEOUT_MS + 5_000;
+// Large React Native trees can legitimately exceed the stock dump timeout while
+// the helper is still making progress; keep this below the full fallback path.
+const HELPER_COMMAND_TIMEOUT_MS = 30_000;
 
 type AndroidSnapshotOptions = SnapshotOptions & {
   helperArtifact?: AndroidSnapshotHelperArtifact;
@@ -182,13 +184,39 @@ async function captureStockUiHierarchy(
   fallbackReason?: string,
   adb?: AndroidAdbExecutor,
 ): Promise<{ xml: string; metadata: AndroidSnapshotBackendMetadata }> {
+  let xml: string;
+  try {
+    xml = await dumpUiHierarchy(device, adb);
+  } catch (error) {
+    if (fallbackReason) {
+      throw enrichStockSnapshotFailureWithHelperReason(error, fallbackReason);
+    }
+    throw error;
+  }
   return {
-    xml: await dumpUiHierarchy(device, adb),
+    xml,
     metadata: {
       backend: 'uiautomator-dump',
       ...(fallbackReason ? { fallbackReason } : {}),
     },
   };
+}
+
+function enrichStockSnapshotFailureWithHelperReason(
+  error: unknown,
+  fallbackReason: string,
+): AppError {
+  const normalized = normalizeError(error);
+  return new AppError(
+    toAppErrorCode(normalized.code),
+    `${normalized.message} Android snapshot helper failed before stock fallback: ${fallbackReason}`,
+    {
+      ...normalized.details,
+      androidSnapshotHelperFallbackReason: fallbackReason,
+      ...(normalized.hint ? { hint: normalized.hint } : {}),
+    },
+    error,
+  );
 }
 
 function getAndroidSnapshotHelperDeviceKey(device: DeviceInfo): string {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -970,6 +970,10 @@ test('usageForCommand resolves react-devtools help topic', () => {
     /agent-device react-devtools profile diff before\.json after\.json --limit 10/,
   );
   assert.match(help, /render causes and changed props\/state\/hooks/);
+  assert.match(help, /logs clear --restart before the first logs mark/);
+  assert.match(help, /agent-device logs mark "before catalog search"/);
+  assert.match(help, /Do not write agent-devtools/);
+  assert.match(help, /agent-device network dump --include headers/);
   assert.match(help, /@c refs reset after reload\/remount/);
   assert.match(help, /isolated --state-dir/);
   assert.match(help, /local service tunnel/);

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -301,6 +301,185 @@ test('formatSnapshotText keeps zero-height visible nodes out of off-screen summa
   assert.match(text, /\[off-screen below\] 1 interactive item: "Later"/);
 });
 
+test('formatSnapshotText collapses inactive Android helper nodes in human output', () => {
+  const nodes = [
+    {
+      ref: 'e1',
+      index: 0,
+      depth: 0,
+      type: 'Window',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+    },
+    {
+      ref: 'e2',
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.widget.Button',
+      label: 'Alice, Today, filed the expense',
+      rect: { x: 0, y: 420, width: 390, height: 96 },
+      hittable: true,
+    },
+    {
+      ref: 'e3',
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'android.widget.Button',
+      label: 'alice@example.com',
+      rect: { x: 16, y: 432, width: 48, height: 48 },
+      hittable: true,
+    },
+    {
+      ref: 'e4',
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'android.widget.Button',
+      label: 'alice@example.com',
+      rect: { x: 80, y: 432, width: 120, height: 48 },
+      hittable: true,
+    },
+    {
+      ref: 'e5',
+      index: 4,
+      depth: 3,
+      parentIndex: 3,
+      type: 'android.widget.TextView',
+      label: 'Alice',
+      rect: { x: 80, y: 432, width: 120, height: 48 },
+    },
+    {
+      ref: 'e6',
+      index: 5,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.widget.Button',
+      label: 'Invisible stale action',
+      rect: { x: 0, y: 160, width: 390, height: 0 },
+      hittable: true,
+    },
+    {
+      ref: 'e7',
+      index: 6,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.widget.EditText',
+      label: 'Write something...',
+      identifier: 'composer',
+      rect: { x: 72, y: 760, width: 240, height: 44 },
+      hittable: true,
+    },
+    {
+      ref: 'e8',
+      index: 7,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.view.View',
+      label: 'Dashboard',
+      rect: { x: 0, y: 720, width: 78, height: 96 },
+      hittable: true,
+    },
+    {
+      ref: 'e9',
+      index: 8,
+      depth: 2,
+      parentIndex: 7,
+      type: 'android.widget.TextView',
+      label: 'Dashboard',
+      rect: { x: 20, y: 780, width: 40, height: 24 },
+    },
+    {
+      ref: 'e10',
+      index: 9,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.view.View',
+      label: 'Messages. Your review is required',
+      rect: { x: 78, y: 720, width: 78, height: 96 },
+      hittable: true,
+    },
+    {
+      ref: 'e11',
+      index: 10,
+      depth: 2,
+      parentIndex: 9,
+      type: 'android.widget.TextView',
+      label: 'Messages',
+      rect: { x: 98, y: 780, width: 40, height: 24 },
+    },
+    {
+      ref: 'e12',
+      index: 11,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.view.View',
+      label: 'Billing',
+      rect: { x: 156, y: 720, width: 78, height: 96 },
+      hittable: true,
+    },
+    {
+      ref: 'e13',
+      index: 12,
+      depth: 2,
+      parentIndex: 11,
+      type: 'android.widget.TextView',
+      label: 'Billing',
+      rect: { x: 176, y: 780, width: 40, height: 24 },
+    },
+    {
+      ref: 'e14',
+      index: 13,
+      depth: 1,
+      parentIndex: 0,
+      type: 'android.view.View',
+      label: 'Profile, My settings.',
+      rect: { x: 312, y: 720, width: 78, height: 96 },
+      hittable: true,
+    },
+    {
+      ref: 'e15',
+      index: 14,
+      depth: 2,
+      parentIndex: 13,
+      type: 'android.widget.TextView',
+      label: 'Profile',
+      rect: { x: 332, y: 780, width: 40, height: 24 },
+    },
+  ];
+  const text = withNoColor(() =>
+    formatSnapshotText({
+      nodes,
+      truncated: false,
+      androidSnapshot: { backend: 'android-helper' },
+    }),
+  );
+
+  assert.match(text, /Snapshot: 4 visible nodes \(15 total\)/);
+  assert.match(text, /Collapsed 11 inactive Android helper nodes from text output/);
+  assert.match(text, /@e3 \[button\] "alice@example\.com"/);
+  assert.doesNotMatch(text, /@e4 \[button\] "alice@example\.com"/);
+  assert.doesNotMatch(text, /Invisible stale action/);
+  assert.doesNotMatch(text, /\[group\] "Dashboard"/);
+  assert.doesNotMatch(text, /\[group\] "Messages/);
+  assert.doesNotMatch(text, /\[group\] "Billing"/);
+  assert.doesNotMatch(text, /\[group\] "Profile/);
+  assert.doesNotMatch(text, /possible repeated nav subtree/);
+
+  const raw = withNoColor(() =>
+    formatSnapshotText(
+      {
+        nodes,
+        truncated: false,
+        androidSnapshot: { backend: 'android-helper' },
+      },
+      { raw: true },
+    ),
+  );
+  assert.match(raw, /"Invisible stale action"/);
+  assert.match(raw, /"Messages\. Your review is required"/);
+});
+
 test('formatSnapshotText renders explicit hidden scroll-area content hints', () => {
   const text = withNoColor(() =>
     formatSnapshotText({

--- a/src/utils/android-helper-snapshot-presentation.ts
+++ b/src/utils/android-helper-snapshot-presentation.ts
@@ -1,0 +1,273 @@
+import type { Rect, SnapshotNode } from './snapshot.ts';
+import { displayNodeLabel } from './snapshot-tree.ts';
+
+export type AndroidHelperPresentationInput = {
+  nodes: SnapshotNode[];
+  filteredCount: number;
+};
+
+export function buildAndroidHelperPresentationInput(
+  data: Record<string, unknown>,
+  nodes: SnapshotNode[],
+  options: { raw?: boolean },
+): AndroidHelperPresentationInput {
+  if (options.raw || !isAndroidHelperSnapshot(data)) {
+    return { nodes, filteredCount: 0 };
+  }
+  const filtered = filterAndroidHelperTextOutputNodes(nodes);
+  return {
+    nodes: filtered,
+    filteredCount: nodes.length - filtered.length,
+  };
+}
+
+export function detectPossibleRepeatedNavSubtree(nodes: SnapshotNode[]): boolean {
+  if (nodes.length < 20) {
+    return false;
+  }
+  const counts = new Map<string, number>();
+  for (const node of nodes) {
+    const type = (node.type ?? '').toLowerCase();
+    const label = normalizeRepeatedNodeLabel(displayNodeLabel(node));
+    if (!label) continue;
+    const signature = `${type}|${label}`;
+    counts.set(signature, (counts.get(signature) ?? 0) + 1);
+  }
+  let duplicateCount = 0;
+  for (const count of counts.values()) {
+    if (count > 1) {
+      duplicateCount += count;
+    }
+  }
+  return duplicateCount >= 8;
+}
+
+function isAndroidHelperSnapshot(data: Record<string, unknown>): boolean {
+  const metadata = data.androidSnapshot;
+  if (!metadata || typeof metadata !== 'object') return false;
+  return (metadata as Record<string, unknown>).backend === 'android-helper';
+}
+
+function filterAndroidHelperTextOutputNodes(nodes: SnapshotNode[]): SnapshotNode[] {
+  if (nodes.length === 0) return nodes;
+
+  const removed = new Set<number>();
+  markZeroAreaNodesForRemoval(nodes, removed);
+  markBottomNavNodesNearComposerForRemoval(nodes, removed);
+  markDuplicateEmailButtonsForRemoval(nodes, removed);
+
+  return nodes.filter((node) => !removed.has(node.index));
+}
+
+function markZeroAreaNodesForRemoval(nodes: SnapshotNode[], removed: Set<number>): void {
+  for (const node of nodes) {
+    if (!node.rect || hasRenderableArea(node.rect) || isRootNode(node)) {
+      continue;
+    }
+    markNodeAndDescendantsForRemoval(nodes, node.index, removed);
+  }
+}
+
+function markBottomNavNodesNearComposerForRemoval(
+  nodes: SnapshotNode[],
+  removed: Set<number>,
+): void {
+  const composer = findBottomEditableNode(nodes);
+  if (!composer?.rect) return;
+
+  const navNodes = findBottomNavigationLikeNodes(nodes, composer.rect);
+  for (const node of navNodes) {
+    markNodeAndDescendantsForRemoval(nodes, node.index, removed);
+  }
+}
+
+function markDuplicateEmailButtonsForRemoval(nodes: SnapshotNode[], removed: Set<number>): void {
+  const seenByParent = new Map<string, SnapshotNode>();
+  for (const node of nodes) {
+    if (removed.has(node.index) || !isEmailLikeLabel(displayNodeLabel(node))) {
+      continue;
+    }
+    const parentKey = typeof node.parentIndex === 'number' ? String(node.parentIndex) : 'root';
+    const signature = `${parentKey}|${displayNodeLabel(node).trim().toLowerCase()}`;
+    const previous = seenByParent.get(signature);
+    if (!previous) {
+      seenByParent.set(signature, node);
+      continue;
+    }
+    if (areSameVisualRow(previous.rect, node.rect)) {
+      markNodeAndDescendantsForRemoval(nodes, node.index, removed);
+    }
+  }
+}
+
+function markNodeAndDescendantsForRemoval(
+  nodes: SnapshotNode[],
+  rootIndex: number,
+  removed: Set<number>,
+): void {
+  removed.add(rootIndex);
+  const pending = [rootIndex];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const node of nodes) {
+      if (node.parentIndex !== current || removed.has(node.index)) continue;
+      removed.add(node.index);
+      pending.push(node.index);
+    }
+  }
+}
+
+function hasRenderableArea(rect: Rect): boolean {
+  return rect.width > 0 && rect.height > 0;
+}
+
+function isRootNode(node: SnapshotNode): boolean {
+  return typeof node.parentIndex !== 'number';
+}
+
+function resolveLikelyViewport(nodes: SnapshotNode[]): Rect | null {
+  let best: Rect | null = null;
+  let bestArea = 0;
+  for (const node of nodes) {
+    if (!node.rect || !hasRenderableArea(node.rect)) continue;
+    const area = node.rect.width * node.rect.height;
+    if (area > bestArea) {
+      best = node.rect;
+      bestArea = area;
+    }
+  }
+  return best;
+}
+
+function findBottomEditableNode(nodes: SnapshotNode[]): SnapshotNode | null {
+  const viewport = resolveLikelyViewport(nodes);
+  const lowerBound = viewport ? viewport.y + viewport.height * 0.65 : Number.NEGATIVE_INFINITY;
+  return (
+    nodes.find((node) => {
+      if (!node.rect || node.rect.y < lowerBound) return false;
+      return isEditableNode(node);
+    }) ?? null
+  );
+}
+
+function findBottomNavigationLikeNodes(nodes: SnapshotNode[], composerRect: Rect): SnapshotNode[] {
+  const rows = new Map<string, SnapshotNode[]>();
+  for (const node of nodes) {
+    if (!isBottomNavigationCandidate(node, nodes, composerRect)) continue;
+    const rect = node.rect!;
+    const parentKey = typeof node.parentIndex === 'number' ? String(node.parentIndex) : 'root';
+    const rowKey = [
+      parentKey,
+      bucket(rect.y + rect.height / 2, 24),
+      bucket(rect.width, 24),
+      bucket(rect.height, 24),
+    ].join('|');
+    const row = rows.get(rowKey);
+    if (row) {
+      row.push(node);
+    } else {
+      rows.set(rowKey, [node]);
+    }
+  }
+
+  const navigationNodes: SnapshotNode[] = [];
+  for (const row of rows.values()) {
+    if (!isBottomNavigationRow(row, nodes, composerRect)) continue;
+    navigationNodes.push(...row);
+  }
+  return navigationNodes;
+}
+
+function isNearComposerVerticalBand(rect: Rect, composerRect: Rect): boolean {
+  const tolerance = Math.max(composerRect.height * 2, 96);
+  return (
+    rect.y <= composerRect.y + composerRect.height + tolerance &&
+    rect.y + rect.height >= composerRect.y - tolerance
+  );
+}
+
+function isBottomNavigationCandidate(
+  node: SnapshotNode,
+  nodes: SnapshotNode[],
+  composerRect: Rect,
+): boolean {
+  if (
+    !node.rect ||
+    !hasRenderableArea(node.rect) ||
+    isRootNode(node) ||
+    isEditableNode(node) ||
+    isTextOnlyNode(node) ||
+    !isNearComposerVerticalBand(node.rect, composerRect)
+  ) {
+    return false;
+  }
+  return normalizeRepeatedNodeLabel(getNodeOrDescendantLabel(node, nodes)) !== null;
+}
+
+function isBottomNavigationRow(
+  row: SnapshotNode[],
+  nodes: SnapshotNode[],
+  composerRect: Rect,
+): boolean {
+  if (row.length < 3) return false;
+  const labels = new Set<string>();
+  for (const node of row) {
+    const label = normalizeRepeatedNodeLabel(getNodeOrDescendantLabel(node, nodes));
+    if (label) labels.add(label);
+  }
+  if (labels.size < 3) return false;
+
+  const sorted = [...row].sort((left, right) => left.rect!.x - right.rect!.x);
+  const first = sorted[0]!.rect!;
+  const last = sorted[sorted.length - 1]!.rect!;
+  const horizontalSpan = last.x + last.width - first.x;
+  return horizontalSpan >= composerRect.width;
+}
+
+function isEditableNode(node: SnapshotNode): boolean {
+  const type = (node.type ?? '').toLowerCase();
+  const identifier = (node.identifier ?? '').trim().toLowerCase();
+  return type.includes('edittext') || type.includes('textfield') || identifier === 'composer';
+}
+
+function isTextOnlyNode(node: SnapshotNode): boolean {
+  const type = (node.type ?? '').toLowerCase();
+  return type.includes('textview') || type === 'text';
+}
+
+function getNodeOrDescendantLabel(node: SnapshotNode, nodes: SnapshotNode[]): string {
+  const label = displayNodeLabel(node);
+  if (label.trim()) return label;
+  const pending = [node.index];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const child of nodes) {
+      if (child.parentIndex !== current) continue;
+      const childLabel = displayNodeLabel(child);
+      if (childLabel.trim()) return childLabel;
+      pending.push(child.index);
+    }
+  }
+  return '';
+}
+
+function normalizeRepeatedNodeLabel(label: string): string | null {
+  const normalized = label.trim().replace(/\s+/g, ' ').toLowerCase();
+  if (!normalized || isEmailLikeLabel(normalized)) return null;
+  return normalized;
+}
+
+function bucket(value: number, size: number): number {
+  return Math.round(value / size);
+}
+
+function isEmailLikeLabel(label: string): boolean {
+  return /\S+@\S+\.\S+/.test(label);
+}
+
+function areSameVisualRow(left: Rect | undefined, right: Rect | undefined): boolean {
+  if (!left || !right) return true;
+  const leftCenterY = left.y + left.height / 2;
+  const rightCenterY = right.y + right.height / 2;
+  return Math.abs(leftCenterY - rightCenterY) <= Math.max(left.height, right.height, 1);
+}

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -439,16 +439,20 @@ Core commands:
 
 Profiling loop:
   1. Verify the app is connected: react-devtools status, then wait --connected if needed.
-  2. Start profiling immediately before the interaction.
-  3. Drive the interaction with normal agent-device commands.
-  4. Stop profiling.
-  5. Inspect slow components and rerenders.
-  6. Use profile report @cN for render causes and changed props/state/hooks; use get component @cN for current props/state/hooks.
+  2. If correlating with logs or network, run logs clear --restart before the first logs mark.
+  3. Start profiling immediately before the interaction.
+  4. Drive the interaction with normal agent-device commands and mark before/after the repro when timing matters.
+  5. Stop profiling.
+  6. Inspect slow components and rerenders.
+  7. Use profile report @cN for render causes and changed props/state/hooks; use get component @cN for current props/state/hooks.
 
 Rules:
+  Every React DevTools command is an agent-device subcommand: agent-device react-devtools ...
+  Do not write agent-devtools, agent-react-devtools, or bare react-devtools commands in final command plans.
   Start with get tree --depth 3 or find <name>; use find --exact when fuzzy results are noisy.
   @c refs reset after reload/remount. After reload, wait --connected and inspect again.
   Keep the profile window narrow; unrelated navigation makes render data noisy.
+  For network evidence, use agent-device network dump --include headers; headers is not a positional argument.
   For cross-platform validation with explicit device selectors, prefer isolated --state-dir and restart react-devtools between platforms.
   Remote Android and iOS bridge runs normally through agent-device react-devtools; the CLI keeps the needed local service tunnel alive until agent-device react-devtools stop or disconnect. Expo support depends on the SDK's bundled React Native runtime.
   Remote iOS apps attempt the legacy React DevTools websocket during JavaScript startup. If the app was already open before react-devtools start, run open <bundle-id> --platform ios --relaunch, then wait --connected.
@@ -456,12 +460,16 @@ Rules:
 Example:
   agent-device react-devtools status
   agent-device react-devtools wait --connected
+  agent-device logs clear --restart
+  agent-device logs mark "before catalog search"
   agent-device react-devtools profile start
   agent-device fill 'id="catalog-search"' "tart" --delay-ms 80
+  agent-device logs mark "after catalog search"
   agent-device react-devtools profile stop
   agent-device react-devtools profile slow --limit 5
   agent-device react-devtools profile rerenders --limit 5
   agent-device react-devtools profile report @c5
+  agent-device network dump --include headers
 
 Use snapshot, screenshot, logs, network, and perf for device/app runtime evidence. Use react-devtools only when component internals or React rendering behavior matters.`,
   },

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,8 +1,12 @@
 import path from 'node:path';
+import {
+  buildAndroidHelperPresentationInput,
+  detectPossibleRepeatedNavSubtree,
+  type AndroidHelperPresentationInput,
+} from './android-helper-snapshot-presentation.ts';
 import { AppError, normalizeError, type NormalizedError } from './errors.ts';
 import { buildSnapshotDisplayLines, formatSnapshotLine } from './snapshot-lines.ts';
 import type { SnapshotNode, SnapshotVisibility } from './snapshot.ts';
-import { displayNodeLabel } from './snapshot-tree.ts';
 import type { ScreenshotDiffResult } from './screenshot-diff.ts';
 import type { ScreenshotDiffRegion } from './screenshot-diff-regions.ts';
 import { styleText } from 'node:util';
@@ -58,17 +62,26 @@ export function formatSnapshotText(
   const rawNodes = data.nodes;
   const nodes = Array.isArray(rawNodes) ? (rawNodes as SnapshotNode[]) : [];
   const backend = typeof data.backend === 'string' ? data.backend : undefined;
+  const helperPresentation = buildAndroidHelperPresentationInput(data, nodes, options);
   const visiblePresentation =
-    options.raw || backend === 'macos-helper' ? null : buildMobileSnapshotPresentation(nodes);
+    options.raw || backend === 'macos-helper'
+      ? null
+      : buildMobileSnapshotPresentation(helperPresentation.nodes);
   const truncated = Boolean(data.truncated);
   const displayedNodes = visiblePresentation?.nodes ?? nodes;
   const visibility =
     options.raw || backend === 'macos-helper'
       ? null
-      : readSnapshotVisibility(data, visiblePresentation, displayedNodes.length, nodes.length);
+      : readSnapshotVisibility(
+          data,
+          visiblePresentation,
+          displayedNodes.length,
+          nodes.length,
+          helperPresentation.filteredCount,
+        );
   const header = formatSnapshotHeader(nodes.length, visibility, truncated);
   const prefix = formatSnapshotMetaPrefix(data);
-  const notices = buildSnapshotNotices(data, nodes, options);
+  const notices = buildSnapshotNotices(data, nodes, options, helperPresentation);
   const noticesBlock = notices.length > 0 ? `${notices.join('\n')}\n` : '';
   if (nodes.length === 0) {
     return `${prefix}${header}\n${noticesBlock}`;
@@ -133,28 +146,14 @@ function readSnapshotVisibility(
   visiblePresentation: ReturnType<typeof buildMobileSnapshotPresentation> | null,
   displayedNodeCount: number,
   totalNodeCount: number,
+  filteredCount: number = 0,
 ): SnapshotVisibility | null {
-  const candidate = data.visibility;
-  if (candidate && typeof candidate === 'object') {
-    const visibility = candidate as Partial<SnapshotVisibility>;
-    if (
-      typeof visibility.partial === 'boolean' &&
-      typeof visibility.visibleNodeCount === 'number' &&
-      typeof visibility.totalNodeCount === 'number' &&
-      Array.isArray(visibility.reasons)
-    ) {
-      return {
-        partial: visibility.partial,
-        visibleNodeCount: visibility.visibleNodeCount,
-        totalNodeCount: visibility.totalNodeCount,
-        reasons: visibility.reasons.filter(
-          (reason): reason is SnapshotVisibility['reasons'][number] => typeof reason === 'string',
-        ),
-      };
-    }
+  const payloadVisibility = readPayloadSnapshotVisibility(data);
+  if (filteredCount === 0 && payloadVisibility) {
+    return payloadVisibility;
   }
 
-  const hiddenCount = visiblePresentation?.hiddenCount ?? 0;
+  const hiddenCount = (visiblePresentation?.hiddenCount ?? 0) + filteredCount;
   const hasExplicitHiddenContentHints = visiblePresentation
     ? visiblePresentation.nodes.some((node) => node.hiddenContentAbove || node.hiddenContentBelow)
     : false;
@@ -162,9 +161,15 @@ function readSnapshotVisibility(
     return {
       partial: true,
       visibleNodeCount: displayedNodeCount,
-      totalNodeCount,
-      reasons: ['offscreen-nodes'],
+      totalNodeCount: Math.max(totalNodeCount, payloadVisibility?.totalNodeCount ?? totalNodeCount),
+      reasons: uniqueSnapshotVisibilityReasons([
+        ...(payloadVisibility?.reasons ?? []),
+        'offscreen-nodes',
+      ]),
     };
+  }
+  if (payloadVisibility) {
+    return payloadVisibility;
   }
   if (hasExplicitHiddenContentHints) {
     return {
@@ -175,6 +180,34 @@ function readSnapshotVisibility(
     };
   }
   return null;
+}
+
+function readPayloadSnapshotVisibility(data: Record<string, unknown>): SnapshotVisibility | null {
+  const candidate = data.visibility;
+  if (!candidate || typeof candidate !== 'object') return null;
+  const visibility = candidate as Partial<SnapshotVisibility>;
+  if (
+    typeof visibility.partial !== 'boolean' ||
+    typeof visibility.visibleNodeCount !== 'number' ||
+    typeof visibility.totalNodeCount !== 'number' ||
+    !Array.isArray(visibility.reasons)
+  ) {
+    return null;
+  }
+  return {
+    partial: visibility.partial,
+    visibleNodeCount: visibility.visibleNodeCount,
+    totalNodeCount: visibility.totalNodeCount,
+    reasons: visibility.reasons.filter(
+      (reason): reason is SnapshotVisibility['reasons'][number] => typeof reason === 'string',
+    ),
+  };
+}
+
+function uniqueSnapshotVisibilityReasons(
+  reasons: SnapshotVisibility['reasons'],
+): SnapshotVisibility['reasons'] {
+  return [...new Set(reasons)];
 }
 
 export function formatSnapshotDiffText(data: Record<string, unknown>): string {
@@ -526,9 +559,16 @@ function buildSnapshotNotices(
   data: Record<string, unknown>,
   nodes: SnapshotNode[],
   options: { raw?: boolean; flatten?: boolean },
+  helperPresentation: AndroidHelperPresentationInput = { nodes, filteredCount: 0 },
 ): string[] {
   const notices = readSnapshotWarnings(data);
-  if (!options.raw && detectPossibleRepeatedNavSubtree(nodes)) {
+  if (!options.raw && helperPresentation.filteredCount > 0) {
+    notices.push(
+      `Collapsed ${helperPresentation.filteredCount} inactive Android helper node${helperPresentation.filteredCount === 1 ? '' : 's'} from text output; use --raw or --json for the full hierarchy.`,
+    );
+  }
+  const repeatedNavNodes = helperPresentation.filteredCount > 0 ? helperPresentation.nodes : nodes;
+  if (!options.raw && detectPossibleRepeatedNavSubtree(repeatedNavNodes)) {
     notices.push('Warning: possible repeated nav subtree detected.');
   }
   return notices;
@@ -542,30 +582,6 @@ function readSnapshotWarnings(data: Record<string, unknown>): string[] {
   return rawWarnings.filter(
     (entry): entry is string => typeof entry === 'string' && entry.length > 0,
   );
-}
-
-// Detects likely duplicated navigation chrome (e.g. bottom tab bars rendered once
-// per tab).  Thresholds: ≥20 total nodes to avoid false positives on tiny trees,
-// and ≥8 cumulative duplicate-signature nodes to surface the warning.
-function detectPossibleRepeatedNavSubtree(nodes: SnapshotNode[]): boolean {
-  if (nodes.length < 20) {
-    return false;
-  }
-  const counts = new Map<string, number>();
-  for (const node of nodes) {
-    const type = (node.type ?? '').toLowerCase();
-    const label = displayNodeLabel(node).trim().toLowerCase();
-    if (!label) continue;
-    const signature = `${type}|${label}`;
-    counts.set(signature, (counts.get(signature) ?? 0) + 1);
-  }
-  let duplicateCount = 0;
-  for (const count of counts.values()) {
-    if (count > 1) {
-      duplicateCount += count;
-    }
-  }
-  return duplicateCount >= 8;
 }
 
 function renderSnapshotDisplayLines(lines: ReturnType<typeof buildSnapshotDisplayLines>): string[] {


### PR DESCRIPTION
## Summary

Improve Android helper-backed snapshot reliability and human output.

Adds a larger helper command envelope for large React Native trees, preserves the helper failure reason when stock UIAutomator fallback also fails, and warns when snapshots fall back to stock UIAutomator. Human snapshot text now collapses helper-only noise such as zero-area stale nodes, duplicated email/avatar buttons, and stale bottom navigation rows while keeping `--raw` and `--json` full fidelity.

Also tightens React DevTools guidance for profiling flows after SkillGym exposed command-shape misses around log markers, `agent-device react-devtools`, and `network dump --include headers`.

Touched files: 9. Scope expanded from Android snapshot handling to React DevTools help guidance because validation uncovered related planning regressions.

## Validation

- `pnpm exec vitest run src/platforms/android/__tests__/snapshot.test.ts src/utils/__tests__/args.test.ts src/utils/__tests__/output.test.ts src/__tests__/runtime-snapshot.test.ts`
- `pnpm check:quick`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case react-native-diagnostics-flow`
- `pnpm exec skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case truncated-text-input-scope-ref`
- Manual: Expensify Android `snapshot -i --platform android --session expensify` used `android-helper` and collapsed stale helper-only nodes from human output.

Known gap: broad `pnpm test:skillgym` was attempted twice and still showed varying unrelated `claude-haiku` planning misses; the focused cases affected by this PR pass.
