### PR TITLE
docs: update PR guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,9 +242,8 @@ Command-only flags (like `find --first`) that don't flow to the platform layer o
 - Open a ready-for-review PR by default. Use a draft PR only when the user explicitly asks for one or the work is intentionally incomplete.
 - Run required checks for touched scope from **Testing Matrix**.
 - PR body must be short and include:
-  - `## Summary`
-  - `## Validation` written as evidence of what was checked and what passed; prefer concise prose such as "Unit tests covered X", "SkillGym confirmed Y planning", "Manual Android run showed Z before/after". Avoid dumping raw command lists unless a specific command is the useful evidence.
-- In the summary, describe behavior changes as before/after when that makes the fix easier to review.
+  - `## Summary`: describe the user-visible or reviewer-relevant change as before/after when useful, and include the issue closed by the PR using `Closes #123` when applicable.
+  - `## Validation`: answer this prompt in concise prose: "How did you verify the change, and what passed or changed on screen?" Prefer evidence over command dumps; mention the relevant check category or scenario, and include screenshots when visual/UI behavior is relevant.
 - Call out known gaps/follow-ups explicitly.
 - Include touched-file count and note if scope expanded beyond initial command family.
 


### PR DESCRIPTION
## Summary

Before: PR body guidance split before/after wording and validation expectations across separate bullets with command-oriented examples.

After: PR guidance now asks for before/after summary context, issue closure when applicable, and one simple validation prompt that favors evidence and screenshots for visual changes.

Touched files: 1. Scope stayed within AGENTS.md PR guidance. No linked issue.

## Validation

Reviewed the focused AGENTS.md diff. This is a docs-only change, so no tests were required by the Testing Matrix.