### PR TITLE
fix: make swift helper cache builds concurrent-safe

### DIFF
--- a/src/recording/__tests__/overlay.test.ts
+++ b/src/recording/__tests__/overlay.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../utils/video.ts', () => ({
 }));
 
 import { overlayRecordingTouches } from '../overlay.ts';
+import { AppError } from '../../utils/errors.ts';
 import { runCmd } from '../../utils/exec.ts';
 
 const mockRunCmd = vi.mocked(runCmd);
@@ -76,4 +77,24 @@ test('overlay burns touches through a cached helper and same-directory temp outp
   expect(helperOptions?.env?.CLANG_MODULE_CACHE_PATH).toBe(
     path.join(tmpDir, 'swift-cache', 'module-cache'),
   );
+});
+
+test('overlay preserves Swift helper compile hints', async () => {
+  const videoPath = path.join(tmpDir, 'recording.mp4');
+  const telemetryPath = path.join(tmpDir, 'recording.gesture-telemetry.json');
+  const hint = 'Remove the stale Swift cache lock and retry.';
+  fs.writeFileSync(videoPath, 'original');
+  fs.writeFileSync(telemetryPath, '{"events":[]}');
+
+  mockRunCmd.mockImplementationOnce(async () => {
+    throw new AppError('COMMAND_FAILED', 'Timed out waiting for Swift cache lock', { hint });
+  });
+
+  await expect(overlayRecordingTouches({ videoPath, telemetryPath })).rejects.toMatchObject({
+    code: 'COMMAND_FAILED',
+    message: 'Failed to add touch overlays to the recording',
+    details: {
+      hint,
+    },
+  });
 });

