### PR TITLE
fix: simplify iOS interactive snapshots

### DIFF
--- a/src/commands/react-native/__tests__/overlay.test.ts
+++ b/src/commands/react-native/__tests__/overlay.test.ts
@@ -26,6 +26,46 @@ describe('React Native overlay helpers', () => {
     });
   });
 
+  test('targets visible close affordance when collapsed banner keeps outer bounds', () => {
+    const nodes = [
+      node({
+        ref: 'e3',
+        label: '!, Open debugger to view warnings.',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+        hittable: false,
+      }),
+      node({
+        ref: 'e125',
+        label: '!, Open debugger to view warnings.',
+        rect: { x: 10, y: 786.666, width: 382, height: 67.333 },
+        hittable: false,
+      }),
+    ];
+
+    const target = resolveReactNativeOverlayDismissTarget(nodes);
+
+    expect(detectReactNativeOverlay(nodes).detected).toBe(true);
+    expect(target).toMatchObject({
+      action: 'close-collapsed-banner',
+      ref: 'e125',
+      point: { x: 369, y: 813 },
+    });
+  });
+
+  test('detects full-screen open-debugger wrappers but does not use them as targets', () => {
+    const nodes = [
+      node({
+        ref: 'e3',
+        label: '!, Open debugger to view warnings.',
+        rect: { x: 0, y: 0, width: 402, height: 874 },
+        hittable: false,
+      }),
+    ];
+
+    expect(detectReactNativeOverlay(nodes).detected).toBe(true);
+    expect(resolveReactNativeOverlayDismissTarget(nodes)).toBeNull();
+  });
+
   test('prefers Minimize for RedBox overlays', () => {
     const nodes = [
       node({ ref: 'e1', label: 'Runtime Error', rect: { x: 0, y: 0, width: 390, height: 100 } }),

--- a/src/commands/react-native/overlay.ts
+++ b/src/commands/react-native/overlay.ts
@@ -1,4 +1,10 @@
 import { centerOfRect, type Point, type SnapshotNode } from '../../utils/snapshot.ts';
+import {
+  hasKnownReactNativeOverlayText,
+  isReactNativeCollapsedWarningLabel,
+  isReactNativeOpenDebuggerWarningLabel,
+  isReactNativeStackFrame,
+} from '../../utils/react-native-overlay-signals.ts';
 
 export type ReactNativeOverlayState = {
   detected: boolean;
@@ -42,8 +48,12 @@ export function detectReactNativeOverlay(nodes: SnapshotNode[]): ReactNativeOver
   const minimizeNodes = collectOverlayNodes(nodes, isMinimizeLabel);
   const collapsedNodes = collectOverlayNodes(
     nodes,
-    isCollapsedReactNativeWarningLabel,
+    isReactNativeCollapsedWarningLabel,
     isLikelyCollapsedWarningControl,
+  );
+  const openDebuggerWarningNodes = collectOverlayNodes(
+    nodes,
+    isReactNativeOpenDebuggerWarningLabel,
   );
   const dismissRefs = refsOf(dismissNodes);
   const minimizeRefs = refsOf(minimizeNodes);
@@ -56,6 +66,7 @@ export function detectReactNativeOverlay(nodes: SnapshotNode[]): ReactNativeOver
     (hasReactNativeStackFrame && hasOverlayControl);
   const detected =
     collapsedRefs.length > 0 ||
+    openDebuggerWarningNodes.length > 0 ||
     (hasOverlayControl && (hasKnownReactNativeOverlayText(text) || hasReactNativeStackFrame));
   return {
     detected,
@@ -100,19 +111,6 @@ export function resolveReactNativeOverlayDismissTarget(
   };
 }
 
-function hasKnownReactNativeOverlayText(text: string): boolean {
-  return /\b(logbox|redbox|reload js|copy stack|component stack|call stack|runtime error|open debugger to view warnings)\b/.test(
-    text,
-  );
-}
-
-function isReactNativeStackFrame(text: string): boolean {
-  return (
-    /\b[\w.$<>/-]+\.(?:tsx?|jsx?):\d+(?::\d+)?\b/.test(text) ||
-    /\b[\w.$<>/-]+\.(?:tsx?|jsx?)\s+\(\d+:\d+\)/.test(text)
-  );
-}
-
 function isDismissControlLabel(label: string): boolean {
   return label === 'dismiss' || label === 'close' || isCloseIconLabel(label);
 }
@@ -123,20 +121,6 @@ function isCloseIconLabel(label: string): boolean {
 
 function isMinimizeLabel(label: string): boolean {
   return /^minimi[sz]e$/.test(label);
-}
-
-function isCollapsedReactNativeWarningLabel(label: string): boolean {
-  return (
-    label.includes('open debugger to view warnings') ||
-    /^!,\s+/.test(label) ||
-    /^(warn|warning|error):\s+/.test(label) ||
-    /\b(?:possible\s+)?unhandled (?:promise )?rejection\b/.test(label) ||
-    label.includes('getsnapshot should be cached to avoid an infinite loop') ||
-    label.includes('unique "key" prop') ||
-    label.includes("unique 'key' prop") ||
-    label.includes('virtualizedlists should never be nested') ||
-    label.includes('failed prop type')
-  );
 }
 
 function isLikelyCollapsedWarningControl(node: SnapshotNode): boolean {
@@ -155,7 +139,7 @@ function collectOverlayNodes(
     const labels = [node.label, node.value, node.identifier]
       .map((value) => value?.trim().toLowerCase())
       .filter((value): value is string => Boolean(value));
-    if (!labels.some(matches)) continue;
+    if (!labels.some((label) => matches(label))) continue;
     matchedNodes.push(node);
   }
   return matchedNodes;
@@ -206,7 +190,8 @@ function chooseCollapsedWarningNode(nodes: SnapshotNode[]): SnapshotNode | null 
 
 function collapsedBannerClosePoint(node: SnapshotNode): Point {
   if (!node.rect) throw new Error('Collapsed React Native warning node must have rect');
-  const inset = Math.min(36, Math.max(18, node.rect.height * 0.45));
+  const closeTargetHeight = Math.min(node.rect.height, 52);
+  const inset = Math.min(36, Math.max(18, closeTargetHeight * 0.45));
   return {
     x: Math.round(
       clamp(
@@ -215,7 +200,7 @@ function collapsedBannerClosePoint(node: SnapshotNode): Point {
         node.rect.x + node.rect.width - 1,
       ),
     ),
-    y: Math.round(node.rect.y + node.rect.height / 2),
+    y: Math.round(node.rect.y + closeTargetHeight / 2),
   };
 }
 

--- a/src/daemon/__tests__/request-router-screenshot.test.ts
+++ b/src/daemon/__tests__/request-router-screenshot.test.ts
@@ -15,7 +15,7 @@ import type { SessionState } from '../types.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { attachRefs } from '../../utils/snapshot.ts';
 import { PNG } from 'pngjs';
-import { ANDROID_EMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
+import { ANDROID_EMULATOR, IOS_SIMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
 import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
 import { makeSession as makeBaseSession } from '../../__tests__/test-utils/session-factories.ts';
 
@@ -23,6 +23,10 @@ const mockDispatch = vi.mocked(dispatchCommand);
 
 function makeSession(name: string): SessionState {
   return makeBaseSession(name, { device: ANDROID_EMULATOR });
+}
+
+function makeIosSession(name: string): SessionState {
+  return makeBaseSession(name, { device: IOS_SIMULATOR });
 }
 
 function makeMacOsMenubarSession(name: string): SessionState {
@@ -413,6 +417,102 @@ test('screenshot --overlay-refs captures a fresh snapshot when the session has n
     ]);
   }
   expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['screenshot', 'snapshot']);
+});
+
+test('screenshot --overlay-refs uses interactive iOS presentation for row-like other nodes', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-screenshot-');
+  sessionStore.set('default', makeIosSession('default'));
+  const screenshotPath = path.join(os.tmpdir(), `agent-device-overlay-ios-${Date.now()}.png`);
+
+  mockDispatch.mockImplementation(async (_device, command) => {
+    if (command === 'screenshot') {
+      writeSolidPng(screenshotPath, 402, 874);
+      return { path: screenshotPath };
+    }
+    if (command === 'snapshot') {
+      return {
+        backend: 'xctest',
+        nodes: [
+          {
+            index: 0,
+            depth: 0,
+            type: 'Application',
+            label: 'New Expensify Dev',
+            rect: { x: 0, y: 0, width: 402, height: 874 },
+          },
+          {
+            index: 1,
+            depth: 1,
+            parentIndex: 0,
+            type: 'Other',
+            label: '!, Open debugger to view warnings.',
+            rect: { x: 0, y: 0, width: 402, height: 874 },
+          },
+          {
+            index: 2,
+            depth: 1,
+            parentIndex: 0,
+            type: 'ScrollView',
+            label: 'Recent chats',
+            rect: { x: 8, y: 212, width: 386, height: 600 },
+          },
+          {
+            index: 3,
+            depth: 2,
+            parentIndex: 2,
+            type: 'Other',
+            label: 'Recent chats',
+            rect: { x: 0, y: 220, width: 402, height: 16 },
+          },
+          {
+            index: 4,
+            depth: 2,
+            parentIndex: 2,
+            type: 'Other',
+            label: 'Receipt missing details, Receipt scanning failed. Enter details manually.',
+            rect: { x: 8, y: 367, width: 386, height: 64 },
+          },
+        ],
+      };
+    }
+    return {};
+  });
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'default',
+    command: 'screenshot',
+    positionals: [screenshotPath],
+    flags: { overlayRefs: true },
+    meta: { requestId: 'req-overlay-ios-rows' },
+  });
+
+  expect(response.ok).toBe(true);
+  if (response.ok) {
+    expect(response.data?.overlayRefs).toEqual([
+      {
+        ref: 'e5',
+        label: 'Receipt missing details, Receipt scanning failed. Enter details manually.',
+        rect: { x: 8, y: 367, width: 386, height: 64 },
+        overlayRect: { x: 8, y: 367, width: 386, height: 64 },
+        center: { x: 201, y: 399 },
+      },
+    ]);
+  }
+  expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['screenshot', 'snapshot']);
+  expect(mockDispatch.mock.calls[1]?.[4]).toMatchObject({
+    snapshotInteractiveOnly: true,
+    snapshotCompact: true,
+  });
+  expect(sessionStore.get('default')?.snapshot?.nodes[4]?.type).toBe('Cell');
 });
 
 test('screenshot --overlay-refs uses a fresh snapshot instead of stale session snapshot', async () => {

--- a/src/daemon/__tests__/screenshot-overlay.test.ts
+++ b/src/daemon/__tests__/screenshot-overlay.test.ts
@@ -80,6 +80,45 @@ test('buildScreenshotOverlayRefs promotes labeled children to actionable ancesto
   ]);
 });
 
