### PR TITLE
fix: ios press idle timeout

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Lifecycle.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Lifecycle.swift
@@ -109,18 +109,53 @@ extension RunnerTests {
     operation: () -> Void
   ) {
     let setter = NSSelectorFromString("setWaitForIdleTimeout:")
-    guard target.responds(to: setter) else {
-      operation()
-      return
+    let supportsWaitForIdleTimeout = target.responds(to: setter)
+    let previous = supportsWaitForIdleTimeout
+      ? (target.value(forKey: "waitForIdleTimeout") as? NSNumber)
+      : nil
+    if supportsWaitForIdleTimeout {
+      target.setValue(resolveScrollInteractionIdleTimeout(), forKey: "waitForIdleTimeout")
     }
-    let previous = target.value(forKey: "waitForIdleTimeout") as? NSNumber
-    target.setValue(resolveScrollInteractionIdleTimeout(), forKey: "waitForIdleTimeout")
     defer {
       if let previous {
         target.setValue(previous.doubleValue, forKey: "waitForIdleTimeout")
       }
     }
-    operation()
+    performWithQuiescenceSkippedIfSupported(target, operation: operation)
+  }
+
+  // Some apps never report post-gesture quiescence, even after XCTest has synthesized the event.
+  private func performWithQuiescenceSkippedIfSupported(
+    _ target: XCUIApplication,
+    operation: () -> Void
+  ) {
+    let selector = NSSelectorFromString("_performWithInteractionOptions:block:")
+    guard target.responds(to: selector) else {
+      operation()
+      return
+    }
+    typealias PerformWithInteractionOptions = @convention(c) (
+      NSObject,
+      Selector,
+      UInt,
+      @convention(block) () -> Void
+    ) -> Void
+    let implementation = target.method(for: selector)
+    let performWithOptions = unsafeBitCast(
+      implementation,
+      to: PerformWithInteractionOptions.self
+    )
+    let skipPreEventQuiescence = UInt(1)
+    let skipPostEventQuiescence = UInt(2)
+    withoutActuallyEscaping(operation) { escapableOperation in
+      let block: @convention(block) () -> Void = escapableOperation
+      performWithOptions(
+        target,
+        selector,
+        skipPreEventQuiescence | skipPostEventQuiescence,
+        block
+      )
+    }
   }
 
   private func resolveScrollInteractionIdleTimeout() -> TimeInterval {

--- a/src/platforms/ios/__tests__/runner-command-retry.test.ts
+++ b/src/platforms/ios/__tests__/runner-command-retry.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+import { IOS_SIMULATOR } from '../../../__tests__/test-utils/index.ts';
+import { AppError } from '../../../utils/errors.ts';
+import type { RunnerSession } from '../runner-session-types.ts';
+
+const { mockEnsureRunnerSession, mockExecuteRunnerCommandWithSession, mockStopRunnerSession } =
+  vi.hoisted(() => ({
+    mockEnsureRunnerSession: vi.fn(),
+    mockExecuteRunnerCommandWithSession: vi.fn(),
+    mockStopRunnerSession: vi.fn(),
+  }));
+
+vi.mock('../runner-session.ts', async () => {
+  const actual =
+    await vi.importActual<typeof import('../runner-session.ts')>('../runner-session.ts');
+  return {
+    ...actual,
+    ensureRunnerSession: mockEnsureRunnerSession,
+    executeRunnerCommandWithSession: mockExecuteRunnerCommandWithSession,
+    stopRunnerSession: mockStopRunnerSession,
+  };
+});
+
+import { runIosRunnerCommand } from '../runner-client.ts';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('mutating commands restart stale ready sessions when the preflight probe never reaches the runner', async () => {
+  const staleSession = makeRunnerSession({ port: 8100, ready: true });
+  const freshSession = makeRunnerSession({ port: 8101, ready: false });
+
+  mockEnsureRunnerSession.mockResolvedValueOnce(staleSession).mockResolvedValueOnce(freshSession);
+  mockExecuteRunnerCommandWithSession
+    .mockRejectedValueOnce(new AppError('COMMAND_FAILED', 'Runner did not accept connection'))
+    .mockResolvedValueOnce({ message: 'tapped' });
+
+  const result = await runIosRunnerCommand(IOS_SIMULATOR, { command: 'tap', x: 120, y: 240 });
+
+  assert.deepEqual(result, { message: 'tapped' });
+  assert.equal(mockEnsureRunnerSession.mock.calls.length, 2);
+  assert.equal(mockStopRunnerSession.mock.calls.length, 1);
+  assert.equal(mockStopRunnerSession.mock.calls[0]?.[0], staleSession);
+  assert.equal(mockExecuteRunnerCommandWithSession.mock.calls.length, 2);
+  assert.equal(mockExecuteRunnerCommandWithSession.mock.calls[0]?.[2].command, 'tap');
+  assert.equal(mockExecuteRunnerCommandWithSession.mock.calls[1]?.[1], freshSession);
+});
+
+test('mutating commands do not restart or replay after command send failure', async () => {
+  const session = makeRunnerSession({ port: 8100, ready: true });
+
+  mockEnsureRunnerSession.mockResolvedValueOnce(session);
+  mockExecuteRunnerCommandWithSession.mockRejectedValueOnce(
+    new Error('request timed out after reaching runner'),
+  );
+
+  await assert.rejects(() =>
+    runIosRunnerCommand(IOS_SIMULATOR, { command: 'tap', x: 120, y: 240 }),
+  );
+
+  assert.equal(mockEnsureRunnerSession.mock.calls.length, 1);
+  assert.equal(mockStopRunnerSession.mock.calls.length, 0);
+  assert.equal(mockExecuteRunnerCommandWithSession.mock.calls.length, 1);
+});
+
+function makeRunnerSession(overrides: Partial<RunnerSession> = {}): RunnerSession {
+  return {
+    sessionId: `session-${overrides.port ?? 8100}`,
+    device: IOS_SIMULATOR,
+    deviceId: IOS_SIMULATOR.id,
+    port: 8100,
+    xctestrunPath: '/tmp/runner.xctestrun',
+    jsonPath: '/tmp/runner.json',
+    testPromise: Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+    child: { pid: 1234, exitCode: null },
+    ready: true,
+    ...overrides,
+  } as RunnerSession;
+}

--- a/src/platforms/ios/__tests__/runner-transport.test.ts
+++ b/src/platforms/ios/__tests__/runner-transport.test.ts
@@ -17,7 +17,11 @@ vi.mock('../../../utils/exec.ts', async () => {
   };
 });
 
-import { clearDeviceTunnelIpCache, waitForRunner } from '../runner-transport.ts';
+import {
+  clearDeviceTunnelIpCache,
+  sendRunnerCommandOnce,
+  waitForRunner,
+} from '../runner-transport.ts';
 
 const iosSimulator: DeviceInfo = {
   platform: 'ios',
@@ -142,6 +146,22 @@ test('waitForRunner invalidates cached tunnel IP when localhost fallback succeed
     'http://127.0.0.1:8100/command',
     'http://[fd00::456]:8100/command',
   ]);
+});
+
+test('sendRunnerCommandOnce does not retry or simulator fallback after request failure', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('request timed out after reaching runner');
+    }),
+  );
+
+  await assert.rejects(() =>
+    sendRunnerCommandOnce(iosSimulator, 8100, { command: 'tap', x: 120, y: 240 }, 5_000),
+  );
+
+  assert.equal(vi.mocked(fetch).mock.calls.length, 1);
+  assert.equal(mockRunCmd.mock.calls.length, 0);
 });
 
 function stubSuccessfulFetch(): void {

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -82,6 +82,7 @@ async function executeRunnerCommand(
   } catch (err) {
     const appErr = err instanceof AppError ? err : new AppError('COMMAND_FAILED', String(err));
     if (
+      isReadOnlyRunnerCommand(command.command) &&
       appErr.code === 'COMMAND_FAILED' &&
       typeof appErr.message === 'string' &&
       appErr.message.includes('Runner did not accept connection') &&

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -2,11 +2,7 @@ import { AppError } from '../../utils/errors.ts';
 import { withRetry } from '../../utils/retry.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { getRequestSignal } from '../../daemon/request-cancel.ts';
-import {
-  waitForRunner,
-  RUNNER_COMMAND_TIMEOUT_MS,
-  RUNNER_STARTUP_TIMEOUT_MS,
-} from './runner-transport.ts';
+import { RUNNER_COMMAND_TIMEOUT_MS, RUNNER_STARTUP_TIMEOUT_MS } from './runner-transport.ts';
 import {
   type RunnerSession,
   ensureRunnerSession,
@@ -14,7 +10,6 @@ import {
   stopIosRunnerSession,
   validateRunnerDevice,
   executeRunnerCommandWithSession,
-  parseRunnerResponse,
 } from './runner-session.ts';
 import {
   assertRunnerRequestActive,
@@ -82,7 +77,6 @@ async function executeRunnerCommand(
   } catch (err) {
     const appErr = err instanceof AppError ? err : new AppError('COMMAND_FAILED', String(err));
     if (
-      isReadOnlyRunnerCommand(command.command) &&
       appErr.code === 'COMMAND_FAILED' &&
       typeof appErr.message === 'string' &&
       appErr.message.includes('Runner did not accept connection') &&
@@ -96,16 +90,14 @@ async function executeRunnerCommand(
         await stopIosRunnerSession(device.id);
       }
       session = await ensureRunnerSession(device, options);
-      const response = await waitForRunner(
-        session.device,
-        session.port,
+      return await executeRunnerCommandWithSession(
+        device,
+        session,
         command,
         options.logPath,
         RUNNER_STARTUP_TIMEOUT_MS,
-        undefined,
         signal,
       );
-      return await parseRunnerResponse(response, session, options.logPath);
     }
     throw err;
   }

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -11,6 +11,7 @@ import type { DeviceInfo } from '../../utils/device.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
 import {
   waitForRunner,
+  sendRunnerCommandOnce,
   getFreePort,
   logChunk,
   cleanupTempFile,
@@ -26,7 +27,7 @@ import {
   resolveRunnerMaxConcurrentDestinationsFlag,
   runnerPrepProcesses,
 } from './runner-xctestrun.ts';
-import type { RunnerCommand } from './runner-contract.ts';
+import { isReadOnlyRunnerCommand, type RunnerCommand } from './runner-contract.ts';
 import type { RunnerSession } from './runner-session-types.ts';
 
 export type { RunnerSession } from './runner-session-types.ts';
@@ -334,15 +335,31 @@ export async function executeRunnerCommandWithSession(
   timeoutMs: number,
   signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
-  const response = await waitForRunner(
+  const readOnlyCommand = isReadOnlyRunnerCommand(command.command);
+  if (readOnlyCommand) {
+    const response = await waitForRunner(
+      device,
+      session.port,
+      command,
+      logPath,
+      timeoutMs,
+      session,
+      signal,
+    );
+    return await parseRunnerResponse(response, session, logPath);
+  }
+
+  const readinessResponse = await waitForRunner(
     device,
     session.port,
-    command,
+    { command: 'uptime' },
     logPath,
-    timeoutMs,
+    RUNNER_STARTUP_TIMEOUT_MS,
     session,
     signal,
   );
+  await parseRunnerResponse(readinessResponse, session, logPath);
+  const response = await sendRunnerCommandOnce(device, session.port, command, timeoutMs, signal);
   return await parseRunnerResponse(response, session, logPath);
 }
 

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -6,6 +6,7 @@ import {
   type ExecBackgroundResult,
 } from '../../utils/exec.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
+import { Deadline } from '../../utils/retry.ts';
 import { isProcessAlive, isProcessGroupAlive } from '../../utils/process-identity.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
@@ -349,17 +350,22 @@ export async function executeRunnerCommandWithSession(
     return await parseRunnerResponse(response, session, logPath);
   }
 
+  const deadline = Deadline.fromTimeoutMs(timeoutMs);
   const readinessResponse = await waitForRunner(
     device,
     session.port,
     { command: 'uptime' },
     logPath,
-    RUNNER_STARTUP_TIMEOUT_MS,
+    Math.min(RUNNER_STARTUP_TIMEOUT_MS, deadline.remainingMs()),
     session,
     signal,
   );
   await parseRunnerResponse(readinessResponse, session, logPath);
-  const response = await sendRunnerCommandOnce(device, session.port, command, timeoutMs, signal);
+  const remainingMs = deadline.remainingMs();
+  if (remainingMs <= 0) {
+    throw new AppError('COMMAND_FAILED', 'Runner command deadline exceeded', { timeoutMs });
+  }
+  const response = await sendRunnerCommandOnce(device, session.port, command, remainingMs, signal);
   return await parseRunnerResponse(response, session, logPath);
 }
 

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -183,14 +183,19 @@ export async function sendRunnerCommandOnce(
   if (signal?.aborted) {
     throw createRequestCanceledError();
   }
+  const deadline = Deadline.fromTimeoutMs(timeoutMs);
   const { getEndpoints } = createRunnerEndpointResolver(device, port);
-  const { endpoints } = await getEndpoints(timeoutMs);
+  const { endpoints } = await getEndpoints(deadline.remainingMs());
   const endpoint = endpoints[0];
   if (!endpoint) {
     throw new AppError('COMMAND_FAILED', 'Runner command endpoint not available', {
       port,
       endpoints,
     });
+  }
+  const remainingMs = deadline.remainingMs();
+  if (remainingMs <= 0) {
+    throw new AppError('COMMAND_FAILED', 'Runner command deadline exceeded', { timeoutMs });
   }
   return await fetchWithTimeout(
     endpoint,
@@ -199,7 +204,7 @@ export async function sendRunnerCommandOnce(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(command),
     },
-    timeoutMs,
+    remainingMs,
     signal,
   );
 }

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -77,22 +77,7 @@ export async function waitForRunner(
   signal?: AbortSignal,
 ): Promise<Response> {
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  let requestTunnelIp: string | null | undefined;
-  const getEndpoints = async (timeoutBudgetMs?: number, forceRefresh = false) => {
-    const tunnelIp = await getDeviceTunnelIpForRequest({
-      device,
-      timeoutBudgetMs,
-      forceRefresh,
-      requestTunnelIp,
-      setRequestTunnelIp: (ip) => {
-        requestTunnelIp = ip;
-      },
-    });
-    return {
-      endpoints: resolveRunnerCommandEndpoints(device, port, tunnelIp.ip),
-      cached: tunnelIp.sharedCacheHit,
-    };
-  };
+  const { getEndpoints } = createRunnerEndpointResolver(device, port);
   let { endpoints } = await getEndpoints(deadline.remainingMs());
   let lastError: unknown = null;
   const maxAttempts = Math.max(1, Math.ceil(timeoutMs / RUNNER_CONNECT_ATTEMPT_INTERVAL_MS));
@@ -186,6 +171,58 @@ export async function waitForRunner(
   }
 
   throw buildRunnerConnectError({ port, endpoints, logPath, lastError });
+}
+
+export async function sendRunnerCommandOnce(
+  device: DeviceInfo,
+  port: number,
+  command: RunnerCommand,
+  timeoutMs: number = RUNNER_COMMAND_TIMEOUT_MS,
+  signal?: AbortSignal,
+): Promise<Response> {
+  if (signal?.aborted) {
+    throw createRequestCanceledError();
+  }
+  const { getEndpoints } = createRunnerEndpointResolver(device, port);
+  const { endpoints } = await getEndpoints(timeoutMs);
+  const endpoint = endpoints[0];
+  if (!endpoint) {
+    throw new AppError('COMMAND_FAILED', 'Runner command endpoint not available', {
+      port,
+      endpoints,
+    });
+  }
+  return await fetchWithTimeout(
+    endpoint,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(command),
+    },
+    timeoutMs,
+    signal,
+  );
+}
+
+function createRunnerEndpointResolver(device: DeviceInfo, port: number) {
+  let requestTunnelIp: string | null | undefined;
+  return {
+    getEndpoints: async (timeoutBudgetMs?: number, forceRefresh = false) => {
+      const tunnelIp = await getDeviceTunnelIpForRequest({
+        device,
+        timeoutBudgetMs,
+        forceRefresh,
+        requestTunnelIp,
+        setRequestTunnelIp: (ip) => {
+          requestTunnelIp = ip;
+        },
+      });
+      return {
+        endpoints: resolveRunnerCommandEndpoints(device, port, tunnelIp.ip),
+        cached: tunnelIp.sharedCacheHit,
+      };
+    },
+  };
 }
 
 async function tryRunnerEndpoints(


### PR DESCRIPTION
**[Disclaimer: code is written by Codex so not to be taken seriously, but I hope it gives out some hints, if there is even a problem]**

Hello! Thanks a lot for this project, it should save a ton of time for me :) 

I was testing this at my job, and I started with simple commands as per README - open, snapshot and press. Unfortunately, press command timed out every single time.

**OS and Node version:** 
macOS 15.7.3
node v24.14.1

**Xcode/Android SDK versions**
Xcode 26.3
iOS simulator 26.3

**Exact command and output**
agent-device open [my bundle id] --platform ios
agent-device snapshot -i
[list of items]
@e204 [button] "Go to More"
agent-device press @e204 --debug

<details>
<summary>full log:</summary>
[agent-device][diag] {"ts":"2026-05-15T09:04:29.742Z","level":"info","phase":"daemon_startup","session":"default","requestId":"458b4bd0a6dca39e","command":"press","durationMs":5,"data":{"requestId":"458b4bd0a6dca39e","session":"default"}}
[agent-device][diag] {"ts":"2026-05-15T09:04:29.743Z","level":"info","phase":"daemon_request_prepare","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"requestId":"458b4bd0a6dca39e","command":"press","session":"default"}}
[agent-device][diag] {"ts":"2026-05-15T09:00:54.509Z","level":"info","phase":"request_start","session":"default","requestId":"d2b5d4d4da8a84a7","command":"press","data":{"session":"default","command":"press"}}
[agent-device][diag] {"ts":"2026-05-15T09:00:54.511Z","level":"error","phase":"request_failed","session":"default","requestId":"d2b5d4d4da8a84a7","command":"press","data":{"code":"SESSION_NOT_FOUND","message":"No active session. Run open first."}}
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test-without-building -only-testing AgentDeviceRunnerUITests/RunnerTests/testCommand -parallel-testing-enabled NO -test-timeouts-enabled NO -collect-test-diagnostics never -maximum-concurrent-test-simulator-destinations 1 -destination-timeout 20 -xctestrun /Users/alex/.agent-device/ios-runner/derived/Build/Products/AgentDeviceRunner.env.session-F12C18EA-7E1C-4461-A1A5-42D19EE11159-55350.xctestrun -destination "platform=iOS Simulator,id=F12C18EA-7E1C-4461-A1A5-42D19EE11159"

2026-05-15 11:01:33.930 xcodebuild[10542:17955821] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:01:33.937 xcodebuild[10542:17955821] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:01:34.256 xcodebuild[10542:17955821] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:01:34.994 xcodebuild[10542:17955821] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:01:35.711292+0200 AgentDeviceRunnerUITests-Runner[10545:17955954] [Default] Running tests...
    t =      nans Interface orientation changed to Portrait
Test Suite 'Selected tests' started at 2026-05-15 11:01:36.257.
Test Suite 'AgentDeviceRunnerUITests.xctest' started at 2026-05-15 11:01:36.257.
Test Suite 'RunnerTests' started at 2026-05-15 11:01:36.257.
Test Case '-[AgentDeviceRunnerUITests.RunnerTests testCommand]' started.
    t =     0.00s Start Test at 2026-05-15 11:01:36.258
    t =     0.02s Set Up
    t =     0.02s Open com.callstack.agentdevice.runner
    t =     0.02s     Launch com.callstack.agentdevice.runner
    t =     0.63s         Setting up automation session
    t =     1.33s         Wait for com.callstack.agentdevice.runner to idle
2026-05-15 11:01:38.798117+0200 AgentDeviceRunnerUITests-Runner[10545:17955954] AGENT_DEVICE_RUNNER_DESIRED_PORT=55350
2026-05-15 11:01:38.801671+0200 AgentDeviceRunnerUITests-Runner[10545:17955954] AGENT_DEVICE_RUNNER_WAITING
2026-05-15 11:01:38.802000+0200 AgentDeviceRunnerUITests-Runner[10545:17956083] [] nw_listener_socket_inbox_create_socket setsockopt SO_NECP_LISTENUUID failed [2: No such file or directory]
2026-05-15 11:01:38.802245+0200 AgentDeviceRunnerUITests-Runner[10545:17955991] AGENT_DEVICE_RUNNER_LISTENER_READY
2026-05-15 11:01:38.802303+0200 AgentDeviceRunnerUITests-Runner[10545:17955991] AGENT_DEVICE_RUNNER_PORT=55350
2026-05-15 11:01:39.079707+0200 AgentDeviceRunnerUITests-Runner[10545:17955954] AGENT_DEVICE_RUNNER_ACTIVATE bundle=com.redacted.bundle state=3 reason=bundle_changed
    t =     2.82s Open com.redacted.bundle
    t =     2.82s     Activate com.redacted.bundle
    t =     2.85s         Wait for com.redacted.bundle to idle
    t =     2.90s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =     3.95s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =     3.95s         Checking existence of `Application 'com.redacted.bundle'`
    t =     4.13s Get all elements bound by index for: Descendants matching type Alert
    t =     4.15s Get all elements bound by index for: Descendants matching type Sheet
    t =     4.17s Get all elements bound by index for: Descendants matching type Window
    t =     4.30s Checking existence of `Window (Element at index 0)`
    t =     4.43s Find the Window (Element at index 0)
    t =     4.57s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     4.71s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     4.83s Find the Application 'com.redacted.bundle'
[agent-device][diag] {"ts":"2026-05-15T09:01:51.376Z","level":"info","phase":"request_start","session":"default","requestId":"232b7e9835dcb4e1","command":"press","data":{"session":"default","command":"press"}}
[agent-device][diag] {"ts":"2026-05-15T09:01:51.378Z","level":"debug","phase":"platform_command_prepare","session":"default","requestId":"232b7e9835dcb4e1","command":"press","data":{"command":"press","platform":"ios","kind":"simulator"}}
    t =    15.12s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =    16.15s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    16.16s         Checking existence of `Application 'com.redacted.bundle'`
    t =    16.27s Waiting 2.0s for Application 'com.redacted.bundle' to exist
    t =    17.31s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    17.31s         Checking existence of `Application 'com.redacted.bundle'`
    t =    17.88s Find the Application 'com.redacted.bundle'
    t =    18.00s Find the Window (First Match)
    t =    18.01s Checking existence of `Window at {{0.0, 0.0}, {402.0, 874.0}}`
    t =    18.01s Get all elements bound by index for: Descendants matching type Window
    t =    18.13s Checking existence of `Window (Element at index 0)`
    t =    18.26s Find the Window (Element at index 0)
    t =    18.38s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    18.51s Tap Window at {{0.0, 0.0}, {402.0, 874.0}}[0.00, 0.00] -> (362.0, 816.0)
    t =    18.51s     Wait for com.redacted.bundle to idle
    t =    18.51s     Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    18.63s     Check for interrupting elements affecting Window
    t =    18.76s     Synthesize event
    t =    18.76s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    18.88s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    19.01s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    19.42s     Wait for com.redacted.bundle to idle
[agent-device][diag] {"ts":"2026-05-15T09:01:55.679Z","level":"debug","phase":"retry","session":"default","requestId":"232b7e9835dcb4e1","command":"press","data":{"phase":"ios_runner_connect","event":"succeeded","attempt":1,"maxAttempts":180,"elapsedMs":4301,"remainingMs":40699}}
[agent-device][diag] {"ts":"2026-05-15T09:01:55.679Z","level":"info","phase":"platform_command","session":"default","requestId":"232b7e9835dcb4e1","command":"press","durationMs":4301,"data":{"command":"press","platform":"ios"}}
[agent-device][diag] {"ts":"2026-05-15T09:01:55.680Z","level":"debug","phase":"record_action","session":"default","requestId":"232b7e9835dcb4e1","command":"press","data":{"command":"press","session":"default"}}
[agent-device][diag] {"ts":"2026-05-15T09:01:55.680Z","level":"info","phase":"request_success","session":"default","requestId":"232b7e9835dcb4e1","command":"press"}
    t =    65.25s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =    66.29s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    66.29s         Checking existence of `Application 'com.redacted.bundle'`
    t =    66.49s Get all elements bound by index for: Descendants matching type Alert
    t =    66.51s Get all elements bound by index for: Descendants matching type Sheet
    t =    66.53s Get all elements bound by index for: Descendants matching type Window
    t =    66.65s Checking existence of `Window (Element at index 0)`
    t =    66.78s Find the Window (Element at index 0)
    t =    66.90s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    67.03s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    67.15s Find the Application 'com.redacted.bundle'
[agent-device][diag] {"ts":"2026-05-15T09:02:54.377Z","level":"info","phase":"request_start","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"session":"default","command":"press"}}
[agent-device][diag] {"ts":"2026-05-15T09:02:54.377Z","level":"debug","phase":"platform_command_prepare","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"command":"press","platform":"ios","kind":"simulator"}}
    t =    78.12s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =    79.16s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    79.16s         Checking existence of `Application 'com.redacted.bundle'`
    t =    79.27s Waiting 2.0s for Application 'com.redacted.bundle' to exist
    t =    80.31s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    80.31s         Checking existence of `Application 'com.redacted.bundle'`
    t =    80.64s Find the Application 'com.redacted.bundle'
    t =    80.76s Find the Window (First Match)
    t =    80.77s Checking existence of `Window at {{0.0, 0.0}, {402.0, 874.0}}`
    t =    80.77s Get all elements bound by index for: Descendants matching type Window
    t =    80.89s Checking existence of `Window (Element at index 0)`
    t =    81.01s Find the Window (Element at index 0)
    t =    81.13s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.26s Tap Window at {{0.0, 0.0}, {402.0, 874.0}}[0.00, 0.00] -> (298.0, 816.0)
    t =    81.26s     Wait for com.redacted.bundle to idle
    t =    81.26s     Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.38s     Check for interrupting elements affecting Window
    t =    81.51s     Synthesize event
    t =    81.51s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.63s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.76s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"debug","phase":"retry","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"phase":"ios_runner_connect","event":"succeeded","attempt":1,"maxAttempts":180,"elapsedMs":4048,"remainingMs":40952}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"info","phase":"platform_command","session":"default","requestId":"ac1aa065ef870641","command":"press","durationMs":4048,"data":{"command":"press","platform":"ios"}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"debug","phase":"record_action","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"command":"press","session":"default"}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"info","phase":"request_success","session":"default","requestId":"ac1aa065ef870641","command":"press"}
    t =    82.16s     Wait for com.redacted.bundle to idle
2026-05-15 11:03:38.945953+0200 AgentDeviceRunnerUITests-Runner[10545:17955954] AGENT_DEVICE_RUNNER_WAIT_RESULT=XCTWaiterResult(rawValue: 1)
    t =   122.69s Tear Down
    t =   122.90s Checking for crash reports corresponding to unexpected termination of com.callstack.agentdevice.runner
Test Case '-[AgentDeviceRunnerUITests.RunnerTests testCommand]' passed (123.936 seconds).
Test Suite 'RunnerTests' passed at 2026-05-15 11:03:40.195.
	 Executed 1 test, with 0 failures (0 unexpected) in 123.936 (123.938) seconds
Test Suite 'AgentDeviceRunnerUITests.xctest' passed at 2026-05-15 11:03:40.201.
	 Executed 1 test, with 0 failures (0 unexpected) in 123.936 (123.944) seconds
Test Suite 'Selected tests' passed at 2026-05-15 11:03:40.201.
	 Executed 1 test, with 0 failures (0 unexpected) in 123.936 (123.945) seconds
2026-05-15 11:03:40.496 xcodebuild[10542:17955821] [MT] IDETestOperationsObserverDebug: 126.198 elapsed -- Testing started completed.
2026-05-15 11:03:40.496 xcodebuild[10542:17955821] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2026-05-15 11:03:40.496 xcodebuild[10542:17955821] [MT] IDETestOperationsObserverDebug: 126.198 sec, +126.198 sec -- end

Test session results, code coverage, and logs:
	/Users/alex/Library/Developer/Xcode/DerivedData/AgentDeviceRunner-feesenornylowmerbxdptdfbtwgc/Logs/Test/Test-AgentDeviceRunner-2026.05.15_11-01-33-+0200.xcresult

** TEST EXECUTE SUCCEEDED **

Testing started
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test-without-building -only-testing AgentDeviceRunnerUITests/RunnerTests/testCommand -parallel-testing-enabled NO -test-timeouts-enabled NO -collect-test-diagnostics never -maximum-concurrent-test-simulator-destinations 1 -destination-timeout 20 -xctestrun /Users/alex/.agent-device/ios-runner/derived/Build/Products/AgentDeviceRunner.env.session-F12C18EA-7E1C-4461-A1A5-42D19EE11159-55652.xctestrun -destination "platform=iOS Simulator,id=F12C18EA-7E1C-4461-A1A5-42D19EE11159"

2026-05-15 11:04:11.674 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:11.681 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:12.000 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:12.611 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:13.331802+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] [Default] Running tests...
    t =      nans Interface orientation changed to Portrait
Test Suite 'Selected tests' started at 2026-05-15 11:04:13.865.
Test Suite 'AgentDeviceRunnerUITests.xctest' started at 2026-05-15 11:04:13.865.
Test Suite 'RunnerTests' started at 2026-05-15 11:04:13.865.
Test Case '-[AgentDeviceRunnerUITests.RunnerTests testCommand]' started.
    t =     0.00s Start Test at 2026-05-15 11:04:13.866
    t =     0.02s Set Up
    t =     0.02s Open com.callstack.agentdevice.runner
    t =     0.02s     Launch com.callstack.agentdevice.runner
    t =     0.63s         Setting up automation session
    t =     1.36s         Wait for com.callstack.agentdevice.runner to idle
2026-05-15 11:04:16.441477+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] AGENT_DEVICE_RUNNER_DESIRED_PORT=55652
2026-05-15 11:04:16.444798+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] AGENT_DEVICE_RUNNER_WAITING
2026-05-15 11:04:16.445161+0200 AgentDeviceRunnerUITests-Runner[11711:17962929] [] nw_listener_socket_inbox_create_socket setsockopt SO_NECP_LISTENUUID failed [2: No such file or directory]
2026-05-15 11:04:16.445394+0200 AgentDeviceRunnerUITests-Runner[11711:17962932] AGENT_DEVICE_RUNNER_LISTENER_READY
2026-05-15 11:04:16.445492+0200 AgentDeviceRunnerUITests-Runner[11711:17962932] AGENT_DEVICE_RUNNER_PORT=55652
2026-05-15 11:04:17.146924+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] AGENT_DEVICE_RUNNER_ACTIVATE bundle=com.redacted.bundle state=2 reason=bundle_changed
    t =     3.28s Open com.redacted.bundle
    t =     3.28s     Activate com.redacted.bundle
    t =     3.31s         Wait for com.redacted.bundle to idle
    t =     3.40s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =     4.40s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =     4.40s         Checking existence of `Application 'com.redacted.bundle'`
    t =     4.59s Get all elements bound by index for: Descendants matching type Alert
    t =     4.61s Get all elements bound by index for: Descendants matching type Sheet
    t =     4.63s Get all elements bound by index for: Descendants matching type Window
    t =     4.76s Checking existence of `Window (Element at index 0)`
    t =     4.88s Find the Window (Element at index 0)
    t =     5.02s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     5.16s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     5.29s Find the Application 'com.redacted.bundle'
[agent-device][diag] {"ts":"2026-05-15T09:04:29.744Z","level":"info","phase":"request_start","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"session":"default","command":"press"}}
[agent-device][diag] {"ts":"2026-05-15T09:04:29.744Z","level":"debug","phase":"platform_command_prepare","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"command":"press","platform":"ios","kind":"simulator"}}
    t =    15.88s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =    16.92s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    16.92s         Checking existence of `Application 'com.redacted.bundle'`
    t =    17.03s Waiting 2.0s for Application 'com.redacted.bundle' to exist
    t =    18.07s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    18.07s         Checking existence of `Application 'com.redacted.bundle'`
    t =    18.65s Find the Application 'com.redacted.bundle'
    t =    18.76s Find the Window (First Match)
    t =    18.77s Checking existence of `Window at {{0.0, 0.0}, {402.0, 874.0}}`
    t =    18.77s Get all elements bound by index for: Descendants matching type Window
    t =    18.89s Checking existence of `Window (Element at index 0)`
    t =    19.02s Find the Window (Element at index 0)
    t =    19.14s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    19.27s Tap Window at {{0.0, 0.0}, {402.0, 874.0}}[0.00, 0.00] -> (362.0, 816.0)
    t =    19.27s     Wait for com.redacted.bundle to idle
[agent-device][diag] {"ts":"2026-05-15T09:04:49.747Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":1,"maxAttempts":180,"elapsedMs":20003,"remainingMs":24997}}
[agent-device][diag] {"ts":"2026-05-15T09:04:49.747Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":1,"maxAttempts":180,"delayMs":338.5077220718457,"elapsedMs":20003,"remainingMs":24997}}
[agent-device][diag] {"ts":"2026-05-15T09:05:10.091Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":2,"maxAttempts":180,"elapsedMs":40347,"remainingMs":4653}}
[agent-device][diag] {"ts":"2026-05-15T09:05:10.092Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":2,"maxAttempts":180,"delayMs":685.3676246677435,"elapsedMs":40348,"remainingMs":4652}}
[agent-device][diag] {"ts":"2026-05-15T09:05:14.748Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"exhausted","attempt":180,"maxAttempts":180,"elapsedMs":45004,"remainingMs":0}}
[agent-device][diag] {"ts":"2026-05-15T09:05:14.747Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":3,"maxAttempts":180,"elapsedMs":45003,"remainingMs":0}}
2026-05-15 11:05:20.091868+0200 AgentDeviceRunnerUITests-Runner[11711:17963022] [connection] nw_socket_handle_socket_event [C4:1] Socket SO_ERROR [54: Connection reset by peer]
2026-05-15 11:05:20.092054+0200 AgentDeviceRunnerUITests-Runner[11711:17963022] [connection] nw_protocol_socket_reset_linger [C4:1] setsockopt SO_LINGER failed [22: Invalid argument]
[agent-device][diag] {"ts":"2026-05-15T09:05:29.752Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":1,"maxAttempts":60,"elapsedMs":15003,"remainingMs":0}}
[agent-device][diag] {"ts":"2026-05-15T09:05:29.752Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"exhausted","attempt":60,"maxAttempts":60,"elapsedMs":15003,"remainingMs":0}}
** BUILD INTERRUPTED **
[agent-device][diag] {"ts":"2026-05-15T09:05:30.442Z","level":"info","phase":"runner_xctestrun_cache","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"action":"reuse","reason":"reuse_ready","derived":"/Users/alex/.agent-device/ios-runner/derived","xctestrunPath":"/Users/alex/.agent-device/ios-runner/derived/Build/Products/AgentDeviceRunner_AgentDeviceRunner_iphonesimulator26.2-arm64.xctestrun"}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.462Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":1,"maxAttempts":180,"elapsedMs":1,"remainingMs":44999}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.462Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":1,"maxAttempts":180,"delayMs":252.27366058723106,"elapsedMs":1,"remainingMs":44999}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.716Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":2,"maxAttempts":180,"delayMs":655.4649460366638,"elapsedMs":255,"remainingMs":44745}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.716Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":2,"maxAttempts":180,"elapsedMs":255,"remainingMs":44745}}
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test-without-building -only-testing AgentDeviceRunnerUITests/RunnerTests/testCommand -parallel-testing-enabled NO -test-timeouts-enabled NO -collect-test-diagnostics never -maximum-concurrent-test-simulator-destinations 1 -destination-timeout 20 -xctestrun /Users/alex/.agent-device/ios-runner/derived/Build/Products/AgentDeviceRunner.env.session-F12C18EA-7E1C-4461-A1A5-42D19EE11159-55713.xctestrun -destination "platform=iOS Simulator,id=F12C18EA-7E1C-4461-A1A5-42D19EE11159"