--- a/src/recording/overlay.ts
+++ b/src/recording/overlay.ts
@@ -89,12 +89,9 @@ async function exportProcessedVideo(params: {
       'COMMAND_FAILED',
       commandDescription,
       {
+        ...cause.details,
         videoPath,
         script: scriptPath,
-        stderr: cause.details?.stderr,
-        stdout: cause.details?.stdout,
-        exitCode: cause.details?.exitCode,
-        processExitError: cause.details?.processExitError,
       },
       cause,
     );

--- a/src/utils/__tests__/swift-cache.test.ts
+++ b/src/utils/__tests__/swift-cache.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('../exec.ts', () => ({
+  runCmd: vi.fn(async (_cmd: string, args: string[]) => {
+    const outputPath = args[args.indexOf('-o') + 1];
+    fs.writeFileSync(outputPath, 'compiled');
+    fs.chmodSync(outputPath, 0o755);
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }),
+}));
+
+import { runCmd } from '../exec.ts';
+import { compileSwiftSourceFile } from '../swift-cache.ts';
+
+const mockRunCmd = vi.mocked(runCmd);
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-swift-cache-test-'));
+  vi.stubEnv('AGENT_DEVICE_SWIFT_CACHE_DIR', path.join(tmpDir, 'swift-cache'));
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('compileSwiftSourceFile compiles to a unique temp executable before publishing cache entry', async () => {
+  const sourcePath = writeSourceFile('print("hello")');
+
+  const executablePath = await compileSwiftSourceFile({
+    cacheName: 'recording-helper',
+    sourcePath,
+  });
+
+  const compileCall = mockRunCmd.mock.calls[0];
+  const outputPath = compileCall[1][compileCall[1].indexOf('-o') + 1];
+
+  expect(outputPath).not.toBe(executablePath);
+  expect(path.dirname(outputPath)).toContain(path.join('swift-cache', 'bin'));
+  expect(path.basename(outputPath)).toBe(path.basename(executablePath));
+  expect(fs.statSync(executablePath).mode & 0o111).not.toBe(0);
+  expect(fs.existsSync(outputPath)).toBe(false);
+});
+
+test('concurrent file-backed helper compiles for the same cache key reuse the winning executable', async () => {
+  const sourcePath = writeSourceFile();
+
+  await expectConcurrentCacheReuse(() =>
+    compileSwiftSourceFile({
+      sourcePath,
+      cacheName: 'recording-overlay',
+    }),
+  );
+});
+
+test('stale cache locks are removed before compiling', async () => {
+  const { sourcePath, executablePath, lockDir } = await createBlockedCacheEntry();
+  const staleTime = new Date(Date.now() - 1_000);
+  fs.utimesSync(lockDir, staleTime, staleTime);
+
+  await expect(
+    compileSwiftSourceFile({
+      sourcePath,
+      cacheName: 'recording-overlay',
+      timeoutMs: 100,
+    }),
+  ).resolves.toBe(executablePath);
+
+  expect(fs.existsSync(lockDir)).toBe(false);
+  expect(mockRunCmd).toHaveBeenCalledTimes(1);
+});
+
+test('cache lock timeout reports the lock path', async () => {
+  const { sourcePath, lockDir } = await createBlockedCacheEntry();
+  const futureTime = new Date(Date.now() + 60_000);
+  fs.utimesSync(lockDir, futureTime, futureTime);
+
+  await expect(
+    compileSwiftSourceFile({
+      sourcePath,
+      cacheName: 'recording-overlay',
+      timeoutMs: 1,
+    }),
+  ).rejects.toMatchObject({
+    code: 'COMMAND_FAILED',
+    message: `Timed out waiting for Swift cache lock: ${lockDir} (1ms)`,
+    details: {
+      lockDir,
+      timeoutMs: 1,
+      hint: expect.stringContaining(`remove "${lockDir}"`),
+    },
+  });
+
+  expect(mockRunCmd).not.toHaveBeenCalled();
+});
+
+function writeSourceFile(source = 'print("recording")'): string {
+  const sourcePath = path.join(tmpDir, 'recording-overlay.swift');
+  fs.writeFileSync(sourcePath, source);
+  return sourcePath;
+}
+
+async function createBlockedCacheEntry() {
+  const sourcePath = writeSourceFile();
+  const executablePath = await compileSwiftSourceFile({
+    sourcePath,
+    cacheName: 'recording-overlay',
+  });
+  const lockDir = `${executablePath}.lock`;
+  fs.rmSync(executablePath);
+  fs.mkdirSync(lockDir);
+  vi.clearAllMocks();
+  return { executablePath, lockDir, sourcePath };
+}
+
+async function expectConcurrentCacheReuse(compile: () => Promise<string>): Promise<void> {
+  let releaseCompile: () => void = () => {};
+  const compileStarted = new Promise<void>((resolve) => {
+    mockRunCmd.mockImplementationOnce(async (_cmd: string, args: string[]) => {
+      resolve();
+      await new Promise<void>((release) => {
+        releaseCompile = release;
+      });
+      const outputPath = args[args.indexOf('-o') + 1];
+      fs.writeFileSync(outputPath, 'compiled once');
+      fs.chmodSync(outputPath, 0o755);
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+  });
+
+  const firstCompile = compile();
+  await compileStarted;
+  const originalMkdirSync = fs.mkdirSync;
+  const lockAttempted = new Promise<void>((resolve) => {
+    const mkdirSpy = vi.spyOn(fs, 'mkdirSync').mockImplementation((dirPath, options) => {
+      if (typeof dirPath === 'string' && dirPath.endsWith('.lock')) {
+        resolve();
+        mkdirSpy.mockRestore();
+      }
+      return originalMkdirSync(dirPath, options);
+    });
+  });
+  const secondCompile = compile();
+
+  await lockAttempted;
+  expect(mockRunCmd).toHaveBeenCalledTimes(1);
+
+  releaseCompile();
+  const [firstExecutable, secondExecutable] = await Promise.all([firstCompile, secondCompile]);
+
+  expect(secondExecutable).toBe(firstExecutable);
+  expect(fs.readFileSync(firstExecutable, 'utf8')).toBe('compiled once');
+  expect(mockRunCmd).toHaveBeenCalledTimes(1);
+}

--- a/src/utils/swift-cache.ts
+++ b/src/utils/swift-cache.ts
@@ -2,9 +2,12 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { AppError } from './errors.ts';
 import { runCmd } from './exec.ts';
 
-const SWIFT_CACHE_VERSION = '1';
+const SWIFT_CACHE_VERSION = '2';
+const LOCK_RETRY_DELAY_MS = 25;
 
 export function buildSwiftToolEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const root = getSwiftCacheRoot();
@@ -56,14 +59,10 @@ export async function compileSwiftSourceText(params: {
   const sourcePath = path.join(getSwiftCacheRoot(), 'sources', `${cacheName}-${key}.swift`);
   const executablePath = path.join(getSwiftCacheRoot(), 'bin', `${cacheName}-${key}`);
 
-  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
-  if (!fs.existsSync(sourcePath)) {
-    fs.writeFileSync(sourcePath, params.source);
-  }
-
   await ensureSwiftExecutable({
     sourcePath,
     executablePath,
+    sourceText: params.source,
     timeoutMs: params.timeoutMs,
   });
   return executablePath;
@@ -80,24 +79,86 @@ function getSwiftCacheRoot(): string {
 async function ensureSwiftExecutable(params: {
   sourcePath: string;
   executablePath: string;
+  sourceText?: string;
   timeoutMs?: number;
 }): Promise<void> {
   if (isExecutableFile(params.executablePath)) {
     return;
   }
 
-  fs.mkdirSync(path.dirname(params.executablePath), { recursive: true });
-  const tempExecutablePath = `${params.executablePath}.${process.pid}.${Date.now()}.tmp`;
+  const executableDir = path.dirname(params.executablePath);
+  fs.mkdirSync(executableDir, { recursive: true });
+  const lockDir = `${params.executablePath}.lock`;
+  if (!(await acquireSwiftCacheLock(lockDir, params.executablePath, params.timeoutMs ?? 120_000))) {
+    return;
+  }
+
+  const tempDir = fs.mkdtempSync(
+    path.join(executableDir, `.${path.basename(params.executablePath)}.${process.pid}.`),
+  );
+  const tempExecutablePath = path.join(tempDir, path.basename(params.executablePath));
   try {
+    if (isExecutableFile(params.executablePath)) {
+      return;
+    }
+    if (params.sourceText !== undefined && !fs.existsSync(params.sourcePath)) {
+      fs.mkdirSync(path.dirname(params.sourcePath), { recursive: true });
+      fs.writeFileSync(params.sourcePath, params.sourceText);
+    }
     await runCmd('xcrun', ['swiftc', params.sourcePath, '-o', tempExecutablePath], {
       timeoutMs: params.timeoutMs ?? 120_000,
       env: buildSwiftToolEnv(),
     });
-    if (!isExecutableFile(params.executablePath)) {
-      fs.renameSync(tempExecutablePath, params.executablePath);
-    }
+    fs.renameSync(tempExecutablePath, params.executablePath);
   } finally {
-    fs.rmSync(tempExecutablePath, { force: true });
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  }
+}
+
+async function acquireSwiftCacheLock(
+  lockDir: string,
+  executablePath: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    if (isExecutableFile(executablePath)) {
+      return false;
+    }
+    try {
+      fs.mkdirSync(lockDir);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') {
+        throw error;
+      }
+      if (isStaleSwiftCacheLock(lockDir, timeoutMs)) {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new AppError(
+          'COMMAND_FAILED',
+          `Timed out waiting for Swift cache lock: ${lockDir} (${timeoutMs}ms)`,
+          {
+            lockDir,
+            timeoutMs,
+            hint: `Another agent-device process may still be compiling this Swift helper. Retry shortly; if no agent-device process is active, remove "${lockDir}" and retry.`,
+          },
+        );
+      }
+      await delay(LOCK_RETRY_DELAY_MS);
+    }
+  }
+}
+
+function isStaleSwiftCacheLock(lockDir: string, timeoutMs: number): boolean {
+  try {
+    return Date.now() - fs.statSync(lockDir).mtimeMs >= timeoutMs;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

Make Swift helper executable cache publication safe when multiple `agent-device` processes compile the same cache key concurrently. Helper builds now coordinate through a cache-key lock, compile into a unique temporary executable, and let losing builders reuse the completed cache entry.

Adds focused coverage for temp executable publishing and concurrent file-backed helper compiles.

Closes #570

Touched files: 2.

## Validation

Verified with the focused Swift cache, recording overlay, and Swift recording-script suites; all passed. Also ran the repo quick check and formatter.

- `pnpm exec vitest run src/utils/__tests__/swift-cache.test.ts src/recording/__tests__/overlay.test.ts src/platforms/ios/__tests__/recording-scripts.test.ts`
- `pnpm check:quick`
- `pnpm format`

Docs/skills were not updated because this is an internal cache race fix with no CLI or workflow surface change.