### PR TITLE
fix: compact unchanged snapshot output

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -526,3 +526,16 @@ test('client capture.snapshot preserves visibility metadata from daemon response
     reasons: ['offscreen-nodes'],
   });
 });
+
+test('client capture.snapshot forwards force-full as snapshotForceFull flag', async () => {
+  const setup = createTransport(async () => ({
+    ok: true,
+    data: { nodes: [], truncated: false },
+  }));
+  const client = createAgentDeviceClient(setup.config, { transport: setup.transport });
+
+  await client.capture.snapshot({ forceFull: true });
+
+  assert.equal(setup.calls[0]?.command, 'snapshot');
+  assert.equal(setup.calls[0]?.flags?.snapshotForceFull, true);
+});

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -11,13 +11,21 @@ export const snapshotCommand: ClientCommandHandler = async ({ flags, client }) =
     depth: flags.snapshotDepth,
     scope: flags.snapshotScope,
     raw: flags.snapshotRaw,
+    forceFull: flags.snapshotForceFull,
   });
   const data = serializeSnapshotResult(result);
-  writeCommandOutput(flags, data, () =>
-    formatSnapshotText(data, {
+  // Programmatic SDK callers can see `unchanged`; CLI --json hides it for schema compatibility.
+  const outputData = flags.json ? withoutUnchanged(data) : data;
+  writeCommandOutput(flags, outputData, () =>
+    formatSnapshotText(outputData, {
       raw: flags.snapshotRaw,
       flatten: flags.snapshotInteractiveOnly,
     }),
   );
   return true;
 };
+
+function withoutUnchanged(data: Record<string, unknown>): Record<string, unknown> {
+  const { unchanged: _unchanged, ...outputData } = data;
+  return outputData;
+}

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -268,6 +268,7 @@ export function buildFlags(options: InternalRequestOptions): CommandFlags {
     snapshotDepth: options.depth,
     snapshotScope: options.scope,
     snapshotRaw: options.raw,
+    snapshotForceFull: options.forceFull,
     screenshotFullscreen: options.screenshotFullscreen,
     screenshotMaxSize: options.screenshotMaxSize,
     overlayRefs: options.overlayRefs,

--- a/src/client-shared.ts
+++ b/src/client-shared.ts
@@ -188,5 +188,6 @@ export function serializeSnapshotResult(result: CaptureSnapshotResult): Record<s
     ...(result.visibility ? { visibility: result.visibility } : {}),
     ...(result.androidSnapshot ? { androidSnapshot: result.androidSnapshot } : {}),
     ...(result.warnings && result.warnings.length > 0 ? { warnings: result.warnings } : {}),
+    ...(result.unchanged ? { unchanged: result.unchanged } : {}),
   };
 }

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -10,7 +10,12 @@ import type {
 import type { DeviceKind, DeviceTarget, Platform, PlatformSelector } from './utils/device.ts';
 import type { FindLocator } from './utils/finders.ts';
 import type { AndroidSnapshotBackendMetadata } from './platforms/android/snapshot-types.ts';
-import type { ScreenshotOverlayRef, SnapshotNode, SnapshotVisibility } from './utils/snapshot.ts';
+import type {
+  ScreenshotOverlayRef,
+  SnapshotNode,
+  SnapshotUnchanged,
+  SnapshotVisibility,
+} from './utils/snapshot.ts';
 import type {
   MetroPrepareKind,
   PrepareMetroRuntimeResult,
@@ -313,6 +318,7 @@ export type CaptureSnapshotOptions = AgentDeviceRequestOverrides &
     depth?: number;
     scope?: string;
     raw?: boolean;
+    forceFull?: boolean;
   };
 
 export type CaptureSnapshotResult = {
@@ -323,6 +329,7 @@ export type CaptureSnapshotResult = {
   visibility?: SnapshotVisibility;
   androidSnapshot?: AndroidSnapshotBackendMetadata;
   warnings?: string[];
+  unchanged?: SnapshotUnchanged;
   identifiers: AgentDeviceIdentifiers;
 };
 
@@ -751,6 +758,7 @@ type CommandExecutionOptions = {
   depth?: number;
   scope?: string;
   raw?: boolean;
+  forceFull?: boolean;
   screenshotFullscreen?: boolean;
   screenshotMaxSize?: number;
   count?: number;

--- a/src/client.ts
+++ b/src/client.ts
@@ -301,31 +301,7 @@ export function createAgentDeviceClient(
       snapshot: async (options: CaptureSnapshotOptions = {}) => {
         const session = resolveRequestSession(options);
         const data = await execute(PUBLIC_COMMANDS.snapshot, [], options);
-        const appBundleId = readOptionalString(data, 'appBundleId');
-        const visibility =
-          typeof data.visibility === 'object' && data.visibility !== null
-            ? (data.visibility as CaptureSnapshotResult['visibility'])
-            : undefined;
-        const androidSnapshot =
-          typeof data.androidSnapshot === 'object' && data.androidSnapshot !== null
-            ? (data.androidSnapshot as CaptureSnapshotResult['androidSnapshot'])
-            : undefined;
-        return {
-          nodes: readSnapshotNodes(data.nodes),
-          truncated: data.truncated === true,
-          appName: readOptionalString(data, 'appName'),
-          appBundleId,
-          ...(visibility ? { visibility } : {}),
-          ...(androidSnapshot ? { androidSnapshot } : {}),
-          warnings: Array.isArray(data.warnings)
-            ? data.warnings.filter((entry): entry is string => typeof entry === 'string')
-            : undefined,
-          identifiers: {
-            session,
-            appId: appBundleId,
-            appBundleId,
-          },
-        };
+        return normalizeSnapshotResult(data, session);
       },
       screenshot: async (options: CaptureScreenshotOptions = {}) => {
         const session = resolveRequestSession(options);
@@ -483,6 +459,52 @@ export function createAgentDeviceClient(
         ),
     },
   };
+}
+
+function normalizeSnapshotResult(
+  data: Record<string, unknown>,
+  session: string | undefined,
+): CaptureSnapshotResult {
+  const appBundleId = readOptionalString(data, 'appBundleId');
+  return {
+    nodes: readSnapshotNodes(data.nodes),
+    truncated: data.truncated === true,
+    appName: readOptionalString(data, 'appName'),
+    appBundleId,
+    ...optionalSnapshotResponseFields(data),
+    identifiers: {
+      session,
+      appId: appBundleId,
+      appBundleId,
+    },
+  };
+}
+
+function optionalSnapshotResponseFields(
+  data: Record<string, unknown>,
+): Partial<
+  Pick<CaptureSnapshotResult, 'androidSnapshot' | 'unchanged' | 'visibility' | 'warnings'>
+> {
+  const visibility = readObject(data.visibility);
+  const androidSnapshot = readObject(data.androidSnapshot);
+  const unchanged = readObject(data.unchanged);
+  const warnings = Array.isArray(data.warnings)
+    ? data.warnings.filter((entry): entry is string => typeof entry === 'string')
+    : undefined;
+  return {
+    ...(visibility ? { visibility: visibility as CaptureSnapshotResult['visibility'] } : {}),
+    ...(androidSnapshot
+      ? { androidSnapshot: androidSnapshot as CaptureSnapshotResult['androidSnapshot'] }
+      : {}),
+    ...(unchanged ? { unchanged: unchanged as CaptureSnapshotResult['unchanged'] } : {}),
+    ...(warnings ? { warnings } : {}),
+  };
+}
+
+function readObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 function stringifyPayload(payload: AppPushOptions['payload']): string {

--- a/src/commands/__tests__/snapshot-unchanged.test.ts
+++ b/src/commands/__tests__/snapshot-unchanged.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from 'vitest';
+import {
+  buildUnchangedSnapshotMetadata,
+  ensureSnapshotPresentationKey,
+} from '../snapshot-unchanged.ts';
+import type { SnapshotState } from '../../utils/snapshot.ts';
+
+function snapshot(
+  label: string,
+  overrides: Partial<SnapshotState> = {},
+  options: Parameters<typeof ensureSnapshotPresentationKey>[1] = {},
+): SnapshotState {
+  return ensureSnapshotPresentationKey(
+    {
+      nodes: [
+        {
+          ref: 'e1',
+          index: 0,
+          depth: 0,
+          type: 'Button',
+          label,
+          pid: 1234,
+          hittable: true,
+        },
+      ],
+      createdAt: 1_000,
+      backend: 'xctest',
+      ...overrides,
+    },
+    options,
+  );
+}
+
+test('unchanged metadata ignores refs and volatile process ids', () => {
+  const previous = snapshot('Create');
+  const current = snapshot('Create', {
+    nodes: [{ ...previous.nodes[0]!, ref: 'e99', pid: 5678 }],
+  });
+
+  expect(buildUnchangedSnapshotMetadata({ previous, current, options: {} })).toMatchObject({
+    nodeCount: 1,
+  });
+});
+
+test('unchanged metadata detects visible label changes', () => {
+  expect(
+    buildUnchangedSnapshotMetadata({
+      previous: snapshot('Create'),
+      current: snapshot('Send'),
+      options: {},
+    }),
+  ).toBeUndefined();
+});
+
+test('unchanged metadata requires comparison-safe snapshots', () => {
+  expect(
+    buildUnchangedSnapshotMetadata({
+      previous: snapshot('Create', { comparisonSafe: false }),
+      current: snapshot('Create'),
+      options: {},
+    }),
+  ).toBeUndefined();
+
+  expect(
+    buildUnchangedSnapshotMetadata({
+      previous: snapshot('Create'),
+      current: snapshot('Create', { comparisonSafe: false }),
+      options: {},
+    }),
+  ).toBeUndefined();
+});
+
+test('unchanged metadata requires matching presentation key and identity', () => {
+  const previous = snapshot('Create', { createdAt: 1_000 });
+  const current = snapshot('Create', { createdAt: 3_500 });
+
+  expect(
+    buildUnchangedSnapshotMetadata({
+      previous,
+      current: snapshot('Create', { createdAt: 3_500 }, { scope: 'Composer' }),
+      options: { scope: 'Composer' },
+    }),
+  ).toBeUndefined();
+
+  expect(
+    buildUnchangedSnapshotMetadata({
+      previous,
+      current,
+      options: {},
+      identity: {
+        previousAppBundleId: 'com.example.before',
+        currentAppBundleId: 'com.example.after',
+      },
+    }),
+  ).toBeUndefined();
+
+  expect(
+    buildUnchangedSnapshotMetadata({
+      previous: snapshot(
+        'Create',
+        { createdAt: 1_000 },
+        { interactiveOnly: true, scope: 'Composer' },
+      ),
+      current: snapshot(
+        'Create',
+        { createdAt: 3_500 },
+        { interactiveOnly: true, scope: 'Composer' },
+      ),
+      options: { interactiveOnly: true, scope: 'Composer' },
+      identity: {
+        previousAppBundleId: 'com.example.app',
+        currentAppBundleId: 'com.example.app',
+      },
+    }),
+  ).toMatchObject({ ageMs: 2_500, nodeCount: 1, interactiveOnly: true, scope: 'Composer' });
+});
+
+test('unchanged metadata trims scope in compact output metadata', () => {
+  expect(
+    buildUnchangedSnapshotMetadata({
+      previous: snapshot('Create', { createdAt: 1_000 }, { scope: ' Composer ' }),
+      current: snapshot('Create', { createdAt: 3_500 }, { scope: ' Composer ' }),
+      options: { scope: ' Composer ' },
+    }),
+  ).toMatchObject({ scope: 'Composer' });
+});
+
+test('force-full and raw snapshots do not emit unchanged metadata', () => {
+  const previous = snapshot('Create');
+  const current = snapshot('Create');
+
+  expect(
+    buildUnchangedSnapshotMetadata({ previous, current, options: { forceFull: true } }),
+  ).toBeUndefined();
+  expect(
+    buildUnchangedSnapshotMetadata({ previous, current, options: { raw: true } }),
+  ).toBeUndefined();
+});

--- a/src/commands/capture-definition.ts
+++ b/src/commands/capture-definition.ts
@@ -17,10 +17,10 @@ const SNAPSHOT_FLAGS = [
 const snapshotCommandDefinition = defineCommand({
   name: PUBLIC_COMMANDS.snapshot,
   schema: {
-    usageOverride: 'snapshot [--diff] [-i] [-c] [-d <depth>] [-s <scope>] [--raw]',
+    usageOverride: 'snapshot [--diff] [-i] [-c] [-d <depth>] [-s <scope>] [--raw] [--force-full]',
     helpDescription: 'Capture accessibility tree or diff against the previous session baseline',
     positionalArgs: [],
-    allowedFlags: ['snapshotDiff', ...SNAPSHOT_FLAGS],
+    allowedFlags: ['snapshotDiff', ...SNAPSHOT_FLAGS, 'snapshotForceFull'],
   },
   capability: ALL_DEVICE_COMMAND_CAPABILITY,
 });

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -4,8 +4,17 @@ import type { AgentDeviceRuntime, CommandSessionRecord } from '../runtime-contra
 import { AppError } from '../utils/errors.ts';
 import { buildSnapshotDiff, countSnapshotComparableLines } from '../utils/snapshot-diff.ts';
 import type { SnapshotDiffLine, SnapshotDiffSummary } from '../utils/snapshot-diff.ts';
-import type { SnapshotNode, SnapshotState, SnapshotVisibility } from '../utils/snapshot.ts';
+import type {
+  SnapshotNode,
+  SnapshotState,
+  SnapshotUnchanged,
+  SnapshotVisibility,
+} from '../utils/snapshot.ts';
 import { buildSnapshotVisibility } from '../utils/snapshot-visibility.ts';
+import {
+  buildUnchangedSnapshotMetadata,
+  ensureSnapshotPresentationKey,
+} from './snapshot-unchanged.ts';
 import type {
   DiffSnapshotCommandOptions,
   RuntimeCommand,
@@ -23,6 +32,7 @@ export type SnapshotCommandResult = {
   visibility?: SnapshotVisibility;
   androidSnapshot?: AndroidSnapshotBackendMetadata;
   warnings?: string[];
+  unchanged?: SnapshotUnchanged;
 };
 
 export type DiffSnapshotCommandResult = {
@@ -45,6 +55,15 @@ export const snapshotCommand: RuntimeCommand<
   SnapshotCommandResult
 > = async (runtime, options): Promise<SnapshotCommandResult> => {
   const capture = await captureRuntimeSnapshot(runtime, options);
+  const unchanged = buildUnchangedSnapshotMetadata({
+    previous: capture.session?.snapshot,
+    current: capture.snapshot,
+    options,
+    identity: {
+      previousAppBundleId: capture.session?.appBundleId,
+      currentAppBundleId: capture.result.appBundleId ?? capture.session?.appBundleId,
+    },
+  });
   await runtime.sessions.set(nextSnapshotSession(options.session, capture));
   return {
     nodes: capture.snapshot.nodes,
@@ -56,6 +75,7 @@ export const snapshotCommand: RuntimeCommand<
     }),
     ...(capture.result.androidSnapshot ? { androidSnapshot: capture.result.androidSnapshot } : {}),
     ...(capture.warnings.length > 0 ? { warnings: capture.warnings } : {}),
+    ...(unchanged ? { unchanged } : {}),
     ...snapshotAppFields(capture),
   };
 };
@@ -127,7 +147,10 @@ async function captureRuntimeSnapshot(
       raw: options.raw,
     },
   );
-  const snapshot = normalizeBackendSnapshot(result, runtime);
+  const snapshot = ensureSnapshotPresentationKey(
+    normalizeBackendSnapshot(result, runtime),
+    options,
+  );
   const warningTime = now(runtime);
   return {
     snapshot,

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -28,6 +28,7 @@ export type SnapshotCommandOptions = CommandContext & {
   depth?: number;
   scope?: string;
   raw?: boolean;
+  forceFull?: boolean;
 };
 
 export type DiffSnapshotCommandOptions = SnapshotCommandOptions;

--- a/src/commands/snapshot-unchanged.ts
+++ b/src/commands/snapshot-unchanged.ts
@@ -1,0 +1,106 @@
+import type { SnapshotCommandOptions } from './runtime-types.ts';
+import {
+  buildSnapshotPresentationKey,
+  type SnapshotNode,
+  type SnapshotState,
+  type SnapshotUnchanged,
+} from '../utils/snapshot.ts';
+
+type SnapshotIdentity = {
+  previousAppBundleId?: string;
+  currentAppBundleId?: string;
+};
+
+export function ensureSnapshotPresentationKey(
+  snapshot: SnapshotState,
+  options: SnapshotCommandOptions,
+): SnapshotState {
+  if (snapshot.presentationKey) return snapshot;
+  return {
+    ...snapshot,
+    presentationKey: buildSnapshotPresentationKey(options),
+  };
+}
+
+export function buildUnchangedSnapshotMetadata(params: {
+  previous: SnapshotState | undefined;
+  current: SnapshotState;
+  options: SnapshotCommandOptions;
+  identity?: SnapshotIdentity;
+}): SnapshotUnchanged | undefined {
+  const { previous, current, options, identity } = params;
+  if (options.forceFull === true || options.raw === true) return undefined;
+  if (!previous) return undefined;
+  if (previous.comparisonSafe === false || current.comparisonSafe === false) return undefined;
+  if (!hasSameSnapshotIdentity(previous, current, identity)) return undefined;
+  if (!previous.presentationKey || previous.presentationKey !== current.presentationKey) {
+    return undefined;
+  }
+  if (!areSnapshotPresentationsEquivalent(previous, current)) return undefined;
+  const scope = options.scope?.trim();
+  return {
+    ageMs: Math.max(0, current.createdAt - previous.createdAt),
+    nodeCount: current.nodes.length,
+    ...(options.interactiveOnly === true ? { interactiveOnly: true } : {}),
+    ...(scope ? { scope } : {}),
+  };
+}
+
+function hasSameSnapshotIdentity(
+  previous: SnapshotState,
+  current: SnapshotState,
+  identity: SnapshotIdentity | undefined,
+): boolean {
+  if (previous.backend && current.backend && previous.backend !== current.backend) {
+    return false;
+  }
+  if (
+    identity?.previousAppBundleId &&
+    identity.currentAppBundleId &&
+    identity.previousAppBundleId !== identity.currentAppBundleId
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function areSnapshotPresentationsEquivalent(
+  previous: SnapshotState,
+  current: SnapshotState,
+): boolean {
+  if (previous.truncated !== current.truncated) return false;
+  // TODO: replace stringify with a field-by-field comparison or stable presentation hash.
+  return (
+    JSON.stringify(buildComparableSnapshotPresentation(previous.nodes)) ===
+    JSON.stringify(buildComparableSnapshotPresentation(current.nodes))
+  );
+}
+
+function buildComparableSnapshotPresentation(
+  nodes: readonly SnapshotNode[],
+): ComparableSnapshotNode[] {
+  return nodes.map((node) => ({
+    index: node.index,
+    depth: node.depth,
+    parentIndex: node.parentIndex,
+    type: node.type,
+    role: node.role,
+    subrole: node.subrole,
+    label: node.label,
+    value: node.value,
+    identifier: node.identifier,
+    enabled: node.enabled,
+    selected: node.selected,
+    focused: node.focused,
+    hittable: node.hittable,
+    rect: node.rect,
+    bundleId: node.bundleId,
+    appName: node.appName,
+    windowTitle: node.windowTitle,
+    surface: node.surface,
+    hiddenContentAbove: node.hiddenContentAbove,
+    hiddenContentBelow: node.hiddenContentBelow,
+  }));
+}
+
+type ComparableSnapshotNode = Omit<SnapshotNode, 'ref' | 'pid'>;

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -34,6 +34,7 @@ export async function dispatchSnapshotViaRuntime(params: {
         depth: req.flags?.snapshotDepth,
         scope: snapshotScope,
         raw: req.flags?.snapshotRaw,
+        forceFull: req.flags?.snapshotForceFull,
       });
       return {
         data: result,

--- a/src/utils/__tests__/snapshot-unchanged-output.test.ts
+++ b/src/utils/__tests__/snapshot-unchanged-output.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { formatSnapshotText } from '../output.ts';
+
+const oneButtonSnapshot = {
+  nodes: [{ ref: 'e1', index: 0, depth: 0, type: 'Button', label: 'Create' }],
+  truncated: false,
+} as const;
+
+test('formatSnapshotText compacts unchanged snapshots while preserving warnings', () => {
+  const text = formatSnapshotText({
+    ...oneButtonSnapshot,
+    warnings: ['Snapshot warning stays visible.'],
+    unchanged: { ageMs: 8_200, nodeCount: 1 },
+  });
+  assert.match(text, /Snapshot warning stays visible/);
+  assert.match(text, /Snapshot unchanged since previous read 8\.2s ago/);
+  assert.equal(text.includes('Refs from the previous snapshot are still valid'), true);
+  assert.equal(text.includes('find/get/is'), true);
+  assert.equal(text.includes('@e1'), false);
+});
+
+test('formatSnapshotText compacts unchanged interactive snapshots', () => {
+  const text = formatSnapshotText(
+    {
+      ...oneButtonSnapshot,
+      unchanged: { ageMs: 120_000, nodeCount: 73, interactiveOnly: true },
+    },
+    { flatten: true },
+  );
+  assert.match(text, /Interactive snapshot unchanged since previous read 2\.0m ago/);
+  assert.match(text, /73 visible nodes are unchanged/);
+  assert.match(text, /Previous @e refs are still valid/);
+});
+
+test('formatSnapshotText keeps raw output full when unchanged metadata is present', () => {
+  const text = formatSnapshotText(
+    {
+      ...oneButtonSnapshot,
+      unchanged: { ageMs: 8_200, nodeCount: 1 },
+    },
+    { raw: true },
+  );
+  assert.match(text, /Snapshot: 1 nodes/);
+  assert.match(text, /"ref":"e1"/);
+  assert.doesNotMatch(text, /Snapshot unchanged/);
+});

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -52,6 +52,7 @@ export type CliFlags = RemoteConfigMetroOptions & {
   snapshotDepth?: number;
   snapshotScope?: string;
   snapshotRaw?: boolean;
+  snapshotForceFull?: boolean;
   networkInclude?: 'summary' | 'headers' | 'body' | 'all';
   overlayRefs?: boolean;
   screenshotFullscreen?: boolean;
@@ -161,6 +162,7 @@ const AGENT_QUICKSTART_LINES = [
   'Use selectors or refs as positional targets: id="submit", label="Allow", or @e12 from snapshot -i.',
   'Plain snapshot reads state; snapshot -i is required to refresh interactive refs.',
   'Read-only visible/state question: use snapshot/get/is/find; use snapshot -i only when refs are needed.',
+  'Anti-pattern: snapshot -i followed by snapshot -i | grep ...; prior refs stay valid until app state changes, and --force-full is the explicit full re-read.',
   'Truncated text/input preview: expand first with snapshot -s @e12, not get text.',
   'React Native apps: read help react-native for Metro, LogBox/RedBox overlays, DevTools routing, and RN-specific blockers.',
   'Expo Go/dev clients: use the provided URL when given; on iOS prefer open "Expo Go" <url>; Android URL opens infer the foreground package for logs/perf when possible.',
@@ -252,6 +254,9 @@ Snapshots and refs:
     @e14 [cell] label="Profiles" focused -> tvOS focus is currently on this row.
     [off-screen below] 4 items: "Privacy", "About" -> scroll down, then snapshot -i; those are hints, not refs.
   Re-snapshot after navigation, submit, modal/list/reload/dynamic changes.
+  Anti-pattern: snapshot -i followed by snapshot -i | grep ...
+  Refs from the first snapshot remain valid until you press, fill, scroll, go back, wait for async UI, or otherwise change app state.
+  For a targeted query, use find/get/is. If you truly need the full tree again, pass --force-full.
   Off-screen summaries are scroll hints; use scroll, not swipe, then snapshot -i.
   Missing target in a long list: use a short manual scroll + snapshot loop with a max attempt count; do not rely on unbounded scrollintoview.
   Truncated text/input previews: do not use get text first; expand with snapshot -s @ref (for example snapshot -s @e7), then read the scoped output.
@@ -1370,6 +1375,13 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'boolean',
     usageLabel: '--raw',
     usageDescription: 'Snapshot: raw node output',
+  },
+  {
+    key: 'snapshotForceFull',
+    names: ['--force-full'],
+    type: 'boolean',
+    usageLabel: '--force-full',
+    usageDescription: 'Snapshot: re-emit the full tree even when unchanged',
   },
   {
     key: 'findFirst',

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -6,7 +6,7 @@ import {
 } from './android-helper-snapshot-presentation.ts';
 import { AppError, normalizeError, type NormalizedError } from './errors.ts';
 import { buildSnapshotDisplayLines, formatSnapshotLine } from './snapshot-lines.ts';
-import type { SnapshotNode, SnapshotVisibility } from './snapshot.ts';
+import type { SnapshotNode, SnapshotUnchanged, SnapshotVisibility } from './snapshot.ts';
 import type { ScreenshotDiffResult } from './screenshot-diff.ts';
 import type { ScreenshotDiffRegion } from './screenshot-diff-regions.ts';
 import { styleText } from 'node:util';
@@ -63,6 +63,13 @@ export function formatSnapshotText(
   const nodes = Array.isArray(rawNodes) ? (rawNodes as SnapshotNode[]) : [];
   const backend = typeof data.backend === 'string' ? data.backend : undefined;
   const helperPresentation = buildAndroidHelperPresentationInput(data, nodes, options);
+  const prefix = formatSnapshotMetaPrefix(data);
+  const notices = buildSnapshotNotices(data, nodes, options, helperPresentation);
+  const noticesBlock = notices.length > 0 ? `${notices.join('\n')}\n` : '';
+  const unchanged = options.raw ? null : readUnchangedSnapshot(data);
+  if (unchanged) {
+    return `${prefix}${noticesBlock}${formatUnchangedSnapshotText(unchanged)}\n`;
+  }
   const visiblePresentation =
     options.raw || backend === 'macos-helper'
       ? null
@@ -80,9 +87,6 @@ export function formatSnapshotText(
           helperPresentation.filteredCount,
         );
   const header = formatSnapshotHeader(nodes.length, visibility, truncated);
-  const prefix = formatSnapshotMetaPrefix(data);
-  const notices = buildSnapshotNotices(data, nodes, options, helperPresentation);
-  const noticesBlock = notices.length > 0 ? `${notices.join('\n')}\n` : '';
   if (nodes.length === 0) {
     return `${prefix}${header}\n${noticesBlock}`;
   }
@@ -93,6 +97,50 @@ export function formatSnapshotText(
     return `${prefix}${header}\n${noticesBlock}${formatFlattenedSnapshotLines(displayedNodes)}${formatSnapshotSummaryBlock(visiblePresentation)}\n`;
   }
   return `${prefix}${header}\n${noticesBlock}${formatStructuredSnapshotLines(displayedNodes)}${formatSnapshotSummaryBlock(visiblePresentation)}\n`;
+}
+
+function readUnchangedSnapshot(data: Record<string, unknown>): SnapshotUnchanged | null {
+  const raw = data.unchanged;
+  if (!raw || typeof raw !== 'object') return null;
+  const unchanged = raw as Record<string, unknown>;
+  if (typeof unchanged.ageMs !== 'number' || typeof unchanged.nodeCount !== 'number') {
+    return null;
+  }
+  return {
+    ageMs: unchanged.ageMs,
+    nodeCount: unchanged.nodeCount,
+    interactiveOnly: unchanged.interactiveOnly === true ? true : undefined,
+    scope: typeof unchanged.scope === 'string' ? unchanged.scope : undefined,
+  };
+}
+
+function formatUnchangedSnapshotText(unchanged: SnapshotUnchanged): string {
+  const age = formatSnapshotAge(unchanged.ageMs);
+  if (unchanged.scope) {
+    return [
+      `Scoped snapshot unchanged for scope "${unchanged.scope}" since previous read ${age} ago.`,
+      'Previous refs in this scope remain valid. Use find/get/is for a targeted query, or --force-full to re-emit.',
+    ].join('\n');
+  }
+  if (unchanged.interactiveOnly) {
+    return [
+      `Interactive snapshot unchanged since previous read ${age} ago.`,
+      `${unchanged.nodeCount} visible nodes are unchanged. Previous @e refs are still valid. Use find/get/is for a targeted query, or --force-full to re-emit.`,
+    ].join('\n');
+  }
+  return [
+    `Snapshot unchanged since previous read ${age} ago.`,
+    'Refs from the previous snapshot are still valid. Use --force-full to re-emit the tree, or use find/get/is for a targeted query.',
+  ].join('\n');
+}
+
+function formatSnapshotAge(ageMs: number): string {
+  if (ageMs < 1000) return `${Math.round(ageMs)}ms`;
+  if (ageMs < 60_000) return `${(Math.round(ageMs / 100) / 10).toFixed(1)}s`;
+  const minutes = ageMs / 60_000;
+  if (minutes < 60) return `${(Math.round(minutes * 10) / 10).toFixed(1)}m`;
+  const hours = minutes / 60;
+  return `${(Math.round(hours * 10) / 10).toFixed(1)}h`;
 }
 
 function formatSnapshotMetaPrefix(data: Record<string, unknown>): string {

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -59,6 +59,14 @@ export type SnapshotState = {
   truncated?: boolean;
   backend?: SnapshotBackend;
   comparisonSafe?: boolean;
+  presentationKey?: string;
+};
+
+export type SnapshotUnchanged = {
+  ageMs: number;
+  nodeCount: number;
+  interactiveOnly?: boolean;
+  scope?: string;
 };
 
 export type SnapshotVisibilityReason =
@@ -97,6 +105,16 @@ export function normalizeRef(input: string): string | null {
 
 export function findNodeByRef(nodes: SnapshotNode[], ref: string): SnapshotNode | null {
   return nodes.find((node) => node.ref === ref) ?? null;
+}
+
+export function buildSnapshotPresentationKey(flags: SnapshotOptions | undefined): string {
+  return JSON.stringify({
+    interactiveOnly: flags?.interactiveOnly === true,
+    compact: flags?.compact === true,
+    depth: typeof flags?.depth === 'number' ? flags.depth : null,
+    scope: flags?.scope?.trim() || null,
+    raw: flags?.raw === true,
+  });
 }
 
 export function centerOfRect(rect: Rect): Point {


### PR DESCRIPTION
## Summary

Compact repeated unchanged human snapshot output while preserving full JSON/raw behavior.

Closes: none linked yet. I could not find a matching GitHub issue for this unchanged-snapshot task by title or key phrases, and PR #547 currently has no closing issue reference.

## Before

Running the same human snapshot twice without changing app state re-emitted the full accessibility tree again:

```bash
agent-device snapshot -i
agent-device snapshot -i
```

Agents often followed this with shell filtering, for example `agent-device snapshot -i | grep Create`, which recaptured the same UI hierarchy, refreshed session snapshot state, and lost the surrounding refs/context needed for follow-up actions.

## After

Repeated equivalent human snapshots return a compact unchanged response instead of the full tree:

```txt
Snapshot unchanged since previous read 8.2s ago.
Refs from the previous snapshot are still valid. Use --force-full to re-emit the tree, or use find/get/is for a targeted query.
```

Interactive and scoped snapshots get matching compact messages, `--force-full` re-emits the full tree, and `--json`/`--raw` keep full-fidelity output.

## Implementation

- Add unchanged snapshot metadata for human-mode `snapshot` only, keyed by presentation options and app/backend identity.
- Keep the comparison isolated in `src/commands/snapshot-unchanged.ts` and leave `diff snapshot` behavior unchanged.
- Preserve snapshot warnings in compact output.
- Respect `comparisonSafe: false` so degraded captures never compact as unchanged.
- Trim scoped snapshot names consistently between the presentation key and compact message.
- Add `--force-full` plumbing through CLI, client options, daemon/runtime flags, and help text.
- Add help guidance for the `snapshot -i` followed by `snapshot -i | grep ...` anti-pattern.

Programmatic SDK callers can see `unchanged` in `CaptureSnapshotResult`; CLI `--json` hides it to preserve the existing script-facing schema. Persisted sessions captured before this change have no `presentationKey`, so the first post-upgrade snapshot renders the full tree and establishes the new baseline.

Touched files: 16. Scope stayed within the snapshot command family plus client/output plumbing.

## Validation

- `pnpm exec vitest run src/commands/__tests__/snapshot-unchanged.test.ts src/__tests__/client.test.ts src/utils/__tests__/snapshot-unchanged-output.test.ts`
- `pnpm check:quick`
- `pnpm check:fallow`
- `pnpm check:unit`
- `pnpm format`
- `git diff --check`

Known gap: live Android/New Expensify and test-app device verification was not run in this local worktree.