2026-05-15 11:05:31.229 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:05:31.236 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
[agent-device][diag] {"ts":"2026-05-15T09:05:31.373Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":3,"maxAttempts":180,"elapsedMs":912,"remainingMs":44088}}
[agent-device][diag] {"ts":"2026-05-15T09:05:31.373Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":3,"maxAttempts":180,"delayMs":1330.6922946961802,"elapsedMs":912,"remainingMs":44088}}
2026-05-15 11:05:31.553 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:05:32.161 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
[agent-device][diag] {"ts":"2026-05-15T09:05:32.705Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":4,"maxAttempts":180,"delayMs":2380.312207028922,"elapsedMs":2244,"remainingMs":42756}}
[agent-device][diag] {"ts":"2026-05-15T09:05:32.705Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":4,"maxAttempts":180,"elapsedMs":2244,"remainingMs":42756}}
2026-05-15 11:05:32.884693+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] [Default] Running tests...
    t =      nans Interface orientation changed to Portrait
Test Suite 'Selected tests' started at 2026-05-15 11:05:33.412.
Test Suite 'AgentDeviceRunnerUITests.xctest' started at 2026-05-15 11:05:33.412.
Test Suite 'RunnerTests' started at 2026-05-15 11:05:33.412.
Test Case '-[AgentDeviceRunnerUITests.RunnerTests testCommand]' started.
    t =     0.00s Start Test at 2026-05-15 11:05:33.413
    t =     0.02s Set Up
    t =     0.02s Open com.callstack.agentdevice.runner
    t =     0.02s     Launch com.callstack.agentdevice.runner
    t =     0.43s         Setting up automation session
    t =     1.28s         Wait for com.callstack.agentdevice.runner to idle