+test('buildScreenshotOverlayRefs includes non-hittable iOS cell rows', () => {
+  const snapshot = makeSnapshotState([
+    {
+      index: 0,
+      type: 'XCUIElementTypeApplication',
+      label: 'New Expensify Dev',
+      hittable: true,
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeScrollView',
+      label: 'Recent chats',
+      rect: { x: 8, y: 212, width: 386, height: 600 },
+    },
+    {
+      index: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Receipt missing details, Receipt scanning failed. Enter details manually.',
+      hittable: false,
+      rect: { x: 8, y: 367, width: 386, height: 64 },
+    },
+  ]);
+
+  const overlayRefs = buildScreenshotOverlayRefs(snapshot, 804, 1748);
+
+  assert.deepEqual(overlayRefs, [
+    {
+      ref: 'e3',
+      label: 'Receipt missing details, Receipt scanning failed. Enter details manually.',
+      rect: { x: 8, y: 367, width: 386, height: 64 },
+      overlayRect: { x: 16, y: 734, width: 772, height: 128 },
+      center: { x: 402, y: 798 },
+    },
+  ]);
+});
+
 test('buildScreenshotOverlayRefs suppresses contained duplicates with the same label, keeping the smaller rect', () => {
   const snapshot = makeSnapshotState([
     {

--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -183,6 +183,56 @@ test('replay heal rewrites longpress selector and preserves duration', async () 
   expect(healed?.positionals[1]).toBe('800');
 });
 
+test('replay heal uses canonical iOS snapshot presentation', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-ios-row-'));
+  const sessionsDir = path.join(tempRoot, 'sessions');
+  const sessionStore = new SessionStore(sessionsDir);
+  const sessionName = 'heal-ios-row-session';
+  sessionStore.set(sessionName, makeSession(sessionName));
+  const rowRect = { x: 16, y: 293, width: 370, height: 52 };
+
+  mockDispatchCommand.mockResolvedValue({
+    nodes: [
+      { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+      { index: 1, depth: 1, parentIndex: 0, type: 'CollectionView' },
+      { index: 2, depth: 2, parentIndex: 1, type: 'Cell', label: 'General', rect: rowRect },
+      { index: 3, depth: 3, parentIndex: 2, type: 'Other', label: 'General', rect: rowRect },
+      {
+        index: 4,
+        depth: 4,
+        parentIndex: 3,
+        type: 'Button',
+        label: 'General',
+        identifier: 'com.apple.settings.general',
+        rect: rowRect,
+      },
+      { index: 5, depth: 5, parentIndex: 4, type: 'StaticText', label: 'General', rect: rowRect },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const healed = await healReplayAction({
+    action: {
+      ts: Date.now(),
+      command: 'click',
+      positionals: ['label="General"'],
+      flags: {},
+      result: { selectorChain: ['label="General"'] },
+    },
+    sessionName,
+    logPath: '/tmp/replay.log',
+    sessionStore,
+  });
+
+  expect(healed?.positionals[0]).toContain('com.apple.settings.general');
+  expect(sessionStore.get(sessionName)?.snapshot?.nodes.map((node) => node.type)).toEqual([
+    'Application',
+    'CollectionView',
+    'Cell',
+  ]);
+});
+
 test('replay --update heals selector and rewrites replay file', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-heal-'));
   const sessionsDir = path.join(tempRoot, 'sessions');

--- a/src/daemon/handlers/__tests__/snapshot-capture.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-capture.test.ts
@@ -59,6 +59,51 @@ test('buildSnapshotState marks comparisonSafe false for non-Android backends', (
   expect(state.comparisonSafe).toBe(false);
 });
 
+test('buildSnapshotState applies iOS interactive presentation for xctest snapshots', () => {
+  const rowRect = { x: 16, y: 293, width: 370, height: 52 };
+  const state = buildSnapshotState(
+    {
+      nodes: [
+        { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+        { index: 1, depth: 1, parentIndex: 0, type: 'CollectionView' },
+        { index: 2, depth: 2, parentIndex: 1, type: 'Cell', label: 'General', rect: rowRect },
+        { index: 3, depth: 3, parentIndex: 2, type: 'Button', label: 'General', rect: rowRect },
+      ],
+      backend: 'xctest',
+    },
+    { snapshotInteractiveOnly: true },
+  );
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.parentIndex])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['CollectionView', undefined, 0],
+    ['Cell', 'General', 1],
+  ]);
+});
+
+test('buildSnapshotState keeps raw iOS snapshots uncollapsed', () => {
+  const rowRect = { x: 16, y: 293, width: 370, height: 52 };
+  const nodes = [
+    { index: 0, depth: 0, type: 'Cell', label: 'General', rect: rowRect },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'General',
+      identifier: 'com.apple.settings.general',
+      rect: rowRect,
+    },
+  ];
+
+  const state = buildSnapshotState(
+    { nodes, backend: 'xctest' },
+    { snapshotInteractiveOnly: true, snapshotRaw: true },
+  );
+
+  expect(state.nodes.map((node) => node.type)).toEqual(['Cell', 'Button']);
+});
+
 test('buildSnapshotState returns empty nodes when scoped snapshot has no label match', () => {
   const nodes = [
     { index: 0, depth: 0, type: 'Window', label: 'Root' },

--- a/src/daemon/handlers/session-replay-heal.ts
+++ b/src/daemon/handlers/session-replay-heal.ts
@@ -1,12 +1,6 @@
 import { dispatchCommand } from '../../core/dispatch.ts';
 import { setSessionSnapshot } from '../session-snapshot.ts';
-import {
-  attachRefs,
-  type RawSnapshotNode,
-  type SnapshotBackend,
-  type SnapshotState,
-} from '../../utils/snapshot.ts';
-import { pruneGroupNodes } from '../snapshot-processing.ts';
+import type { RawSnapshotNode, SnapshotBackend, SnapshotState } from '../../utils/snapshot.ts';
 import {
   buildSelectorChainForNode,
   resolveSelectorChain,
@@ -19,6 +13,7 @@ import type { SessionAction, SessionState } from '../types.ts';
 import { isTouchTargetCommand } from '../../replay/script-utils.ts';
 import { contextFromFlags } from '../context.ts';
 import { SessionStore } from '../session-store.ts';
+import { buildSnapshotState } from './snapshot-capture.ts';
 
 function parseSelectorWaitPositionals(positionals: string[]): {
   selectorExpression: string | null;
@@ -226,14 +221,11 @@ async function captureSnapshotForReplay(
     truncated?: boolean;
     backend?: SnapshotBackend;
   };
-  const rawNodes = data?.nodes ?? [];
-  const nodes = attachRefs(action.flags?.snapshotRaw ? rawNodes : pruneGroupNodes(rawNodes));
-  const snapshot: SnapshotState = {
-    nodes,
-    truncated: data?.truncated,
-    createdAt: Date.now(),
-    backend: data?.backend,
-  };
+  const snapshot = buildSnapshotState(data, {
+    ...(action.flags ?? {}),
+    snapshotInteractiveOnly: interactiveOnly,
+    snapshotCompact: interactiveOnly,
+  });
   setSessionSnapshot(session, snapshot);
   sessionStore.set(session.name, session);
   return snapshot;

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -31,6 +31,7 @@ import { contextFromFlags } from '../context.ts';
 import { capturePostGestureStabilizedSnapshot } from '../post-gesture-stabilization.ts';
 import { findNodeByLabel, pruneGroupNodes, resolveRefLabel } from '../snapshot-processing.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import { presentIosInteractiveSnapshot } from '../snapshot-presentation/ios/index.ts';
 
 type CaptureSnapshotParams = {
   device: SessionState['device'];
@@ -245,7 +246,10 @@ export function buildSnapshotState(
     flags?.snapshotScope && data?.backend !== 'macos-helper'
       ? scopeSnapshotNodes(normalizedNodes, flags.snapshotScope)
       : normalizedNodes;
-  const nodes = attachRefs(scopedNodes);
+  const presentableNodes = shouldPresentIosInteractiveSnapshot(data?.backend, flags)
+    ? presentIosInteractiveSnapshot(scopedNodes)
+    : scopedNodes;
+  const nodes = attachRefs(presentableNodes);
   return {
     nodes,
     truncated: data?.truncated,
@@ -255,13 +259,42 @@ export function buildSnapshotState(
     // Only broad Android snapshots become freshness baselines. If the user asked for a scoped
     // or filtered view, preserve that output contract but avoid pretending it is safe for
     // route-level comparisons on the next capture.
-    comparisonSafe:
-      data?.backend === 'android' &&
-      flags?.snapshotInteractiveOnly !== true &&
-      flags?.snapshotCompact !== true &&
-      typeof flags?.snapshotDepth !== 'number' &&
-      !flags?.snapshotScope,
+    comparisonSafe: isAndroidComparisonSafeSnapshot(data?.backend, flags),
   };
+}
+
+function shouldPresentIosInteractiveSnapshot(
+  backend: SnapshotBackend | undefined,
+  flags:
+    | (Pick<
+        CommandFlags,
+        'snapshotCompact' | 'snapshotDepth' | 'snapshotInteractiveOnly' | 'snapshotRaw'
+      > &
+        Partial<Pick<CommandFlags, 'snapshotScope'>>)
+    | undefined,
+): boolean {
+  return (
+    backend === 'xctest' && flags?.snapshotInteractiveOnly === true && flags.snapshotRaw !== true
+  );
+}
+
+function isAndroidComparisonSafeSnapshot(
+  backend: SnapshotBackend | undefined,
+  flags:
+    | (Pick<
+        CommandFlags,
+        'snapshotCompact' | 'snapshotDepth' | 'snapshotInteractiveOnly' | 'snapshotRaw'
+      > &
+        Partial<Pick<CommandFlags, 'snapshotScope'>>)
+    | undefined,
+): boolean {
+  return (
+    backend === 'android' &&
+    flags?.snapshotInteractiveOnly !== true &&
+    flags?.snapshotCompact !== true &&
+    typeof flags?.snapshotDepth !== 'number' &&
+    !flags?.snapshotScope
+  );
 }
 
 function shapeDesktopSurfaceSnapshot(

--- a/src/daemon/request-generic-dispatch.ts
+++ b/src/daemon/request-generic-dispatch.ts
@@ -173,14 +173,18 @@ async function applyScreenshotOverlay(
   data: Record<string, unknown>,
   logPath: string,
 ): Promise<void> {
+  const overlaySnapshotFlags = {
+    snapshotInteractiveOnly: true,
+    snapshotCompact: true,
+  } satisfies CommandFlags;
   const overlaySnapshotData = await captureSnapshotData({
     device: session.device,
     session,
-    flags: undefined,
+    flags: overlaySnapshotFlags,
     logPath,
     snapshotScope: undefined,
   });
-  const overlaySnapshot = buildSnapshotState(overlaySnapshotData, undefined);
+  const overlaySnapshot = buildSnapshotState(overlaySnapshotData, overlaySnapshotFlags);
   setSessionSnapshot(session, overlaySnapshot);
   const overlayRefs = await annotateScreenshotWithRefs({
     screenshotPath: data.path as string,

--- a/src/daemon/snapshot-presentation/ios/actions.ts
+++ b/src/daemon/snapshot-presentation/ios/actions.ts
@@ -1,0 +1,75 @@
+import type { RawSnapshotNode } from '../../../utils/snapshot.ts';
+import { normalizeType } from '../../snapshot-processing.ts';
+import {
+  findLargestViewportRect,
+  findNearestAncestor,
+  isMostlyViewportSizedRect,
+  mergeReplacement,
+  type SnapshotTreeRuleContext,
+} from '../tree.ts';
+
+export function collectIosImplicitScrollableActions(
+  nodes: RawSnapshotNode[],
+  context: SnapshotTreeRuleContext,
+): void {
+  const byIndex = new Map(nodes.map((node) => [node.index, node]));
+  const viewport = findLargestViewportRect(byIndex.values());
+  for (const node of nodes) {
+    if (!isImplicitScrollableAction(node, byIndex, viewport)) {
+      continue;
+    }
+    mergeReplacement(context.replacements, node, { type: 'Cell' });
+  }
+}
+
+function isImplicitScrollableAction(
+  node: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+  viewport: RawSnapshotNode['rect'],
+): boolean {
+  if (normalizeType(node.type ?? '') !== 'other') {
+    return false;
+  }
+  if (node.enabled === false || !node.rect || !isMeaningfulImplicitActionLabel(node.label)) {
+    return false;
+  }
+  if (!findNearestAncestor(node, byIndex, isImplicitActionScrollAncestor)) {
+    return false;
+  }
+  if (!isRowSizedImplicitAction(node)) {
+    return false;
+  }
+  if (isMostlyViewportSizedRect(node.rect, viewport)) {
+    return false;
+  }
+  return true;
+}
+
+function isRowSizedImplicitAction(node: RawSnapshotNode): boolean {
+  if (!node.rect) {
+    return false;
+  }
+  return node.rect.height >= 44 && node.rect.height <= 160 && node.rect.width >= 120;
+}
+
+function isImplicitActionScrollAncestor(node: RawSnapshotNode): boolean {
+  const type = normalizeType(node.type ?? '');
+  return type === 'scrollview' || type === 'scrollarea';
+}
+
+function isMeaningfulImplicitActionLabel(label: string | undefined): boolean {
+  const trimmed = label?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (/^(toolbar|window|application)$/i.test(trimmed)) {
+    return false;
+  }
+  if (trimmed.startsWith('!,')) {
+    return false;
+  }
+  if (/debugger|fast refresh/i.test(trimmed)) {
+    return false;
+  }
+  return true;
+}

--- a/src/daemon/snapshot-presentation/ios/index.ts
+++ b/src/daemon/snapshot-presentation/ios/index.ts
@@ -1,0 +1,41 @@
+import type { RawSnapshotNode } from '../../../utils/snapshot.ts';
+import { collectIosImplicitScrollableActions } from './actions.ts';
+import { collectIosPresentationNoiseSuppression } from './noise.ts';
+import { collectIosRowPresentation } from './rows.ts';
+import {
+  reindexSnapshotNodesWithSuppressedParents,
+  type SnapshotTreeRuleContext,
+} from '../tree.ts';
+
+const IOS_PRESENTATION_RULES: Array<
+  (nodes: RawSnapshotNode[], context: SnapshotTreeRuleContext) => void
+> = [
+  collectIosPresentationNoiseSuppression,
+  collectIosImplicitScrollableActions,
+  collectIosRowPresentation,
+];
+
+export function presentIosInteractiveSnapshot(nodes: RawSnapshotNode[]): RawSnapshotNode[] {
+  if (nodes.length === 0) {
+    return nodes;
+  }
+
+  const replacements = new Map<number, RawSnapshotNode>();
+  const suppressedIndexes = new Set<number>();
+
+  for (const rule of IOS_PRESENTATION_RULES) {
+    rule(nodes, { replacements, suppressedIndexes });
+  }
+
+  if (suppressedIndexes.size === 0 && replacements.size === 0) {
+    return nodes;
+  }
+
+  return reindexSnapshotNodesWithSuppressedParents(
+    nodes
+      .filter((node) => !suppressedIndexes.has(node.index))
+      .map((node) => replacements.get(node.index) ?? node),
+    suppressedIndexes,
+    nodes,
+  );
+}

--- a/src/daemon/snapshot-presentation/ios/noise.ts
+++ b/src/daemon/snapshot-presentation/ios/noise.ts
@@ -1,0 +1,328 @@
+import type { RawSnapshotNode } from '../../../utils/snapshot.ts';
+import { isReactNativeCollapsedWarningLabel } from '../../../utils/react-native-overlay-signals.ts';
+import { normalizeType } from '../../snapshot-processing.ts';
+import { collectIosScrollIndicatorPresentation } from './scroll.ts';
+import {
+  areRectsApproximatelyEqual,
+  collectDescendants,
+  findLargestViewportRect,
+  isRepeatedStaticNode,
+  isScrollableSnapshotType,
+  isSemanticActionNode,
+  type SnapshotTreeRuleContext,
+} from '../tree.ts';
+
+export function collectIosPresentationNoiseSuppression(
+  nodes: RawSnapshotNode[],
+  context: SnapshotTreeRuleContext,
+): void {
+  const { suppressedIndexes } = context;
+  collectIosOffscreenKeyboardSuppression(nodes, suppressedIndexes);
+  collectIosStructuralIdentifierSuppression(nodes, suppressedIndexes);
+  collectIosScrollIndicatorPresentation(nodes, context);
+  collectIosSearchToolbarSuppression(nodes, suppressedIndexes);
+  collectIosActionWrapperSuppression(nodes, suppressedIndexes);
+  collectIosReactNativeOverlayWrapperSuppression(nodes, suppressedIndexes);
+  collectIosRepeatedStaticSuppression(nodes, suppressedIndexes);
+}
+
+function collectIosReactNativeOverlayWrapperSuppression(
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+): void {
+  forEachOtherNodeWithLabel(nodes, (node, nodeLabel, position) => {
+    if (!isReactNativeCollapsedWarningLabel(nodeLabel) || !isFullScreenOverlayRect(node.rect)) {
+      return;
+    }
+
+    const hasVisibleBannerDescendant = collectDescendants(nodes, position).some(
+      (descendant) =>
+        descendant.label?.trim() === nodeLabel && isReactNativeCollapsedWarningBanner(descendant),
+    );
+    if (hasVisibleBannerDescendant) {
+      suppressedIndexes.add(node.index);
+    }
+  });
+}
+
+function isFullScreenOverlayRect(rect: RawSnapshotNode['rect']): boolean {
+  if (!rect) {
+    return false;
+  }
+  return rect.x <= 1 && rect.y <= 1 && rect.width >= 300 && rect.height >= 600;
+}
+
+function isReactNativeCollapsedWarningBanner(node: RawSnapshotNode): boolean {
+  if (!node.rect) {
+    return false;
+  }
+  return node.rect.width >= 120 && node.rect.height >= 36 && node.rect.height <= 180;
+}
+
+function collectIosRepeatedStaticSuppression(
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+): void {
+  for (let position = 0; position < nodes.length; position += 1) {
+    const node = nodes[position];
+    const nodeLabel = node?.label?.trim();
+    if (!node || suppressedIndexes.has(node.index) || !nodeLabel) {
+      continue;
+    }
+
+    collectRepeatedStaticSuppressionForNode(nodes, position, node, nodeLabel, suppressedIndexes);
+  }
+}
+
+function collectRepeatedStaticSuppressionForNode(
+  nodes: RawSnapshotNode[],
+  position: number,
+  node: RawSnapshotNode,
+  nodeLabel: string,
+  suppressedIndexes: Set<number>,
+): void {
+  const descendants = collectDescendants(nodes, position);
+  const type = normalizeType(node.type ?? '');
+  if (type === 'statictext' || type === 'link') {
+    suppressRepeatedStaticDescendants(descendants, nodeLabel, suppressedIndexes);
+    return;
+  }
+  if (type !== 'other') {
+    return;
+  }
+  if (hasEquivalentSemanticDescendant(descendants, nodeLabel)) {
+    suppressedIndexes.add(node.index);
+    return;
+  }
+  suppressRepeatedStaticDescendants(descendants, nodeLabel, suppressedIndexes);
+}
+
+function hasEquivalentSemanticDescendant(
+  descendants: RawSnapshotNode[],
+  nodeLabel: string,
+): boolean {
+  return descendants.some((descendant) => {
+    const type = normalizeType(descendant.type ?? '');
+    return (
+      (type === 'link' || type === 'searchfield' || isScrollableSnapshotType(descendant.type)) &&
+      descendant.label?.trim() === nodeLabel
+    );
+  });
+}
+
+function suppressRepeatedStaticDescendants(
+  descendants: RawSnapshotNode[],
+  label: string,
+  suppressedIndexes: Set<number>,
+): void {
+  for (const descendant of descendants) {
+    if (isRepeatedStaticNode(descendant, label)) {
+      suppressedIndexes.add(descendant.index);
+    }
+  }
+}
+
+function collectIosActionWrapperSuppression(
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+): void {
+  forEachOtherNodeWithLabel(nodes, (node, nodeLabel, position) => {
+    const semanticDescendant = collectDescendants(nodes, position).find(
+      (descendant) =>
+        isSemanticActionNode(descendant) &&
+        descendant.label?.trim() === nodeLabel &&
+        (areRectsApproximatelyEqual(descendant.rect, node.rect) ||
+          isIosBackdropDismissWrapper(node, descendant)),
+    );
+    if (semanticDescendant) {
+      suppressedIndexes.add(node.index);
+    }
+  });
+}
+
+function isIosBackdropDismissWrapper(node: RawSnapshotNode, descendant: RawSnapshotNode): boolean {
+  if (descendant.label?.trim() !== node.label?.trim()) {
+    return false;
+  }
+  const descendantType = normalizeType(descendant.type ?? '');
+  return (
+    isNamedButtonBackdrop(node, descendantType) ||
+    descendantType === 'textfield' ||
+    isFullscreenActionLabelWrapper(node, descendantType, descendant)
+  );
+}
+
+function isNamedButtonBackdrop(node: RawSnapshotNode, descendantType: string): boolean {
+  const label = node.label?.trim();
+  return descendantType === 'button' && (label === 'Dismiss' || label === 'Back');
+}
+
+function isFullscreenActionLabelWrapper(
+  node: RawSnapshotNode,
+  descendantType: string,
+  descendant: RawSnapshotNode,
+): boolean {
+  if (descendantType !== 'button') {
+    return false;
+  }
+  if (!node.rect || !descendant.rect) {
+    return false;
+  }
+  return (
+    node.rect.x === 0 &&
+    node.rect.y === 0 &&
+    node.rect.width >= 300 &&
+    node.rect.height >= 600 &&
+    descendant.rect.width < node.rect.width
+  );
+}
+
+function collectIosOffscreenKeyboardSuppression(
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+): void {
+  const viewport = findLargestViewportRect(nodes);
+  const screenBottom = viewport ? viewport.y + viewport.height : null;
+  if (screenBottom === null) {
+    return;
+  }
+  for (let position = 0; position < nodes.length; position += 1) {
+    const node = nodes[position];
+    if (!node || !isOffscreenKeyboardNode(node, screenBottom)) {
+      continue;
+    }
+    suppressedIndexes.add(node.index);
+    suppressOffscreenKeyboardAncestors(node, nodes, suppressedIndexes, screenBottom);
+    for (const descendant of collectDescendants(nodes, position)) {
+      suppressedIndexes.add(descendant.index);
+    }
+  }
+}
+
+function isOffscreenKeyboardNode(node: RawSnapshotNode, screenBottom: number): boolean {
+  if (!node.rect || normalizeType(node.type ?? '') !== 'keyboard') {
+    return false;
+  }
+  return node.rect.y >= screenBottom;
+}
+
+function suppressOffscreenKeyboardAncestors(
+  node: RawSnapshotNode,
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+  screenBottom: number,
+): void {
+  const byIndex = new Map(nodes.map((candidate) => [candidate.index, candidate]));
+  let current = typeof node.parentIndex === 'number' ? byIndex.get(node.parentIndex) : undefined;
+  while (current?.rect && current.rect.y >= screenBottom) {
+    suppressedIndexes.add(current.index);
+    current =
+      typeof current.parentIndex === 'number' ? byIndex.get(current.parentIndex) : undefined;
+  }
+}
+
+function collectIosStructuralIdentifierSuppression(
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+): void {
+  for (const node of nodes) {
+    if (normalizeType(node.type ?? '') !== 'other') {
+      continue;
+    }
+    if (node.hittable === true || node.label?.trim() || node.value?.trim()) {
+      continue;
+    }
+    if (!node.identifier?.trim()) {
+      continue;
+    }
+    suppressedIndexes.add(node.index);
+  }
+}
+
+function collectIosSearchToolbarSuppression(
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+): void {
+  for (let position = 0; position < nodes.length; position += 1) {
+    const node = nodes[position];
+    if (!node || normalizeType(node.type ?? '') !== 'searchfield') {
+      continue;
+    }
+    if (node.label === 'Search') {
+      suppressSearchToolbarDescendants(nodes, position, null, suppressedIndexes);
+      continue;
+    }
+    if (node.label !== 'Toolbar') {
+      continue;
+    }
+    const descendants = collectDescendants(nodes, position);
+    const innerSearch = descendants.find(
+      (candidate) =>
+        normalizeType(candidate.type ?? '') === 'searchfield' && candidate.label === 'Search',
+    );
+    if (!innerSearch) {
+      continue;
+    }
+
+    suppressedIndexes.add(node.index);
+    suppressToolbarAncestors(node, nodes, suppressedIndexes);
+    suppressSearchToolbarDescendants(nodes, position, innerSearch.index, suppressedIndexes);
+  }
+}
+
+function suppressSearchToolbarDescendants(
+  nodes: RawSnapshotNode[],
+  position: number,
+  keptSearchIndex: number | null,
+  suppressedIndexes: Set<number>,
+): void {
+  for (const descendant of collectDescendants(nodes, position)) {
+    if (descendant.index === keptSearchIndex) {
+      continue;
+    }
+    if (shouldSuppressIosSearchToolbarDescendant(descendant)) {
+      suppressedIndexes.add(descendant.index);
+    }
+  }
+}
+
+function suppressToolbarAncestors(
+  node: RawSnapshotNode,
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+): void {
+  const byIndex = new Map(nodes.map((candidate) => [candidate.index, candidate]));
+  let current = node;
+  while (typeof current.parentIndex === 'number') {
+    const parent = byIndex.get(current.parentIndex);
+    if (!parent || parent.label !== 'Toolbar') {
+      return;
+    }
+    suppressedIndexes.add(parent.index);
+    current = parent;
+  }
+}
+
+function shouldSuppressIosSearchToolbarDescendant(node: RawSnapshotNode): boolean {
+  const type = normalizeType(node.type ?? '');
+  if (type === 'button') {
+    return false;
+  }
+  if (type === 'image') {
+    return true;
+  }
+  return node.label === 'Search';
+}
+
+function forEachOtherNodeWithLabel(
+  nodes: RawSnapshotNode[],
+  visitor: (node: RawSnapshotNode, label: string, position: number) => void,
+): void {
+  for (let position = 0; position < nodes.length; position += 1) {
+    const node = nodes[position];
+    const label = node?.label?.trim();
+    if (node && label && normalizeType(node.type ?? '') === 'other') {
+      visitor(node, label, position);
+    }
+  }
+}

--- a/src/daemon/snapshot-presentation/ios/presentation.test.ts
+++ b/src/daemon/snapshot-presentation/ios/presentation.test.ts
@@ -1,0 +1,1087 @@
+import { expect, test } from 'vitest';
+import { attachRefs, type RawSnapshotNode } from '../../../utils/snapshot.ts';
+import { buildSnapshotVisibility } from '../../../utils/snapshot-visibility.ts';
+import { presentIosInteractiveSnapshot } from './index.ts';
+
+function buildSnapshotState(data: { nodes?: RawSnapshotNode[]; backend?: 'xctest' }) {
+  return {
+    nodes: attachRefs(presentIosInteractiveSnapshot(data.nodes ?? [])),
+    backend: data.backend,
+    createdAt: Date.now(),
+  };
+}
+
+test('buildSnapshotState collapses iOS interactive row backing nodes', () => {
+  const rowRect = { x: 16, y: 293, width: 370, height: 52 };
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    { index: 1, depth: 1, parentIndex: 0, type: 'CollectionView' },
+    { index: 2, depth: 2, parentIndex: 1, type: 'Cell', label: 'General', rect: rowRect },
+    { index: 3, depth: 3, parentIndex: 2, type: 'Other', label: 'General', rect: rowRect },
+    {
+      index: 4,
+      depth: 4,
+      parentIndex: 3,
+      type: 'Button',
+      label: 'General',
+      identifier: 'com.apple.settings.general',
+      rect: rowRect,
+    },
+    { index: 5, depth: 5, parentIndex: 4, type: 'StaticText', label: 'General', rect: rowRect },
+    {
+      index: 6,
+      depth: 5,
+      parentIndex: 4,
+      type: 'Image',
+      identifier: 'chevron.forward',
+      rect: { x: 360, y: 313, width: 7, height: 12 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.identifier])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['CollectionView', undefined, undefined],
+    ['Cell', 'General', 'com.apple.settings.general'],
+  ]);
+});
+
+test('buildSnapshotState promotes iOS switch rows to the switch control', () => {
+  const rowRect = { x: 16, y: 293, width: 370, height: 52 };
+  const switchRect = { x: 320, y: 302, width: 51, height: 31 };
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    { index: 1, depth: 1, parentIndex: 0, type: 'CollectionView' },
+    { index: 2, depth: 2, parentIndex: 1, type: 'Cell', label: 'Airplane Mode', rect: rowRect },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'Airplane Mode',
+      identifier: 'com.apple.settings.airplane-mode',
+      rect: rowRect,
+    },
+    {
+      index: 4,
+      depth: 4,
+      parentIndex: 3,
+      type: 'Switch',
+      label: 'Airplane Mode',
+      value: '0',
+      rect: switchRect,
+    },
+    {
+      index: 5,
+      depth: 5,
+      parentIndex: 4,
+      type: 'Switch',
+      label: '0',
+      value: '0',
+      rect: { x: 320, y: 302, width: 51, height: 31 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.identifier])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['CollectionView', undefined, undefined],
+    ['Switch', 'Airplane Mode', 'com.apple.settings.airplane-mode'],
+  ]);
+  expect(state.nodes[2]?.parentIndex).toBe(1);
+});
+
+test('buildSnapshotState ignores unlabeled accessory buttons when collapsing iOS rows', () => {
+  const rowRect = { x: 16, y: 293, width: 370, height: 52 };
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    { index: 1, depth: 1, parentIndex: 0, type: 'CollectionView' },
+    { index: 2, depth: 2, parentIndex: 1, type: 'Cell', label: 'General', rect: rowRect },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      identifier: 'accessory-button',
+      rect: rowRect,
+    },
+    {
+      index: 4,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'General',
+      identifier: 'com.apple.settings.general',
+      rect: rowRect,
+    },
+    { index: 5, depth: 4, parentIndex: 4, type: 'StaticText', label: 'General', rect: rowRect },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.identifier])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['CollectionView', undefined, undefined],
+    ['Cell', 'General', 'com.apple.settings.general'],
+  ]);
+});
+
+test('buildSnapshotState collapses inset iOS rows with text-area buttons and disabled chevrons', () => {
+  const rowRect = { x: 20, y: 391, width: 362, height: 53 };
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    { index: 1, depth: 1, parentIndex: 0, type: 'Table', label: 'General' },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'About',
+      identifier: 'About',
+      rect: rowRect,
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Other',
+      label: 'About',
+      rect: { x: 20, y: 391, width: 331, height: 53 },
+    },
+    {
+      index: 4,
+      depth: 4,
+      parentIndex: 3,
+      type: 'Button',
+      label: 'About',
+      identifier: 'About',
+      rect: { x: 34, y: 404, width: 88, height: 28 },
+    },
+    {
+      index: 5,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'chevron',
+      enabled: false,
+      rect: { x: 351, y: 410, width: 10, height: 14 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.identifier])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['Table', 'General', undefined],
+    ['Cell', 'About', 'About'],
+  ]);
+});
+
+test('buildSnapshotState collapses iOS rows with only repeated text and disabled chevrons', () => {
+  const rowRect = { x: 20, y: 441, width: 362, height: 53 };
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    { index: 1, depth: 1, parentIndex: 0, type: 'Table', label: 'Camera' },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Formats',
+      identifier: 'CameraFormatsSettingsList',
+      rect: rowRect,
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Other',
+      label: 'Formats',
+      rect: { x: 20, y: 441, width: 331, height: 53 },
+    },
+    {
+      index: 4,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'chevron',
+      enabled: false,
+      rect: { x: 351, y: 458, width: 10, height: 14 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.identifier])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['Table', 'Camera', undefined],
+    ['Cell', 'Formats', 'CameraFormatsSettingsList'],
+  ]);
+});
+
+test('buildSnapshotState collapses duplicate descendants under scoped iOS action roots', () => {
+  const rowRect = { x: 16, y: 293, width: 370, height: 52 };
+  const nodes = [
+    {
+      index: 0,
+      depth: 0,
+      type: 'Button',
+      label: 'General',
+      identifier: 'com.apple.settings.general',
+      rect: rowRect,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Image',
+      identifier: 'chevron.forward',
+      rect: { x: 360, y: 313, width: 7, height: 12 },
+    },
+    { index: 2, depth: 1, parentIndex: 0, type: 'StaticText', label: 'General', rect: rowRect },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.identifier])).toEqual([
+    ['Button', 'General', 'com.apple.settings.general'],
+  ]);
+});
+
+test('buildSnapshotState collapses iOS other wrappers around same-rect actions', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'New Expensify Dev' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Press release, Expensify named Expense Platform of the Year',
+      rect: { x: 20, y: 489, width: 362, height: 64 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Button',
+      label: 'Press release, Expensify named Expense Platform of the Year',
+      rect: { x: 20, y: 489, width: 362, height: 64 },
+    },
+    {
+      index: 3,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Open actions menu',
+      rect: { x: 334, y: 710, width: 52, height: 52 },
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 3,
+      type: 'Button',
+      label: 'Open actions menu',
+      identifier: 'floating-action-button',
+      rect: { x: 334, y: 710, width: 52, height: 52 },
+    },
+    {
+      index: 5,
+      depth: 3,
+      parentIndex: 4,
+      type: 'Other',
+      identifier: 'fab-animated-container',
+      rect: { x: 334, y: 710, width: 52, height: 52 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(
+    state.nodes.map((node) => [node.type, node.label, node.identifier, node.parentIndex]),
+  ).toEqual([
+    ['Application', 'New Expensify Dev', undefined, undefined],
+    ['Button', 'Press release, Expensify named Expense Platform of the Year', undefined, 0],
+    ['Button', 'Open actions menu', 'floating-action-button', 0],
+  ]);
+});
+
+test('buildSnapshotState promotes iOS scroll-contained other rows to cells', () => {
+  const nodes = [
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      label: 'New Expensify Dev',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: '!, Open debugger to view warnings.',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 2,
+      depth: 1,
+      parentIndex: 0,
+      type: 'ScrollView',
+      label: 'Recent chats',
+      rect: { x: 8, y: 212, width: 386, height: 600 },
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 2,
+      type: 'Other',
+      label: 'Recent chats',
+      rect: { x: 0, y: 220, width: 402, height: 16 },
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 2,
+      type: 'Other',
+      label: 'Receipt missing details, Receipt scanning failed. Enter details manually.',
+      rect: { x: 8, y: 367, width: 386, height: 64 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.parentIndex])).toEqual([
+    ['Application', 'New Expensify Dev', undefined],
+    ['Other', '!, Open debugger to view warnings.', 0],
+    ['ScrollView', 'Recent chats', 0],
+    ['Other', 'Recent chats', 2],
+    ['Cell', 'Receipt missing details, Receipt scanning failed. Enter details manually.', 2],
+  ]);
+});
+
+test('buildSnapshotState keeps React Native warning banner instead of full-screen wrapper', () => {
+  const nodes = [
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      label: 'New Expensify Dev',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: '!, Open debugger to view warnings.',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Other',
+      identifier: 'SearchRouterPage',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Other',
+      label: '!, Open debugger to view warnings.',
+      rect: { x: 10, y: 786.666, width: 382, height: 67.333 },
+    },
+    {
+      index: 4,
+      depth: 3,
+      parentIndex: 3,
+      type: 'Other',
+      label: '!, Open debugger to view warnings.',
+      rect: { x: 10, y: 787.333, width: 382, height: 48 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(
+    state.nodes.map((node) => [node.type, node.label, node.rect?.y, node.parentIndex]),
+  ).toEqual([
+    ['Application', 'New Expensify Dev', 0, undefined],
+    ['Other', '!, Open debugger to view warnings.', 786.666, 0],
+  ]);
+});
+
+test('buildSnapshotState collapses iOS backdrop dismiss wrappers', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'New Expensify Dev' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Dismiss',
+      rect: { x: 0, y: 458, width: 402, height: 416 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Button',
+      label: 'Dismiss',
+      rect: { x: 0, y: 458, width: 402, height: 10 },
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Button',
+      label: 'Create expense',
+      rect: { x: 0, y: 474, width: 402, height: 64 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.parentIndex])).toEqual([
+    ['Application', 'New Expensify Dev', undefined],
+    ['Button', 'Dismiss', 0],
+    ['Button', 'Create expense', 0],
+  ]);
+});
+
+test('buildSnapshotState collapses iOS back and text-field wrappers', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'New Expensify Dev' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Back',
+      rect: { x: 0, y: 62, width: 402, height: 72 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Button',
+      label: 'Back',
+      rect: { x: 8, y: 78, width: 40, height: 40 },
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: 'Search',
+      rect: { x: 48, y: 88, width: 54, height: 20 },
+    },
+    {
+      index: 4,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Search for something...',
+      rect: { x: 21, y: 147, width: 360, height: 52 },
+    },
+    {
+      index: 5,
+      depth: 2,
+      parentIndex: 4,
+      type: 'TextField',
+      label: 'Search for something...',
+      identifier: 'search-autocomplete-text-input',
+      rect: { x: 33, y: 147, width: 336, height: 52 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(
+    state.nodes.map((node) => [node.type, node.label, node.identifier, node.parentIndex]),
+  ).toEqual([
+    ['Application', 'New Expensify Dev', undefined, undefined],
+    ['Button', 'Back', undefined, 0],
+    ['StaticText', 'Search', undefined, 0],
+    ['TextField', 'Search for something...', 'search-autocomplete-text-input', 0],
+  ]);
+});
+
+test('buildSnapshotState suppresses offscreen iOS keyboard subtrees', () => {
+  const nodes = [
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      label: 'New Expensify Dev',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'SearchRouterPage',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 2,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Padding-Left',
+      rect: { x: 0, y: 874, width: 402, height: 233 },
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 2,
+      type: 'Keyboard',
+      label: 'Padding-Left',
+      rect: { x: 0, y: 874, width: 402, height: 233 },
+    },
+    {
+      index: 4,
+      depth: 3,
+      parentIndex: 3,
+      type: 'Key',
+      label: 'q',
+      rect: { x: 4, y: 881, width: 39, height: 54 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label])).toEqual([
+    ['Application', 'New Expensify Dev'],
+    ['Other', 'SearchRouterPage'],
+  ]);
+});
+
+test('buildSnapshotState does not use scoped root rect as iOS keyboard viewport', () => {
+  const nodes = [
+    {
+      index: 0,
+      depth: 0,
+      type: 'Other',
+      label: 'Search form',
+      rect: { x: 0, y: 120, width: 402, height: 52 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Keyboard',
+      label: 'Padding-Left',
+      rect: { x: 0, y: 874, width: 402, height: 233 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Key',
+      label: 'q',
+      rect: { x: 4, y: 881, width: 39, height: 54 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label])).toEqual([
+    ['Other', 'Search form'],
+    ['Keyboard', 'Padding-Left'],
+    ['Key', 'q'],
+  ]);
+});
+
+test('buildSnapshotState suppresses structural iOS identifier-only nodes', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'New Expensify Dev' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      identifier: 'SearchRouterPage',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 2,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Receipt missing details',
+      rect: { x: 8, y: 240, width: 386, height: 64 },
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 2,
+      type: 'Other',
+      identifier: 'ReportActionAvatars-SingleAvatar',
+      rect: { x: 20, y: 252, width: 40, height: 40 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(
+    state.nodes.map((node) => [node.type, node.label, node.identifier, node.parentIndex]),
+  ).toEqual([
+    ['Application', 'New Expensify Dev', undefined, undefined],
+    ['Other', 'Receipt missing details', undefined, 0],
+  ]);
+});
+
+test('buildSnapshotState collapses duplicated iOS search toolbar wrappers', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    { index: 1, depth: 1, parentIndex: 0, type: 'Other', label: 'Toolbar' },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'SearchField',
+      label: 'Toolbar',
+      identifier: 'Toolbar',
+      rect: { x: 0, y: 788, width: 402, height: 86 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Other',
+      label: 'Search',
+      rect: { x: 28, y: 798, width: 0, height: 0 },
+    },
+    {
+      index: 4,
+      depth: 4,
+      parentIndex: 3,
+      type: 'Other',
+      label: 'Search',
+      rect: { x: 28, y: 798, width: 346, height: 48 },
+    },
+    {
+      index: 5,
+      depth: 5,
+      parentIndex: 4,
+      type: 'SearchField',
+      label: 'Search',
+      rect: { x: 33, y: 803, width: 336, height: 38 },
+    },
+    {
+      index: 6,
+      depth: 6,
+      parentIndex: 5,
+      type: 'Button',
+      label: 'Dictate',
+      identifier: 'Dictate',
+      rect: { x: 335, y: 811, width: 17, height: 22 },
+    },
+    {
+      index: 7,
+      depth: 6,
+      parentIndex: 5,
+      type: 'Image',
+      label: 'Search',
+      identifier: 'magnifyingglass',
+      rect: { x: 46, y: 812, width: 20, height: 18 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(
+    state.nodes.map((node) => [node.type, node.label, node.identifier, node.parentIndex]),
+  ).toEqual([
+    ['Application', 'Settings', undefined, undefined],
+    ['SearchField', 'Search', undefined, 0],
+    ['Button', 'Dictate', 'Dictate', 1],
+  ]);
+});
+
+test('buildSnapshotState collapses exposed iOS search field wrappers', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Search',
+      rect: { x: 28, y: 798, width: 0, height: 0 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'SearchField',
+      label: 'Search',
+      rect: { x: 33, y: 803, width: 336, height: 38 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'Dictate',
+      identifier: 'Dictate',
+      rect: { x: 335, y: 811, width: 17, height: 22 },
+    },
+    {
+      index: 4,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Image',
+      label: 'Search',
+      identifier: 'magnifyingglass',
+      rect: { x: 46, y: 812, width: 20, height: 18 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(
+    state.nodes.map((node) => [node.type, node.label, node.identifier, node.parentIndex]),
+  ).toEqual([
+    ['Application', 'Settings', undefined, undefined],
+    ['SearchField', 'Search', undefined, 0],
+    ['Button', 'Dictate', 'Dictate', 1],
+  ]);
+});
+
+test('buildSnapshotState collapses duplicated iOS static and link surfaces', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    { index: 1, depth: 1, parentIndex: 0, type: 'Table', label: 'Camera' },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Other',
+      label: 'Composition',
+      rect: { x: 0, y: 564, width: 402, height: 38 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Other',
+      label: 'Composition',
+      rect: { x: 20, y: 564, width: 362, height: 38 },
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Other',
+      label: 'About Camera and ARKit & Privacy…',
+      rect: { x: 0, y: 760, width: 402, height: 32 },
+    },
+    {
+      index: 5,
+      depth: 3,
+      parentIndex: 4,
+      type: 'Link',
+      label: 'About Camera and ARKit & Privacy…',
+      rect: { x: 0, y: 760, width: 402, height: 32 },
+    },
+    {
+      index: 6,
+      depth: 4,
+      parentIndex: 5,
+      type: 'Link',
+      label: 'About Camera and ARKit & Privacy…',
+      rect: { x: 0, y: 115, width: 0, height: 17 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.parentIndex])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['Table', 'Camera', 0],
+    ['Other', 'Composition', 1],
+    ['Link', 'About Camera and ARKit & Privacy…', 1],
+  ]);
+});
+
+test('buildSnapshotState collapses nested duplicated iOS static text', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'New Expensify Dev' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'StaticText',
+      label: "You're done!",
+      rect: { x: 137, y: 302, width: 128, height: 27 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'StaticText',
+      label: "You're done!",
+      rect: { x: 137, y: 302, width: 128, height: 27 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.parentIndex])).toEqual([
+    ['Application', 'New Expensify Dev', undefined],
+    ['StaticText', "You're done!", 0],
+  ]);
+});
+
+test('buildSnapshotState collapses duplicated iOS scrollable wrappers', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Camera',
+      rect: { x: 0, y: 116, width: 402, height: 724 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Table',
+      label: 'Camera',
+      rect: { x: 0, y: 116, width: 402, height: 724 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Cell',
+      label: 'Formats',
+      rect: { x: 20, y: 441, width: 362, height: 53 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label, node.parentIndex])).toEqual([
+    ['Application', 'Settings', undefined],
+    ['Table', 'Camera', 0],
+    ['Cell', 'Formats', 1],
+  ]);
+});
+
+test('buildSnapshotVisibility keeps iOS hidden-below hints after row collapse', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Table',
+      label: 'Settings',
+      rect: { x: 0, y: 100, width: 402, height: 300 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Visible',
+      rect: { x: 20, y: 120, width: 362, height: 53 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'Visible',
+      rect: { x: 20, y: 120, width: 362, height: 53 },
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Below',
+      rect: { x: 20, y: 430, width: 362, height: 53 },
+    },
+    {
+      index: 5,
+      depth: 3,
+      parentIndex: 4,
+      type: 'Button',
+      label: 'Below',
+      rect: { x: 20, y: 430, width: 362, height: 53 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+  const visibility = buildSnapshotVisibility({ nodes: state.nodes, backend: state.backend });
+
+  expect(visibility.reasons).toContain('scroll-hidden-below');
+  expect(visibility.reasons).not.toContain('scroll-hidden-above');
+});
+
+test('buildSnapshotState transfers iOS scroll indicator values to scroll containers', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Other',
+      label: 'Vertical scroll bar, 2 pages',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'CollectionView',
+      label: 'Vertical scroll bar, 2 pages',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Cell',
+      label: 'General',
+      rect: { x: 16, y: 293, width: 370, height: 52 },
+    },
+    {
+      index: 4,
+      depth: 4,
+      parentIndex: 3,
+      type: 'Button',
+      label: 'General',
+      rect: { x: 16, y: 293, width: 370, height: 52 },
+    },
+    {
+      index: 5,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Other',
+      label: 'Vertical scroll bar, 2 pages',
+      value: '0%',
+      rect: { x: 369, y: 116, width: 30, height: 672 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+
+  expect(state.nodes.map((node) => [node.type, node.label])).toEqual([
+    ['Application', 'Settings'],
+    ['CollectionView', 'Vertical scroll bar, 2 pages'],
+    ['Cell', 'General'],
+  ]);
+  expect(state.nodes[1]?.hiddenContentAbove).toBeUndefined();
+  expect(state.nodes[1]?.hiddenContentBelow).toBe(true);
+  expect(state.nodes[1]?.rect).toEqual({ x: 0, y: 116, width: 402, height: 672 });
+});
+
+test('buildSnapshotVisibility keeps iOS hidden-above hints after row collapse', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Table',
+      label: 'Settings',
+      rect: { x: 0, y: 100, width: 402, height: 300 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Above',
+      rect: { x: 20, y: 20, width: 362, height: 53 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'Above',
+      rect: { x: 20, y: 20, width: 362, height: 53 },
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Visible',
+      rect: { x: 20, y: 120, width: 362, height: 53 },
+    },
+    {
+      index: 5,
+      depth: 3,
+      parentIndex: 4,
+      type: 'Button',
+      label: 'Visible',
+      rect: { x: 20, y: 120, width: 362, height: 53 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+  const visibility = buildSnapshotVisibility({ nodes: state.nodes, backend: state.backend });
+
+  expect(visibility.reasons).toContain('scroll-hidden-above');
+  expect(visibility.reasons).not.toContain('scroll-hidden-below');
+});
+
+test('buildSnapshotState transfers bottomed iOS scroll indicators without hidden-below', () => {
+  const nodes = [
+    { index: 0, depth: 0, type: 'Application', label: 'Settings' },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Table',
+      label: 'Settings',
+      rect: { x: 0, y: 100, width: 402, height: 300 },
+    },
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Cell',
+      label: 'Visible',
+      rect: { x: 20, y: 120, width: 362, height: 53 },
+    },
+    {
+      index: 3,
+      depth: 3,
+      parentIndex: 2,
+      type: 'Button',
+      label: 'Visible',
+      rect: { x: 20, y: 120, width: 362, height: 53 },
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Other',
+      label: 'Vertical scroll bar, 2 pages',
+      value: '100%',
+      rect: { x: 369, y: 116, width: 30, height: 672 },
+    },
+  ];
+
+  const state = buildSnapshotState({ nodes, backend: 'xctest' });
+  const visibility = buildSnapshotVisibility({ nodes: state.nodes, backend: state.backend });
+
+  expect(state.nodes[1]?.hiddenContentAbove).toBe(true);
+  expect(state.nodes[1]?.hiddenContentBelow).toBeUndefined();
+  expect(visibility.reasons).toContain('scroll-hidden-above');
+  expect(visibility.reasons).not.toContain('scroll-hidden-below');
+});

--- a/src/daemon/snapshot-presentation/ios/rows.ts
+++ b/src/daemon/snapshot-presentation/ios/rows.ts
@@ -1,0 +1,201 @@
+import type { RawSnapshotNode } from '../../../utils/snapshot.ts';
+import { normalizeType } from '../../snapshot-processing.ts';
+import {
+  areRectsApproximatelyEqual,
+  collectDescendants,
+  isDisabledChevronButton,
+  mergeReplacement,
+  shouldSuppressRepeatedTextDescendant,
+  type SnapshotTreeRuleContext,
+} from '../tree.ts';
+
+export function collectIosRowPresentation(
+  nodes: RawSnapshotNode[],
+  context: SnapshotTreeRuleContext,
+): void {
+  for (let position = 0; position < nodes.length; position += 1) {
+    const row = nodes[position];
+    const rowLabel = row?.label?.trim();
+    if (!row?.rect || !rowLabel) {
+      continue;
+    }
+    collectIosRowPresentationForNode(nodes, position, row, rowLabel, context);
+  }
+}
+
+function collectIosRowPresentationForNode(
+  nodes: RawSnapshotNode[],
+  position: number,
+  row: RawSnapshotNode,
+  rowLabel: string,
+  context: SnapshotTreeRuleContext,
+): void {
+  const descendants = collectDescendants(nodes, position);
+  const rowType = normalizeType(row.type ?? '');
+  if (rowType === 'button') {
+    suppressRepeatedRowDescendants(descendants, rowLabel, context.suppressedIndexes, row);
+    return;
+  }
+  if (rowType !== 'cell') {
+    return;
+  }
+  if (collectSwitchRowPresentation(descendants, row, rowLabel, context)) {
+    return;
+  }
+  collectButtonRowPresentation(descendants, row, rowLabel, context);
+}
+
+function collectSwitchRowPresentation(
+  descendants: RawSnapshotNode[],
+  row: RawSnapshotNode,
+  rowLabel: string,
+  context: SnapshotTreeRuleContext,
+): boolean {
+  const switchControl = descendants.find((candidate) =>
+    isIosRowSwitchCandidate(candidate, row, rowLabel),
+  );
+  if (!switchControl) {
+    return false;
+  }
+  const rowButton = descendants.find((candidate) =>
+    isIosRowButtonCandidate(candidate, row, rowLabel),
+  );
+  const promotedIdentifier = switchControl.identifier
+    ? undefined
+    : (rowButton?.identifier ?? row.identifier);
+  if (promotedIdentifier) {
+    mergeReplacement(context.replacements, switchControl, { identifier: promotedIdentifier });
+  }
+  context.suppressedIndexes.add(row.index);
+  suppressSwitchRowDescendants(
+    descendants,
+    row,
+    rowLabel,
+    switchControl,
+    context.suppressedIndexes,
+  );
+  return true;
+}
+
+function collectButtonRowPresentation(
+  descendants: RawSnapshotNode[],
+  row: RawSnapshotNode,
+  rowLabel: string,
+  context: SnapshotTreeRuleContext,
+): void {
+  const rowButton = descendants.find((candidate) =>
+    isIosRowButtonCandidate(candidate, row, rowLabel),
+  );
+  if (!rowButton) {
+    if (descendants.some(isDisabledChevronButton)) {
+      suppressRepeatedRowDescendants(descendants, rowLabel, context.suppressedIndexes, row);
+    }
+    return;
+  }
+
+  if (!row.identifier && rowButton.identifier) {
+    mergeReplacement(context.replacements, row, { identifier: rowButton.identifier });
+  }
+
+  context.suppressedIndexes.add(rowButton.index);
+  suppressRepeatedRowDescendants(
+    descendants.filter((descendant) => descendant.index !== rowButton.index),
+    rowLabel,
+    context.suppressedIndexes,
+    row,
+  );
+}
+
+function suppressSwitchRowDescendants(
+  descendants: RawSnapshotNode[],
+  row: RawSnapshotNode,
+  rowLabel: string,
+  switchControl: RawSnapshotNode,
+  suppressedIndexes: Set<number>,
+): void {
+  for (const descendant of descendants) {
+    if (descendant.index === switchControl.index) {
+      continue;
+    }
+    if (
+      isIosRowButtonCandidate(descendant, row, rowLabel) ||
+      isEmptyRowButtonWrapper(descendant, row) ||
+      isIosSwitchValueDescendant(descendant, switchControl) ||
+      shouldSuppressRepeatedTextDescendant(descendant, rowLabel)
+    ) {
+      suppressedIndexes.add(descendant.index);
+    }
+  }
+}
+
+function suppressRepeatedRowDescendants(
+  descendants: RawSnapshotNode[],
+  rowLabel: string,
+  suppressedIndexes: Set<number>,
+  row?: RawSnapshotNode,
+): void {
+  for (const descendant of descendants) {
+    if (
+      shouldSuppressRepeatedTextDescendant(descendant, rowLabel) ||
+      (row && isEmptyRowButtonWrapper(descendant, row))
+    ) {
+      suppressedIndexes.add(descendant.index);
+    }
+  }
+}
+
+function isIosRowButtonCandidate(
+  candidate: RawSnapshotNode,
+  row: RawSnapshotNode,
+  rowLabel: string,
+): boolean {
+  if (normalizeType(candidate.type ?? '') !== 'button') {
+    return false;
+  }
+  const rowIdentifier = row.identifier?.trim();
+  const candidateIdentifier = candidate.identifier?.trim();
+  if (rowIdentifier && candidateIdentifier && rowIdentifier === candidateIdentifier) {
+    return true;
+  }
+  const candidateLabel = candidate.label?.trim();
+  return candidateLabel === rowLabel && areRectsApproximatelyEqual(candidate.rect, row.rect);
+}
+
+function isEmptyRowButtonWrapper(node: RawSnapshotNode, row: RawSnapshotNode): boolean {
+  return (
+    normalizeType(node.type ?? '') === 'button' &&
+    !node.label?.trim() &&
+    !node.value?.trim() &&
+    areRectsApproximatelyEqual(node.rect, row.rect)
+  );
+}
+
+function isIosRowSwitchCandidate(
+  candidate: RawSnapshotNode,
+  row: RawSnapshotNode,
+  rowLabel: string,
+): boolean {
+  if (normalizeType(candidate.type ?? '') !== 'switch') {
+    return false;
+  }
+  const rowIdentifier = row.identifier?.trim();
+  const candidateIdentifier = candidate.identifier?.trim();
+  if (rowIdentifier && candidateIdentifier && rowIdentifier === candidateIdentifier) {
+    return true;
+  }
+  return candidate.label?.trim() === rowLabel;
+}
+
+function isIosSwitchValueDescendant(
+  node: RawSnapshotNode,
+  switchControl: RawSnapshotNode,
+): boolean {
+  if (normalizeType(node.type ?? '') !== 'switch') {
+    return false;
+  }
+  if (node.index === switchControl.index) {
+    return false;
+  }
+  const label = node.label?.trim();
+  return label === switchControl.value?.trim() || label === '0' || label === '1';
+}

--- a/src/daemon/snapshot-presentation/ios/scroll.ts
+++ b/src/daemon/snapshot-presentation/ios/scroll.ts
@@ -1,0 +1,97 @@
+import type { RawSnapshotNode } from '../../../utils/snapshot.ts';
+import {
+  inferVerticalScrollIndicatorDirections,
+  isSystemScrollIndicatorLabel,
+} from '../../../utils/scroll-indicator.ts';
+import {
+  findNearestScrollableContainer,
+  isScrollableSnapshotType,
+  mergeReplacement,
+  type SnapshotTreeRuleContext,
+} from '../tree.ts';
+
+export function collectIosScrollIndicatorPresentation(
+  nodes: RawSnapshotNode[],
+  context: SnapshotTreeRuleContext,
+): void {
+  const byIndex = new Map(nodes.map((node) => [node.index, node]));
+  for (const node of nodes) {
+    if (!isIosScrollIndicatorNode(node)) {
+      continue;
+    }
+    collectIosScrollIndicatorNodePresentation(node, byIndex, context);
+  }
+}
+
+function isIosScrollIndicatorNode(node: RawSnapshotNode): boolean {
+  const label = node.label?.trim();
+  return Boolean(label && isSystemScrollIndicatorLabel(label));
+}
+
+function collectIosScrollIndicatorNodePresentation(
+  node: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+  context: SnapshotTreeRuleContext,
+): void {
+  if (!isScrollableSnapshotType(node.type)) {
+    context.suppressedIndexes.add(node.index);
+  }
+
+  const directions = inferVerticalScrollIndicatorDirections(node.label?.trim() ?? '', node.value);
+  if (!directions) {
+    return;
+  }
+
+  const container = findNearestScrollableContainer(node, byIndex, { includeSelf: true });
+  if (!container) {
+    return;
+  }
+
+  applyScrollIndicatorReplacement(context, container, node, directions);
+}
+
+function applyScrollIndicatorReplacement(
+  context: SnapshotTreeRuleContext,
+  container: RawSnapshotNode,
+  indicator: RawSnapshotNode,
+  directions: { above: boolean; below: boolean },
+): void {
+  mergeReplacement(context.replacements, container, {
+    rect: deriveScrollableViewportRect(container.rect, indicator.rect) ?? container.rect,
+    hiddenContentAbove: mergeHiddenContentFlag(container.hiddenContentAbove, directions.above),
+    hiddenContentBelow: mergeHiddenContentFlag(container.hiddenContentBelow, directions.below),
+  });
+}
+
+function mergeHiddenContentFlag(
+  existing: boolean | undefined,
+  inferred: boolean,
+): true | undefined {
+  return existing === true || inferred ? true : undefined;
+}
+
+function deriveScrollableViewportRect(
+  containerRect: RawSnapshotNode['rect'],
+  indicatorRect: RawSnapshotNode['rect'],
+): RawSnapshotNode['rect'] | undefined {
+  if (!containerRect || !indicatorRect) {
+    return undefined;
+  }
+  if (indicatorRect.height <= 0 || indicatorRect.height >= containerRect.height) {
+    return undefined;
+  }
+  if (
+    indicatorRect.y < containerRect.y ||
+    indicatorRect.y > containerRect.y + containerRect.height
+  ) {
+    return undefined;
+  }
+  return {
+    ...containerRect,
+    y: indicatorRect.y,
+    height: Math.min(
+      indicatorRect.height,
+      containerRect.y + containerRect.height - indicatorRect.y,
+    ),
+  };
+}

--- a/src/daemon/snapshot-presentation/tree.ts
+++ b/src/daemon/snapshot-presentation/tree.ts
@@ -1,0 +1,230 @@
+import type { RawSnapshotNode } from '../../utils/snapshot.ts';
+import { normalizeType } from '../snapshot-processing.ts';
+
+export type SnapshotTreeRuleContext = {
+  replacements: Map<number, RawSnapshotNode>;
+  suppressedIndexes: Set<number>;
+};
+
+const RECT_FIELDS = ['x', 'y', 'width', 'height'] as const;
+
+export function collectDescendants(
+  nodes: RawSnapshotNode[],
+  startPosition: number,
+): RawSnapshotNode[] {
+  const startDepth = nodes[startPosition]?.depth ?? 0;
+  const descendants: RawSnapshotNode[] = [];
+  for (let position = startPosition + 1; position < nodes.length; position += 1) {
+    const node = nodes[position];
+    if (!node) {
+      continue;
+    }
+    if ((node.depth ?? 0) <= startDepth) {
+      break;
+    }
+    descendants.push(node);
+  }
+  return descendants;
+}
+
+function collectAncestors(
+  node: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+): RawSnapshotNode[] {
+  const ancestors: RawSnapshotNode[] = [];
+  let current = typeof node.parentIndex === 'number' ? byIndex.get(node.parentIndex) : undefined;
+  const visited = new Set<number>();
+  while (current && !visited.has(current.index)) {
+    visited.add(current.index);
+    ancestors.push(current);
+    current =
+      typeof current.parentIndex === 'number' ? byIndex.get(current.parentIndex) : undefined;
+  }
+  return ancestors;
+}
+
+export function findNearestAncestor(
+  node: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+  predicate: (ancestor: RawSnapshotNode) => boolean,
+): RawSnapshotNode | null {
+  for (const ancestor of collectAncestors(node, byIndex)) {
+    if (predicate(ancestor)) {
+      return ancestor;
+    }
+  }
+  return null;
+}
+
+export function findNearestScrollableContainer(
+  node: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+  options: { includeSelf?: boolean } = {},
+): RawSnapshotNode | null {
+  const self = options.includeSelf === true && isScrollableSnapshotType(node.type) ? node : null;
+  return (
+    self ??
+    findNearestAncestor(node, byIndex, (ancestor) => isScrollableSnapshotType(ancestor.type))
+  );
+}
+
+export function shouldSuppressRepeatedTextDescendant(
+  node: RawSnapshotNode,
+  parentLabel: string,
+): boolean {
+  const type = normalizeType(node.type ?? '');
+  const label = node.label?.trim();
+  if (isDisabledChevronButton(node)) {
+    return true;
+  }
+  if (type === 'other' && !label && !node.value) {
+    return true;
+  }
+  if ((type === 'other' || type === 'statictext') && label && parentLabel.includes(label)) {
+    return true;
+  }
+  if (type === 'image') {
+    return true;
+  }
+  return false;
+}
+
+export function isSemanticActionNode(node: RawSnapshotNode): boolean {
+  const type = normalizeType(node.type ?? '');
+  return (
+    type === 'button' ||
+    type === 'link' ||
+    type === 'switch' ||
+    type === 'searchfield' ||
+    type === 'textfield'
+  );
+}
+
+export function isDisabledChevronButton(node: RawSnapshotNode): boolean {
+  return (
+    normalizeType(node.type ?? '') === 'button' &&
+    node.label?.trim() === 'chevron' &&
+    node.enabled === false
+  );
+}
+
+export function isScrollableSnapshotType(type: string | undefined): boolean {
+  const normalized = normalizeType(type ?? '');
+  return (
+    normalized === 'collectionview' ||
+    normalized === 'table' ||
+    normalized === 'scrollview' ||
+    normalized === 'scrollarea'
+  );
+}
+
+export function isRepeatedStaticNode(node: RawSnapshotNode, parentLabel: string): boolean {
+  const label = node.label?.trim();
+  if (!label || label !== parentLabel) {
+    return false;
+  }
+  const type = normalizeType(node.type ?? '');
+  return type === 'other' || type === 'statictext' || type === 'link';
+}
+
+export function mergeReplacement(
+  replacements: Map<number, RawSnapshotNode>,
+  node: RawSnapshotNode,
+  patch: Partial<RawSnapshotNode>,
+): void {
+  replacements.set(node.index, {
+    ...node,
+    ...replacements.get(node.index),
+    ...patch,
+  });
+}
+
+export function areRectsApproximatelyEqual(
+  left: RawSnapshotNode['rect'],
+  right: RawSnapshotNode['rect'],
+): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  const tolerance = 0.5;
+  return RECT_FIELDS.every((key) => Math.abs(left[key] - right[key]) <= tolerance);
+}
+
+export function findLargestViewportRect(nodes: Iterable<RawSnapshotNode>): RawSnapshotNode['rect'] {
+  let viewport: RawSnapshotNode['rect'];
+  for (const node of nodes) {
+    const type = normalizeType(node.type ?? '');
+    if ((type === 'application' || type === 'window') && isLargerRect(node.rect, viewport)) {
+      viewport = node.rect;
+    }
+  }
+  return viewport;
+}
+
+export function isMostlyViewportSizedRect(
+  rect: RawSnapshotNode['rect'],
+  viewport: RawSnapshotNode['rect'],
+  minRatio = 0.8,
+): boolean {
+  const rectArea = getRectArea(rect);
+  const viewportArea = getRectArea(viewport);
+  return rectArea > 0 && viewportArea > 0 && rectArea / viewportArea >= minRatio;
+}
+
+function isLargerRect(
+  candidate: RawSnapshotNode['rect'],
+  current: RawSnapshotNode['rect'],
+): candidate is NonNullable<RawSnapshotNode['rect']> {
+  return Boolean(candidate && (!current || getRectArea(candidate) > getRectArea(current)));
+}
+
+function getRectArea(rect: RawSnapshotNode['rect']): number {
+  return rect ? rect.width * rect.height : 0;
+}
+
+export function reindexSnapshotNodesWithSuppressedParents(
+  nodes: RawSnapshotNode[],
+  suppressedIndexes: Set<number>,
+  originalNodes: RawSnapshotNode[],
+): RawSnapshotNode[] {
+  const originalByIndex = new Map(originalNodes.map((node) => [node.index, node]));
+  const indexMap = new Map<number, number>();
+  for (const [index, node] of nodes.entries()) {
+    indexMap.set(node.index, index);
+  }
+  return nodes.map((node, index) => {
+    let parentIndex =
+      typeof node.parentIndex === 'number' ? indexMap.get(node.parentIndex) : undefined;
+    if (parentIndex === undefined && typeof node.parentIndex === 'number') {
+      parentIndex = findNearestKeptAncestorIndex(
+        node.parentIndex,
+        suppressedIndexes,
+        originalByIndex,
+        indexMap,
+      );
+    }
+    return {
+      ...node,
+      index,
+      parentIndex,
+    };
+  });
+}
+
+function findNearestKeptAncestorIndex(
+  parentIndex: number,
+  suppressedIndexes: Set<number>,
+  originalByIndex: Map<number, RawSnapshotNode>,
+  indexMap: Map<number, number>,
+): number | undefined {
+  let currentIndex: number | undefined = parentIndex;
+  const visited = new Set<number>();
+  while (typeof currentIndex === 'number' && !visited.has(currentIndex)) {
+    visited.add(currentIndex);
+    if (!suppressedIndexes.has(currentIndex)) {
+      return indexMap.get(currentIndex);
+    }
+    currentIndex = originalByIndex.get(currentIndex)?.parentIndex;
+  }
+  return undefined;
+}

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -950,7 +950,7 @@ test('formatSnapshotText keeps flattened output and adds duplicate nav warning',
     rect:
       index === 0
         ? { x: 0, y: 0, width: 1080, height: 2400 }
-        : { x: 20, y: 40 + index * 80, width: 300, height: 48 },
+        : { x: 20, y: 40, width: 300, height: 48 },
     hittable: index !== 0,
     enabled: true,
   }));
