### PR TITLE
fix: handle busy Android RN snapshots

### DIFF
--- a/src/__tests__/runtime-snapshot.test.ts
+++ b/src/__tests__/runtime-snapshot.test.ts
@@ -149,15 +149,8 @@ test('runtime snapshot warns on collapsed Android React Native warning banners',
         ref: 'e1',
         index: 0,
         depth: 0,
-        type: 'android.view.ViewGroup',
-        label: '!, Open debugger to view warnings.',
-      },
-      {
-        ref: 'e2',
-        index: 1,
-        depth: 1,
         type: 'android.widget.TextView',
-        label: 'Open debugger to view warnings.',
+        label: 'Warning: Each child in a list should have a unique "key" prop.',
       },
     ],
     truncated: false,
@@ -167,6 +160,38 @@ test('runtime snapshot warns on collapsed Android React Native warning banners',
   const result = await device.capture.snapshot({ session: 'default', interactiveOnly: true });
 
   assertReactNativeOverlayWarning(result.warnings);
+  assert.match(result.warnings?.[0] ?? '', /Press @e1/);
+});
+
+test('runtime snapshot prefers TextView Minimize over Dismiss on Android React Native stack overlays', async () => {
+  const result = await createSnapshotOnlyDevice({
+    nodes: [
+      { ref: 'e1', index: 0, depth: 0, type: 'android.widget.TextView', label: 'useOnyx.ts:80:43' },
+      { ref: 'e2', index: 1, depth: 1, type: 'android.widget.Button', label: 'Dismiss' },
+      { ref: 'e3', index: 2, depth: 1, type: 'android.widget.TextView', label: 'Minimize' },
+    ],
+    truncated: false,
+    backend: 'android',
+  }).capture.snapshot({ session: 'default', interactiveOnly: true });
+
+  assertReactNativeOverlayWarning(result.warnings);
+  assert.match(result.warnings?.[0] ?? '', /press @e3/);
+  assert.match(result.warnings?.[0] ?? '', /Prefer Minimize over Dismiss/);
+});
+
+test('runtime snapshot does not suggest Dismiss for Android RedBox stacks without Minimize', async () => {
+  const result = await createSnapshotOnlyDevice({
+    nodes: [
+      { ref: 'e1', index: 0, depth: 0, type: 'android.widget.TextView', label: 'useOnyx.ts:80:43' },
+      { ref: 'e2', index: 1, depth: 1, type: 'android.widget.Button', label: 'Dismiss' },
+    ],
+    truncated: false,
+    backend: 'android',
+  }).capture.snapshot({ session: 'default', interactiveOnly: true });
+
+  assertReactNativeOverlayWarning(result.warnings);
+  assert.match(result.warnings?.[0] ?? '', /RedBox stack overlay/);
+  assert.doesNotMatch(result.warnings?.[0] ?? '', /Dismiss before continuing|press @e2/);
 });
 
 test('runtime snapshot warns when iOS hierarchy looks like a React Native overlay', async () => {

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -215,46 +215,67 @@ function buildSnapshotWarnings(params: {
   runtimeNow: number;
 }): string[] {
   const warnings = [...(params.result.warnings ?? [])];
-  const interactiveOnly = params.options.interactiveOnly === true;
-  const analysis = params.result.analysis;
-  const androidSnapshot = params.result.androidSnapshot;
+  warnings.push(...buildEmptyAndroidInteractiveWarnings(params));
 
+  const helperFallbackWarning = formatAndroidHelperFallbackWarning(params.result.androidSnapshot);
+  if (helperFallbackWarning) warnings.push(helperFallbackWarning);
+
+  const reactNativeOverlayWarning = formatReactNativeOverlayWarning(params.snapshot.nodes);
+  if (reactNativeOverlayWarning) warnings.push(reactNativeOverlayWarning);
+
+  const recentDropWarning = formatRecentSnapshotDropWarning(params);
+  if (recentDropWarning) warnings.push(recentDropWarning);
+
+  warnings.push(...formatFreshnessWarnings(params.result.freshness, params.snapshot.backend));
+  return Array.from(new Set(warnings));
+}
+
+function buildEmptyAndroidInteractiveWarnings(params: {
+  result: BackendSnapshotResult;
+  snapshot: SnapshotState;
+  options: SnapshotCommandOptions;
+}): string[] {
+  const analysis = params.result.analysis;
   if (
-    params.snapshot.backend === 'android' &&
-    interactiveOnly &&
-    params.snapshot.nodes.length === 0 &&
-    analysis &&
-    (analysis.rawNodeCount ?? 0) >= 12
+    params.snapshot.backend !== 'android' ||
+    params.options.interactiveOnly !== true ||
+    params.snapshot.nodes.length > 0 ||
+    !analysis ||
+    (analysis.rawNodeCount ?? 0) < 12
+  ) {
+    return [];
+  }
+
+  const warnings = [
+    `Interactive snapshot is empty after filtering ${analysis.rawNodeCount} raw Android nodes. Likely causes: the app content is not accessibility-visible yet, a transient route change, or depth/filter options hid the target.`,
+  ];
+  if (
+    typeof params.options.depth === 'number' &&
+    typeof analysis.maxDepth === 'number' &&
+    analysis.maxDepth >= params.options.depth + 2
   ) {
     warnings.push(
-      `Interactive snapshot is empty after filtering ${analysis.rawNodeCount} raw Android nodes. Likely causes: the app content is not accessibility-visible yet, a transient route change, or depth/filter options hid the target.`,
-    );
-    if (
-      typeof params.options.depth === 'number' &&
-      typeof analysis.maxDepth === 'number' &&
-      analysis.maxDepth >= params.options.depth + 2
-    ) {
-      warnings.push(
-        `Interactive output is empty at depth ${params.options.depth}; retry without -d.`,
-      );
-    }
-  }
-
-  if (androidSnapshot?.backend === 'uiautomator-dump') {
-    const reason = androidSnapshot.fallbackReason
-      ? ` Reason: ${androidSnapshot.fallbackReason}`
-      : '';
-    warnings.push(
-      `Android snapshot helper unavailable; using stock UIAutomator dump, which can time out on busy React Native UIs.${reason}`,
+      `Interactive output is empty at depth ${params.options.depth}; retry without -d.`,
     );
   }
+  return warnings;
+}
 
-  if (hasReactNativeOverlay(params.snapshot.nodes)) {
-    warnings.push(
-      'Possible React Native warning/error overlay detected. Capture screenshot --overlay-refs, check react-devtools errors if connected, dismiss Dismiss/Close only if unrelated, re-snapshot, and report it.',
-    );
-  }
+function formatAndroidHelperFallbackWarning(
+  androidSnapshot: AndroidSnapshotBackendMetadata | undefined,
+): string | undefined {
+  if (androidSnapshot?.backend !== 'uiautomator-dump') return undefined;
+  const reason = androidSnapshot.fallbackReason ? ` Reason: ${androidSnapshot.fallbackReason}` : '';
+  return `Android snapshot helper unavailable; using stock UIAutomator dump, which can time out on busy React Native UIs.${reason}`;
+}
 
+function formatRecentSnapshotDropWarning(params: {
+  result: BackendSnapshotResult;
+  snapshot: SnapshotState;
+  session: CommandSessionRecord | undefined;
+  capturedAt: number;
+  runtimeNow: number;
+}): string | undefined {
   const previousSnapshot = params.session?.snapshot;
   const isRecentSnapshot = previousSnapshot
     ? [params.capturedAt, params.runtimeNow].some((timestamp) => {
@@ -268,25 +289,25 @@ function buildSnapshotWarnings(params: {
     isRecentSnapshot &&
     isLikelyStaleSnapshotDrop(previousSnapshot.nodes.length, params.snapshot.nodes.length)
   ) {
-    warnings.push(
-      'Recent snapshots dropped sharply in node count, which suggests stale or mid-transition UI. Use screenshot as visual truth, wait briefly, then re-snapshot once.',
-    );
+    return STALE_SNAPSHOT_DROP_WARNING;
   }
+  return undefined;
+}
 
-  const freshness = params.result.freshness;
-  if (freshness?.staleAfterRetries && params.snapshot.backend === 'android') {
-    if (freshness.reason === 'stuck-route') {
-      warnings.push(
-        `Recent ${freshness.action} was followed by a nearly identical snapshot after ${freshness.retryCount} automatic retr${freshness.retryCount === 1 ? 'y' : 'ies'}. If you expected navigation or submit, the tree may still be stale. Use screenshot as visual truth, wait briefly, then re-snapshot once.`,
-      );
-    } else if (freshness.reason === 'sharp-drop') {
-      warnings.push(
-        'Recent snapshots dropped sharply in node count, which suggests stale or mid-transition UI. Use screenshot as visual truth, wait briefly, then re-snapshot once.',
-      );
-    }
+const STALE_SNAPSHOT_DROP_WARNING =
+  'Recent snapshots dropped sharply in node count, which suggests stale or mid-transition UI. Use screenshot as visual truth, wait briefly, then re-snapshot once.';
+
+function formatFreshnessWarnings(
+  freshness: BackendSnapshotResult['freshness'],
+  backend: SnapshotState['backend'],
+): string[] {
+  if (!freshness?.staleAfterRetries || backend !== 'android') return [];
+  if (freshness.reason === 'stuck-route') {
+    return [
+      `Recent ${freshness.action} was followed by a nearly identical snapshot after ${freshness.retryCount} automatic retr${freshness.retryCount === 1 ? 'y' : 'ies'}. If you expected navigation or submit, the tree may still be stale. Use screenshot as visual truth, wait briefly, then re-snapshot once.`,
+    ];
   }
-
-  return Array.from(new Set(warnings));
+  return freshness.reason === 'sharp-drop' ? [STALE_SNAPSHOT_DROP_WARNING] : [];
 }
 
 function isLikelyStaleSnapshotDrop(previousCount: number, currentCount: number): boolean {
@@ -294,7 +315,32 @@ function isLikelyStaleSnapshotDrop(previousCount: number, currentCount: number):
   return currentCount <= Math.floor(previousCount * 0.2);
 }
 
-function hasReactNativeOverlay(nodes: SnapshotNode[]): boolean {
+function formatReactNativeOverlayWarning(nodes: SnapshotNode[]): string | undefined {
+  const overlay = detectReactNativeOverlay(nodes);
+  if (!overlay.detected) return undefined;
+  if (overlay.redBox) return formatRedBoxOverlayWarning(overlay.minimizeRefs);
+  if (overlay.dismissRefs.length > 0) {
+    return `Possible React Native warning/error overlay detected. Dismiss before continuing: press ${formatRefList(
+      overlay.dismissRefs,
+    )}, then snapshot -i and report the warning/error in the final summary. Use screenshot --overlay-refs only if visual evidence is required.`;
+  }
+  if (overlay.collapsedRefs.length > 0) {
+    return `Possible React Native warning/error overlay detected. Warning banner detected. Press ${formatRefList(
+      overlay.collapsedRefs,
+    )} to expand or clear it; if Dismiss/Close appears, press it, then snapshot -i and report the warning/error in the final summary.`;
+  }
+  return 'Possible React Native warning/error overlay detected. Dismiss visible Dismiss/Close before continuing, then snapshot -i and report the warning/error in the final summary. Use screenshot --overlay-refs only if visual evidence is required.';
+}
+
+type ReactNativeOverlayState = {
+  detected: boolean;
+  redBox: boolean;
+  dismissRefs: string[];
+  minimizeRefs: string[];
+  collapsedRefs: string[];
+};
+
+function detectReactNativeOverlay(nodes: SnapshotNode[]): ReactNativeOverlayState {
   const text = nodes
     .map((node) =>
       [node.label, node.value, node.identifier, node.type, node.role].filter(Boolean).join(' '),
@@ -302,7 +348,79 @@ function hasReactNativeOverlay(nodes: SnapshotNode[]): boolean {
     .join('\n')
     .toLowerCase();
 
+  const dismissRefs = collectOverlayRefs(nodes, isDismissLabel);
+  const minimizeRefs = collectOverlayRefs(nodes, isMinimizeLabel);
+  const collapsedRefs = collectOverlayRefs(nodes, isCollapsedReactNativeWarningLabel);
+  const hasReactNativeStackFrame = isReactNativeStackFrame(text);
+  const hasOverlayControl = dismissRefs.length > 0 || minimizeRefs.length > 0;
+  const redBox =
+    /\b(redbox|runtime error|reload js|copy stack|component stack|call stack)\b/.test(text) ||
+    (hasReactNativeStackFrame && hasOverlayControl);
+  const detected =
+    hasKnownReactNativeOverlayText(text) ||
+    collapsedRefs.length > 0 ||
+    (hasReactNativeStackFrame && hasOverlayControl);
+  return { detected, redBox, dismissRefs, minimizeRefs, collapsedRefs };
+}
+
+function formatRedBoxOverlayWarning(minimizeRefs: string[]): string {
+  if (minimizeRefs.length > 0) {
+    return `Possible React Native warning/error overlay detected. React Native RedBox stack overlay detected. Minimize before continuing: press ${formatRefList(
+      minimizeRefs,
+    )}, then snapshot -i and report the error in the final summary. Prefer Minimize over Dismiss when the error may re-render immediately.`;
+  }
+  return 'Possible React Native warning/error overlay detected. React Native RedBox stack overlay detected. Do not press Dismiss if the error may re-render immediately; use screenshot --overlay-refs if visual evidence is required and report the error in the final summary.';
+}
+
+function hasKnownReactNativeOverlayText(text: string): boolean {
   return /\b(logbox|redbox|reload js|copy stack|component stack|call stack|runtime error|open debugger to view warnings)\b/.test(
     text,
   );
+}
+
+function isReactNativeStackFrame(text: string): boolean {
+  return (
+    /\b[\w.$<>/-]+\.(?:tsx?|jsx?):\d+(?::\d+)?\b/.test(text) ||
+    /\b[\w.$<>/-]+\.(?:tsx?|jsx?)\s+\(\d+:\d+\)/.test(text)
+  );
+}
+
+function isDismissLabel(label: string): boolean {
+  return label === 'dismiss' || label === 'close';
+}
+
+function isMinimizeLabel(label: string): boolean {
+  return /^minimi[sz]e$/.test(label);
+}
+
+function isCollapsedReactNativeWarningLabel(label: string): boolean {
+  return (
+    label.includes('open debugger to view warnings') ||
+    /^!,\s+/.test(label) ||
+    /^(warn|warning|error):\s+/.test(label) ||
+    /\b(?:possible\s+)?unhandled (?:promise )?rejection\b/.test(label) ||
+    label.includes('getsnapshot should be cached to avoid an infinite loop') ||
+    label.includes('unique "key" prop') ||
+    label.includes("unique 'key' prop") ||
+    label.includes('virtualizedlists should never be nested') ||
+    label.includes('failed prop type')
+  );
+}
+
+function collectOverlayRefs(nodes: SnapshotNode[], matches: (label: string) => boolean): string[] {
+  const refs: string[] = [];
+  for (const node of nodes) {
+    if (!node.ref) continue;
+    const label = (node.label ?? '').trim().toLowerCase();
+    if (!matches(label)) continue;
+    refs.push(node.ref);
+  }
+  return refs;
+}
+
+function formatRefList(refs: string[]): string {
+  return refs
+    .slice(0, 3)
+    .map((ref) => `@${ref}`)
+    .join(', ');
 }

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -58,6 +58,38 @@ const helperManifest: AndroidSnapshotHelperManifest = {
   installArgs: ['install', '-r', '-t'],
 };
 
+const helperArtifact = {
+  apkPath: '/tmp/helper.apk',
+  manifest: helperManifest,
+};
+const installedHelperProbe = {
+  exitCode: 0,
+  stdout: 'package:com.callstack.agentdevice.snapshothelper versionCode:13003',
+  stderr: '',
+};
+
+function snapshotAndroidWithHelper(helperAdb: AndroidAdbExecutor) {
+  return snapshotAndroid(device, {
+    helperAdb,
+    helperArtifact,
+  });
+}
+
+function createHelperAdb(
+  handlers: Partial<Record<'instrument' | 'stock', AndroidAdbExecutor>>,
+): AndroidAdbExecutor {
+  return async (args, options) => {
+    if (args.includes('--show-versioncode')) return installedHelperProbe;
+    if (args.includes('instrument') && handlers.instrument) {
+      return await handlers.instrument(args, options);
+    }
+    if (args.includes('exec-out') && handlers.stock) {
+      return await handlers.stock(args, options);
+    }
+    throw new Error(`unexpected helper adb args: ${args.join(' ')}`);
+  };
+}
+
 beforeEach(() => {
   resetAndroidSnapshotHelperInstallCache();
   mockRunCmd.mockReset();
@@ -75,17 +107,7 @@ test('screenshotAndroid waits for transient UI to settle before capture', async 
   const events: string[] = [];
   const outPath = path.join(os.tmpdir(), `agent-device-android-screenshot-${Date.now()}.png`);
 
-  mockRunCmd.mockImplementation(async (_cmd, args) => {
-    if (args.includes('exec-out')) {
-      events.push('capture');
-      return { exitCode: 0, stdout: '', stderr: '', stdoutBuffer: VALID_PNG };
-    }
-    events.push(args.some((arg) => arg.includes('exit')) ? 'disable' : 'enable');
-    return { exitCode: 0, stdout: '', stderr: '' };
-  });
-  mockSleep.mockImplementation(async (ms) => {
-    events.push(`settle:${ms}`);
-  });
+  mockScreenshotEvents(events);
 
   await screenshotAndroid(device, outPath);
 
@@ -102,17 +124,7 @@ test('screenshotAndroid skips stabilization when requested', async () => {
   const events: string[] = [];
   const outPath = path.join(os.tmpdir(), `agent-device-android-screenshot-${Date.now()}.png`);
 
-  mockRunCmd.mockImplementation(async (_cmd, args) => {
-    if (args.includes('exec-out')) {
-      events.push('capture');
-      return { exitCode: 0, stdout: '', stderr: '', stdoutBuffer: VALID_PNG };
-    }
-    events.push(args.some((arg) => arg.includes('exit')) ? 'disable' : 'enable');
-    return { exitCode: 0, stdout: '', stderr: '' };
-  });
-  mockSleep.mockImplementation(async (ms) => {
-    events.push(`settle:${ms}`);
-  });
+  mockScreenshotEvents(events);
 
   await screenshotAndroid(device, outPath, { stabilize: false });
 
@@ -197,6 +209,20 @@ function helperOutput(xml: string): string {
   ].join('\n');
 }
 
+function mockScreenshotEvents(events: string[]): void {
+  mockRunCmd.mockImplementation(async (_cmd, args) => {
+    if (args.includes('exec-out')) {
+      events.push('capture');
+      return { exitCode: 0, stdout: '', stderr: '', stdoutBuffer: VALID_PNG };
+    }
+    events.push(args.some((arg) => arg.includes('exit')) ? 'disable' : 'enable');
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
+  mockSleep.mockImplementation(async (ms) => {
+    events.push(`settle:${ms}`);
+  });
+}
+
 function mockScreenshotPayload(payload: Buffer): void {
   mockRunCmd.mockImplementation(async (_cmd, args) => {
     if (args.includes('exec-out')) {
@@ -228,6 +254,29 @@ function mockAndroidSnapshotXml(xml: string, activityDump = ''): void {
     }
     throw new Error(`unexpected args: ${args.join(' ')}`);
   });
+}
+
+function adbTimeout(args: string[]): AppError {
+  return new AppError('COMMAND_FAILED', 'adb timed out after 8000ms', {
+    cmd: 'adb',
+    args,
+    timeoutMs: 8000,
+  });
+}
+
+async function captureDiagnostics(
+  scope: Parameters<typeof withDiagnosticsScope>[0],
+  callback: () => Promise<string | null>,
+): Promise<string> {
+  const previousHome = process.env.HOME;
+  process.env.HOME = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-device-android-diag-'));
+  try {
+    const diagnosticsPath = await withDiagnosticsScope(scope, callback);
+    assert.ok(diagnosticsPath);
+    return await fs.readFile(diagnosticsPath, 'utf8');
+  } finally {
+    process.env.HOME = previousHome;
+  }
 }
 
 test('dumpUiHierarchy returns streamed XML even when exec-out exits non-zero', async () => {
@@ -271,10 +320,7 @@ test('snapshotAndroid uses injected helper artifact before stock uiautomator', a
 
   const result = await snapshotAndroid(device, {
     helperAdb,
-    helperArtifact: {
-      apkPath: '/tmp/helper.apk',
-      manifest: helperManifest,
-    },
+    helperArtifact,
   });
 
   assert.equal(result.nodes[0]?.label, 'helper');
@@ -283,7 +329,7 @@ test('snapshotAndroid uses injected helper artifact before stock uiautomator', a
   assert.equal(result.androidSnapshot.installReason, 'current');
   assert.equal(result.androidSnapshot.captureMode, 'interactive-windows');
   assert.equal(result.androidSnapshot.windowCount, 1);
-  assert.deepEqual(timeouts, [30000, 30000]);
+  assert.deepEqual(timeouts, [30000, 8000]);
   assert.equal(mockRunCmd.mock.calls.length, 0);
 });
 
@@ -308,22 +354,17 @@ test('snapshotAndroid emits helper phase diagnostics', async () => {
     throw new Error(`unexpected helper adb args: ${args.join(' ')}`);
   };
 
-  const diagnosticsPath = await withDiagnosticsScope(
+  const diagnostics = await captureDiagnostics(
     { session: 'snapshot-helper', requestId: 'req-1', command: 'snapshot', debug: true },
     async () => {
       await snapshotAndroid(device, {
         helperAdb,
-        helperArtifact: {
-          apkPath: '/tmp/helper.apk',
-          manifest: helperManifest,
-        },
+        helperArtifact,
       });
       return flushDiagnosticsToSessionFile({ force: true });
     },
   );
 
-  assert.ok(diagnosticsPath);
-  const diagnostics = await fs.readFile(diagnosticsPath, 'utf8');
   assert.match(diagnostics, /android_snapshot_helper_artifact_resolution/);
   assert.match(diagnostics, /android_snapshot_helper_install/);
   assert.match(diagnostics, /android_snapshot_helper_install_decision/);
@@ -357,10 +398,7 @@ test('snapshotAndroid resolves helper adb through scoped provider', async () => 
 
   const result = await withAndroidAdbProvider(provider, { serial: device.id }, async () =>
     snapshotAndroid(device, {
-      helperArtifact: {
-        apkPath: '/tmp/helper.apk',
-        manifest: helperManifest,
-      },
+      helperArtifact,
     }),
   );
 
@@ -394,10 +432,7 @@ test('snapshotAndroid falls back to stock uiautomator when helper fails', async 
 
   const result = await snapshotAndroid(device, {
     helperAdb,
-    helperArtifact: {
-      apkPath: '/tmp/helper.apk',
-      manifest: helperManifest,
-    },
+    helperArtifact,
   });
 
   assert.equal(result.nodes[0]?.label, 'stock');
@@ -430,22 +465,17 @@ test('snapshotAndroid emits fallback and stock capture diagnostics', async () =>
     return { exitCode: 1, stdout: '', stderr: 'helper unavailable' };
   };
 
-  const diagnosticsPath = await withDiagnosticsScope(
+  const diagnostics = await captureDiagnostics(
     { session: 'snapshot-fallback', requestId: 'req-2', command: 'snapshot', debug: true },
     async () => {
       await snapshotAndroid(device, {
         helperAdb,
-        helperArtifact: {
-          apkPath: '/tmp/helper.apk',
-          manifest: helperManifest,
-        },
+        helperArtifact,
       });
       return flushDiagnosticsToSessionFile({ force: true });
     },
   );
 
-  assert.ok(diagnosticsPath);
-  const diagnostics = await fs.readFile(diagnosticsPath, 'utf8');
   assert.match(diagnostics, /android_snapshot_helper_fallback/);
   assert.match(diagnostics, /android_snapshot_stock_capture/);
   assert.match(diagnostics, /helper unavailable/);
@@ -463,7 +493,7 @@ test('snapshotAndroid emits unavailable diagnostics when helper artifact is miss
   const accessSpy = vi.spyOn(fs, 'access').mockRejectedValueOnce(new Error('helper missing'));
 
   try {
-    const diagnosticsPath = await withDiagnosticsScope(
+    const diagnostics = await captureDiagnostics(
       {
         session: 'snapshot-helper-missing',
         requestId: 'req-missing',
@@ -478,8 +508,6 @@ test('snapshotAndroid emits unavailable diagnostics when helper artifact is miss
       },
     );
 
-    assert.ok(diagnosticsPath);
-    const diagnostics = await fs.readFile(diagnosticsPath, 'utf8');
     assert.match(diagnostics, /android_snapshot_helper_artifact_resolution/);
     assert.match(diagnostics, /android_snapshot_helper_unavailable/);
     assert.match(diagnostics, /artifact_not_found/);
@@ -492,21 +520,14 @@ test('snapshotAndroid emits unavailable diagnostics when helper artifact is miss
 test('snapshotAndroid emits timeout fallback diagnostics when helper capture times out', async () => {
   const stockXml =
     '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node text="stock" bounds="[0,0][10,10]" /></hierarchy>';
-  const helperAdb: AndroidAdbExecutor = async (args) => {
-    if (args.includes('--show-versioncode')) {
-      return {
-        exitCode: 0,
-        stdout: 'package:com.callstack.agentdevice.snapshothelper versionCode:13003',
-        stderr: '',
-      };
-    }
-    if (args.includes('exec-out')) {
-      return { exitCode: 0, stdout: stockXml, stderr: '' };
-    }
-    throw new AppError('COMMAND_FAILED', 'helper capture timed out');
-  };
+  const helperAdb = createHelperAdb({
+    instrument: async () => {
+      throw new AppError('COMMAND_FAILED', 'helper capture timed out');
+    },
+    stock: async () => ({ exitCode: 0, stdout: stockXml, stderr: '' }),
+  });
 
-  const diagnosticsPath = await withDiagnosticsScope(
+  const diagnostics = await captureDiagnostics(
     {
       session: 'snapshot-helper-timeout',
       requestId: 'req-timeout',
@@ -514,24 +535,72 @@ test('snapshotAndroid emits timeout fallback diagnostics when helper capture tim
       debug: true,
     },
     async () => {
-      const result = await snapshotAndroid(device, {
-        helperAdb,
-        helperArtifact: {
-          apkPath: '/tmp/helper.apk',
-          manifest: helperManifest,
-        },
-      });
+      const result = await snapshotAndroidWithHelper(helperAdb);
       assert.equal(result.androidSnapshot.backend, 'uiautomator-dump');
       assert.match(result.androidSnapshot.fallbackReason ?? '', /helper capture timed out/);
       return flushDiagnosticsToSessionFile({ force: true });
     },
   );
 
-  assert.ok(diagnosticsPath);
-  const diagnostics = await fs.readFile(diagnosticsPath, 'utf8');
   assert.match(diagnostics, /android_snapshot_helper_fallback/);
   assert.match(diagnostics, /helper capture timed out/);
   assert.match(diagnostics, /android_snapshot_stock_capture/);
+});
+
+test('snapshotAndroid skips stock fallback after structured helper timeout', async () => {
+  let stockAttempted = false;
+  const helperAdb = createHelperAdb({
+    instrument: async () => ({
+      exitCode: 1,
+      stdout: [
+        'INSTRUMENTATION_RESULT: agentDeviceProtocol=android-snapshot-helper-v1',
+        'INSTRUMENTATION_RESULT: helperApiVersion=1',
+        'INSTRUMENTATION_RESULT: ok=false',
+        'INSTRUMENTATION_RESULT: outputFormat=uiautomator-xml',
+        'INSTRUMENTATION_RESULT: errorType=java.util.concurrent.TimeoutException',
+        'INSTRUMENTATION_RESULT: message=Timed out waiting for accessibility root',
+        'INSTRUMENTATION_CODE: 1',
+      ].join('\n'),
+      stderr: '',
+    }),
+    stock: async () => {
+      stockAttempted = true;
+      throw new Error('stock fallback should not run');
+    },
+  });
+
+  await assert.rejects(
+    () => snapshotAndroidWithHelper(helperAdb),
+    (error) => {
+      assert.match((error as Error).message, /Timed out waiting for accessibility root/);
+      assert.match((error as Error).message, /Stock UIAutomator fallback was skipped/);
+      assert.equal(
+        (error as { details?: Record<string, unknown> }).details?.hint,
+        'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout and report the busy UI if it persists.',
+      );
+      return true;
+    },
+  );
+  assert.equal(stockAttempted, false);
+});
+
+test('snapshotAndroid falls back to stock dump after helper adb timeout', async () => {
+  const stockXml =
+    '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node text="stock" bounds="[0,0][10,10]" /></hierarchy>';
+  const helperAdb = createHelperAdb({
+    instrument: async (args) => {
+      throw new AppError('COMMAND_FAILED', 'adb timed out after 8000ms', {
+        args,
+        timeoutMs: 8000,
+      });
+    },
+    stock: async () => ({ exitCode: 0, stdout: stockXml, stderr: '' }),
+  });
+
+  const result = await snapshotAndroidWithHelper(helperAdb);
+
+  assert.equal(result.androidSnapshot.backend, 'uiautomator-dump');
+  assert.match(result.androidSnapshot.fallbackReason ?? '', /adb timed out after 8000ms/);
 });
 
 test('snapshotAndroid preserves helper failure reason when stock fallback fails', async () => {
@@ -553,10 +622,7 @@ test('snapshotAndroid preserves helper failure reason when stock fallback fails'
     () =>
       snapshotAndroid(device, {
         helperAdb,
-        helperArtifact: {
-          apkPath: '/tmp/helper.apk',
-          manifest: helperManifest,
-        },
+        helperArtifact,
       }),
     (error) => {
       assert.ok(error instanceof AppError);
@@ -605,10 +671,7 @@ test('snapshotAndroid re-probes helper install after helper capture failure', as
     '<?xml version="1.0" encoding="UTF-8"?><hierarchy><node text="stock" bounds="[0,0][10,10]" /></hierarchy>';
   const helperOptions = {
     helperAdb,
-    helperArtifact: {
-      apkPath: '/tmp/helper.apk',
-      manifest: helperManifest,
-    },
+    helperArtifact,
   };
 
   const fallback = await snapshotAndroid(device, helperOptions);
@@ -709,11 +772,7 @@ test('dumpUiHierarchy retries when fallback dump file is temporarily missing', a
 test('dumpUiHierarchy explains timeout on looping Android animations', async () => {
   mockRunCmd.mockImplementation(async (_cmd, args) => {
     if (args.includes('uiautomator')) {
-      throw new AppError('COMMAND_FAILED', 'adb timed out after 8000ms', {
-        cmd: 'adb',
-        args,
-        timeoutMs: 8000,
-      });
+      throw adbTimeout(args);
     }
     throw new Error(`unexpected args: ${args.join(' ')}`);
   });
@@ -724,7 +783,8 @@ test('dumpUiHierarchy explains timeout on looping Android animations', async () 
       error instanceof AppError &&
       error.message.includes('Android UI hierarchy dump timed out') &&
       typeof error.details?.hint === 'string' &&
-      error.details.hint.includes('settings animations off'),
+      error.details.hint.includes('Android accessibility snapshots can be blocked') &&
+      error.details.hint.includes('Use screenshot as visual truth after this timeout'),
   );
 });
 
@@ -737,11 +797,7 @@ test('dumpUiHierarchy does not attach animation hint to non-dump timeouts', asyn
       return { exitCode: 0, stdout: 'UI hierarchy dumped to: /sdcard/window_dump.xml', stderr: '' };
     }
     if (args.includes('cat')) {
-      throw new AppError('COMMAND_FAILED', 'adb timed out after 8000ms', {
-        cmd: 'adb',
-        args,
-        timeoutMs: 8000,
-      });
+      throw adbTimeout(args);
     }
     throw new Error(`unexpected args: ${args.join(' ')}`);
   });

--- a/src/platforms/android/snapshot-helper-capture.ts
+++ b/src/platforms/android/snapshot-helper-capture.ts
@@ -70,6 +70,7 @@ export async function captureAndroidSnapshotWithHelper(
     // The helper can report structured ok=false details even when am exits non-zero.
     output = parseAndroidSnapshotHelperOutput(`${result.stdout}\n${result.stderr}`);
   } catch (error) {
+    if (error instanceof AppError && result.exitCode !== 0 && error.details?.helper) throw error;
     throw new AppError(
       'COMMAND_FAILED',
       result.exitCode === 0

--- a/src/platforms/android/snapshot.ts
+++ b/src/platforms/android/snapshot.ts
@@ -40,9 +40,8 @@ import {
 
 const UI_HIERARCHY_DUMP_TIMEOUT_MS = 8_000;
 const HELPER_INSTALL_TIMEOUT_MS = 30_000;
-// Large React Native trees can legitimately exceed the stock dump timeout while
-// the helper is still making progress; keep this below the full fallback path.
-const HELPER_COMMAND_TIMEOUT_MS = 30_000;
+const HELPER_CAPTURE_TIMEOUT_MS = 5_000;
+const HELPER_COMMAND_TIMEOUT_MS = 8_000;
 
 type AndroidSnapshotOptions = SnapshotOptions & {
   helperArtifact?: AndroidSnapshotHelperArtifact;
@@ -135,13 +134,13 @@ async function captureAndroidUiHierarchy(
             packageName: helper.artifact!.manifest.packageName,
             instrumentationRunner: helper.artifact!.manifest.instrumentationRunner,
             waitForIdleTimeoutMs: ANDROID_SNAPSHOT_HELPER_WAIT_FOR_IDLE_TIMEOUT_MS,
-            timeoutMs: UI_HIERARCHY_DUMP_TIMEOUT_MS,
+            timeoutMs: HELPER_CAPTURE_TIMEOUT_MS,
             commandTimeoutMs: HELPER_COMMAND_TIMEOUT_MS,
           }),
         {
           packageName: helper.artifact.manifest.packageName,
           version: helper.artifact.manifest.version,
-          timeoutMs: UI_HIERARCHY_DUMP_TIMEOUT_MS,
+          timeoutMs: HELPER_CAPTURE_TIMEOUT_MS,
           commandTimeoutMs: HELPER_COMMAND_TIMEOUT_MS,
         },
       );
@@ -165,6 +164,8 @@ async function captureAndroidUiHierarchy(
         },
       };
     } catch (error) {
+      const busyError = formatAndroidSnapshotHelperBusyError(error);
+      if (busyError) throw busyError;
       const fallbackReason = formatAndroidSnapshotHelperFallbackReason(error);
       emitDiagnostic({
         level: 'warn',
@@ -190,11 +191,45 @@ async function captureAndroidUiHierarchy(
 
 function formatAndroidSnapshotHelperFallbackReason(error: unknown): string {
   const normalized = normalizeError(error);
+  const helperMessage = readHelperMessage(normalized.details?.helper);
+  if (helperMessage && helperMessage !== normalized.message) {
+    return `${normalized.message}: ${helperMessage}`;
+  }
+  if (helperMessage) return helperMessage;
   const stderr =
     typeof normalized.details?.stderr === 'string' ? normalized.details.stderr.trim() : '';
-  if (!stderr) return normalized.message;
-  const firstLine = stderr.split(/\r?\n/).find((line) => line.trim().length > 0);
+  const firstLine = stderr.split(/\r?\n/).find((line) => line.trim());
   return firstLine ? `${normalized.message}: ${firstLine}` : normalized.message;
+}
+
+function formatAndroidSnapshotHelperBusyError(error: unknown): AppError | undefined {
+  const normalized = normalizeError(error);
+  if (!isStructuredHelperTimeout(normalized.details?.helper, normalized.message)) return undefined;
+  const reason = formatAndroidSnapshotHelperFallbackReason(error);
+  const hint =
+    'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout and report the busy UI if it persists.';
+  return new AppError(
+    toAppErrorCode(normalized.code),
+    `${reason}. Stock UIAutomator fallback was skipped because this usually means the Android accessibility tree is busy or stalled.`,
+    {
+      ...normalized.details,
+      hint,
+    },
+    error,
+  );
+}
+
+function readHelperMessage(helper: unknown): string | undefined {
+  if (!helper || typeof helper !== 'object' || !('message' in helper)) return undefined;
+  const message = String(helper.message).trim();
+  return message && message !== 'null' ? message : undefined;
+}
+
+function isStructuredHelperTimeout(helper: unknown, fallbackMessage: string): boolean {
+  if (!helper || typeof helper !== 'object') return false;
+  const errorType = 'errorType' in helper ? String(helper.errorType) : '';
+  const message = readHelperMessage(helper) ?? fallbackMessage;
+  return /TimeoutException/.test(errorType) || /timed out/i.test(message);
 }
 
 async function resolveAndroidSnapshotHelperArtifact(
@@ -311,7 +346,7 @@ export async function dumpUiHierarchy(
   } catch (error) {
     if (isUiHierarchyDumpTimeout(error)) {
       const hint =
-        'If the app has looping animations, use screenshot as visual truth, try settings animations off, then retry snapshot. Stock Android UIAutomator may still time out on app-owned infinite animations.';
+        'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout. Stock Android UIAutomator may still time out on app-owned infinite animations.';
       throw new AppError(
         'COMMAND_FAILED',
         `Android UI hierarchy dump timed out while waiting for the UI to become idle. ${hint}`,

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -487,6 +487,7 @@ Choose the next help topic:
   Remote/cloud config, leases, and local service tunnels: help remote.
 
 React Native dev loop:
+  For "start from screen X" flows, prefer open --relaunch before the first snapshot so the app does not reuse a prior in-progress navigation state.
   JS-only change with Metro connected:
     agent-device metro reload
     agent-device find "Home"
@@ -495,8 +496,9 @@ React Native dev loop:
   Expo Go/dev clients are host shells. Use provided project URLs, verify with snapshot -i after opening, and ask instead of inventing app ids or URLs. Help workflow owns the full Expo URL command shapes.
 
 Overlays and busy RN UIs:
-  React Native warning/error overlays belong to the app run. Treat them as findings or blockers: capture screenshot --overlay-refs, run react-devtools errors when connected, dismiss visible Dismiss/Close only if unrelated, re-snapshot, and report the overlay.
-  If snapshot times out because the UI never becomes idle, use screenshot as visual truth, try settings animations off for Android, or wait briefly and retry; report the busy UI as the blocker if it persists.
+  React Native warning/error overlays belong to the app run. Treat them as blockers before normal app work: press visible Dismiss/Close immediately when unrelated, or press the collapsed warning banner first if only a warning chip is visible; then re-snapshot and report the overlay in the final summary. Use screenshot --overlay-refs only if visual evidence is required.
+  Full-screen RedBox stack traces are app errors, not failed navigation. If Minimize is visible, prefer Minimize over Dismiss; Dismiss can re-trigger infinite-loop render errors such as getSnapshot/useOnyx stack paths.
+  If snapshot times out because the UI never becomes idle, Android accessibility may be blocked by busy or continuously changing app UI. After that timeout, use screenshot as visual truth instead of repeatedly retrying snapshots.
   Android runtime permission dialogs are visible UI: inspect snapshot -i and press Allow/Deny by visible label/ref. Use alert wait/accept/dismiss only where the platform supports native alerts.
 
 React DevTools routing:

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -901,6 +901,26 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     ],
   }),
   makeCase({
+    id: 'rn-collapsed-warning-banner-expand-dismiss',
+    contract: [
+      'App name: Agent Device Tester',
+      'Current screen has a collapsed React Native warning banner',
+      'Fresh interactive snapshot shows @e12 label="!, Open debugger to view warnings."',
+      'Dismiss is not visible until the warning banner is pressed',
+      'Target selector after dismissing overlay: id="submit-order"',
+    ],
+    task: 'Plan commands to press the collapsed warning banner, re-snapshot to find Dismiss or Close, dismiss the overlay, re-snapshot, then continue to id="submit-order".',
+    outputs: [
+      /(?:snapshot -i[\s\S]*)?(?:press|click)\s+@e12[\s\S]*snapshot -i[\s\S]*(?:(?:press|click)\b[^\n]*(?:Dismiss|Close)|find\b[^\n]*(?:Dismiss|Close)[^\n]*(?:press|click))[\s\S]*snapshot -i[\s\S]*submit-order/i,
+    ],
+    forbiddenOutputs: [
+      plannedCommand('screenshot'),
+      RAW_COORDINATE_TARGET,
+      /(?:^|\n)(?:agent-device\s+)?(?:press|click)\b[^\n]*submit-order[\s\S]*(?:@e12|Dismiss|Close)/i,
+      /alert accept/i,
+    ],
+  }),
+  makeCase({
     id: 'rn-error-overlay-human-flag',
     contract: [
       'App name: Agent Device Tester',
@@ -922,6 +942,28 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       /submit-order/i,
     ],
     forbiddenOutputs: [RAW_COORDINATE_TARGET, /alert accept/i, /ignore/i],
+  }),
+  makeCase({
+    id: 'rn-redbox-stack-minimize-before-continuing',
+    contract: [
+      'App name: Agent Device Tester',
+      'Platform: Android',
+      'Fresh interactive snapshot shows a full-screen React Native RedBox stack trace',
+      'Stack includes useOnyx.ts:80:43 and LHNOptionsList.tsx:77',
+      'Overlay controls include Dismiss and Minimize',
+      'The RedBox may be caused by an infinite render loop',
+      'Target selector after minimizing overlay: id="submit-order"',
+    ],
+    task: 'Plan commands to recognize the RedBox stack trace, press Minimize instead of Dismiss, re-snapshot, then continue to id="submit-order" while reporting the RedBox later.',
+    outputs: [
+      /snapshot -i[\s\S]*(?:press|click)\b[^\n]*Minimize[\s\S]*snapshot -i[\s\S]*submit-order/i,
+    ],
+    forbiddenOutputs: [
+      RAW_COORDINATE_TARGET,
+      /(?:press|click)\b[^\n]*Dismiss/i,
+      /alert accept/i,
+      /failed nav|navigation failed/i,
+    ],
   }),
   makeCase({
     id: 'expo-go-ios-project-url',


### PR DESCRIPTION
## Summary

Fail Android snapshot helper captures fast when the accessibility tree is busy, while giving the host adb instrumentation call enough overhead on slower CI emulators. The helper capture budget is 5s and the host command budget is 8s.

Detect React Native warning banners and RedBox overlays in snapshot output so agents expand collapsed warnings, prefer Minimize when present, and avoid pressing Dismiss on RedBox stacks when Minimize is unavailable.

Host-side adb instrumentation timeouts now fall back to stock UIAutomator instead of being treated as busy-tree signals.

Touched files: 7. Scope stayed within Android snapshot handling, snapshot overlay warnings, versioned help, and focused tests.

## Validation

Focused Android snapshot and runtime snapshot tests passed: 43 tests.

pnpm check:fallow --base origin/main passed.

pnpm check:quick passed.

pnpm build passed before the final cleanup; the final cleanup narrowed matchers, simplified helper timeout handling, and removed redundant tests.

SkillGym cases passed before cleanup: rn-redbox-stack-minimize-before-continuing 2/2 and rn-collapsed-warning-banner-expand-dismiss 2/2. After cleanup, a non-escalated rerun crashed both model runners before assertions; no code/test assertion failed.