[agent-device][diag] {"ts":"2026-05-15T09:05:35.091Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":5,"maxAttempts":180,"elapsedMs":4630,"remainingMs":40370}}
[agent-device][diag] {"ts":"2026-05-15T09:05:35.091Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":5,"maxAttempts":180,"delayMs":1863.8701827976045,"elapsedMs":4630,"remainingMs":40370}}
2026-05-15 11:05:35.914483+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] AGENT_DEVICE_RUNNER_DESIRED_PORT=55713
2026-05-15 11:05:35.918253+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] AGENT_DEVICE_RUNNER_WAITING
2026-05-15 11:05:35.918786+0200 AgentDeviceRunnerUITests-Runner[12045:17965098] [] nw_listener_socket_inbox_create_socket setsockopt SO_NECP_LISTENUUID failed [2: No such file or directory]
2026-05-15 11:05:35.919167+0200 AgentDeviceRunnerUITests-Runner[12045:17965116] AGENT_DEVICE_RUNNER_LISTENER_READY
2026-05-15 11:05:35.919219+0200 AgentDeviceRunnerUITests-Runner[12045:17965116] AGENT_DEVICE_RUNNER_PORT=55713
2026-05-15 11:05:36.978214+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] AGENT_DEVICE_RUNNER_ACTIVATE bundle=com.redacted.bundle state=2 reason=bundle_changed
    t =     3.57s Open com.redacted.bundle
    t =     3.57s     Activate com.redacted.bundle
    t =     3.60s         Wait for com.redacted.bundle to idle
    t =     3.61s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =     4.69s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =     4.69s         Checking existence of `Application 'com.redacted.bundle'`
    t =     4.81s Waiting 2.0s for Application 'com.redacted.bundle' to exist
    t =     5.85s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =     5.85s         Checking existence of `Application 'com.redacted.bundle'`
    t =     6.22s Find the Application 'com.redacted.bundle'
    t =     6.34s Find the Window (First Match)
    t =     6.34s Checking existence of `Window at {{0.0, 0.0}, {402.0, 874.0}}`
    t =     6.35s Get all elements bound by index for: Descendants matching type Window
    t =     6.47s Checking existence of `Window (Element at index 0)`
    t =     6.60s Find the Window (Element at index 0)
    t =     6.72s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     6.85s Tap Window at {{0.0, 0.0}, {402.0, 874.0}}[0.00, 0.00] -> (362.0, 816.0)
    t =     6.85s     Wait for com.redacted.bundle to idle