@@ -959,42 +959,6 @@ test('formatSnapshotText keeps flattened output and adds duplicate nav warning',
   );
   assert.match(text, /Warning: possible repeated nav subtree detected\./);
   assert.match(text, /@e2 \[button\] "Inbox"/);
-});
-
-test('detectPossibleRepeatedNavSubtree does not warn for small trees', () => {
-  // 19 nodes (below the 20-node floor) — even if all are duplicates, no warning
-  const nodes = Array.from({ length: 19 }, (_, index) => ({
-    ref: `e${index + 1}`,
-    index,
-    depth: index === 0 ? 0 : 1,
-    type: 'android.widget.Button',
-    label: 'Inbox',
-    rect: { x: 20, y: 40 + index * 80, width: 300, height: 48 },
-    hittable: true,
-    enabled: true,
-  }));
-  const text = withNoColor(() =>
-    formatSnapshotText({ nodes, truncated: false }, { flatten: true }),
-  );
-  assert.doesNotMatch(text, /Warning: possible repeated nav subtree detected\./);
-});
-
-test('detectPossibleRepeatedNavSubtree does not warn when duplicates are below threshold', () => {
-  // 20 nodes but only 6 share a signature (below the 8 cumulative threshold)
-  const nodes = Array.from({ length: 20 }, (_, index) => ({
-    ref: `e${index + 1}`,
-    index,
-    depth: index === 0 ? 0 : 1,
-    type: 'android.widget.Button',
-    label: index < 7 ? `Unique${index}` : index < 10 ? 'Shared' : `Other${index}`,
-    rect: { x: 20, y: 40 + index * 80, width: 300, height: 48 },
-    hittable: true,
-    enabled: true,
-  }));
-  const text = withNoColor(() =>
-    formatSnapshotText({ nodes, truncated: false }, { flatten: true }),
-  );
-  assert.doesNotMatch(text, /Warning: possible repeated nav subtree detected\./);
 });
 
 test('formatSnapshotLine keeps snapshot-only metadata off the default formatter path', () => {

--- a/src/utils/__tests__/repeated-nav-subtree.test.ts
+++ b/src/utils/__tests__/repeated-nav-subtree.test.ts
@@ -1,0 +1,77 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { detectPossibleRepeatedNavSubtree } from '../repeated-nav-subtree.ts';
+import type { SnapshotNode } from '../snapshot.ts';
+
+test('detectPossibleRepeatedNavSubtree warns for overlapping duplicate rows', () => {
+  const nodes = makeNodes(24, (index) => ({
+    type: index === 0 ? 'android.widget.FrameLayout' : 'android.widget.Button',
+    label: index === 0 ? 'Root' : 'Inbox',
+    rect:
+      index === 0
+        ? { x: 0, y: 0, width: 1080, height: 2400 }
+        : { x: 20, y: 40, width: 300, height: 48 },
+  }));
+
+  assert.equal(detectPossibleRepeatedNavSubtree(nodes), true);
+});
+
+test('detectPossibleRepeatedNavSubtree does not warn for repeated list rows', () => {
+  const nodes = makeNodes(24, (index) => ({
+    type: index === 0 ? 'android.widget.FrameLayout' : 'android.widget.Button',
+    label: index === 0 ? 'Root' : 'Receipt missing details',
+    rect:
+      index === 0
+        ? { x: 0, y: 0, width: 1080, height: 2400 }
+        : { x: 20, y: 40 + index * 80, width: 300, height: 48 },
+  }));
+
+  assert.equal(detectPossibleRepeatedNavSubtree(nodes), false);
+});
+
+test('detectPossibleRepeatedNavSubtree tolerates subpixel adjacent list rows', () => {
+  const nodes = makeNodes(24, (index) => ({
+    type: index === 0 ? 'android.widget.FrameLayout' : 'android.widget.Button',
+    label: index === 0 ? 'Root' : 'Receipt missing details',
+    rect:
+      index === 0
+        ? { x: 0, y: 0, width: 1080, height: 2400 }
+        : { x: 20, y: 40 + index * 63.99998, width: 300, height: 64 },
+  }));
+
+  assert.equal(detectPossibleRepeatedNavSubtree(nodes), false);
+});
+
+test('detectPossibleRepeatedNavSubtree does not warn for small trees', () => {
+  const nodes = makeNodes(19, (index) => ({
+    type: 'android.widget.Button',
+    label: 'Inbox',
+    rect: { x: 20, y: 40 + index * 80, width: 300, height: 48 },
+  }));
+
+  assert.equal(detectPossibleRepeatedNavSubtree(nodes), false);
+});
+
+test('detectPossibleRepeatedNavSubtree does not warn when duplicates are below threshold', () => {
+  const nodes = makeNodes(20, (index) => ({
+    type: 'android.widget.Button',
+    label: index < 7 ? `Unique${index}` : index < 10 ? 'Shared' : `Other${index}`,
+    rect: { x: 20, y: 40 + index * 80, width: 300, height: 48 },
+  }));
+
+  assert.equal(detectPossibleRepeatedNavSubtree(nodes), false);
+});
+
+function makeNodes(
+  count: number,
+  build: (index: number) => Pick<SnapshotNode, 'type' | 'label' | 'rect'>,
+): SnapshotNode[] {
+  return Array.from({ length: count }, (_, index) => ({
+    ref: `e${index + 1}`,
+    index,
+    depth: index === 0 ? 0 : 1,
+    hittable: index !== 0,
+    enabled: true,
+    ...build(index),
+  }));
+}

--- a/src/utils/android-helper-snapshot-presentation.ts
+++ b/src/utils/android-helper-snapshot-presentation.ts
@@ -1,4 +1,5 @@
 import type { Rect, SnapshotNode } from './snapshot.ts';
+import { isEmailLikeLabel, normalizeRepeatedNodeLabel } from './snapshot-label-signals.ts';
 import { displayNodeLabel } from './snapshot-tree.ts';
 
 const ACTIONABLE_STRUCTURAL_TYPE_TOKENS = ['button', 'switch', 'checkbox', 'radio'];
@@ -22,27 +23,6 @@ export function buildAndroidHelperPresentationInput(
     nodes: filtered,
     filteredCount: nodes.length - filtered.length,
   };
-}
-
-export function detectPossibleRepeatedNavSubtree(nodes: SnapshotNode[]): boolean {
-  if (nodes.length < 20) {
-    return false;
-  }
-  const counts = new Map<string, number>();
-  for (const node of nodes) {
-    const type = (node.type ?? '').toLowerCase();
-    const label = normalizeRepeatedNodeLabel(displayNodeLabel(node));
-    if (!label) continue;
-    const signature = `${type}|${label}`;
-    counts.set(signature, (counts.get(signature) ?? 0) + 1);
-  }
-  let duplicateCount = 0;
-  for (const count of counts.values()) {
-    if (count > 1) {
-      duplicateCount += count;
-    }
-  }
-  return duplicateCount >= 8;
 }
 
 function isAndroidHelperSnapshot(data: Record<string, unknown>): boolean {
@@ -407,18 +387,8 @@ function getNodeOrDescendantLabel(node: SnapshotNode, nodes: SnapshotNode[]): st
   return '';
 }
 
-function normalizeRepeatedNodeLabel(label: string): string | null {
-  const normalized = label.trim().replace(/\s+/g, ' ').toLowerCase();
-  if (!normalized || isEmailLikeLabel(normalized)) return null;
-  return normalized;
-}
-
 function bucket(value: number, size: number): number {
   return Math.round(value / size);
-}
-
-function isEmailLikeLabel(label: string): boolean {
-  return /\S+@\S+\.\S+/.test(label);
 }
 
 function areSameVisualRow(left: Rect | undefined, right: Rect | undefined): boolean {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
 import {
   buildAndroidHelperPresentationInput,
-  detectPossibleRepeatedNavSubtree,
   type AndroidHelperPresentationInput,
 } from './android-helper-snapshot-presentation.ts';
 import { AppError, normalizeError, type NormalizedError } from './errors.ts';
+import { detectPossibleRepeatedNavSubtree } from './repeated-nav-subtree.ts';
 import { buildSnapshotDisplayLines, formatSnapshotLine } from './snapshot-lines.ts';
 import type { SnapshotNode, SnapshotUnchanged, SnapshotVisibility } from './snapshot.ts';
 import type { ScreenshotDiffResult } from './screenshot-diff.ts';

--- a/src/utils/react-native-overlay-signals.ts
+++ b/src/utils/react-native-overlay-signals.ts
@@ -1,0 +1,32 @@
+export function hasKnownReactNativeOverlayText(text: string): boolean {
+  return /\b(logbox|redbox|reload js|copy stack|component stack|call stack|runtime error|open debugger to view warnings)\b/.test(
+    text,
+  );
+}
+
+export function isReactNativeStackFrame(text: string): boolean {
+  return (
+    /\b[\w.$<>/-]+\.(?:tsx?|jsx?):\d+(?::\d+)?\b/.test(text) ||
+    /\b[\w.$<>/-]+\.(?:tsx?|jsx?)\s+\(\d+:\d+\)/.test(text)
+  );
+}
+
+export function isReactNativeCollapsedWarningLabel(rawLabel: string | undefined): boolean {
+  const label = rawLabel?.trim().toLowerCase();
+  if (!label) return false;
+  return (
+    label.includes('open debugger to view warnings') ||
+    /^!,\s+/.test(label) ||
+    /^(warn|warning|error):\s+/.test(label) ||
+    /\b(?:possible\s+)?unhandled (?:promise )?rejection\b/.test(label) ||
+    label.includes('getsnapshot should be cached to avoid an infinite loop') ||
+    label.includes('unique "key" prop') ||
+    label.includes("unique 'key' prop") ||
+    label.includes('virtualizedlists should never be nested') ||
+    label.includes('failed prop type')
+  );
+}
+
+export function isReactNativeOpenDebuggerWarningLabel(label: string): boolean {
+  return label.includes('open debugger to view warnings') || /^!,\s+open debugger\b/.test(label);
+}

--- a/src/utils/repeated-nav-subtree.ts
+++ b/src/utils/repeated-nav-subtree.ts
@@ -1,0 +1,51 @@
+import type { Rect, SnapshotNode } from './snapshot.ts';
+import { normalizeRepeatedNodeLabel } from './snapshot-label-signals.ts';
+import { displayNodeLabel } from './snapshot-tree.ts';
+
+export function detectPossibleRepeatedNavSubtree(nodes: SnapshotNode[]): boolean {
+  if (nodes.length < 20) {
+    return false;
+  }
+  const groups = new Map<string, SnapshotNode[]>();
+  for (const node of nodes) {
+    const type = (node.type ?? '').toLowerCase();
+    const label = normalizeRepeatedNodeLabel(displayNodeLabel(node));
+    if (!label) continue;
+    const signature = `${type}|${label}`;
+    const group = groups.get(signature) ?? [];
+    group.push(node);
+    groups.set(signature, group);
+  }
+  let duplicateCount = 0;
+  for (const group of groups.values()) {
+    if (group.length <= 1 || !hasOverlappingDuplicateRects(group)) {
+      continue;
+    }
+    duplicateCount += group.length;
+  }
+  return duplicateCount >= 8;
+}
+
+function hasOverlappingDuplicateRects(nodes: SnapshotNode[]): boolean {
+  for (let left = 0; left < nodes.length; left += 1) {
+    for (let right = left + 1; right < nodes.length; right += 1) {
+      if (rectsOverlap(nodes[left]?.rect, nodes[right]?.rect)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function rectsOverlap(left: Rect | undefined, right: Rect | undefined): boolean {
+  if (!left || !right) {
+    return true;
+  }
+  const tolerance = 0.5;
+  return !(
+    left.x + left.width <= right.x + tolerance ||
+    right.x + right.width <= left.x + tolerance ||
+    left.y + left.height <= right.y + tolerance ||
+    right.y + right.height <= left.y + tolerance
+  );
+}

--- a/src/utils/snapshot-label-signals.ts
+++ b/src/utils/snapshot-label-signals.ts
@@ -1,0 +1,9 @@
+export function normalizeRepeatedNodeLabel(label: string): string | null {
+  const normalized = label.trim().replace(/\s+/g, ' ').toLowerCase();
+  if (!normalized || isEmailLikeLabel(normalized)) return null;
+  return normalized;
+}
+
+export function isEmailLikeLabel(label: string): boolean {
+  return /\S+@\S+\.\S+/.test(label);
+}

--- a/website/docs/docs/_meta.json
+++ b/website/docs/docs/_meta.json
@@ -70,6 +70,11 @@
     "label": "Snapshots"
   },
   {
+    "name": "ios-snapshot-elements",
+    "type": "file",
+    "label": "iOS Snapshot Elements"
+  },
+  {
     "name": "known-limitations",
     "type": "file",
     "label": "Known Limitations"

--- a/website/docs/docs/ios-snapshot-elements.md
+++ b/website/docs/docs/ios-snapshot-elements.md
@@ -1,0 +1,86 @@
+---
+title: iOS Snapshot Element Support
+---
+
+# iOS Snapshot Element Support
+
+This page tracks how `snapshot -i` presents common iOS interaction surfaces. It
+is scoped to the XCTest-backed iOS snapshot path and the default non-raw
+presentation. Use `snapshot --raw` or `snapshot --json` when investigating the
+provider tree itself.
+
+Sources used for this checklist:
+
+- Apple Human Interface Guidelines: [Components](https://developer.apple.com/design/human-interface-guidelines/components/)
+- Apple Human Interface Guidelines: [Selection and input](https://developer.apple.com/design/human-interface-guidelines/selection-and-input)
+- Apple Human Interface Guidelines: [Navigation and search](https://developer.apple.com/design/human-interface-guidelines/navigation-and-search)
+- Apple Human Interface Guidelines: [Menus and actions](https://developer.apple.com/design/human-interface-guidelines/menus-and-actions)
+- UIKit accessibility behavior: [UIAccessibility](https://developer.apple.com/documentation/UIKit/uiaccessibility-protocol) and [UIAccessibilityTraits](https://developer.apple.com/documentation/uikit/uiaccessibilitytraits)
+
+## Status Key
+
+| Status | Meaning |
+| --- | --- |
+| Supported | Expected to produce one actionable, unambiguous node in `snapshot -i`. |
+| Pass-through | Preserved when XCTest exposes it, but no custom iOS presentation shaping yet. |
+| Command-supported | Handled by a dedicated command rather than snapshot presentation. |
+| Needs fixture | Known common element, but we still need raw tree and screenshot-overlay samples before claiming support. |
+| Out of scope | Useful UI information, but not an interaction target for `snapshot -i`. |
+
+## Matrix
+
+| Apple/HIG area | Common iOS surface | Expected XCTest/accessibility shape | Current support | Tested with | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Menus and actions | Button, toolbar button, pull-down or menu button | `Button`, sometimes wrapped in `Other` with the same label/rect | Supported | Settings rows, Expensify Home, Expensify action menu | Same-rect `Other -> Button` wrappers collapse to the button. Descendant duplicate text/image decoration is suppressed. |
+| Menus and actions | Link | `Link`, sometimes wrapped in repeated static/link nodes | Supported | Unit fixture from Settings privacy link shape | Repeated link/static descendants collapse to one link. Needs more live Safari/Mail coverage. |
+| Selection and input | Switch toggle | `Cell -> Button -> Switch`, or a standalone `Switch` | Supported | Settings Camera live screen, unit fixture | Row-backed switch collapses to the switch control, not the row/button wrapper. |
+| Selection and input | Toggle button | Usually `Button` with selected/value/trait semantics | Pass-through | None yet | We keep the button. Need real samples to decide whether selected/value should be surfaced more explicitly. |
+| Selection and input | Checkbox | `CheckBox`/`Checkbox` or button-like custom node | Pass-through | None yet | Common on macOS and web-like/custom iOS apps. Interactive filtering keeps role strings containing checkbox, but iOS shaping has no special checkbox rules. |
+| Selection and input | Radio button/group | `RadioButton`, `RadioGroup`, or button-like custom nodes | Pass-through | None yet | Interactive filtering keeps role strings containing radio. Need grouped native/custom samples. |
+| Selection and input | Text field | `TextField`, `SecureTextField`, or wrapper `Other -> TextField` | Supported | Expensify Search, unit fixture | Fillability already recognizes text/search/secure/text-view types. Wrapper collapses to the editable node. |
+| Selection and input | Search field | `SearchField`, often inside toolbar/search wrappers | Supported | Settings search field, Expensify search field | Settings toolbar duplicates collapse to one search field plus Dictate button. |
+| Selection and input | Text view / multiline editor | `TextView`/`TextArea` | Pass-through | Unit coverage for read/fill helpers | Fillability recognizes text views, but iOS presentation has no live complex editor sample yet. |
+| Selection and input | Token field | `TextField`, token cells/buttons, or custom wrappers | Needs fixture | None yet | Need Mail/Calendar recipient-field samples. Likely mixed editable field plus token buttons. |
+| Selection and input | Digit entry / OTP | Multiple `TextField`s, one hidden text field, or custom key grid | Needs fixture | None yet | We should avoid collapsing distinct digit boxes until tested. |
+| Selection and input | Slider | `Slider`, usually adjustable and rect-backed | Pass-through | None yet | `snapshot -i` keeps rect-backed controls. Need Settings volume/brightness samples to verify value formatting and adjustability. |
+| Selection and input | Stepper | `Stepper` or increment/decrement buttons | Needs fixture | None yet | Need native examples to decide whether to expose one adjustable control or separate buttons. |
+| Selection and input | Segmented control | `SegmentedControl` with segment buttons, or collapsed adjustable-like control | Needs fixture | None yet | Current workflow docs still call out horizontal tab/filter bars that may collapse into one composite. Needs real-app coverage. |
+| Selection and input | Picker / picker wheel | `Picker`, `PickerWheel`, option cells, or modal sheet | Needs fixture | None yet | Need Clock/Calendar/Settings samples. We should not over-collapse value wheels before testing. |
+| Selection and input | Date picker | `DatePicker`, calendar buttons, picker wheels, compact button + popover | Needs fixture | None yet | Test compact, inline, and wheels styles separately. |
+| Selection and input | Virtual keyboard and keys | `Keyboard`, `Key` | Command-supported | Expensify Search | Offscreen keyboard subtrees are suppressed when they are below the app viewport. Keyboard interaction belongs to `keyboard`/`fill`/`type`; visible app-owned Done buttons remain normal buttons. |
+| Navigation and search | Navigation bar / toolbar | `NavigationBar`, `Toolbar`, title text, bar buttons | Supported | Settings, Expensify Search | Navigation/action buttons remain; duplicated title/search wrapper nodes are suppressed when they duplicate semantic children. |
+| Navigation and search | Tab bar | `TabBar`, tab buttons, or custom `Other` nodes | Pass-through | Expensify Home | Expensify tabs are exposed as distinct `Other` items. Need native UITabBar samples to decide if `TabBar` container should stay visible or collapse. |
+| Navigation and search | Sidebar/list navigation | `Table`, `CollectionView`, `Cell`, row button wrappers | Supported | Settings top/bottom, Expensify lists | Row-backed Settings cells collapse to a single `Cell`. Scroll-hidden above/below hints stay on the scroll container. |
+| Navigation and search | Search results list | `ScrollView`/`Table`/`CollectionView` plus rows | Supported | Expensify Search | Repeated legitimate list rows do not trigger the duplicate-nav warning when they are stacked instead of overlapping. |
+| Menus and actions | Context menu / edit menu | `Menu`, `MenuItem`, sheet/popover, or transient system surface | Needs fixture | None yet | Need long-press samples from Photos/Files/Text selection. |
+| Menus and actions | Activity/share view | Sheet with buttons, collections, extension cells | Needs fixture | None yet | Treat as normal app/system UI until samples show duplication patterns. |
+| Presentation | Alert | `Alert` plus buttons, or native alert command result | Command-supported | Provider tests | Use `alert wait/get/accept/dismiss` for native alerts. Snapshot should still be inspected when an app-owned sheet looks like an alert. |
+| Presentation | Sheet, bottom sheet, popover | `Sheet`/`Popover`/`Other` wrappers plus buttons/fields | Supported for common wrappers | Expensify action menu | Backdrop dismiss and action-row wrappers collapse when semantic children are present. Need native sheet/popover examples. |
+| Status | Activity indicator, progress indicator, gauge | `ActivityIndicator`, `ProgressIndicator`, `Other` with value | Out of scope | None yet | These are important state, but not primary interaction targets. They should stay in full snapshots; `snapshot -i` may omit them unless rect-backed. |
+| Status | Page control / page indicator | `PageIndicator`, adjustable trait, dots/buttons | Needs fixture | None yet | Often interactive via swipe or adjustable actions. Need samples before deciding presentation. |
+| Layout and organization | Static text, headers, images, decoration | `StaticText`, `Image`, `Other` | Supported as descendants/noise | Settings, Expensify | Repeated static/link/image descendants under an actionable parent are suppressed. Standalone useful text remains visible when retained by the interactive tree. |
+| Layout and organization | Scroll bars / scroll indicators | `Other` with labels like vertical scroll bar | Supported | Settings top/bottom, Expensify lists | Scroll indicator nodes are removed from the interactive tree and converted into `[content above/below ... hidden]` hints on the nearest scroll container. |
+| Layout and organization | Collection/table/scroll containers | `CollectionView`, `Table`, `ScrollView` | Supported | Settings, Expensify | Containers remain when they communicate scrollability or hidden content. |
+
+## Next Apps To Sample
+
+Use `snapshot -i`, `snapshot -i --raw --json`, and `screenshot --overlay-refs` for each sample before updating this page.
+
+| Element family | Suggested apps/screens |
+| --- | --- |
+| Slider / page indicator | Settings > Sounds & Haptics, Photos onboarding/carousel, Control Center if accessible |
+| Segmented controls | Photos library filters, Calendar view switcher, App Store tabs/filters |
+| Picker/date picker | Clock alarm editor, Calendar event editor, Reminders date picker |
+| Stepper | Calendar/Reminders repeat or count fields, any system form that exposes increment/decrement |
+| Token field | Mail compose recipients, Calendar invitees |
+| Context/edit menu | Files long-press, Photos long-press, text selection in Notes |
+| Native tab bar | App Store, Phone, Photos |
+| Share/activity sheet | Photos share, Safari share |
+
+When adding coverage, record:
+
+- app and screen;
+- shaped `snapshot -i` output;
+- raw `snapshot -i --raw --json` node shape for the relevant subtree;
+- overlay screenshot path;
+- whether the result is supported, pass-through, or needs implementation work.

--- a/website/docs/docs/snapshots.md
+++ b/website/docs/docs/snapshots.md
@@ -46,6 +46,7 @@ It does not automatically switch to AX.
 - Use `diff snapshot` between mutations to validate structural changes with lower output volume.
 - Use `snapshot --diff` when you discover the feature from snapshot help, but keep `diff snapshot` as the default exploration command.
 - Keep `--raw` for troubleshooting only when you need the full tree instead of visible-first output.
+- For the current iOS interaction-element support matrix, see [iOS Snapshot Element Support](/docs/ios-snapshot-elements).
 
 `diff snapshot` and `snapshot --diff` behavior:
 - First run initializes baseline (`baselineInitialized: true` in JSON).


### PR DESCRIPTION
## Summary

Simplifies iOS interactive snapshots so table/list rows are represented once, with row-level refs instead of repeated cell/container/button/text duplicates.

Adds a modular iOS snapshot presentation pipeline, shared tree helpers, extracted repeated-nav warning logic, and docs for iOS snapshot elements. Repeated-nav warnings now require overlapping duplicate rects, reducing false positives on ordinary vertical lists. Screenshot overlay refs now use the same interactive/compact presentation path.

Fixes the React Native collapsed `Open debugger to view warnings` overlay case found during Expensify verification: `snapshot -i` now warns agents to use `react-native dismiss-overlay`, preserves the visible banner target instead of the full-screen wrapper, and dismisses via the narrow close affordance. Follow-up deeper RN overlay work is tracked in #577.

Review hardening: switch rows now preserve promoted identifiers, unlabeled row-sized buttons no longer win row collapse by order, and iOS keyboard suppression derives its viewport only from Application/Window nodes instead of scoped roots.

Touched-file count: 26. Scope stayed within snapshot presentation, screenshot overlay refs, RN overlay handling, tests, and docs.

## Validation

Ran focused snapshot/RN/output tests: 8 files, 101 tests passed.

Ran `pnpm check:quick`, `pnpm format`, and `pnpm build` successfully.

Manual iOS verification covered Settings snapshots and New Expensify Dev. In Expensify, before the fix `react-native dismiss-overlay` reported no overlay for the visible `Open debugger...` banner; after the fix `snapshot -i` emitted the RN overlay hint, `react-native dismiss-overlay` tapped the close target at `(369, 813)`, and a follow-up compact snapshot confirmed the overlay was gone.