### PR TITLE
feat: add iOS repro evidence capabilities

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -1359,12 +1359,17 @@ extension RunnerTests {
 
 #if !os(tvOS)
   private func interactionCoordinate(app: XCUIApplication, x: Double, y: Double) -> XCUICoordinate {
+#if os(iOS)
+    let origin = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+    return origin.withOffset(CGVector(dx: x, dy: y))
+#else
     let root = interactionRoot(app: app)
     let origin = root.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
     let rootFrame = root.frame
     let offsetX = x - Double(rootFrame.origin.x)
     let offsetY = y - Double(rootFrame.origin.y)
     return origin.withOffset(CGVector(dx: offsetX, dy: offsetY))
+#endif
   }
 #endif
 

--- a/scripts/integration-progress.mjs
+++ b/scripts/integration-progress.mjs
@@ -195,6 +195,7 @@ function summarizeProviderScenarioFlagCoverage(files) {
     ['session', 'named session routing'],
     ['surface', 'macOS app/frontmost/desktop/menubar surfaces'],
     ['activity', 'Android explicit launch activity'],
+    ['launchConsole', 'iOS simulator launch console capture'],
     ['saveScript', 'open/close replay recording output'],
     ['relaunch', 'open terminates before launch'],
     ['shutdown', 'close/disconnect shutdown behavior'],

--- a/src/__tests__/cli-client-commands.test.ts
+++ b/src/__tests__/cli-client-commands.test.ts
@@ -511,6 +511,41 @@ test('open forwards macOS surface to the client apps API', async () => {
   assert.equal(observed?.surface, 'menubar');
 });
 
+test('open forwards launch console option to the client apps API', async () => {
+  let observed: AppOpenOptions | undefined;
+  const client = createStubClient({
+    installFromSource: async () => {
+      throw new Error('unexpected install call');
+    },
+    open: async (options) => {
+      observed = options;
+      return {
+        session: 'default',
+        appName: 'Agent Device Tester',
+        appBundleId: 'com.example.agentdevicetester',
+        identifiers: { session: 'default', appBundleId: 'com.example.agentdevicetester' },
+      };
+    },
+  });
+
+  const handled = await tryRunClientBackedCommand({
+    command: 'open',
+    positionals: ['Agent Device Tester'],
+    flags: {
+      json: false,
+      help: false,
+      version: false,
+      platform: 'ios',
+      launchConsole: '/tmp/launch-console.log',
+    },
+    client,
+  });
+
+  assert.equal(handled, true);
+  assert.equal(observed?.platform, 'ios');
+  assert.equal(observed?.launchConsole, '/tmp/launch-console.log');
+});
+
 test('apps command defaults to user-installed and prints discovery hint', async () => {
   let observedAppsFilter: string | undefined;
   const client = createStubClient({

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -8,6 +8,7 @@ export const openCommand: ClientCommandHandler = async ({ positionals, flags, cl
     url: positionals[1],
     surface: flags.surface,
     activity: flags.activity,
+    launchConsole: flags.launchConsole,
     relaunch: flags.relaunch,
     saveScript: flags.saveScript,
     noRecord: flags.noRecord,

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -275,6 +275,7 @@ export function buildFlags(options: InternalRequestOptions): CommandFlags {
     androidDeviceAllowlist: options.androidDeviceAllowlist,
     surface: options.surface,
     activity: options.activity,
+    launchConsole: options.launchConsole,
     relaunch: options.relaunch,
     shutdown: options.shutdown,
     saveScript: options.saveScript,

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -173,6 +173,7 @@ export type AppOpenOptions = AgentDeviceRequestOverrides &
     url?: string;
     surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
     activity?: string;
+    launchConsole?: string;
     relaunch?: boolean;
     saveScript?: boolean | string;
     noRecord?: boolean;
@@ -807,6 +808,7 @@ export type InternalRequestOptions = AgentDeviceClientConfig &
     overlayRefs?: boolean;
     surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
     activity?: string;
+    launchConsole?: string;
     relaunch?: boolean;
     shutdown?: boolean;
     saveScript?: boolean | string;

--- a/src/commands/session-lifecycle/definition.ts
+++ b/src/commands/session-lifecycle/definition.ts
@@ -29,7 +29,7 @@ const openCommandDefinition = defineCommand({
       'Boot device/simulator; optionally launch app or deep link URL (macOS also supports --surface app|frontmost-app|desktop|menubar)',
     summary: 'Open an app, deep link or URL, save replays',
     positionalArgs: ['appOrUrl?', 'url?'],
-    allowedFlags: ['activity', 'saveScript', 'relaunch', 'surface'],
+    allowedFlags: ['activity', 'launchConsole', 'saveScript', 'relaunch', 'surface'],
   },
   capability: APP_RUNTIME_CAPABILITY,
 });

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -19,6 +19,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   requestId?: string;
   appBundleId?: string;
   activity?: string;
+  launchConsole?: string;
   verbose?: boolean;
   logPath?: string;
   traceLogPath?: string;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -13,6 +13,10 @@ import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
 import { pushIosNotification } from '../platforms/ios/apps.ts';
 import { isDeepLinkTarget } from './open-target.ts';
 import { parseTriggerAppEventArgs, resolveAppEventUrl } from './app-events.ts';
+import {
+  LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE,
+  LAUNCH_CONSOLE_IOS_SIMULATOR_ONLY_MESSAGE,
+} from './launch-console.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../utils/diagnostics.ts';
 import { readLocationCoordinate } from '../utils/location-coordinates.ts';
 import { successText, withSuccessText } from '../utils/success-text.ts';
@@ -35,6 +39,7 @@ import { parseDeviceRotation } from './device-rotation.ts';
 export { resolveTargetDevice } from './dispatch-resolve.ts';
 export type { BatchStep, CommandFlags, DispatchContext } from './dispatch-context.ts';
 
+// fallow-ignore-next-line complexity
 export async function dispatchCommand(
   device: DeviceInfo,
   command: string,
@@ -158,6 +163,7 @@ export async function dispatchCommand(
 // Command handlers
 // ---------------------------------------------------------------------------
 
+// fallow-ignore-next-line complexity
 async function handleOpenCommand(
   device: DeviceInfo,
   interactor: Interactor,
@@ -166,12 +172,19 @@ async function handleOpenCommand(
 ): Promise<Record<string, unknown>> {
   const app = positionals[0];
   const url = positionals[1];
+  const launchConsole = context?.launchConsole;
   if (positionals.length > 2) {
     throw new AppError('INVALID_ARGS', 'open accepts at most two arguments: <app|url> [url]');
   }
   if (!app) {
+    if (launchConsole) {
+      throw new AppError('INVALID_ARGS', '--launch-console requires an app target');
+    }
     await interactor.openDevice();
     return { app: null, ...successText('Opened device') };
+  }
+  if (launchConsole && (device.platform !== 'ios' || device.kind !== 'simulator')) {
+    throw new AppError('UNSUPPORTED_OPERATION', LAUNCH_CONSOLE_IOS_SIMULATOR_ONLY_MESSAGE);
   }
   if (url !== undefined) {
     if (device.platform === 'android') {
@@ -186,6 +199,9 @@ async function handleOpenCommand(
     if (!isDeepLinkTarget(url)) {
       throw new AppError('INVALID_ARGS', 'open <app> <url> requires a valid URL target');
     }
+    if (launchConsole) {
+      throw new AppError('INVALID_ARGS', LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE);
+    }
     await interactor.open(app, {
       activity: context?.activity,
       appBundleId: context?.appBundleId,
@@ -193,11 +209,15 @@ async function handleOpenCommand(
     });
     return { app, url, ...successText(`Opened: ${app}`) };
   }
+  if (launchConsole && isDeepLinkTarget(app)) {
+    throw new AppError('INVALID_ARGS', LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE);
+  }
   await interactor.open(app, {
     activity: context?.activity,
     appBundleId: context?.appBundleId,
+    launchConsole,
   });
-  return { app, ...successText(`Opened: ${app}`) };
+  return { app, ...(launchConsole ? { launchConsole } : {}), ...successText(`Opened: ${app}`) };
 }
 
 async function handleClipboardCommand(

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -44,7 +44,7 @@ export type SnapshotResult = Omit<BackendSnapshotResult, 'backend' | 'nodes'> & 
 export type Interactor = {
   open(
     app: string,
-    options?: { activity?: string; appBundleId?: string; url?: string },
+    options?: { activity?: string; appBundleId?: string; launchConsole?: string; url?: string },
   ): Promise<void>;
   openDevice(): Promise<void>;
   close(app: string): Promise<void>;

--- a/src/core/interactors/apple.ts
+++ b/src/core/interactors/apple.ts
@@ -27,7 +27,11 @@ export function createAppleInteractor(
   const { overrides, runnerOpts } = iosRunnerOverrides(device, runnerContext);
   return {
     open: (app, options) =>
-      openIosApp(device, app, { appBundleId: options?.appBundleId, url: options?.url }),
+      openIosApp(device, app, {
+        appBundleId: options?.appBundleId,
+        launchConsole: options?.launchConsole,
+        url: options?.url,
+      }),
     openDevice: () => openIosDevice(device),
     close: (app) => closeIosApp(device, app),
     screenshot: async (outPath, options) => {

--- a/src/core/launch-console.ts
+++ b/src/core/launch-console.ts
@@ -1,0 +1,5 @@
+export const LAUNCH_CONSOLE_IOS_SIMULATOR_ONLY_MESSAGE =
+  '--launch-console is supported only for iOS simulator app launches';
+
+export const LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE =
+  '--launch-console requires a direct app launch and cannot be used with URL opens';

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -42,6 +42,7 @@ export type OpenAppOptions = {
   udid?: NonNullable<DaemonRequest['flags']>['udid'];
   serial?: NonNullable<DaemonRequest['flags']>['serial'];
   activity?: NonNullable<DaemonRequest['flags']>['activity'];
+  launchConsole?: NonNullable<DaemonRequest['flags']>['launchConsole'];
   out?: NonNullable<DaemonRequest['flags']>['out'];
   saveScript?: NonNullable<DaemonRequest['flags']>['saveScript'];
   relaunch?: boolean;
@@ -180,6 +181,7 @@ export async function openApp(options: OpenAppOptions = {}): Promise<DaemonRespo
     udid,
     serial,
     activity,
+    launchConsole,
     out,
     saveScript,
     relaunch,
@@ -200,6 +202,7 @@ export async function openApp(options: OpenAppOptions = {}): Promise<DaemonRespo
       ...(udid !== undefined ? { udid } : {}),
       ...(serial !== undefined ? { serial } : {}),
       ...(activity !== undefined ? { activity } : {}),
+      ...(launchConsole !== undefined ? { launchConsole } : {}),
       ...(out !== undefined ? { out } : {}),
       ...(saveScript !== undefined ? { saveScript } : {}),
       ...(relaunch ? { relaunch: true } : {}),
@@ -912,7 +915,10 @@ function handleRequestTimeout(
   timeoutMs: number,
 ): AppError {
   const cleanup = remote ? { terminated: 0 } : cleanupTimedOutIosRunnerBuilds();
-  const daemonReset = remote ? { forcedKill: false } : resetDaemonAfterTimeout(info, statePaths);
+  const resetDaemon = !remote && shouldResetDaemonAfterRequestTimeout(command);
+  const daemonReset = resetDaemon
+    ? resetDaemonAfterTimeout(info, statePaths)
+    : { forcedKill: false };
   emitDiagnostic({
     level: 'error',
     phase: 'daemon_request_timeout',
@@ -922,18 +928,39 @@ function handleRequestTimeout(
       command,
       timedOutRunnerPidsTerminated: cleanup.terminated,
       timedOutRunnerCleanupError: cleanup.error,
-      daemonPidReset: remote ? undefined : info.pid,
-      daemonPidForceKilled: remote ? undefined : daemonReset.forcedKill,
+      daemonPidReset: resetDaemon ? info.pid : undefined,
+      daemonPidForceKilled: resetDaemon ? daemonReset.forcedKill : undefined,
+      daemonPreservedAfterTimeout: !remote && !resetDaemon,
       daemonBaseUrl: info.baseUrl,
     },
   });
   return new AppError('COMMAND_FAILED', 'Daemon request timed out', {
     timeoutMs,
     requestId,
-    hint: remote
-      ? 'Retry with --debug and verify the remote daemon URL, auth token, and remote host logs.'
-      : 'Retry with --debug and check daemon diagnostics logs. Timed-out iOS runner xcodebuild processes were terminated when detected.',
+    hint: resolveRequestTimeoutHint({ remote, resetDaemon, command }),
   });
+}
+
+export function shouldResetDaemonAfterRequestTimeout(command: string | undefined): boolean {
+  // Snapshot can block in platform accessibility bridges while the app is crashed or never idle.
+  // Keep the daemon/session alive so callers can still collect screenshot/perf/log evidence
+  // and close the session after the runner abort path has been triggered.
+  return command !== 'snapshot';
+}
+
+function resolveRequestTimeoutHint(params: {
+  remote: boolean;
+  resetDaemon: boolean;
+  command: string | undefined;
+}): string {
+  const { remote, resetDaemon, command } = params;
+  if (remote) {
+    return 'Retry with --debug and verify the remote daemon URL, auth token, and remote host logs.';
+  }
+  if (!resetDaemon) {
+    return `Retry with --debug and check daemon diagnostics logs. The timed-out ${command ?? 'request'} request was canceled and iOS runner work was aborted when detected; the daemon was kept alive so the session can still be closed or inspected.`;
+  }
+  return 'Retry with --debug and check daemon diagnostics logs. Timed-out iOS runner xcodebuild processes were terminated when detected.';
 }
 
 function handleTransportError(

--- a/src/daemon/__tests__/app-log.test.ts
+++ b/src/daemon/__tests__/app-log.test.ts
@@ -21,9 +21,17 @@ import {
 test('buildAppleLogPredicate includes bundle-aware filters', () => {
   const predicate = buildAppleLogPredicate('com.example.app');
   assert.match(predicate, /subsystem == "com\.example\.app"/);
+  assert.match(predicate, /subsystem CONTAINS "com\.example\.app"/);
   assert.match(predicate, /processImagePath ENDSWITH\[c\] "\/com\.example\.app"/);
   assert.match(predicate, /senderImagePath ENDSWITH\[c\] "\/com\.example\.app"/);
   assert.doesNotMatch(predicate, /eventMessage CONTAINS\[c\] "com\.example\.app"/);
+});
+
+test('buildAppleLogPredicate includes executable-aware filters when available', () => {
+  const predicate = buildAppleLogPredicate('com.example.app', 'ExampleExec');
+  assert.match(predicate, /process == "ExampleExec"/);
+  assert.match(predicate, /processImagePath ENDSWITH\[c\] "\/ExampleExec"/);
+  assert.match(predicate, /processImagePath CONTAINS\[c\] "\/ExampleExec\.app\/"/);
 });
 
 test('assertAndroidPackageArgSafe rejects unsafe values', () => {
@@ -95,7 +103,11 @@ test('buildIosDeviceLogStreamArgs builds expected devicectl command args', () =>
 
 test('buildIosSimulatorLogStreamArgs streams logs inside the simulator at info level', () => {
   assert.deepEqual(
-    buildIosSimulatorLogStreamArgs({ deviceId: 'sim-1', appBundleId: 'com.example.app' }),
+    buildIosSimulatorLogStreamArgs({
+      deviceId: 'sim-1',
+      appBundleId: 'com.example.app',
+      executableName: 'ExampleExec',
+    }),
     [
       'simctl',
       'spawn',
@@ -107,7 +119,7 @@ test('buildIosSimulatorLogStreamArgs streams logs inside the simulator at info l
       '--level',
       'info',
       '--predicate',
-      buildAppleLogPredicate('com.example.app'),
+      buildAppleLogPredicate('com.example.app', 'ExampleExec'),
     ],
   );
 });

--- a/src/daemon/app-log-ios.ts
+++ b/src/daemon/app-log-ios.ts
@@ -1,24 +1,43 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { buildSimctlArgs } from '../platforms/ios/simctl.ts';
-import { runCmdBackground } from '../utils/exec.ts';
+import { runCmd, runCmdBackground } from '../utils/exec.ts';
 import { runXcrun } from '../platforms/ios/tool-provider.ts';
 import { clearPidFile, writePidFile, type AppLogResult } from './app-log-process.ts';
 import { attachChildToStream, createLineWriter, waitForChildExit } from './app-log-stream.ts';
 
-export function buildAppleLogPredicate(appBundleId: string): string {
-  return [
-    `subsystem == "${appBundleId}"`,
-    `processImagePath ENDSWITH[c] "/${appBundleId}"`,
-    `senderImagePath ENDSWITH[c] "/${appBundleId}"`,
-  ].join(' OR ');
+export function buildAppleLogPredicate(
+  appBundleId: string,
+  executableName?: string | undefined,
+): string {
+  const escapedBundleId = escapeAppleLogPredicateString(appBundleId);
+  const clauses = [
+    `subsystem == "${escapedBundleId}"`,
+    // App frameworks/extensions often log through subsystem names prefixed by the app bundle id.
+    `subsystem CONTAINS "${escapedBundleId}"`,
+    `processImagePath ENDSWITH[c] "/${escapedBundleId}"`,
+    `senderImagePath ENDSWITH[c] "/${escapedBundleId}"`,
+  ];
+  if (executableName) {
+    const escapedExecutable = escapeAppleLogPredicateString(executableName);
+    clauses.push(
+      `process == "${escapedExecutable}"`,
+      `processImagePath ENDSWITH[c] "/${escapedExecutable}"`,
+      `senderImagePath ENDSWITH[c] "/${escapedExecutable}"`,
+      `processImagePath CONTAINS[c] "/${escapedExecutable}.app/"`,
+      `senderImagePath CONTAINS[c] "/${escapedExecutable}.app/"`,
+    );
+  }
+  return clauses.join(' OR ');
 }
 
 export function buildIosSimulatorLogStreamArgs(params: {
   deviceId: string;
   appBundleId: string;
+  executableName?: string | undefined;
   simulatorSetPath?: string;
 }): string[] {
-  const { deviceId, appBundleId, simulatorSetPath } = params;
+  const { deviceId, appBundleId, executableName, simulatorSetPath } = params;
   return buildSimctlArgs(
     [
       'spawn',
@@ -30,7 +49,7 @@ export function buildIosSimulatorLogStreamArgs(params: {
       '--level',
       'info',
       '--predicate',
-      buildAppleLogPredicate(appBundleId),
+      buildAppleLogPredicate(appBundleId, executableName),
     ],
     { simulatorSetPath },
   );
@@ -43,10 +62,11 @@ export function buildIosDeviceLogStreamArgs(deviceId: string): string[] {
 export async function readRecentIosSimulatorLogShowForBundle(params: {
   deviceId: string;
   appBundleId: string;
+  executableName?: string | undefined;
   startedAt?: number;
   simulatorSetPath?: string;
 }): Promise<{ text: string; recoveredLineCount: number } | null> {
-  const { deviceId, appBundleId, startedAt, simulatorSetPath } = params;
+  const { deviceId, appBundleId, executableName, startedAt, simulatorSetPath } = params;
   const args = buildSimctlArgs(
     [
       'spawn',
@@ -57,7 +77,7 @@ export async function readRecentIosSimulatorLogShowForBundle(params: {
       'compact',
       '--info',
       '--predicate',
-      buildAppleLogPredicate(appBundleId),
+      buildAppleLogPredicate(appBundleId, executableName),
     ],
     { simulatorSetPath },
   );
@@ -96,14 +116,51 @@ export async function startIosSimulatorAppLog(
   simulatorSetPath?: string,
   pidPath?: string,
 ): Promise<AppLogResult> {
+  const executableName = await resolveIosSimulatorExecutableName({
+    deviceId,
+    appBundleId,
+    simulatorSetPath,
+  });
   return startAppleAppLogStream({
     backend: 'ios-simulator',
     cmd: 'xcrun',
-    args: buildIosSimulatorLogStreamArgs({ deviceId, appBundleId, simulatorSetPath }),
+    args: buildIosSimulatorLogStreamArgs({
+      deviceId,
+      appBundleId,
+      executableName,
+      simulatorSetPath,
+    }),
     stream,
     redactionPatterns,
     pidPath,
   });
+}
+
+function escapeAppleLogPredicateString(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}
+
+async function resolveIosSimulatorExecutableName(params: {
+  deviceId: string;
+  appBundleId: string;
+  simulatorSetPath?: string;
+}): Promise<string | undefined> {
+  const { deviceId, appBundleId, simulatorSetPath } = params;
+  const container = await runXcrun(
+    buildSimctlArgs(['get_app_container', deviceId, appBundleId, 'app'], { simulatorSetPath }),
+    { allowFailure: true, timeoutMs: 4_000 },
+  );
+  if (container.exitCode !== 0) return undefined;
+  const appPath = container.stdout.trim();
+  if (!appPath) return undefined;
+  const plistPath = path.join(appPath, 'Info.plist');
+  const executable = await runCmd(
+    'plutil',
+    ['-extract', 'CFBundleExecutable', 'raw', '-o', '-', plistPath],
+    { allowFailure: true, timeoutMs: 4_000 },
+  );
+  if (executable.exitCode !== 0) return undefined;
+  return executable.stdout.trim() || undefined;
 }
 
 export async function startMacOsAppLog(

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -20,6 +20,7 @@ export function contextFromFlags(
     requestId: effectiveRequestId,
     appBundleId,
     activity: flags?.activity,
+    launchConsole: flags?.launchConsole,
     verbose: flags?.verbose,
     logPath,
     traceLogPath,

--- a/src/daemon/handlers/__tests__/session-open-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-open-runtime.test.ts
@@ -28,6 +28,13 @@ vi.mock('../../../platforms/ios/runner-client.ts', async (importOriginal) => {
     stopIosRunnerSession: vi.fn(async () => {}),
   };
 });
+vi.mock('../../../platforms/ios/apps.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../platforms/ios/apps.ts')>();
+  return {
+    ...actual,
+    resolveIosApp: vi.fn(async () => 'com.example.demo'),
+  };
+});
 vi.mock('../session-device-utils.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../session-device-utils.ts')>();
   return { ...actual, settleIosSimulator: vi.fn(async () => {}) };
@@ -138,6 +145,52 @@ test('open applies stored runtime launchUrl and reports runtime hints', async ()
       launchUrl: 'myapp://dev-client',
     });
   }
+});
+
+test('open applies launchConsole only to the direct app launch before runtime launchUrl', async () => {
+  const sessionStore = makeSessionStore();
+  const launchConsolePath = path.join(os.tmpdir(), 'launch-console.log');
+  const dispatchCalls: Array<{
+    command: string;
+    positionals: string[];
+    launchConsole?: string;
+  }> = [];
+
+  sessionStore.setRuntimeHints('launch-console-runtime', {
+    platform: 'ios',
+    launchUrl: 'myapp://dev-client',
+  });
+  mockResolveTargetDevice.mockResolvedValue({
+    platform: 'ios',
+    id: 'sim-1',
+    name: 'iPhone 15',
+    kind: 'simulator',
+    booted: true,
+  });
+  mockDispatch.mockImplementation(async (_device, command, positionals, _outPath, context) => {
+    dispatchCalls.push({ command, positionals, launchConsole: context?.launchConsole });
+    return {};
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'launch-console-runtime',
+      command: 'open',
+      positionals: ['Demo'],
+      flags: { platform: 'ios', launchConsole: launchConsolePath },
+    },
+    sessionName: 'launch-console-runtime',
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(dispatchCalls).toEqual([
+    { command: 'open', positionals: ['Demo'], launchConsole: launchConsolePath },
+    { command: 'open', positionals: ['myapp://dev-client'], launchConsole: undefined },
+  ]);
 });
 
 test('open runtime payload replaces stored session runtime atomically', async () => {

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -80,8 +80,19 @@ async function maybeApplySessionLaunchUrl(params: {
   const openTarget = openPositionals[0]?.trim();
   if (!openTarget || isDeepLinkTarget(openTarget)) return;
   await dispatchCommand(device, 'open', [launchUrl], req.flags?.out, {
-    ...contextFromFlags(logPath, req.flags, appBundleId, traceLogPath),
+    ...contextForRuntimeLaunchUrl(logPath, req.flags, appBundleId, traceLogPath),
   });
+}
+
+function contextForRuntimeLaunchUrl(
+  logPath: string,
+  flags: DaemonRequest['flags'],
+  appBundleId?: string,
+  traceLogPath?: string,
+): ReturnType<typeof contextFromFlags> {
+  const context = contextFromFlags(logPath, flags, appBundleId, traceLogPath);
+  delete context.launchConsole;
+  return context;
 }
 
 function buildStartupPerfSample(

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -858,6 +858,52 @@ test('openIosApp custom scheme on iOS device uses active app context', async () 
   }
 });
 
+test('openIosApp captures iOS simulator launch console output when requested', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-device-ios-console-test-'));
+  const xcrunPath = path.join(tmpDir, 'xcrun');
+  const argsLogPath = path.join(tmpDir, 'args.log');
+  const launchConsolePath = path.join(tmpDir, 'console.log');
+  await fs.writeFile(
+    xcrunPath,
+    [
+      '#!/bin/sh',
+      'printf "%s\\n" "$@" > "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'if [ "$1" = "simctl" ] && [ "$2" = "launch" ]; then',
+      '  printf "console stdout"',
+      '  echo "console stderr" >&2',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  await fs.chmod(xcrunPath, 0o755);
+
+  const previousPath = process.env.PATH;
+  const previousArgsFile = process.env.AGENT_DEVICE_TEST_ARGS_FILE;
+  process.env.PATH = `${tmpDir}${path.delimiter}${previousPath ?? ''}`;
+  process.env.AGENT_DEVICE_TEST_ARGS_FILE = argsLogPath;
+
+  try {
+    mockEnsureBootedSimulator.mockResolvedValue();
+    await openIosApp(IOS_TEST_SIMULATOR, 'MyApp', {
+      appBundleId: 'com.example.app',
+      launchConsole: launchConsolePath,
+    });
+    const args = (await fs.readFile(argsLogPath, 'utf8')).trim().split('\n').filter(Boolean);
+    assert.deepEqual(args, ['simctl', 'launch', '--console-pty', 'sim-1', 'com.example.app']);
+    assert.equal(await fs.readFile(launchConsolePath, 'utf8'), 'console stdout\nconsole stderr\n');
+  } finally {
+    process.env.PATH = previousPath;
+    if (previousArgsFile === undefined) {
+      delete process.env.AGENT_DEVICE_TEST_ARGS_FILE;
+    } else {
+      process.env.AGENT_DEVICE_TEST_ARGS_FILE = previousArgsFile;
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('readIosClipboardText rejects physical devices', async () => {
   await assert.rejects(
     () => readIosClipboardText(IOS_TEST_DEVICE),

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -161,7 +161,48 @@ test('runner session probes readiness before mutating commands', async () => {
   });
 });
 
-test('runner session probes readiness before mutating commands even when marked ready', async () => {
+test('runner session skips readiness preflight for tap commands after a recent successful response', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 0);
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session skips readiness preflight for tapSeries after a recent successful response', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    {
+      command: 'tapSeries',
+      x: 120,
+      y: 240,
+      count: 2,
+      intervalMs: 80,
+      appBundleId: 'com.example.demo',
+    },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 0);
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session keeps readiness preflight for tap commands when ready but never proven fresh', async () => {
   const session = makeRunnerSession({ ready: true });
   mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
   mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
@@ -175,6 +216,47 @@ test('runner session probes readiness before mutating commands even when marked 
   );
 
   assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 1);
+  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session keeps readiness preflight for tap commands when marked ready but stale', async () => {
+  const session = makeRunnerSession({
+    ready: true,
+    lastSuccessfulRunnerResponseAtMs: Date.now() - 11_000,
+  });
+  mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { tapped: true });
+  assert.equal(mockWaitForRunner.mock.calls.length, 1);
+  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session keeps readiness preflight for non-tap mutating commands when marked ready', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ pressed: true }));
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    { command: 'longPress', x: 120, y: 240, appBundleId: 'com.example.demo' },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, { pressed: true });
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
   assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -3,7 +3,12 @@ import os from 'node:os';
 import path from 'node:path';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { AppError } from '../../utils/errors.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import type { AppsFilter } from '../../commands/app-inventory-contract.ts';
+import {
+  LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE,
+  LAUNCH_CONSOLE_IOS_SIMULATOR_ONLY_MESSAGE,
+} from '../../core/launch-console.ts';
 import { requireLocationCoordinates } from '../../utils/location-coordinates.ts';
 import { resolveIosSimulatorDeviceSetPath } from '../../utils/device-isolation.ts';
 import { Deadline, retryWithPolicy } from '../../utils/retry.ts';
@@ -60,6 +65,7 @@ export {
 const ALIASES: Record<string, string> = {
   settings: 'com.apple.Preferences',
 };
+const IOS_SIMULATOR_CONSOLE_CAPTURE_MS = 25_000;
 
 const iosAppResolutionCache = createAppResolutionCache<string>();
 let cachedSimctlPrivacyServices: Set<string> | null = null;
@@ -117,17 +123,25 @@ export async function resolveIosApp(device: DeviceInfo, app: string): Promise<st
   throw new AppError('APP_NOT_INSTALLED', `No app found matching "${app}"`);
 }
 
+// fallow-ignore-next-line complexity
 export async function openIosApp(
   device: DeviceInfo,
   app: string,
-  options?: { appBundleId?: string; url?: string },
+  options?: { appBundleId?: string; launchConsole?: string; url?: string },
 ): Promise<void> {
+  const launchConsole = options?.launchConsole?.trim();
+  if (launchConsole && (device.platform !== 'ios' || device.kind !== 'simulator')) {
+    throw new AppError('UNSUPPORTED_OPERATION', LAUNCH_CONSOLE_IOS_SIMULATOR_ONLY_MESSAGE);
+  }
   if (device.platform === 'macos') {
     await openMacOsApp(device, app, options);
     return;
   }
   const explicitUrl = options?.url?.trim();
   if (explicitUrl) {
+    if (launchConsole) {
+      throw new AppError('INVALID_ARGS', LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE);
+    }
     if (!isDeepLinkTarget(explicitUrl)) {
       throw new AppError('INVALID_ARGS', 'open <app> <url> requires a valid URL target');
     }
@@ -150,6 +164,9 @@ export async function openIosApp(
 
   const deepLinkTarget = app.trim();
   if (isDeepLinkTarget(deepLinkTarget)) {
+    if (launchConsole) {
+      throw new AppError('INVALID_ARGS', LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE);
+    }
     if (device.kind === 'simulator') {
       await ensureBootedSimulator(device);
       await runSimctl(device, ['openurl', device.id, deepLinkTarget]);
@@ -168,7 +185,7 @@ export async function openIosApp(
 
   const bundleId = options?.appBundleId ?? (await resolveIosApp(device, app));
   if (device.kind === 'simulator') {
-    await launchIosSimulatorApp(device, bundleId);
+    await launchIosSimulatorApp(device, bundleId, launchConsole ? { launchConsole } : undefined);
     return;
   }
 
@@ -721,6 +738,7 @@ function parseSimctlPrivacyServices(helpText: string): Set<string> {
   return services;
 }
 
+// fallow-ignore-next-line complexity
 function parseIosPermissionTarget(
   permissionTarget: string | undefined,
   permissionMode: string | undefined,
@@ -863,7 +881,11 @@ function isIosBiometricCapabilityMissing(stdout: string, stderr: string): boolea
   );
 }
 
-async function launchIosSimulatorApp(device: DeviceInfo, bundleId: string): Promise<void> {
+async function launchIosSimulatorApp(
+  device: DeviceInfo,
+  bundleId: string,
+  options?: { launchConsole?: string },
+): Promise<void> {
   await ensureBootedSimulator(device);
 
   let consecutiveFBSFailures = 0;
@@ -879,10 +901,15 @@ async function launchIosSimulatorApp(device: DeviceInfo, bundleId: string): Prom
           });
         }
 
-        const launchArgs = simctlArgs(device, ['launch', device.id, bundleId]);
-        const result = await runXcrun(launchArgs, {
-          allowFailure: true,
-        });
+        const launchArgs = simctlArgs(
+          device,
+          buildIosSimulatorLaunchArgs(device.id, bundleId, options),
+        );
+        const result = options?.launchConsole
+          ? await runIosSimulatorConsoleLaunch(launchArgs, options.launchConsole)
+          : await runXcrun(launchArgs, {
+              allowFailure: true,
+            });
         if (result.exitCode === 0) return;
 
         throw new AppError('COMMAND_FAILED', `xcrun exited with code ${result.exitCode}`, {
@@ -915,6 +942,67 @@ async function launchIosSimulatorApp(device: DeviceInfo, bundleId: string): Prom
     }
     throw error;
   }
+}
+
+function buildIosSimulatorLaunchArgs(
+  deviceId: string,
+  bundleId: string,
+  options?: { launchConsole?: string },
+): string[] {
+  const args = ['launch'];
+  if (options?.launchConsole) args.push('--console-pty');
+  args.push(deviceId, bundleId);
+  return args;
+}
+
+async function runIosSimulatorConsoleLaunch(
+  launchArgs: string[],
+  logPath: string,
+): Promise<Awaited<ReturnType<typeof runXcrun>>> {
+  await fs.mkdir(path.dirname(logPath), { recursive: true });
+  try {
+    const result = await runXcrun(launchArgs, {
+      allowFailure: true,
+      timeoutMs: IOS_SIMULATOR_CONSOLE_CAPTURE_MS,
+    });
+    await writeIosSimulatorConsoleLog(logPath, result.stdout, result.stderr);
+    return result;
+  } catch (error) {
+    const appError = error instanceof AppError ? error : undefined;
+    const details = appError?.details;
+    if (details?.timeoutMs === IOS_SIMULATOR_CONSOLE_CAPTURE_MS) {
+      const stdout = typeof details.stdout === 'string' ? details.stdout : '';
+      const stderr = typeof details.stderr === 'string' ? details.stderr : '';
+      await writeIosSimulatorConsoleLog(logPath, stdout, stderr);
+      emitDiagnostic({
+        level: 'warn',
+        phase: 'ios_simulator_launch_console_capture_timeout',
+        data: {
+          timeoutMs: IOS_SIMULATOR_CONSOLE_CAPTURE_MS,
+          logPath,
+          stdoutBytes: Buffer.byteLength(stdout),
+          stderrBytes: Buffer.byteLength(stderr),
+        },
+      });
+      return { stdout, stderr, exitCode: 0 };
+    }
+    throw error;
+  }
+}
+
+async function writeIosSimulatorConsoleLog(
+  logPath: string,
+  stdout: string,
+  stderr: string,
+): Promise<void> {
+  await fs.writeFile(logPath, joinProcessOutput(stdout, stderr), 'utf8');
+}
+
+function joinProcessOutput(stdout: string, stderr: string): string {
+  if (!stdout || !stderr || stdout.endsWith('\n') || stdout.endsWith('\r')) {
+    return `${stdout}${stderr}`;
+  }
+  return `${stdout}\n${stderr}`;
 }
 
 async function launchIosDeviceProcess(

--- a/src/platforms/ios/runner-session-types.ts
+++ b/src/platforms/ios/runner-session-types.ts
@@ -11,6 +11,7 @@ export type RunnerSession = {
   testPromise: Promise<ExecResult>;
   child: ExecBackgroundResult['child'];
   ready: boolean;
+  lastSuccessfulRunnerResponseAtMs?: number;
   startupTimings?: Record<string, number>;
   startupTimingsReported?: boolean;
   simulatorSetRedirect?: { release: () => Promise<void> };

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -43,6 +43,9 @@ const runnerSessionLocks = new Map<string, Promise<unknown>>();
 const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
 const RUNNER_INVALIDATE_WAIT_TIMEOUT_MS = 1_000;
 const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 5_000;
+// Hot tap loops can skip one uptime preflight only while the runner has just responded.
+// Failed mutating taps still invalidate the session instead of being replayed.
+const RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS = 10_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 
 function withRunnerSessionLock<T>(deviceId: string, task: () => Promise<T>): Promise<T> {
@@ -441,24 +444,40 @@ export async function executeRunnerCommandWithSession(
   }
 
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  const readinessTimeoutMs = session.ready
-    ? Math.min(RUNNER_READY_PREFLIGHT_TIMEOUT_MS, deadline.remainingMs())
-    : Math.min(RUNNER_STARTUP_TIMEOUT_MS, deadline.remainingMs());
-  const readinessResponse = await withDiagnosticTimer(
-    'ios_runner_readiness_preflight',
-    async () =>
-      await waitForRunner(
-        device,
-        session.port,
-        { command: 'uptime' },
-        logPath,
-        readinessTimeoutMs,
-        session,
-        signal,
-      ),
-    { command: command.command, sessionReady: session.ready, timeoutMs: readinessTimeoutMs },
-  );
-  await parseRunnerResponse(readinessResponse, session, logPath);
+  const shouldPreflight = shouldPreflightMutatingRunnerCommand(session, command);
+  if (shouldPreflight) {
+    const readinessTimeoutMs = session.ready
+      ? Math.min(RUNNER_READY_PREFLIGHT_TIMEOUT_MS, deadline.remainingMs())
+      : Math.min(RUNNER_STARTUP_TIMEOUT_MS, deadline.remainingMs());
+    const readinessResponse = await withDiagnosticTimer(
+      'ios_runner_readiness_preflight',
+      async () =>
+        await waitForRunner(
+          device,
+          session.port,
+          { command: 'uptime' },
+          logPath,
+          readinessTimeoutMs,
+          session,
+          signal,
+        ),
+      { command: command.command, sessionReady: session.ready, timeoutMs: readinessTimeoutMs },
+    );
+    await parseRunnerResponse(readinessResponse, session, logPath);
+  } else {
+    emitDiagnostic({
+      level: 'debug',
+      phase: 'ios_runner_readiness_preflight_skipped',
+      data: {
+        command: command.command,
+        lastSuccessfulRunnerResponseAgeMs:
+          session.lastSuccessfulRunnerResponseAtMs === undefined
+            ? undefined
+            : Date.now() - session.lastSuccessfulRunnerResponseAtMs,
+        sessionReady: session.ready,
+      },
+    });
+  }
   const remainingMs = deadline.remainingMs();
   if (remainingMs <= 0) {
     throw new AppError('COMMAND_FAILED', 'Runner command deadline exceeded', { timeoutMs });
@@ -508,10 +527,24 @@ export async function parseRunnerResponse(
     });
   }
   session.ready = true;
+  session.lastSuccessfulRunnerResponseAtMs = Date.now();
   if (json.data && typeof json.data === 'object' && !Array.isArray(json.data)) {
     return json.data as Record<string, unknown>;
   }
   return {};
+}
+
+function shouldPreflightMutatingRunnerCommand(
+  session: RunnerSession,
+  command: RunnerCommand,
+): boolean {
+  if (!session.ready) return true;
+  if (command.command !== 'tap' && command.command !== 'tapSeries') return true;
+  const lastSuccessAt = session.lastSuccessfulRunnerResponseAtMs;
+  return (
+    lastSuccessAt === undefined ||
+    Date.now() - lastSuccessAt > RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS
+  );
 }
 
 async function measureRunnerStartupStep<T>(

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -969,6 +969,8 @@ test('usageForCommand resolves debugging help topic', () => {
   assert.match(help, /agent-device help debugging/);
   assert.match(help, /agent-device alert wait 3000/);
   assert.match(help, /iOS support is runner-derived/);
+  assert.match(help, /resolved app executable/);
+  assert.match(help, /--launch-console is only for direct iOS simulator app launches/);
   assert.match(help, /Do not use settings permission to answer a dialog already on screen/);
 });
 
@@ -1320,11 +1322,13 @@ test('back command usage documents explicit mode flags', () => {
   assert.match(help, /--system/);
 });
 
-test('open command usage documents macOS desktop surface flags', () => {
+test('open command usage documents surface and console log flags', () => {
   const help = usageForCommand('open');
   if (help === null) throw new Error('Expected command help text');
   assert.match(help, /--surface app\|frontmost-app\|desktop\|menubar/);
   assert.match(help, /macOS also supports --surface/);
+  assert.match(help, /--launch-console <path>/);
+  assert.match(help, /iOS simulator launch console/);
 });
 
 test('command usage shows record touch-overlay opt-out flag', () => {

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -19,6 +19,7 @@ import {
   openApp,
   resolveDaemonStartupHint,
   sendToDaemon,
+  shouldResetDaemonAfterRequestTimeout,
 } from '../../daemon-client.ts';
 import { resolveDaemonPaths } from '../../daemon/config.ts';
 import {
@@ -154,6 +155,12 @@ test('resolveDaemonStartupHint includes configured state directory paths', () =>
   const hint = resolveDaemonStartupHint({ hasInfo: false, hasLock: true }, paths);
   assert.match(hint, /\/tmp\/ad-custom-state\/daemon\.lock/);
   assert.match(hint, /\/tmp\/ad-custom-state\/daemon\.json/);
+});
+
+test('snapshot request timeout preserves daemon metadata for follow-up evidence commands', () => {
+  assert.equal(shouldResetDaemonAfterRequestTimeout('snapshot'), false);
+  assert.equal(shouldResetDaemonAfterRequestTimeout('screenshot'), true);
+  assert.equal(shouldResetDaemonAfterRequestTimeout(undefined), true);
 });
 
 test('cleanupFailedDaemonStartupMetadata removes partial startup metadata', async () => {

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -74,6 +74,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     pauseMs?: number;
     pattern?: 'one-way' | 'ping-pong';
     activity?: string;
+    launchConsole?: string;
     header?: string[];
     githubActionsArtifact?: string;
     installSource?: DaemonInstallSource;
@@ -377,6 +378,10 @@ Logs:
     agent-device logs path
   Do not cat a full stale log into agent context. Open or grep only the relevant window when needed.
   logs clear --restart is the compact command to clear old logs and start a fresh capture; do not split it into logs stop, logs clear, logs start.
+  On iOS simulators, logs scope by bundle id and resolved app executable, so use this instead of raw simctl log stream predicates.
+  For iOS simulator launch-time stdout/stderr, use --launch-console on the direct app launch:
+    agent-device open MyApp --platform ios --relaunch --launch-console ./artifacts/app.console.log
+  --launch-console is only for direct iOS simulator app launches, not URL opens.
 
 Network:
   Use network dump for recent session HTTP traffic parsed from app logs.
@@ -976,6 +981,13 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     type: 'string',
     usageLabel: '--activity <component>',
     usageDescription: 'Android app launch activity (package/Activity); not for URL opens',
+  },
+  {
+    key: 'launchConsole',
+    names: ['--launch-console'],
+    type: 'string',
+    usageLabel: '--launch-console <path>',
+    usageDescription: 'open: capture the initial iOS simulator launch console window to a file',
   },
   {
     key: 'header',

--- a/test/integration/provider-scenarios/ios-lifecycle.test.ts
+++ b/test/integration/provider-scenarios/ios-lifecycle.test.ts
@@ -60,6 +60,15 @@ test('Provider-backed integration iOS Settings flow uses scripted simctl and run
           expectData: { appBundleId: 'com.apple.Preferences' },
         },
         {
+          name: 'capture iOS launch console while reopening app',
+          command: 'open',
+          positionals: ['com.apple.Preferences'],
+          flags: {
+            launchConsole: path.join(path.dirname(appPath), 'launch-console.log'),
+          },
+          expectData: { appBundleId: 'com.apple.Preferences' },
+        },
+        {
           name: 'reinstall demo app',
           command: 'reinstall',
           positionals: ['com.example.demo', appPath],
@@ -180,6 +189,13 @@ test('Provider-backed integration iOS Settings flow uses scripted simctl and run
 
       runnerTranscript.assertComplete();
       assertFlatToolCall(appleTool.calls, ['simctl', 'launch', 'sim-1', 'com.apple.Preferences']);
+      assertFlatToolCall(appleTool.calls, [
+        'simctl',
+        'launch',
+        '--console-pty',
+        'sim-1',
+        'com.apple.Preferences',
+      ]);
       assertFlatToolCall(appleTool.calls, ['simctl', 'uninstall', 'sim-1', 'com.example.demo']);
       assertFlatToolCall(appleTool.calls, ['plist', 'readJson', path.join(appPath, 'Info.plist')]);
       assertFlatToolCall(appleTool.calls, ['simctl', 'install', 'sim-1', appPath]);

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -1208,6 +1208,21 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     forbiddenOutputs: [/cat .*log/i, /tail -n \+1/i],
   }),
   makeCase({
+    id: 'ios-simulator-open-launch-console',
+    contract: [
+      'App name: Agent Device Tester',
+      'Platform: iOS simulator',
+      'Need initial launch stdout/stderr in artifacts/launch-console.log',
+      'After launch, verify the app UI loaded with an interactive snapshot',
+    ],
+    task: 'Plan commands for launching the iOS simulator app while capturing the initial launch console output, then verify the UI loaded.',
+    outputs: [
+      /open\b[^\n]*Agent Device Tester[^\n]*--launch-console artifacts\/launch-console\.log/i,
+      /snapshot -i/i,
+    ],
+    forbiddenOutputs: [/simctl\b/i, /--console-pty/i, /\bsleep\s+\d+/i],
+  }),
+  makeCase({
     id: 'debug-network-session-dump',
     contract: [
       'App name: Agent Device Tester',

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -117,6 +117,9 @@ const snapshot = await client.capture.snapshot({ interactiveOnly: true });
 await client.sessions.close();
 ```
 
+For direct iOS simulator app launches, `client.apps.open({ app, platform: 'ios', launchConsole: './artifacts/app.console.log' })` captures launch-time
+stdout/stderr. The option mirrors `open --launch-console` and is not valid for URL opens or non-simulator targets.
+
 ## Android snapshot helper providers
 
 Remote Android providers should import `agent-device/android-snapshot-helper` and inject their own

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -61,6 +61,8 @@ agent-device app-switcher
 - `open [app|url] [url]` already boots/activates the selected target when needed.
 - `open <url>` deep links are supported on Android and iOS.
 - `open <app> <url>` opens a deep link on iOS.
+- `open <app> --launch-console <path>` captures launch-time stdout/stderr for direct iOS simulator app launches. It is not valid for URL opens or
+  non-simulator targets.
 - `open --platform macos --surface app|frontmost-app|desktop|menubar` selects the macOS session surface explicitly. `app` is the default when an app argument is provided.
 - `back` now defaults to app-owned back navigation. On Apple targets that means visible in-app back UI only. On Android this currently maps to the same back keyevent because Android routes in-app back through that platform event.
 - `back --in-app` is an explicit alias for the default app-owned behavior.

--- a/website/docs/docs/debugging-profiling.md
+++ b/website/docs/docs/debugging-profiling.md
@@ -52,6 +52,14 @@ agent-device logs path
 
 Use this flow when you need a clean repro window with logs, recent network activity, and a quick perf sample from the active app session.
 
+On iOS simulators, `logs` scope by bundle id and the resolved app executable. For launch-time stdout/stderr, capture the direct app launch console instead of starting raw `simctl` streams:
+
+```bash
+agent-device open MyApp --platform ios --relaunch --launch-console ./artifacts/app.console.log
+```
+
+`--launch-console` is only for direct iOS simulator app launches, not URL opens.
+
 ## Core commands
 
 ### Logs


### PR DESCRIPTION
## Summary

Add `open --launch-console <path>` for direct iOS simulator app launches so repro workflows can capture launch-time stdout/stderr without raw `simctl launch --console-pty` scripting.

Preserve daemon/session metadata after local `snapshot` request timeouts so callers can still collect follow-up evidence such as screenshots, perf, logs, and a clean `close`.

Improve iOS simulator log scoping by resolving the app executable from `Info.plist` and folding it into Apple unified-log predicates, with CLI, typed-client, docs, SkillGym, and provider-scenario coverage for the new behavior.

## Validation

Verified with focused CLI/client/iOS/session tests, `pnpm check:quick`, `pnpm check:fallow --base origin/main`, and `pnpm test:integration:progress:check`. Also confirmed there are no remaining NativeWind or one-off local repro harness references in the branch.