[agent-device][diag] {"ts":"2026-05-15T09:05:56.955Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":6,"maxAttempts":180,"elapsedMs":26494,"remainingMs":18506}}
[agent-device][diag] {"ts":"2026-05-15T09:05:56.955Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":6,"maxAttempts":180,"delayMs":1791.1067548734652,"elapsedMs":26494,"remainingMs":18506}}
[agent-device][diag] {"ts":"2026-05-15T09:05:59.861Z","level":"error","phase":"daemon_request_timeout","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"timeoutMs":90000,"requestId":"458b4bd0a6dca39e","command":"press","timedOutRunnerPidsTerminated":1,"daemonPidReset":10214,"daemonPidForceKilled":true}}
[agent-device][diag] {"ts":"2026-05-15T09:05:59.861Z","level":"error","phase":"daemon_request","session":"default","requestId":"458b4bd0a6dca39e","command":"press","durationMs":90118,"data":{"requestId":"458b4bd0a6dca39e","command":"press","error":"Daemon request timed out"}}
Error (COMMAND_FAILED): Daemon request timed out
Hint: Retry with --debug and check daemon diagnostics logs. Timed-out iOS runner xcodebuild processes were terminated when detected.
Diagnostic ID: mp6oy5gm-1687f0eb
Diagnostics Log: /Users/alex/.agent-device/logs/default/2026-05-15/2026-05-15T09-05-59-861Z-mp6oy5gm-1687f0eb.ndjson
{
  "timeoutMs": 90000,
  "requestId": "458b4bd0a6dca39e"
}

[daemon log]
    t =    18.51s     Wait for com.redacted.bundle to idle
    t =    18.51s     Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    18.63s     Check for interrupting elements affecting Window
    t =    18.76s     Synthesize event
    t =    18.76s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    18.88s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    19.01s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    19.42s     Wait for com.redacted.bundle to idle
[agent-device][diag] {"ts":"2026-05-15T09:01:55.679Z","level":"debug","phase":"retry","session":"default","requestId":"232b7e9835dcb4e1","command":"press","data":{"phase":"ios_runner_connect","event":"succeeded","attempt":1,"maxAttempts":180,"elapsedMs":4301,"remainingMs":40699}}
[agent-device][diag] {"ts":"2026-05-15T09:01:55.679Z","level":"info","phase":"platform_command","session":"default","requestId":"232b7e9835dcb4e1","command":"press","durationMs":4301,"data":{"command":"press","platform":"ios"}}
[agent-device][diag] {"ts":"2026-05-15T09:01:55.680Z","level":"debug","phase":"record_action","session":"default","requestId":"232b7e9835dcb4e1","command":"press","data":{"command":"press","session":"default"}}
[agent-device][diag] {"ts":"2026-05-15T09:01:55.680Z","level":"info","phase":"request_success","session":"default","requestId":"232b7e9835dcb4e1","command":"press"}
    t =    65.25s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =    66.29s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    66.29s         Checking existence of `Application 'com.redacted.bundle'`
    t =    66.49s Get all elements bound by index for: Descendants matching type Alert
    t =    66.51s Get all elements bound by index for: Descendants matching type Sheet
    t =    66.53s Get all elements bound by index for: Descendants matching type Window
    t =    66.65s Checking existence of `Window (Element at index 0)`
    t =    66.78s Find the Window (Element at index 0)
    t =    66.90s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    67.03s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    67.15s Find the Application 'com.redacted.bundle'
[agent-device][diag] {"ts":"2026-05-15T09:02:54.377Z","level":"info","phase":"request_start","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"session":"default","command":"press"}}
[agent-device][diag] {"ts":"2026-05-15T09:02:54.377Z","level":"debug","phase":"platform_command_prepare","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"command":"press","platform":"ios","kind":"simulator"}}
    t =    78.12s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =    79.16s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    79.16s         Checking existence of `Application 'com.redacted.bundle'`
    t =    79.27s Waiting 2.0s for Application 'com.redacted.bundle' to exist
    t =    80.31s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    80.31s         Checking existence of `Application 'com.redacted.bundle'`
    t =    80.64s Find the Application 'com.redacted.bundle'
    t =    80.76s Find the Window (First Match)
    t =    80.77s Checking existence of `Window at {{0.0, 0.0}, {402.0, 874.0}}`
    t =    80.77s Get all elements bound by index for: Descendants matching type Window
    t =    80.89s Checking existence of `Window (Element at index 0)`
    t =    81.01s Find the Window (Element at index 0)
    t =    81.13s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.26s Tap Window at {{0.0, 0.0}, {402.0, 874.0}}[0.00, 0.00] -> (298.0, 816.0)
    t =    81.26s     Wait for com.redacted.bundle to idle
    t =    81.26s     Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.38s     Check for interrupting elements affecting Window
    t =    81.51s     Synthesize event
    t =    81.51s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.63s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    81.76s         Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"debug","phase":"retry","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"phase":"ios_runner_connect","event":"succeeded","attempt":1,"maxAttempts":180,"elapsedMs":4048,"remainingMs":40952}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"info","phase":"platform_command","session":"default","requestId":"ac1aa065ef870641","command":"press","durationMs":4048,"data":{"command":"press","platform":"ios"}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"debug","phase":"record_action","session":"default","requestId":"ac1aa065ef870641","command":"press","data":{"command":"press","session":"default"}}
[agent-device][diag] {"ts":"2026-05-15T09:02:58.425Z","level":"info","phase":"request_success","session":"default","requestId":"ac1aa065ef870641","command":"press"}
    t =    82.16s     Wait for com.redacted.bundle to idle
2026-05-15 11:03:38.945953+0200 AgentDeviceRunnerUITests-Runner[10545:17955954] AGENT_DEVICE_RUNNER_WAIT_RESULT=XCTWaiterResult(rawValue: 1)
    t =   122.69s Tear Down
    t =   122.90s Checking for crash reports corresponding to unexpected termination of com.callstack.agentdevice.runner
Test Case '-[AgentDeviceRunnerUITests.RunnerTests testCommand]' passed (123.936 seconds).
Test Suite 'RunnerTests' passed at 2026-05-15 11:03:40.195.
	 Executed 1 test, with 0 failures (0 unexpected) in 123.936 (123.938) seconds
Test Suite 'AgentDeviceRunnerUITests.xctest' passed at 2026-05-15 11:03:40.201.
	 Executed 1 test, with 0 failures (0 unexpected) in 123.936 (123.944) seconds
Test Suite 'Selected tests' passed at 2026-05-15 11:03:40.201.
	 Executed 1 test, with 0 failures (0 unexpected) in 123.936 (123.945) seconds
2026-05-15 11:03:40.496 xcodebuild[10542:17955821] [MT] IDETestOperationsObserverDebug: 126.198 elapsed -- Testing started completed.
2026-05-15 11:03:40.496 xcodebuild[10542:17955821] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2026-05-15 11:03:40.496 xcodebuild[10542:17955821] [MT] IDETestOperationsObserverDebug: 126.198 sec, +126.198 sec -- end

Test session results, code coverage, and logs:
	/Users/alex/Library/Developer/Xcode/DerivedData/AgentDeviceRunner-feesenornylowmerbxdptdfbtwgc/Logs/Test/Test-AgentDeviceRunner-2026.05.15_11-01-33-+0200.xcresult

** TEST EXECUTE SUCCEEDED **

Testing started
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test-without-building -only-testing AgentDeviceRunnerUITests/RunnerTests/testCommand -parallel-testing-enabled NO -test-timeouts-enabled NO -collect-test-diagnostics never -maximum-concurrent-test-simulator-destinations 1 -destination-timeout 20 -xctestrun /Users/alex/.agent-device/ios-runner/derived/Build/Products/AgentDeviceRunner.env.session-F12C18EA-7E1C-4461-A1A5-42D19EE11159-55652.xctestrun -destination "platform=iOS Simulator,id=F12C18EA-7E1C-4461-A1A5-42D19EE11159"

2026-05-15 11:04:11.674 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:11.681 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:12.000 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:12.611 xcodebuild[11709:17962746] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:04:13.331802+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] [Default] Running tests...
    t =      nans Interface orientation changed to Portrait
Test Suite 'Selected tests' started at 2026-05-15 11:04:13.865.
Test Suite 'AgentDeviceRunnerUITests.xctest' started at 2026-05-15 11:04:13.865.
Test Suite 'RunnerTests' started at 2026-05-15 11:04:13.865.
Test Case '-[AgentDeviceRunnerUITests.RunnerTests testCommand]' started.
    t =     0.00s Start Test at 2026-05-15 11:04:13.866
    t =     0.02s Set Up
    t =     0.02s Open com.callstack.agentdevice.runner
    t =     0.02s     Launch com.callstack.agentdevice.runner
    t =     0.63s         Setting up automation session
    t =     1.36s         Wait for com.callstack.agentdevice.runner to idle
2026-05-15 11:04:16.441477+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] AGENT_DEVICE_RUNNER_DESIRED_PORT=55652
2026-05-15 11:04:16.444798+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] AGENT_DEVICE_RUNNER_WAITING
2026-05-15 11:04:16.445161+0200 AgentDeviceRunnerUITests-Runner[11711:17962929] [] nw_listener_socket_inbox_create_socket setsockopt SO_NECP_LISTENUUID failed [2: No such file or directory]
2026-05-15 11:04:16.445394+0200 AgentDeviceRunnerUITests-Runner[11711:17962932] AGENT_DEVICE_RUNNER_LISTENER_READY
2026-05-15 11:04:16.445492+0200 AgentDeviceRunnerUITests-Runner[11711:17962932] AGENT_DEVICE_RUNNER_PORT=55652
2026-05-15 11:04:17.146924+0200 AgentDeviceRunnerUITests-Runner[11711:17962890] AGENT_DEVICE_RUNNER_ACTIVATE bundle=com.redacted.bundle state=2 reason=bundle_changed
    t =     3.28s Open com.redacted.bundle
    t =     3.28s     Activate com.redacted.bundle
    t =     3.31s         Wait for com.redacted.bundle to idle
    t =     3.40s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =     4.40s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =     4.40s         Checking existence of `Application 'com.redacted.bundle'`
    t =     4.59s Get all elements bound by index for: Descendants matching type Alert
    t =     4.61s Get all elements bound by index for: Descendants matching type Sheet
    t =     4.63s Get all elements bound by index for: Descendants matching type Window
    t =     4.76s Checking existence of `Window (Element at index 0)`
    t =     4.88s Find the Window (Element at index 0)
    t =     5.02s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     5.16s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     5.29s Find the Application 'com.redacted.bundle'
