### PR TITLE
perf: speed up hot iOS taps

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -13,35 +13,6 @@ extension RunnerTests {
     return (gestureStartUptimeMs, currentUptimeMs())
   }
 
-  private func coordinateTapData(
-    message: String,
-    app: XCUIApplication,
-    x: Double,
-    y: Double,
-    timing: (gestureStartUptimeMs: Double, gestureEndUptimeMs: Double)
-  ) -> DataPayload {
-#if os(iOS)
-    return DataPayload(
-      message: message,
-      gestureStartUptimeMs: timing.gestureStartUptimeMs,
-      gestureEndUptimeMs: timing.gestureEndUptimeMs,
-      x: x,
-      y: y
-    )
-#else
-    let touchFrame = resolvedTouchVisualizationFrame(app: app, x: x, y: y)
-    return DataPayload(
-      message: message,
-      gestureStartUptimeMs: timing.gestureStartUptimeMs,
-      gestureEndUptimeMs: timing.gestureEndUptimeMs,
-      x: touchFrame.x,
-      y: touchFrame.y,
-      referenceWidth: touchFrame.referenceWidth,
-      referenceHeight: touchFrame.referenceHeight
-    )
-#endif
-  }
-
   func unsupportedResponse(for outcome: RunnerInteractionOutcome) -> Response? {
     switch outcome {
     case .performed:
@@ -337,6 +308,7 @@ extension RunnerTests {
         return Response(ok: false, error: ErrorPayload(message: "element not found"))
       }
       if let x = command.x, let y = command.y {
+        let touchFrame = resolvedTouchVisualizationFrame(app: activeApp, x: x, y: y)
         var outcome = RunnerInteractionOutcome.performed
         let timing = measureGesture {
           withTemporaryScrollIdleTimeoutIfSupported(activeApp) {
@@ -348,7 +320,15 @@ extension RunnerTests {
         }
         return Response(
           ok: true,
-          data: coordinateTapData(message: "tapped", app: activeApp, x: x, y: y, timing: timing)
+          data: DataPayload(
+            message: "tapped",
+            gestureStartUptimeMs: timing.gestureStartUptimeMs,
+            gestureEndUptimeMs: timing.gestureEndUptimeMs,
+            x: touchFrame.x,
+            y: touchFrame.y,
+            referenceWidth: touchFrame.referenceWidth,
+            referenceHeight: touchFrame.referenceHeight
+          )
         )
       }
       return Response(ok: false, error: ErrorPayload(message: "tap requires text or x/y"))
@@ -391,6 +371,7 @@ extension RunnerTests {
       let count = max(Int(command.count ?? 1), 1)
       let intervalMs = max(command.intervalMs ?? 0, 0)
       let doubleTap = command.doubleTap ?? false
+      let touchFrame = resolvedTouchVisualizationFrame(app: activeApp, x: x, y: y)
       if doubleTap {
         var outcome = RunnerInteractionOutcome.performed
         let timing = measureGesture {
@@ -407,7 +388,15 @@ extension RunnerTests {
         }
         return Response(
           ok: true,
-          data: coordinateTapData(message: "tap series", app: activeApp, x: x, y: y, timing: timing)
+          data: DataPayload(
+            message: "tap series",
+            gestureStartUptimeMs: timing.gestureStartUptimeMs,
+            gestureEndUptimeMs: timing.gestureEndUptimeMs,
+            x: touchFrame.x,
+            y: touchFrame.y,
+            referenceWidth: touchFrame.referenceWidth,
+            referenceHeight: touchFrame.referenceHeight
+          )
         )
       }
       var outcome = RunnerInteractionOutcome.performed
@@ -425,7 +414,15 @@ extension RunnerTests {
       }
       return Response(
         ok: true,
-        data: coordinateTapData(message: "tap series", app: activeApp, x: x, y: y, timing: timing)
+        data: DataPayload(
+          message: "tap series",
+          gestureStartUptimeMs: timing.gestureStartUptimeMs,
+          gestureEndUptimeMs: timing.gestureEndUptimeMs,
+          x: touchFrame.x,
+          y: touchFrame.y,
+          referenceWidth: touchFrame.referenceWidth,
+          referenceHeight: touchFrame.referenceHeight
+        )
       )
     case .longPress:
       guard let x = command.x, let y = command.y else {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -13,6 +13,35 @@ extension RunnerTests {
     return (gestureStartUptimeMs, currentUptimeMs())
   }
 
+  private func coordinateTapData(
+    message: String,
+    app: XCUIApplication,
+    x: Double,
+    y: Double,
+    timing: (gestureStartUptimeMs: Double, gestureEndUptimeMs: Double)
+  ) -> DataPayload {
+#if os(iOS)
+    return DataPayload(
+      message: message,
+      gestureStartUptimeMs: timing.gestureStartUptimeMs,
+      gestureEndUptimeMs: timing.gestureEndUptimeMs,
+      x: x,
+      y: y
+    )
+#else
+    let touchFrame = resolvedTouchVisualizationFrame(app: app, x: x, y: y)
+    return DataPayload(
+      message: message,
+      gestureStartUptimeMs: timing.gestureStartUptimeMs,
+      gestureEndUptimeMs: timing.gestureEndUptimeMs,
+      x: touchFrame.x,
+      y: touchFrame.y,
+      referenceWidth: touchFrame.referenceWidth,
+      referenceHeight: touchFrame.referenceHeight
+    )
+#endif
+  }
+
   func unsupportedResponse(for outcome: RunnerInteractionOutcome) -> Response? {
     switch outcome {
     case .performed:
@@ -308,7 +337,6 @@ extension RunnerTests {
         return Response(ok: false, error: ErrorPayload(message: "element not found"))
       }
       if let x = command.x, let y = command.y {
-        let touchFrame = resolvedTouchVisualizationFrame(app: activeApp, x: x, y: y)
         var outcome = RunnerInteractionOutcome.performed
         let timing = measureGesture {
           withTemporaryScrollIdleTimeoutIfSupported(activeApp) {
@@ -320,15 +348,7 @@ extension RunnerTests {
         }
         return Response(
           ok: true,
-          data: DataPayload(
-            message: "tapped",
-            gestureStartUptimeMs: timing.gestureStartUptimeMs,
-            gestureEndUptimeMs: timing.gestureEndUptimeMs,
-            x: touchFrame.x,
-            y: touchFrame.y,
-            referenceWidth: touchFrame.referenceWidth,
-            referenceHeight: touchFrame.referenceHeight
-          )
+          data: coordinateTapData(message: "tapped", app: activeApp, x: x, y: y, timing: timing)
         )
       }
       return Response(ok: false, error: ErrorPayload(message: "tap requires text or x/y"))
@@ -371,7 +391,6 @@ extension RunnerTests {
       let count = max(Int(command.count ?? 1), 1)
       let intervalMs = max(command.intervalMs ?? 0, 0)
       let doubleTap = command.doubleTap ?? false
-      let touchFrame = resolvedTouchVisualizationFrame(app: activeApp, x: x, y: y)
       if doubleTap {
         var outcome = RunnerInteractionOutcome.performed
         let timing = measureGesture {
@@ -388,15 +407,7 @@ extension RunnerTests {
         }
         return Response(
           ok: true,
-          data: DataPayload(
-            message: "tap series",
-            gestureStartUptimeMs: timing.gestureStartUptimeMs,
-            gestureEndUptimeMs: timing.gestureEndUptimeMs,
-            x: touchFrame.x,
-            y: touchFrame.y,
-            referenceWidth: touchFrame.referenceWidth,
-            referenceHeight: touchFrame.referenceHeight
-          )
+          data: coordinateTapData(message: "tap series", app: activeApp, x: x, y: y, timing: timing)
         )
       }
       var outcome = RunnerInteractionOutcome.performed
@@ -414,15 +425,7 @@ extension RunnerTests {
       }
       return Response(
         ok: true,
-        data: DataPayload(
-          message: "tap series",
-          gestureStartUptimeMs: timing.gestureStartUptimeMs,
-          gestureEndUptimeMs: timing.gestureEndUptimeMs,
-          x: touchFrame.x,
-          y: touchFrame.y,
-          referenceWidth: touchFrame.referenceWidth,
-          referenceHeight: touchFrame.referenceHeight
-        )
+        data: coordinateTapData(message: "tap series", app: activeApp, x: x, y: y, timing: timing)
       )
     case .longPress:
       guard let x = command.x, let y = command.y else {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -1359,12 +1359,17 @@ extension RunnerTests {
 
 #if !os(tvOS)
   private func interactionCoordinate(app: XCUIApplication, x: Double, y: Double) -> XCUICoordinate {
+#if os(iOS)
+    let origin = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+    return origin.withOffset(CGVector(dx: x, dy: y))
+#else
     let root = interactionRoot(app: app)
     let origin = root.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
     let rootFrame = root.frame
     let offsetX = x - Double(rootFrame.origin.x)
     let offsetY = y - Double(rootFrame.origin.y)
     return origin.withOffset(CGVector(dx: offsetX, dy: offsetY))
+#endif
   }
 #endif
 

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -224,7 +224,7 @@ test('runner session keeps readiness preflight for tap commands when ready but n
 test('runner session keeps readiness preflight for tap commands when marked ready but stale', async () => {
   const session = makeRunnerSession({
     ready: true,
-    lastSuccessfulRunnerResponseAtMs: Date.now() - 61_000,
+    lastSuccessfulRunnerResponseAtMs: Date.now() - 11_000,
   });
   mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
   mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -161,7 +161,48 @@ test('runner session probes readiness before mutating commands', async () => {
   });
 });
 
-test('runner session probes readiness before mutating commands even when marked ready', async () => {
+test('runner session skips readiness preflight for tap commands after a recent successful response', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 0);
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session skips readiness preflight for tapSeries after a recent successful response', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    {
+      command: 'tapSeries',
+      x: 120,
+      y: 240,
+      count: 2,
+      intervalMs: 80,
+      appBundleId: 'com.example.demo',
+    },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 0);
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session keeps readiness preflight for tap commands when ready but never proven fresh', async () => {
   const session = makeRunnerSession({ ready: true });
   mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
   mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
@@ -175,6 +216,47 @@ test('runner session probes readiness before mutating commands even when marked 
   );
 
   assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 1);
+  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session keeps readiness preflight for tap commands when marked ready but stale', async () => {
+  const session = makeRunnerSession({
+    ready: true,
+    lastSuccessfulRunnerResponseAtMs: Date.now() - 61_000,
+  });
+  mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 1);
+  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session keeps readiness preflight for non-tap mutating commands when marked ready', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ pressed: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    { command: 'longPress', x: 120, y: 240, appBundleId: 'com.example.demo' },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { pressed: true });
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
   assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);

--- a/src/platforms/ios/runner-session-types.ts
+++ b/src/platforms/ios/runner-session-types.ts
@@ -11,6 +11,7 @@ export type RunnerSession = {
   testPromise: Promise<ExecResult>;
   child: ExecBackgroundResult['child'];
   ready: boolean;
+  lastSuccessfulRunnerResponseAtMs?: number;
   startupTimings?: Record<string, number>;
   startupTimingsReported?: boolean;
   simulatorSetRedirect?: { release: () => Promise<void> };

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -43,9 +43,9 @@ const runnerSessionLocks = new Map<string, Promise<unknown>>();
 const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
 const RUNNER_INVALIDATE_WAIT_TIMEOUT_MS = 1_000;
 const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 5_000;
-// Hot tap loops can skip one uptime preflight only while the runner has recently responded.
+// Hot tap loops can skip one uptime preflight only while the runner has just responded.
 // Failed mutating taps still invalidate the session instead of being replayed.
-const RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS = 60_000;
+const RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS = 10_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 
 function withRunnerSessionLock<T>(deviceId: string, task: () => Promise<T>): Promise<T> {

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -464,6 +464,19 @@ export async function executeRunnerCommandWithSession(
       { command: command.command, sessionReady: session.ready, timeoutMs: readinessTimeoutMs },
     );
     await parseRunnerResponse(readinessResponse, session, logPath);
+  } else {
+    emitDiagnostic({
+      level: 'debug',
+      phase: 'ios_runner_readiness_preflight_skipped',
+      data: {
+        command: command.command,
+        lastSuccessfulRunnerResponseAgeMs:
+          session.lastSuccessfulRunnerResponseAtMs === undefined
+            ? undefined
+            : Date.now() - session.lastSuccessfulRunnerResponseAtMs,
+        sessionReady: session.ready,
+      },
+    });
   }
   const remainingMs = deadline.remainingMs();
   if (remainingMs <= 0) {

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -43,6 +43,9 @@ const runnerSessionLocks = new Map<string, Promise<unknown>>();
 const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
 const RUNNER_INVALIDATE_WAIT_TIMEOUT_MS = 1_000;
 const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 5_000;
+// Hot tap loops can skip one uptime preflight only while the runner has recently responded.
+// Failed mutating taps still invalidate the session instead of being replayed.
+const RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS = 60_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 
 function withRunnerSessionLock<T>(deviceId: string, task: () => Promise<T>): Promise<T> {
@@ -441,24 +444,27 @@ export async function executeRunnerCommandWithSession(
   }
 
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  const readinessTimeoutMs = session.ready
-    ? Math.min(RUNNER_READY_PREFLIGHT_TIMEOUT_MS, deadline.remainingMs())
-    : Math.min(RUNNER_STARTUP_TIMEOUT_MS, deadline.remainingMs());
-  const readinessResponse = await withDiagnosticTimer(
-    'ios_runner_readiness_preflight',
-    async () =>
-      await waitForRunner(
-        device,
-        session.port,
-        { command: 'uptime' },
-        logPath,
-        readinessTimeoutMs,
-        session,
-        signal,
-      ),
-    { command: command.command, sessionReady: session.ready, timeoutMs: readinessTimeoutMs },
-  );
-  await parseRunnerResponse(readinessResponse, session, logPath);
+  const shouldPreflight = shouldPreflightMutatingRunnerCommand(session, command);
+  if (shouldPreflight) {
+    const readinessTimeoutMs = session.ready
+      ? Math.min(RUNNER_READY_PREFLIGHT_TIMEOUT_MS, deadline.remainingMs())
+      : Math.min(RUNNER_STARTUP_TIMEOUT_MS, deadline.remainingMs());
+    const readinessResponse = await withDiagnosticTimer(
+      'ios_runner_readiness_preflight',
+      async () =>
+        await waitForRunner(
+          device,
+          session.port,
+          { command: 'uptime' },
+          logPath,
+          readinessTimeoutMs,
+          session,
+          signal,
+        ),
+      { command: command.command, sessionReady: session.ready, timeoutMs: readinessTimeoutMs },
+    );
+    await parseRunnerResponse(readinessResponse, session, logPath);
+  }
   const remainingMs = deadline.remainingMs();
   if (remainingMs <= 0) {
     throw new AppError('COMMAND_FAILED', 'Runner command deadline exceeded', { timeoutMs });
@@ -508,10 +514,24 @@ export async function parseRunnerResponse(
     });
   }
   session.ready = true;
+  session.lastSuccessfulRunnerResponseAtMs = Date.now();
   if (json.data && typeof json.data === 'object' && !Array.isArray(json.data)) {
     return json.data as Record<string, unknown>;
   }
   return {};
+}
+
+function shouldPreflightMutatingRunnerCommand(
+  session: RunnerSession,
+  command: RunnerCommand,
+): boolean {
+  if (!session.ready) return true;
+  if (command.command !== 'tap' && command.command !== 'tapSeries') return true;
+  const lastSuccessAt = session.lastSuccessfulRunnerResponseAtMs;
+  return (
+    lastSuccessAt === undefined ||
+    Date.now() - lastSuccessAt > RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS
+  );
 }
 
 async function measureRunnerStartupStep<T>(


### PR DESCRIPTION
## Summary

Skip the iOS runner `uptime` preflight for hot `tap` and `tapSeries` commands when the runner has responded successfully within the last 10 seconds.

Also avoid an extra iOS window enumeration when building coordinate taps by using the app element as the coordinate root on iOS. macOS keeps the existing window-root coordinate path, and tap response metadata still preserves the existing `x/y/referenceWidth/referenceHeight` shape.

Skipped preflights emit a debug diagnostic (`ios_runner_readiness_preflight_skipped`) with command and freshness age so failed hot taps are easier to inspect.

Touched files: 4. Scope stayed within the iOS runner/session tap path.

## Validation

`pnpm format`, `pnpm check:quick`, focused iOS runner/session Vitest coverage, `pnpm build`, and `pnpm build:xcuitest` passed.

End-to-end iOS simulator `click` totals were benchmarked against `origin/main` using `eas-agent-device` after `open` + `snapshot -i`, with one warmup tap and three measured hot taps:

| Target | Baseline total CLI wall | PR total CLI wall | Delta |
| --- | ---: | ---: | ---: |
| `role="statictext" label="Release notice"` | 1501ms, 1520ms, 1502ms; median 1502ms | 1276ms, 1286ms, 1601ms; median 1286ms | -216ms median (-14%) |
| `@e25` | 1091ms, 1062ms, 1064ms; median 1064ms | 899ms, 897ms, 855ms; median 897ms | -167ms median (-16%) |

The role-qualified label target is used because plain `label="Release notice"` is ambiguous on baseline due duplicate accessibility nodes. The matching `@ref` target is from the same interactive snapshot.

Related diagnostic medians from the same benchmark:

| Target | Baseline `daemon_request` | PR `daemon_request` |
| --- | ---: | ---: |
| `role="statictext" label="Release notice"` | 1008ms | 892ms |
| `@e25` | 564ms | 457ms |

Node inspector/CDP profiling of hot `click @ref` showed the daemon was idle for almost all wall time, so the remaining latency is in the iOS runner/XCTest path rather than ref resolution.

Known gap: full aggregate `pnpm check:unit` was not used as the final signal because this worktree has unrelated Android aggregate timeout flakes under full-suite load; the relevant focused runner/session tests passed.
