### PR TITLE
fix: make MCP discovery-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ If you install skills separately, keep the CLI on `agent-device >= 0.14.0`. Olde
 
 - **Agent + terminal**: in Cursor, Codex, Claude Code, Windsurf, and similar clients, run `agent-device` in the integrated terminal. Start planning with `agent-device help workflow`; CLI help is authoritative.
 - **Skills or rules**: install the skill with `npx skills add callstackincubator/agent-device`, use the bundled [agent-device skill](skills/agent-device/SKILL.md), or mirror it as a thin project rule, so the agent checks the installed version and reads `agent-device help workflow` before acting. Use `agent-device help react-native` for React Native apps, overlays, Metro/Fast Refresh blockers, and routing to React DevTools or debugging evidence.
-- **MCP router**: use `agent-device mcp` when an MCP-aware client needs install, status, and version-matched help discovery. MCP is intentionally a thin router; device automation still runs through CLI commands.
+- **MCP router**: use `agent-device mcp` when an MCP-aware client needs to discover the CLI package, install command, version check, and first help command. MCP is discovery-only; device automation still runs through terminal CLI commands.
 
 For client-specific setup, see [AI Agent Setup](https://incubator.callstack.com/agent-device/docs/agent-setup). For agent-readable docs, use [llms-full.txt](https://incubator.callstack.com/agent-device/llms-full.txt).
 
 ### MCP Router
 
-`agent-device` ships an official stdio MCP router for discovery-oriented clients. It exposes only `status`, `install`, and `help` tools plus workflow prompts/resources; it does not expose device automation or generic shell execution over MCP.
+`agent-device` ships an official stdio MCP router for discovery-oriented clients. It exposes only a `status` tool that returns structured CLI handoff guidance: npm package name, installed version, CLI command name, install command, verify command, starting help command, and an explicit note that automation happens through the CLI.
+
+MCP clients must not use this server as a device automation surface or generic shell runner. If the CLI is missing, agents should ask a human before installing or updating packages, then verify with `agent-device --version` and start with `agent-device help workflow`.
 
 Paste one of these into clients that accept `mcpServers`, such as Cursor project `.cursor/mcp.json` or user-level MCP settings.
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.callstackincubator/agent-device",
   "title": "agent-device",
-  "description": "Discovery router for the agent-device CLI with status, install, help, prompts, and resources.",
+  "description": "Let AI agents inspect, control, and debug real iOS, Android, desktop, and TV apps",
   "repository": {
     "url": "https://github.com/callstackincubator/agent-device",
     "source": "github"

--- a/src/mcp/__tests__/router.test.ts
+++ b/src/mcp/__tests__/router.test.ts
@@ -1,145 +1,103 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { handleMcpMessage } from '../router.ts';
-import { handleMcpPayload } from '../server.ts';
 
-test('MCP router exposes status install and help tools only', () => {
+test('MCP initialize advertises discovery-only tool capability', () => {
   const response = handleMcpMessage({
     jsonrpc: '2.0',
     id: 1,
-    method: 'tools/list',
-  });
-
-  assert.equal(response?.jsonrpc, '2.0');
-  assert.ok(response && 'result' in response);
-  const tools = (response.result as { tools: Array<{ name: string }> }).tools;
-  assert.deepEqual(
-    tools.map((tool) => tool.name),
-    ['status', 'install', 'help'],
-  );
-});
-
-test('MCP help tool returns versioned workflow guidance', () => {
-  const response = handleMcpMessage({
-    jsonrpc: '2.0',
-    id: 2,
-    method: 'tools/call',
-    params: {
-      name: 'help',
-      arguments: { topic: 'workflow' },
-    },
-  });
-
-  assert.ok(response && 'result' in response);
-  const result = response.result as { content: Array<{ text: string }>; isError: boolean };
-  assert.equal(result.isError, false);
-  assert.match(result.content[0]?.text ?? '', /agent-device help workflow/);
-  assert.match(result.content[0]?.text ?? '', /snapshot -i/);
-});
-
-test('MCP install tool can return npx client config', () => {
-  const response = handleMcpMessage({
-    jsonrpc: '2.0',
-    id: 3,
-    method: 'tools/call',
-    params: {
-      name: 'install',
-      arguments: { global: false, client: 'Cline' },
-    },
-  });
-
-  assert.ok(response && 'result' in response);
-  const result = response.result as { content: Array<{ text: string }> };
-  const text = result.content[0]?.text ?? '';
-  assert.match(text, /npx -y agent-device mcp/);
-  assert.match(text, /"args": \["-y","agent-device","mcp"\]/);
-  assert.match(text, /Client hint: Cline/);
-});
-
-test('MCP exposes help resources and workflow prompts', () => {
-  const resources = handleMcpMessage({
-    jsonrpc: '2.0',
-    id: 4,
-    method: 'resources/list',
-  });
-  assert.ok(resources && 'result' in resources);
-  const resourceUris = (resources.result as { resources: Array<{ uri: string }> }).resources.map(
-    (resource) => resource.uri,
-  );
-  assert.ok(resourceUris.includes('agent-device://help/workflow'));
-  assert.ok(resourceUris.includes('agent-device://help/react-native'));
-
-  const prompt = handleMcpMessage({
-    jsonrpc: '2.0',
-    id: 5,
-    method: 'prompts/get',
-    params: {
-      name: 'agent-device-dogfood',
-      arguments: { target: 'SampleApp on iOS' },
-    },
-  });
-  assert.ok(prompt && 'result' in prompt);
-  const result = prompt.result as { messages: Array<{ content: { text: string } }> };
-  assert.match(result.messages[0]?.content.text ?? '', /dogfood/);
-  assert.match(result.messages[0]?.content.text ?? '', /SampleApp on iOS/);
-});
-
-test('MCP React Native prompt routes to RN workflow guidance', () => {
-  const prompt = handleMcpMessage({
-    jsonrpc: '2.0',
-    id: 6,
-    method: 'prompts/get',
-    params: {
-      name: 'agent-device-react-native',
-    },
-  });
-
-  assert.ok(prompt && 'result' in prompt);
-  const result = prompt.result as { messages: Array<{ content: { text: string } }> };
-  assert.match(result.messages[0]?.content.text ?? '', /react-native/);
-});
-
-test('MCP initialize returns supported protocol version and unknown methods use JSON-RPC code', () => {
-  const initialized = handleMcpMessage({
-    jsonrpc: '2.0',
-    id: 6,
     method: 'initialize',
     params: {
       protocolVersion: '2099-01-01',
     },
   });
-  assert.ok(initialized && 'result' in initialized);
-  assert.equal((initialized.result as { protocolVersion: string }).protocolVersion, '2025-11-25');
 
-  const unknown = handleMcpMessage({
-    jsonrpc: '2.0',
-    id: 7,
-    method: 'unknown/method',
-  });
-  assert.ok(unknown && 'error' in unknown);
-  assert.equal(unknown.error.code, -32601);
+  assert.ok(response && 'result' in response);
+  const result = response.result as {
+    protocolVersion: string;
+    capabilities: Record<string, unknown>;
+  };
+  assert.equal(result.protocolVersion, '2025-11-25');
+  assert.deepEqual(result.capabilities, { tools: {} });
 });
 
-test('MCP batch requests return one JSON-RPC array response', () => {
-  const response = handleMcpPayload([
-    {
-      jsonrpc: '2.0',
-      id: 8,
-      method: 'ping',
-    },
-    {
-      jsonrpc: '2.0',
-      method: 'notifications/initialized',
-    },
-    {
-      jsonrpc: '2.0',
-      id: 9,
-      method: 'tools/list',
-    },
-  ]);
+test('MCP tools/list exposes only status', () => {
+  const response = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/list',
+  });
 
-  assert.ok(Array.isArray(response));
-  assert.equal(response.length, 2);
-  assert.equal(response[0]?.id, 8);
-  assert.equal(response[1]?.id, 9);
+  assert.ok(response && 'result' in response);
+  const tools = (
+    response.result as { tools: Array<{ name: string; outputSchema?: { type: string } }> }
+  ).tools;
+  assert.deepEqual(
+    tools.map((tool) => tool.name),
+    ['status'],
+  );
+  assert.equal(tools[0]?.outputSchema?.type, 'object');
+});
+
+test('MCP status tool returns structured CLI handoff guidance', () => {
+  const response = handleMcpMessage({
+    jsonrpc: '2.0',
+    id: 3,
+    method: 'tools/call',
+    params: {
+      name: 'status',
+    },
+  });
+
+  assert.ok(response && 'result' in response);
+  const result = response.result as {
+    content: Array<{ text: string }>;
+    isError: boolean;
+    structuredContent: {
+      packageName: string;
+      cliCommandName: string;
+      installCommand: string;
+      verifyCommand: string;
+      startingHelpCommand: string;
+      supportedTargets: string[];
+      capabilities: string[];
+      prerequisites: string[];
+      docsUrl: string;
+      agentDocsUrl: string;
+      firstCommands: string[];
+      automationInterface: string;
+      automationNote: string;
+      installRequiresHumanApproval: boolean;
+      installSafetyNote: string;
+    };
+  };
+  assert.equal(result.isError, false);
+
+  const handoff = result.structuredContent;
+  assert.deepEqual(JSON.parse(result.content[0]?.text ?? ''), handoff);
+  assert.equal(handoff.packageName, 'agent-device');
+  assert.equal(handoff.cliCommandName, 'agent-device');
+  assert.equal(handoff.installCommand, 'npm install -g agent-device@latest');
+  assert.equal(handoff.verifyCommand, 'agent-device --version');
+  assert.equal(handoff.startingHelpCommand, 'agent-device help workflow');
+  assert.ok(handoff.supportedTargets.includes('ios-simulator'));
+  assert.ok(handoff.supportedTargets.includes('android-emulator'));
+  assert.ok(handoff.capabilities.includes('inspect-ui'));
+  assert.ok(handoff.capabilities.includes('interact-with-elements'));
+  assert.ok(handoff.capabilities.includes('accessibility-snapshot'));
+  assert.ok(handoff.capabilities.includes('react-native'));
+  assert.ok(handoff.capabilities.includes('expo'));
+  assert.ok(handoff.capabilities.includes('android-adb'));
+  assert.ok(handoff.capabilities.includes('ios-xcuitest'));
+  assert.ok(handoff.prerequisites.includes('node>=22'));
+  assert.ok(handoff.prerequisites.includes('xcode-for-ios'));
+  assert.ok(handoff.prerequisites.includes('android-sdk-adb-for-android'));
+  assert.equal(handoff.docsUrl, 'https://agent-device.dev/');
+  assert.equal(handoff.agentDocsUrl, 'https://incubator.callstack.com/agent-device/llms-full.txt');
+  assert.ok(handoff.firstCommands.includes('agent-device apps --platform ios'));
+  assert.ok(handoff.firstCommands.includes('agent-device apps --platform android'));
+  assert.equal(handoff.automationInterface, 'cli');
+  assert.match(handoff.automationNote, /discovery-only/);
+  assert.equal(handoff.installRequiresHumanApproval, true);
+  assert.match(handoff.installSafetyNote, /human has approved/);
 });

--- a/src/mcp/catalog.ts
+++ b/src/mcp/catalog.ts
@@ -1,229 +1,144 @@
-import {
-  buildCommandUsageText,
-  buildUsageText,
-  HELP_TOPIC_NAMES,
-  type HelpTopicName,
-} from '../utils/command-schema.ts';
 import { readVersion } from '../utils/version.ts';
 
 export const MCP_SERVER_NAME = 'agent-device';
-const MCP_REGISTRY_NAME = 'io.github.callstackincubator/agent-device';
 
-type InstallArgs = {
-  client?: string;
-  global?: boolean;
+type StatusHandoff = {
+  packageName: string;
+  installedPackageVersion: string;
+  cliCommandName: string;
+  installCommand: string;
+  verifyCommand: string;
+  startingHelpCommand: string;
+  supportedTargets: string[];
+  capabilities: string[];
+  prerequisites: string[];
+  docsUrl: string;
+  agentDocsUrl: string;
+  firstCommands: string[];
+  automationInterface: 'cli';
+  automationNote: string;
+  installRequiresHumanApproval: true;
+  installSafetyNote: string;
 };
 
-export function createStatusText(): string {
-  const status = {
-    name: MCP_SERVER_NAME,
-    registryName: MCP_REGISTRY_NAME,
-    version: readVersion(),
-    transport: 'stdio',
-    command: 'agent-device mcp',
-    node: process.version,
-    capabilities: {
-      tools: ['status', 'install', 'help'],
-      resources: listResources().map((resource) => resource.uri),
-      prompts: listPrompts().map((prompt) => prompt.name),
-    },
-    note: 'This MCP server routes agents to the agent-device CLI. It does not expose device automation or shell execution tools.',
+export function createStatusHandoff(): StatusHandoff {
+  return {
+    packageName: 'agent-device',
+    installedPackageVersion: readVersion(),
+    cliCommandName: 'agent-device',
+    installCommand: 'npm install -g agent-device@latest',
+    verifyCommand: 'agent-device --version',
+    startingHelpCommand: 'agent-device help workflow',
+    supportedTargets: [
+      'ios-simulator',
+      'android-emulator',
+      'ios-device',
+      'android-device',
+      'tvos-simulator',
+      'macos',
+      'linux',
+    ],
+    capabilities: [
+      'inspect-ui',
+      'interact-with-elements',
+      'open-apps',
+      'install-app',
+      'capture-screenshot',
+      'accessibility-snapshot',
+      'collect-logs',
+      'collect-network',
+      'collect-performance',
+      'record-replay',
+      'react-native',
+      'expo',
+      'android-adb',
+      'ios-xcuitest',
+    ],
+    prerequisites: [
+      'node>=22',
+      'xcode-for-ios',
+      'android-sdk-adb-for-android',
+      'macos-accessibility-permission-for-desktop',
+    ],
+    docsUrl: 'https://agent-device.dev/',
+    agentDocsUrl: 'https://incubator.callstack.com/agent-device/llms-full.txt',
+    firstCommands: [
+      'agent-device help workflow',
+      'agent-device apps --platform ios',
+      'agent-device apps --platform android',
+    ],
+    automationInterface: 'cli',
+    automationNote:
+      'Device automation happens through the agent-device CLI. This MCP server is discovery-only and does not expose device automation tools.',
+    installRequiresHumanApproval: true,
+    installSafetyNote:
+      'Agents should not install or update the package unless the human has approved the environment change. If the CLI is missing, ask the human to run the install command, then run the verify command.',
   };
-  return JSON.stringify(status, null, 2);
-}
-
-export function createInstallText(args: InstallArgs = {}): string {
-  const command = args.global === false ? 'npx -y agent-device mcp' : 'agent-device mcp';
-  const packageInstall =
-    args.global === false ? 'No global install required.' : 'npm install -g agent-device';
-  const client = args.client ? `\nClient hint: ${args.client}` : '';
-  return `${packageInstall}
-
-MCP server command:
-  ${command}
-
-Generic MCP JSON:
-  {
-    "mcpServers": {
-      "agent-device": {
-        "command": "${args.global === false ? 'npx' : 'agent-device'}",
-        "args": ${JSON.stringify(args.global === false ? ['-y', 'agent-device', 'mcp'] : ['mcp'])}
-      }
-    }
-  }
-
-Use this server for discovery and routing only. For device actions, call the CLI commands returned by the help tool, starting with:
-  agent-device help workflow${client}
-`;
-}
-
-export function createHelpText(args: { topic?: string; command?: string } = {}): string {
-  if (args.topic && args.command) {
-    throw new Error('Provide either topic or command, not both.');
-  }
-  const target = args.topic ?? args.command;
-  if (!target) return buildUsageText();
-  if (args.topic && !isHelpTopic(args.topic)) {
-    throw new Error(
-      `Unknown help topic: ${args.topic}. Expected one of: ${HELP_TOPIC_NAMES.join(', ')}`,
-    );
-  }
-  const help = buildCommandUsageText(target);
-  if (!help) throw new Error(`Unknown command or help topic: ${target}`);
-  return help;
 }
 
 export function listTools(): unknown[] {
   return [
     {
       name: 'status',
-      description: 'Report the installed agent-device MCP router and CLI metadata.',
+      description:
+        'Return discovery-only handoff metadata for installing, verifying, and using the agent-device CLI.',
       inputSchema: {
         type: 'object',
         properties: {},
         additionalProperties: false,
       },
-    },
-    {
-      name: 'install',
-      description: 'Return install and MCP client configuration snippets for agent-device.',
-      inputSchema: {
+      outputSchema: {
         type: 'object',
         properties: {
-          client: {
-            type: 'string',
-            description: 'Optional client name for labeling the returned guidance.',
+          packageName: { type: 'string' },
+          installedPackageVersion: { type: 'string' },
+          cliCommandName: { type: 'string' },
+          installCommand: { type: 'string' },
+          verifyCommand: { type: 'string' },
+          startingHelpCommand: { type: 'string' },
+          supportedTargets: {
+            type: 'array',
+            items: { type: 'string' },
           },
-          global: {
-            type: 'boolean',
-            description: 'Use a global agent-device binary when true; use npx when false.',
+          capabilities: {
+            type: 'array',
+            items: { type: 'string' },
           },
+          prerequisites: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          docsUrl: { type: 'string' },
+          agentDocsUrl: { type: 'string' },
+          firstCommands: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          automationInterface: { type: 'string', const: 'cli' },
+          automationNote: { type: 'string' },
+          installRequiresHumanApproval: { type: 'boolean', const: true },
+          installSafetyNote: { type: 'string' },
         },
+        required: [
+          'packageName',
+          'installedPackageVersion',
+          'cliCommandName',
+          'installCommand',
+          'verifyCommand',
+          'startingHelpCommand',
+          'supportedTargets',
+          'capabilities',
+          'prerequisites',
+          'docsUrl',
+          'agentDocsUrl',
+          'firstCommands',
+          'automationInterface',
+          'automationNote',
+          'installRequiresHumanApproval',
+          'installSafetyNote',
+        ],
         additionalProperties: false,
       },
     },
-    {
-      name: 'help',
-      description: 'Return version-matched CLI help for a workflow topic or command.',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          topic: {
-            type: 'string',
-            enum: HELP_TOPIC_NAMES,
-            description: 'Agent workflow topic.',
-          },
-          command: {
-            type: 'string',
-            description: 'CLI command name such as snapshot, open, logs, or react-devtools.',
-          },
-        },
-        additionalProperties: false,
-      },
-    },
   ];
-}
-
-export function listResources(): Array<{
-  uri: string;
-  name: string;
-  description: string;
-  mimeType: string;
-}> {
-  return [
-    {
-      uri: 'agent-device://install',
-      name: 'agent-device MCP install',
-      description: 'Install and client configuration snippets.',
-      mimeType: 'text/markdown',
-    },
-    {
-      uri: 'agent-device://help',
-      name: 'agent-device command list',
-      description: 'Version-matched command list and global flags.',
-      mimeType: 'text/plain',
-    },
-    ...HELP_TOPIC_NAMES.map((topic) => ({
-      uri: `agent-device://help/${topic}`,
-      name: `agent-device help ${topic}`,
-      description: `Version-matched ${topic} workflow guidance.`,
-      mimeType: 'text/plain',
-    })),
-  ];
-}
-
-export function readResource(uri: string): string {
-  if (uri === 'agent-device://install') return createInstallText();
-  if (uri === 'agent-device://help') return buildUsageText();
-  const topic = uri.startsWith('agent-device://help/')
-    ? uri.slice('agent-device://help/'.length)
-    : '';
-  if (isHelpTopic(topic)) return createHelpText({ topic });
-  throw new Error(`Unknown resource: ${uri}`);
-}
-
-export function listPrompts(): Array<{ name: string; description: string; arguments: unknown[] }> {
-  return [
-    createPromptDescriptor('agent-device-workflow', 'Plan a normal app automation loop.'),
-    createPromptDescriptor('agent-device-debugging', 'Collect focused debugging evidence.'),
-    createPromptDescriptor(
-      'agent-device-dogfood',
-      'Run exploratory QA with reproducible evidence.',
-    ),
-    createPromptDescriptor(
-      'agent-device-react-native',
-      'Plan React Native app automation with overlay and DevTools routing.',
-    ),
-    createPromptDescriptor('agent-device-macos', 'Inspect a macOS app or surface.'),
-  ];
-}
-
-export function getPrompt(name: string, args: Record<string, string> = {}): unknown {
-  const topicByPrompt: Record<string, HelpTopicName> = {
-    'agent-device-workflow': 'workflow',
-    'agent-device-debugging': 'debugging',
-    'agent-device-dogfood': 'dogfood',
-    'agent-device-react-native': 'react-native',
-    'agent-device-macos': 'macos',
-  };
-  const topic = topicByPrompt[name];
-  if (!topic) throw new Error(`Unknown prompt: ${name}`);
-  const target = args.target ? ` Target: ${args.target}.` : '';
-  return {
-    description: `Use agent-device help ${topic} before planning commands.${target}`,
-    messages: [
-      {
-        role: 'user',
-        content: {
-          type: 'text',
-          text: `Read the agent-device ${topic} guidance through the MCP help tool, then produce a concise command plan using agent-device CLI commands only.${target}`,
-        },
-      },
-    ],
-  };
-}
-
-function createPromptDescriptor(
-  name: string,
-  description: string,
-): {
-  name: string;
-  description: string;
-  arguments: unknown[];
-} {
-  return {
-    name,
-    description,
-    arguments: [
-      {
-        name: 'target',
-        description: 'Optional app, device, or task target.',
-        required: false,
-      },
-    ],
-  };
-}
-
-function isHelpTopic(value: string): value is HelpTopicName {
-  return (HELP_TOPIC_NAMES as readonly string[]).includes(value);
 }

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -1,14 +1,4 @@
-import {
-  createHelpText,
-  createInstallText,
-  createStatusText,
-  getPrompt,
-  listPrompts,
-  listResources,
-  listTools,
-  readResource,
-  MCP_SERVER_NAME,
-} from './catalog.ts';
+import { createStatusHandoff, listTools, MCP_SERVER_NAME } from './catalog.ts';
 import { readVersion } from '../utils/version.ts';
 
 type JsonRpcId = string | number | null;
@@ -53,8 +43,6 @@ function handleRequest(method: string, params: unknown): unknown {
         protocolVersion: supportedProtocolVersion(params),
         capabilities: {
           tools: {},
-          resources: {},
-          prompts: {},
         },
         serverInfo: {
           name: MCP_SERVER_NAME,
@@ -67,14 +55,6 @@ function handleRequest(method: string, params: unknown): unknown {
       return { tools: listTools() };
     case 'tools/call':
       return callTool(params);
-    case 'resources/list':
-      return { resources: listResources() };
-    case 'resources/read':
-      return readMcpResource(params);
-    case 'prompts/list':
-      return { prompts: listPrompts() };
-    case 'prompts/get':
-      return readPrompt(params);
     default:
       throw new JsonRpcMethodNotFoundError(`Unsupported MCP method: ${method}`);
   }
@@ -83,33 +63,12 @@ function handleRequest(method: string, params: unknown): unknown {
 function callTool(params: unknown): unknown {
   const record = asRecord(params);
   const name = stringField(record, 'name');
-  const args = optionalRecord(record.arguments);
   try {
-    if (name === 'status') return textToolResult(createStatusText());
-    if (name === 'install') return textToolResult(createInstallText(args));
-    if (name === 'help') return textToolResult(createHelpText(args));
+    if (name === 'status') return statusToolResult();
     throw new Error(`Unknown tool: ${name}`);
   } catch (error) {
     return textToolResult(error instanceof Error ? error.message : String(error), true);
   }
-}
-
-function readMcpResource(params: unknown): unknown {
-  const uri = stringField(asRecord(params), 'uri');
-  return {
-    contents: [
-      {
-        uri,
-        mimeType: uri === 'agent-device://install' ? 'text/markdown' : 'text/plain',
-        text: readResource(uri),
-      },
-    ],
-  };
-}
-
-function readPrompt(params: unknown): unknown {
-  const record = asRecord(params);
-  return getPrompt(stringField(record, 'name'), optionalStringRecord(record.arguments));
 }
 
 function supportedProtocolVersion(_params: unknown): string {
@@ -120,6 +79,15 @@ function textToolResult(text: string, isError = false): unknown {
   return {
     isError,
     content: [{ type: 'text', text }],
+  };
+}
+
+function statusToolResult(): unknown {
+  const handoff = createStatusHandoff();
+  return {
+    isError: false,
+    structuredContent: handoff,
+    content: [{ type: 'text', text: JSON.stringify(handoff, null, 2) }],
   };
 }
 
@@ -136,20 +104,6 @@ function asRecord(value: unknown): Record<string, unknown> {
     throw new Error('Expected object parameters.');
   }
   return value as Record<string, unknown>;
-}
-
-function optionalRecord(value: unknown): Record<string, unknown> {
-  if (value === undefined) return {};
-  return asRecord(value);
-}
-
-function optionalStringRecord(value: unknown): Record<string, string> {
-  const record = optionalRecord(value);
-  return Object.fromEntries(
-    Object.entries(record).filter(
-      (entry): entry is [string, string] => typeof entry[1] === 'string',
-    ),
-  );
 }
 
 function stringField(record: Record<string, unknown>, key: string): string {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -640,7 +640,6 @@ Rules:
 } as const satisfies Record<string, { summary: string; body: string }>;
 
 export type HelpTopicName = keyof typeof HELP_TOPICS;
-export const HELP_TOPIC_NAMES = Object.freeze(Object.keys(HELP_TOPICS) as HelpTopicName[]);
 
 const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
   {
@@ -1469,6 +1468,14 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
       'metroNoInstallDeps',
       'launchUrl',
     ],
+    skipCapabilityCheck: true,
+  },
+  mcp: {
+    helpDescription:
+      'Start the official stdio MCP discovery router. It exposes only a status tool with CLI install, verify, and starting-help guidance; device automation still runs through terminal CLI commands.',
+    summary: 'Start MCP discovery router',
+    positionalArgs: [],
+    allowedFlags: [],
     skipCapabilityCheck: true,
   },
   disconnect: {

--- a/website/docs/docs/agent-setup.md
+++ b/website/docs/docs/agent-setup.md
@@ -49,12 +49,14 @@ Add this as a project rule, custom instruction, or skill equivalent when your ag
 ```text
 Use agent-device only for app/device automation tasks. Before planning commands, run `agent-device --version` and read `agent-device help workflow`. For exploratory QA, read `agent-device help dogfood`. For logs, network, traces, or runtime failures, read `agent-device help debugging`. For React Native component trees, props/state/hooks, slow renders, or rerenders, read `agent-device help react-devtools`. For React Native apps, overlays, Metro/Fast Refresh blockers, and routing to React DevTools or debugging evidence, read `agent-device help react-native`.
 
-Use the CLI in the integrated terminal. If `agent-device` is not on PATH but the user installed it globally in another shell, resolve the command the same way the user would from a normal terminal session and run that absolute path instead. This may require inspecting shell startup behavior or package-manager/global bin locations; do not assume the agent process `PATH` is the user's `PATH`. Do not silently fall back to `npx -y agent-device@latest`; ask or use an exact version. MCP is only a discovery/help router and does not expose device automation tools. Prefer `open -> snapshot -i -> act -> re-snapshot -> verify -> close`. Use current refs such as `@e3` for exploration and selectors for durable replay. Keep mutating commands against one session serial. Capture screenshots, logs, network, perf, traces, recordings, and `.ad` replay scripts only when they add evidence.
+Use the CLI in the integrated terminal. If `agent-device` is not on PATH but the user installed it globally in another shell, resolve the command the same way the user would from a normal terminal session and run that absolute path instead. This may require inspecting shell startup behavior or package-manager/global bin locations; do not assume the agent process `PATH` is the user's `PATH`. Do not silently fall back to `npx -y agent-device@latest`; ask or use an exact version. MCP is discovery-only, exposes only status handoff metadata, and does not expose device automation tools. Prefer `open -> snapshot -i -> act -> re-snapshot -> verify -> close`. Use current refs such as `@e3` for exploration and selectors for durable replay. Keep mutating commands against one session serial. Capture screenshots, logs, network, perf, traces, recordings, and `.ad` replay scripts only when they add evidence.
 ```
 
 ## MCP router
 
-`agent-device mcp` starts the official stdio MCP router for discovery-oriented clients. It exposes only `status`, `install`, and `help` tools plus workflow prompts/resources. Device automation still runs through the CLI commands returned by version-matched help.
+`agent-device mcp` starts the official stdio MCP router for discovery-oriented clients. It exposes only a `status` tool that returns structured CLI handoff guidance: npm package name, installed version, CLI command name, install command, verify command, starting help command, and an explicit note that automation happens through the CLI.
+
+MCP clients must not use this server as a device automation surface or generic shell runner. If the CLI is missing, agents should ask a human before installing or updating packages, then verify with `agent-device --version` and start with `agent-device help workflow`.
 
 Global install configuration:
 
@@ -123,7 +125,7 @@ agent-device help dogfood
 agent-device help react-native
 ```
 
-If you configure MCP, keep using CLI commands for automation. The MCP router gives Claude install/status/help context only.
+If you configure MCP, keep using CLI commands for automation. The MCP router gives Claude discovery/status handoff metadata only.
 
 ## Windsurf, Cline, Goose, and other MCP clients
 
@@ -133,7 +135,7 @@ If the client has project rules or custom instructions, add the recommended agen
 
 ## Why this setup works
 
-The CLI stays the auditable automation surface, installed help stays version-matched with the commands, skills and rules route agents toward the right help topics, and MCP gives discovery-oriented clients a small install/status/help entry point.
+The CLI stays the auditable automation surface, installed help stays version-matched with the commands, skills and rules route agents toward the right help topics, and MCP gives discovery-oriented clients a small status handoff entry point.
 
 For the broader positioning, supported targets, observability features, and how `agent-device` differs from scripted test frameworks, see [Introduction](/docs/introduction). For exact command groups and platform behavior, see [Commands](/docs/commands).
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -23,6 +23,14 @@ agent-device help dogfood
 
 Skills are recommended for auto-routing when your agent runtime supports them, but they are not required. The CLI help topics are the version-matched operating contract.
 
+For MCP-aware clients that need discovery instead of direct device control, run:
+
+```bash
+agent-device mcp
+```
+
+The MCP router exposes only a `status` tool with CLI install, verify, and starting-help guidance. It does not expose device automation or generic shell execution over MCP.
+
 ## Navigation
 
 ```bash

--- a/website/docs/docs/installation.md
+++ b/website/docs/docs/installation.md
@@ -36,6 +36,16 @@ agent-device --version
 
 Set `AGENT_DEVICE_NO_UPDATE_NOTIFIER=1` to disable the notice.
 
+## Agent clients and MCP
+
+The official MCP router is discovery-only. It exposes a `status` tool with the package name, installed version, CLI command name, install command, verify command, and starting help command, while app and device automation remains explicit CLI activity in the terminal.
+
+```bash
+agent-device mcp
+```
+
+Use [AI Agent Setup](/docs/agent-setup#mcp-router) for copy-paste MCP client configuration.
+
 ## Without installing
 
 ```bash

--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -56,7 +56,7 @@ Use [AI Agent Setup](/docs/agent-setup) for Cursor, Codex, Claude Code, Windsurf
 
 It complements scripted test frameworks such as Appium, Maestro, Detox, XCTest, and Espresso. Keep those for stable human-authored coverage. Use `agent-device` when an agent needs to explore, reproduce, debug, profile, collect evidence, or record a replay from live app behavior.
 
-MCP support is intentionally a thin discovery router for install/status/help. App and device automation remains explicit CLI activity in the terminal.
+MCP support is discovery-only and returns status handoff metadata for installing, verifying, and starting with the CLI. App and device automation remains explicit CLI activity in the terminal.
 
 ## Next steps
 

--- a/website/docs/docs/security-trust.md
+++ b/website/docs/docs/security-trust.md
@@ -10,6 +10,7 @@ description: Security and trust guidance for agent-device local app automation, 
 ## Local control
 
 - Device automation runs through the installed CLI and platform tooling such as Xcode, ADB, macOS accessibility APIs, and Linux AT-SPI.
+- The MCP server is discovery-only. It exposes a single status tool with CLI handoff metadata; it does not expose device automation or generic shell execution over MCP.
 - Mutating commands should run serially against one session. Use separate sessions/devices for parallel work.
 
 ## Sensitive artifacts


### PR DESCRIPTION
## Summary

Make MCP a discovery-only status handoff for the agent-device CLI, exposing only the status tool and removing MCP help/install/prompts/resources.

Update README, website docs, CLI help, and server metadata to say automation runs through the CLI and installs should be human-approved.

Closes #555

## Validation

Verified with focused MCP router tests, CLI help tests, typecheck, MCP metadata check, and the full tooling bundle. pnpm check:tooling passed after lint, typecheck, metadata validation, and build.

Touched 11 files; scope stayed within MCP routing/catalog, smoke tests, CLI help, docs, and server metadata.