[agent-device][diag] {"ts":"2026-05-15T09:04:29.744Z","level":"info","phase":"request_start","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"session":"default","command":"press"}}
[agent-device][diag] {"ts":"2026-05-15T09:04:29.744Z","level":"debug","phase":"platform_command_prepare","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"command":"press","platform":"ios","kind":"simulator"}}
    t =    15.88s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =    16.92s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    16.92s         Checking existence of `Application 'com.redacted.bundle'`
    t =    17.03s Waiting 2.0s for Application 'com.redacted.bundle' to exist
    t =    18.07s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =    18.07s         Checking existence of `Application 'com.redacted.bundle'`
    t =    18.65s Find the Application 'com.redacted.bundle'
    t =    18.76s Find the Window (First Match)
    t =    18.77s Checking existence of `Window at {{0.0, 0.0}, {402.0, 874.0}}`
    t =    18.77s Get all elements bound by index for: Descendants matching type Window
    t =    18.89s Checking existence of `Window (Element at index 0)`
    t =    19.02s Find the Window (Element at index 0)
    t =    19.14s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =    19.27s Tap Window at {{0.0, 0.0}, {402.0, 874.0}}[0.00, 0.00] -> (362.0, 816.0)
    t =    19.27s     Wait for com.redacted.bundle to idle
[agent-device][diag] {"ts":"2026-05-15T09:04:49.747Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":1,"maxAttempts":180,"elapsedMs":20003,"remainingMs":24997}}
[agent-device][diag] {"ts":"2026-05-15T09:04:49.747Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":1,"maxAttempts":180,"delayMs":338.5077220718457,"elapsedMs":20003,"remainingMs":24997}}
[agent-device][diag] {"ts":"2026-05-15T09:05:10.091Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":2,"maxAttempts":180,"elapsedMs":40347,"remainingMs":4653}}
[agent-device][diag] {"ts":"2026-05-15T09:05:10.092Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":2,"maxAttempts":180,"delayMs":685.3676246677435,"elapsedMs":40348,"remainingMs":4652}}
[agent-device][diag] {"ts":"2026-05-15T09:05:14.748Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"exhausted","attempt":180,"maxAttempts":180,"elapsedMs":45004,"remainingMs":0}}
[agent-device][diag] {"ts":"2026-05-15T09:05:14.747Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":3,"maxAttempts":180,"elapsedMs":45003,"remainingMs":0}}
2026-05-15 11:05:20.091868+0200 AgentDeviceRunnerUITests-Runner[11711:17963022] [connection] nw_socket_handle_socket_event [C4:1] Socket SO_ERROR [54: Connection reset by peer]
2026-05-15 11:05:20.092054+0200 AgentDeviceRunnerUITests-Runner[11711:17963022] [connection] nw_protocol_socket_reset_linger [C4:1] setsockopt SO_LINGER failed [22: Invalid argument]
[agent-device][diag] {"ts":"2026-05-15T09:05:29.752Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":1,"maxAttempts":60,"elapsedMs":15003,"remainingMs":0}}
[agent-device][diag] {"ts":"2026-05-15T09:05:29.752Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"exhausted","attempt":60,"maxAttempts":60,"elapsedMs":15003,"remainingMs":0}}
** BUILD INTERRUPTED **
[agent-device][diag] {"ts":"2026-05-15T09:05:30.442Z","level":"info","phase":"runner_xctestrun_cache","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"action":"reuse","reason":"reuse_ready","derived":"/Users/alex/.agent-device/ios-runner/derived","xctestrunPath":"/Users/alex/.agent-device/ios-runner/derived/Build/Products/AgentDeviceRunner_AgentDeviceRunner_iphonesimulator26.2-arm64.xctestrun"}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.462Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":1,"maxAttempts":180,"elapsedMs":1,"remainingMs":44999}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.462Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":1,"maxAttempts":180,"delayMs":252.27366058723106,"elapsedMs":1,"remainingMs":44999}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.716Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":2,"maxAttempts":180,"delayMs":655.4649460366638,"elapsedMs":255,"remainingMs":44745}}
[agent-device][diag] {"ts":"2026-05-15T09:05:30.716Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":2,"maxAttempts":180,"elapsedMs":255,"remainingMs":44745}}
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test-without-building -only-testing AgentDeviceRunnerUITests/RunnerTests/testCommand -parallel-testing-enabled NO -test-timeouts-enabled NO -collect-test-diagnostics never -maximum-concurrent-test-simulator-destinations 1 -destination-timeout 20 -xctestrun /Users/alex/.agent-device/ios-runner/derived/Build/Products/AgentDeviceRunner.env.session-F12C18EA-7E1C-4461-A1A5-42D19EE11159-55713.xctestrun -destination "platform=iOS Simulator,id=F12C18EA-7E1C-4461-A1A5-42D19EE11159"

2026-05-15 11:05:31.229 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:05:31.236 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
[agent-device][diag] {"ts":"2026-05-15T09:05:31.373Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":3,"maxAttempts":180,"elapsedMs":912,"remainingMs":44088}}
[agent-device][diag] {"ts":"2026-05-15T09:05:31.373Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":3,"maxAttempts":180,"delayMs":1330.6922946961802,"elapsedMs":912,"remainingMs":44088}}
2026-05-15 11:05:31.553 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
2026-05-15 11:05:32.161 xcodebuild[12041:17964934] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
[agent-device][diag] {"ts":"2026-05-15T09:05:32.705Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":4,"maxAttempts":180,"delayMs":2380.312207028922,"elapsedMs":2244,"remainingMs":42756}}
[agent-device][diag] {"ts":"2026-05-15T09:05:32.705Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":4,"maxAttempts":180,"elapsedMs":2244,"remainingMs":42756}}
2026-05-15 11:05:32.884693+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] [Default] Running tests...
    t =      nans Interface orientation changed to Portrait
Test Suite 'Selected tests' started at 2026-05-15 11:05:33.412.
Test Suite 'AgentDeviceRunnerUITests.xctest' started at 2026-05-15 11:05:33.412.
Test Suite 'RunnerTests' started at 2026-05-15 11:05:33.412.
Test Case '-[AgentDeviceRunnerUITests.RunnerTests testCommand]' started.
    t =     0.00s Start Test at 2026-05-15 11:05:33.413
    t =     0.02s Set Up
    t =     0.02s Open com.callstack.agentdevice.runner
    t =     0.02s     Launch com.callstack.agentdevice.runner
    t =     0.43s         Setting up automation session
    t =     1.28s         Wait for com.callstack.agentdevice.runner to idle
[agent-device][diag] {"ts":"2026-05-15T09:05:35.091Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":5,"maxAttempts":180,"elapsedMs":4630,"remainingMs":40370}}
[agent-device][diag] {"ts":"2026-05-15T09:05:35.091Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":5,"maxAttempts":180,"delayMs":1863.8701827976045,"elapsedMs":4630,"remainingMs":40370}}
2026-05-15 11:05:35.914483+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] AGENT_DEVICE_RUNNER_DESIRED_PORT=55713
2026-05-15 11:05:35.918253+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] AGENT_DEVICE_RUNNER_WAITING
2026-05-15 11:05:35.918786+0200 AgentDeviceRunnerUITests-Runner[12045:17965098] [] nw_listener_socket_inbox_create_socket setsockopt SO_NECP_LISTENUUID failed [2: No such file or directory]
2026-05-15 11:05:35.919167+0200 AgentDeviceRunnerUITests-Runner[12045:17965116] AGENT_DEVICE_RUNNER_LISTENER_READY
2026-05-15 11:05:35.919219+0200 AgentDeviceRunnerUITests-Runner[12045:17965116] AGENT_DEVICE_RUNNER_PORT=55713
2026-05-15 11:05:36.978214+0200 AgentDeviceRunnerUITests-Runner[12045:17965061] AGENT_DEVICE_RUNNER_ACTIVATE bundle=com.redacted.bundle state=2 reason=bundle_changed
    t =     3.57s Open com.redacted.bundle
    t =     3.57s     Activate com.redacted.bundle
    t =     3.60s         Wait for com.redacted.bundle to idle
    t =     3.61s Waiting 30.0s for Application 'com.redacted.bundle' to exist
    t =     4.69s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =     4.69s         Checking existence of `Application 'com.redacted.bundle'`
    t =     4.81s Waiting 2.0s for Application 'com.redacted.bundle' to exist
    t =     5.85s     Checking `Expect predicate `existsNoRetry == 1` for object Application 'com.redacted.bundle'`
    t =     5.85s         Checking existence of `Application 'com.redacted.bundle'`
    t =     6.22s Find the Application 'com.redacted.bundle'
    t =     6.34s Find the Window (First Match)
    t =     6.34s Checking existence of `Window at {{0.0, 0.0}, {402.0, 874.0}}`
    t =     6.35s Get all elements bound by index for: Descendants matching type Window
    t =     6.47s Checking existence of `Window (Element at index 0)`
    t =     6.60s Find the Window (Element at index 0)
    t =     6.72s Find the Window at {{0.0, 0.0}, {402.0, 874.0}}
    t =     6.85s Tap Window at {{0.0, 0.0}, {402.0, 874.0}}[0.00, 0.00] -> (362.0, 816.0)
    t =     6.85s     Wait for com.redacted.bundle to idle
[agent-device][diag] {"ts":"2026-05-15T09:05:56.955Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":6,"maxAttempts":180,"elapsedMs":26494,"remainingMs":18506}}
[agent-device][diag] {"ts":"2026-05-15T09:05:56.955Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":6,"maxAttempts":180,"delayMs":1791.1067548734652,"elapsedMs":26494,"remainingMs":18506}}
[agent-device][diag] {"ts":"2026-05-15T09:05:59.751Z","level":"warn","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"attempt_failed","attempt":7,"maxAttempts":180,"elapsedMs":29290,"remainingMs":15710}}
[agent-device][diag] {"ts":"2026-05-15T09:05:59.751Z","level":"error","phase":"request_failed","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"code":"COMMAND_FAILED","message":"request canceled"}}
[agent-device][diag] {"ts":"2026-05-15T09:05:59.751Z","level":"error","phase":"platform_command","session":"default","requestId":"458b4bd0a6dca39e","command":"press","durationMs":90007,"data":{"command":"press","platform":"ios","error":"request canceled"}}
[agent-device][diag] {"ts":"2026-05-15T09:05:59.751Z","level":"debug","phase":"retry","session":"default","requestId":"458b4bd0a6dca39e","command":"press","data":{"phase":"ios_runner_connect","event":"retry_scheduled","attempt":7,"maxAttempts":180,"delayMs":2085.7591577428975,"elapsedMs":29290,"remainingMs":15710}}
** BUILD INTERRUPTED **
</details>

or [log.txt](https://github.com/user-attachments/files/27795818/log.txt)

but basically XCTest hangs after Tap on Wait for bundle id to idle

a description of possible fix from Codex:

Fixes an iOS runner failure where `agent-device press @ref` resolves the ref correctly and synthesizes the tap, but XCTest then hangs at:
```
Tap Window ... -> (362.0, 816.0)
Wait for com.redacted.bundle to idle
```
In the attached log, the press request then keeps retrying runner connection attempts and eventually fails with:
```
Error (COMMAND_FAILED): Daemon request timed out
timeoutMs: 90000
timedOutRunnerPidsTerminated: 1
```
The fix keeps read-only commands on the existing retry/startup path, but changes mutating commands to probe runner readiness with uptime and then send the actual press once. It also runs XCTest gestures with pre/post quiescence waiting skipped when supported, so the runner does not block forever after a tap on apps that do not report idle promptly.