### PR TITLE
fix: capture Android snapshot timeout evidence

### DIFF
--- a/src/daemon/android-snapshot-timeout-evidence.ts
+++ b/src/daemon/android-snapshot-timeout-evidence.ts
@@ -5,20 +5,37 @@ import type { DaemonResponse, SessionState } from './types.ts';
 import { dispatchCommand } from '../core/dispatch.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { normalizeError, type NormalizedError } from '../utils/errors.ts';
+import type { ScreenshotOverlayRef } from '../utils/snapshot.ts';
 import { contextFromFlags } from './context.ts';
 import { annotateScreenshotWithRefs } from './screenshot-overlay.ts';
 
-type AndroidSnapshotTimeoutEvidence = {
-  path?: string;
-  overlayRefsRequested?: boolean;
-  overlayRefsAnnotated?: boolean;
-  overlayRefCount?: number;
-  overlayRefSource?: 'session-snapshot' | 'unavailable';
-  overlayRefs?: unknown[];
-  overlayAnnotationError?: string;
-  captureFailed?: boolean;
-  error?: string;
+type CapturedAndroidSnapshotTimeoutEvidenceBase = {
+  path: string;
+  overlayRefsRequested: true;
 };
+
+type AndroidSnapshotTimeoutEvidence =
+  | {
+      captureFailed: true;
+      error: string;
+    }
+  | (CapturedAndroidSnapshotTimeoutEvidenceBase & {
+      overlayRefSource: 'unavailable';
+      overlayRefsAnnotated: false;
+      overlayRefCount: 0;
+    })
+  | (CapturedAndroidSnapshotTimeoutEvidenceBase & {
+      overlayRefSource: 'session-snapshot';
+      overlayRefsAnnotated: boolean;
+      overlayRefCount: number;
+      overlayRefs: ScreenshotOverlayRef[];
+    })
+  | (CapturedAndroidSnapshotTimeoutEvidenceBase & {
+      overlayRefSource: 'session-snapshot';
+      overlayRefsAnnotated: false;
+      overlayRefCount: 0;
+      overlayAnnotationError: string;
+    });
 
 export async function maybeBuildAndroidSnapshotTimeoutFailure(params: {
   error: unknown;
@@ -71,8 +88,9 @@ async function captureAndroidSnapshotTimeoutEvidence(params: {
       phase: 'android_snapshot_timeout_screenshot_captured',
       data: {
         path: resolvedPath,
-        overlayRefCount: evidence.overlayRefCount,
-        overlayRefsAnnotated: evidence.overlayRefsAnnotated,
+        overlayRefCount: 'overlayRefCount' in evidence ? evidence.overlayRefCount : undefined,
+        overlayRefsAnnotated:
+          'overlayRefsAnnotated' in evidence ? evidence.overlayRefsAnnotated : undefined,
       },
     });
     return evidence;
@@ -98,14 +116,12 @@ async function annotateAndroidSnapshotTimeoutEvidence(
     path: screenshotPath,
     overlayRefsRequested: true,
     overlayRefsAnnotated: false,
+    overlayRefSource: 'unavailable',
+    overlayRefCount: 0,
   };
 
   if (!session?.snapshot) {
-    return {
-      ...evidence,
-      overlayRefSource: 'unavailable',
-      overlayRefCount: 0,
-    };
+    return evidence;
   }
 
   try {
@@ -129,17 +145,20 @@ async function annotateAndroidSnapshotTimeoutEvidence(
     });
     return {
       ...evidence,
+      overlayRefSource: 'session-snapshot',
       overlayAnnotationError: normalized.message,
     };
   }
 }
 
 function resolveCapturedScreenshotPath(data: unknown, fallbackPath: string): string {
-  return typeof data === 'object' &&
-    data !== null &&
-    typeof (data as Record<string, unknown>).path === 'string'
-    ? ((data as Record<string, unknown>).path as string)
-    : fallbackPath;
+  return hasStringPath(data) ? data.path : fallbackPath;
+}
+
+function hasStringPath(value: unknown): value is { path: string } {
+  return (
+    typeof value === 'object' && value !== null && 'path' in value && typeof value.path === 'string'
+  );
 }
 
 function isAndroidSnapshotTimeoutError(error: unknown): boolean {

--- a/src/daemon/android-snapshot-timeout-evidence.ts
+++ b/src/daemon/android-snapshot-timeout-evidence.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import type { DaemonResponse, SessionState } from './types.ts';
 import { dispatchCommand } from '../core/dispatch.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
-import { normalizeError } from '../utils/errors.ts';
+import { normalizeError, type NormalizedError } from '../utils/errors.ts';
 import { contextFromFlags } from './context.ts';
 import { annotateScreenshotWithRefs } from './screenshot-overlay.ts';
 
@@ -145,33 +145,42 @@ function resolveCapturedScreenshotPath(data: unknown, fallbackPath: string): str
 function isAndroidSnapshotTimeoutError(error: unknown): boolean {
   const normalized = normalizeError(error);
   if (normalized.code !== 'COMMAND_FAILED') return false;
+  return (
+    hasKnownAndroidSnapshotTimeoutMessage(normalized) ||
+    hasHelperTimeoutDetails(normalized.details?.helper) ||
+    hasUiAutomatorDumpTimeoutDetails(normalized.details)
+  );
+}
 
-  const text = `${normalized.message}\n${normalized.hint ?? ''}`;
+function hasKnownAndroidSnapshotTimeoutMessage(error: NormalizedError): boolean {
+  const text = `${error.message}\n${error.hint ?? ''}`;
   if (/Android UI hierarchy dump timed out/i.test(text)) return true;
   if (/Stock UIAutomator fallback was skipped/i.test(text)) return true;
-  if (/Android accessibility snapshots can be blocked/i.test(text)) return true;
+  return /Android accessibility snapshots can be blocked/i.test(text);
+}
 
-  const details = normalized.details;
-  const helper = details?.helper;
-  if (helper && typeof helper === 'object') {
-    const helperRecord = helper as Record<string, unknown>;
-    const errorType = String(helperRecord.errorType ?? '');
-    const message = String(helperRecord.message ?? '');
-    if (/TimeoutException/i.test(errorType) || /timed out/i.test(message)) return true;
-  }
+function hasHelperTimeoutDetails(helper: unknown): boolean {
+  if (!helper || typeof helper !== 'object') return false;
+  const helperRecord = helper as Record<string, unknown>;
+  const errorType = String(helperRecord.errorType ?? '');
+  const message = String(helperRecord.message ?? '');
+  return /TimeoutException/i.test(errorType) || /timed out/i.test(message);
+}
 
+function hasUiAutomatorDumpTimeoutDetails(details: Record<string, unknown> | undefined): boolean {
+  if (!details) return false;
   const timeoutMs = details?.timeoutMs;
   const cmd = details?.cmd;
-  const rawArgs = details?.args;
-  const args = Array.isArray(rawArgs)
-    ? rawArgs.map(String)
-    : typeof rawArgs === 'string'
-      ? rawArgs.split(/\s+/)
-      : [];
+  const args = normalizeArgList(details?.args);
   return (
     typeof timeoutMs === 'number' &&
     cmd === 'adb' &&
     args.includes('uiautomator') &&
     args.includes('dump')
   );
+}
+
+function normalizeArgList(rawArgs: unknown): string[] {
+  if (Array.isArray(rawArgs)) return rawArgs.map(String);
+  return typeof rawArgs === 'string' ? rawArgs.split(/\s+/) : [];
 }

--- a/src/daemon/android-snapshot-timeout-evidence.ts
+++ b/src/daemon/android-snapshot-timeout-evidence.ts
@@ -1,0 +1,177 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { DaemonResponse, SessionState } from './types.ts';
+import { dispatchCommand } from '../core/dispatch.ts';
+import { emitDiagnostic } from '../utils/diagnostics.ts';
+import { normalizeError } from '../utils/errors.ts';
+import { contextFromFlags } from './context.ts';
+import { annotateScreenshotWithRefs } from './screenshot-overlay.ts';
+
+type AndroidSnapshotTimeoutEvidence = {
+  path?: string;
+  overlayRefsRequested?: boolean;
+  overlayRefsAnnotated?: boolean;
+  overlayRefCount?: number;
+  overlayRefSource?: 'session-snapshot' | 'unavailable';
+  overlayRefs?: unknown[];
+  overlayAnnotationError?: string;
+  captureFailed?: boolean;
+  error?: string;
+};
+
+export async function maybeBuildAndroidSnapshotTimeoutFailure(params: {
+  error: unknown;
+  command: 'snapshot' | 'diff';
+  logPath: string;
+  session: SessionState | undefined;
+  device: SessionState['device'];
+}): Promise<Extract<DaemonResponse, { ok: false }> | undefined> {
+  if (params.command !== 'snapshot') return undefined;
+  if (params.device.platform !== 'android') return undefined;
+  if (!isAndroidSnapshotTimeoutError(params.error)) return undefined;
+
+  const normalized = normalizeError(params.error);
+  return {
+    ok: false,
+    error: {
+      ...normalized,
+      details: {
+        ...(normalized.details ?? {}),
+        androidSnapshotTimeoutScreenshot: await captureAndroidSnapshotTimeoutEvidence(params),
+      },
+    },
+  };
+}
+
+async function captureAndroidSnapshotTimeoutEvidence(params: {
+  logPath: string;
+  session: SessionState | undefined;
+  device: SessionState['device'];
+}): Promise<AndroidSnapshotTimeoutEvidence> {
+  try {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'agent-device-android-snapshot-timeout-'),
+    );
+    const screenshotPath = path.join(tempDir, 'snapshot-timeout-overlay-refs.png');
+    const data = await dispatchCommand(params.device, 'screenshot', [screenshotPath], undefined, {
+      ...contextFromFlags(
+        params.logPath,
+        { screenshotNoStabilize: true },
+        params.session?.appBundleId,
+        params.session?.trace?.outPath,
+      ),
+      surface: params.session?.surface,
+    });
+    const resolvedPath = resolveCapturedScreenshotPath(data, screenshotPath);
+    const evidence = await annotateAndroidSnapshotTimeoutEvidence(resolvedPath, params.session);
+
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'android_snapshot_timeout_screenshot_captured',
+      data: {
+        path: resolvedPath,
+        overlayRefCount: evidence.overlayRefCount,
+        overlayRefsAnnotated: evidence.overlayRefsAnnotated,
+      },
+    });
+    return evidence;
+  } catch (error) {
+    const normalized = normalizeError(error);
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'android_snapshot_timeout_screenshot_failed',
+      data: { error: normalized.message },
+    });
+    return {
+      captureFailed: true,
+      error: normalized.message,
+    };
+  }
+}
+
+async function annotateAndroidSnapshotTimeoutEvidence(
+  screenshotPath: string,
+  session: SessionState | undefined,
+): Promise<AndroidSnapshotTimeoutEvidence> {
+  const evidence: AndroidSnapshotTimeoutEvidence = {
+    path: screenshotPath,
+    overlayRefsRequested: true,
+    overlayRefsAnnotated: false,
+  };
+
+  if (!session?.snapshot) {
+    return {
+      ...evidence,
+      overlayRefSource: 'unavailable',
+      overlayRefCount: 0,
+    };
+  }
+
+  try {
+    const overlayRefs = await annotateScreenshotWithRefs({
+      screenshotPath,
+      snapshot: session.snapshot,
+    });
+    return {
+      ...evidence,
+      overlayRefsAnnotated: overlayRefs.length > 0,
+      overlayRefCount: overlayRefs.length,
+      overlayRefSource: 'session-snapshot',
+      overlayRefs,
+    };
+  } catch (error) {
+    const normalized = normalizeError(error);
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'android_snapshot_timeout_screenshot_overlay_failed',
+      data: { path: screenshotPath, error: normalized.message },
+    });
+    return {
+      ...evidence,
+      overlayAnnotationError: normalized.message,
+    };
+  }
+}
+
+function resolveCapturedScreenshotPath(data: unknown, fallbackPath: string): string {
+  return typeof data === 'object' &&
+    data !== null &&
+    typeof (data as Record<string, unknown>).path === 'string'
+    ? ((data as Record<string, unknown>).path as string)
+    : fallbackPath;
+}
+
+function isAndroidSnapshotTimeoutError(error: unknown): boolean {
+  const normalized = normalizeError(error);
+  if (normalized.code !== 'COMMAND_FAILED') return false;
+
+  const text = `${normalized.message}\n${normalized.hint ?? ''}`;
+  if (/Android UI hierarchy dump timed out/i.test(text)) return true;
+  if (/Stock UIAutomator fallback was skipped/i.test(text)) return true;
+  if (/Android accessibility snapshots can be blocked/i.test(text)) return true;
+
+  const details = normalized.details;
+  const helper = details?.helper;
+  if (helper && typeof helper === 'object') {
+    const helperRecord = helper as Record<string, unknown>;
+    const errorType = String(helperRecord.errorType ?? '');
+    const message = String(helperRecord.message ?? '');
+    if (/TimeoutException/i.test(errorType) || /timed out/i.test(message)) return true;
+  }
+
+  const timeoutMs = details?.timeoutMs;
+  const cmd = details?.cmd;
+  const rawArgs = details?.args;
+  const args = Array.isArray(rawArgs)
+    ? rawArgs.map(String)
+    : typeof rawArgs === 'string'
+      ? rawArgs.split(/\s+/)
+      : [];
+  return (
+    typeof timeoutMs === 'number' &&
+    cmd === 'adb' &&
+    args.includes('uiautomator') &&
+    args.includes('dump')
+  );
+}

--- a/src/daemon/android-snapshot-timeout-evidence.ts
+++ b/src/daemon/android-snapshot-timeout-evidence.ts
@@ -46,9 +46,10 @@ export async function maybeBuildAndroidSnapshotTimeoutFailure(params: {
 }): Promise<Extract<DaemonResponse, { ok: false }> | undefined> {
   if (params.command !== 'snapshot') return undefined;
   if (params.device.platform !== 'android') return undefined;
-  if (!isAndroidSnapshotTimeoutError(params.error)) return undefined;
 
   const normalized = normalizeError(params.error);
+  if (!isAndroidSnapshotTimeoutError(normalized)) return undefined;
+
   return {
     ok: false,
     error: {
@@ -74,6 +75,8 @@ async function captureAndroidSnapshotTimeoutEvidence(params: {
     const data = await dispatchCommand(params.device, 'screenshot', [screenshotPath], undefined, {
       ...contextFromFlags(
         params.logPath,
+        // Use a fresh unstabilized screenshot context; inheriting snapshot flags could repeat the
+        // accessibility stabilization timeout that this fallback is trying to avoid.
         { screenshotNoStabilize: true },
         params.session?.appBundleId,
         params.session?.trace?.outPath,
@@ -81,6 +84,7 @@ async function captureAndroidSnapshotTimeoutEvidence(params: {
       surface: params.session?.surface,
     });
     const resolvedPath = resolveCapturedScreenshotPath(data, screenshotPath);
+    await fs.access(resolvedPath);
     const evidence = await annotateAndroidSnapshotTimeoutEvidence(resolvedPath, params.session);
 
     emitDiagnostic({
@@ -112,16 +116,14 @@ async function annotateAndroidSnapshotTimeoutEvidence(
   screenshotPath: string,
   session: SessionState | undefined,
 ): Promise<AndroidSnapshotTimeoutEvidence> {
-  const evidence: AndroidSnapshotTimeoutEvidence = {
-    path: screenshotPath,
-    overlayRefsRequested: true,
-    overlayRefsAnnotated: false,
-    overlayRefSource: 'unavailable',
-    overlayRefCount: 0,
-  };
-
   if (!session?.snapshot) {
-    return evidence;
+    return {
+      path: screenshotPath,
+      overlayRefsRequested: true,
+      overlayRefsAnnotated: false,
+      overlayRefSource: 'unavailable',
+      overlayRefCount: 0,
+    };
   }
 
   try {
@@ -130,7 +132,8 @@ async function annotateAndroidSnapshotTimeoutEvidence(
       snapshot: session.snapshot,
     });
     return {
-      ...evidence,
+      path: screenshotPath,
+      overlayRefsRequested: true,
       overlayRefsAnnotated: overlayRefs.length > 0,
       overlayRefCount: overlayRefs.length,
       overlayRefSource: 'session-snapshot',
@@ -144,8 +147,11 @@ async function annotateAndroidSnapshotTimeoutEvidence(
       data: { path: screenshotPath, error: normalized.message },
     });
     return {
-      ...evidence,
+      path: screenshotPath,
+      overlayRefsRequested: true,
+      overlayRefsAnnotated: false,
       overlayRefSource: 'session-snapshot',
+      overlayRefCount: 0,
       overlayAnnotationError: normalized.message,
     };
   }
@@ -161,13 +167,12 @@ function hasStringPath(value: unknown): value is { path: string } {
   );
 }
 
-function isAndroidSnapshotTimeoutError(error: unknown): boolean {
-  const normalized = normalizeError(error);
-  if (normalized.code !== 'COMMAND_FAILED') return false;
+function isAndroidSnapshotTimeoutError(error: NormalizedError): boolean {
+  if (error.code !== 'COMMAND_FAILED') return false;
   return (
-    hasKnownAndroidSnapshotTimeoutMessage(normalized) ||
-    hasHelperTimeoutDetails(normalized.details?.helper) ||
-    hasUiAutomatorDumpTimeoutDetails(normalized.details)
+    hasKnownAndroidSnapshotTimeoutMessage(error) ||
+    hasHelperTimeoutDetails(error.details?.helper) ||
+    hasUiAutomatorDumpTimeoutDetails(error.details)
   );
 }
 

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -147,10 +147,10 @@ function expectAndroidTimeoutEvidence(
   if (response.ok) throw new Error('Expected snapshot timeout failure');
   expect(response.error.message).toMatch(/UI hierarchy dump timed out/i);
   expect(response.error.hint).toMatch(/Use screenshot as visual truth/i);
-  expectAndroidTimeoutEvidencePayload(response.error.details?.androidSnapshotTimeoutScreenshot);
+  assertAndroidTimeoutEvidencePayload(response.error.details?.androidSnapshotTimeoutScreenshot);
 }
 
-function expectAndroidTimeoutEvidencePayload(evidence: unknown) {
+function assertAndroidTimeoutEvidencePayload(evidence: unknown) {
   if (!evidence || typeof evidence !== 'object') {
     throw new Error('Expected Android snapshot timeout screenshot evidence');
   }

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -2,6 +2,7 @@ import { test, expect, vi, beforeEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { PNG } from 'pngjs';
 import { handleSnapshotCommands } from '../snapshot.ts';
 import { captureSnapshot } from '../snapshot-capture.ts';
 import { SessionStore } from '../../session-store.ts';
@@ -79,6 +80,17 @@ beforeEach(() => {
   mockRunnerCommand.mockReset();
   mockRunnerCommand.mockResolvedValue({});
 });
+
+function writeSolidPng(filePath: string, width = 390, height = 844): void {
+  const png = new PNG({ width, height });
+  for (let index = 0; index < png.data.length; index += 4) {
+    png.data[index] = 255;
+    png.data[index + 1] = 255;
+    png.data[index + 2] = 255;
+    png.data[index + 3] = 255;
+  }
+  fs.writeFileSync(filePath, PNG.sync.write(png));
+}
 
 async function runWaitCommand(
   sessionName: string,
@@ -266,6 +278,80 @@ test('snapshot surfaces filtered-to-zero Android guidance for interactive snapsh
       'Interactive output is empty at depth 3; retry without -d.',
     ]);
   }
+});
+
+test('snapshot timeout captures Android screenshot evidence with overlay refs', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-timeout-evidence';
+  const session = makeSession(sessionName, androidDevice);
+  session.snapshot = {
+    nodes: [
+      {
+        ref: 'e1',
+        index: 0,
+        depth: 0,
+        type: 'android.widget.Button',
+        label: 'Continue',
+        hittable: true,
+        rect: { x: 20, y: 40, width: 120, height: 48 },
+      },
+    ],
+    createdAt: Date.now(),
+    backend: 'android',
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
+    if (command === 'snapshot') {
+      throw new AppError(
+        'COMMAND_FAILED',
+        'Android UI hierarchy dump timed out while waiting for the UI to become idle.',
+        {
+          cmd: 'adb',
+          args: ['exec-out', 'uiautomator', 'dump', '/dev/tty'],
+          timeoutMs: 8000,
+          hint: 'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout.',
+        },
+      );
+    }
+    if (command === 'screenshot') {
+      const screenshotPath = positionals[0];
+      expect(context?.screenshotNoStabilize).toBe(true);
+      writeSolidPng(screenshotPath);
+      return { path: screenshotPath };
+    }
+    return {};
+  });
+
+  const response = await handleSnapshotCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'snapshot',
+      positionals: [],
+      flags: {},
+    },
+    sessionName,
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+  });
+
+  expect(response?.ok).toBe(false);
+  if (response && !response.ok) {
+    expect(response.error.message).toMatch(/UI hierarchy dump timed out/i);
+    expect(response.error.hint).toMatch(/Use screenshot as visual truth/i);
+    const evidence = response.error.details?.androidSnapshotTimeoutScreenshot as
+      | Record<string, unknown>
+      | undefined;
+    expect(evidence?.path).toEqual(expect.stringContaining('snapshot-timeout-overlay-refs.png'));
+    expect(fs.existsSync(evidence?.path as string)).toBe(true);
+    expect(evidence?.overlayRefsAnnotated).toBe(true);
+    expect(evidence?.overlayRefCount).toBe(1);
+    expect(evidence?.overlayRefs).toEqual([
+      expect.objectContaining({ ref: 'e1', label: 'Continue' }),
+    ]);
+  }
+  expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['snapshot', 'screenshot']);
 });
 
 test('snapshot warns when recent snapshot node count collapses sharply', async () => {

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -92,6 +92,76 @@ function writeSolidPng(filePath: string, width = 390, height = 844): void {
   fs.writeFileSync(filePath, PNG.sync.write(png));
 }
 
+function makeAndroidTimeoutEvidenceSession(sessionName: string): SessionStore {
+  const sessionStore = makeSessionStore();
+  const session = makeSession(sessionName, androidDevice);
+  session.snapshot = {
+    nodes: [
+      {
+        ref: 'e1',
+        index: 0,
+        depth: 0,
+        type: 'android.widget.Button',
+        label: 'Continue',
+        hittable: true,
+        rect: { x: 20, y: 40, width: 120, height: 48 },
+      },
+    ],
+    createdAt: Date.now(),
+    backend: 'android',
+  };
+  sessionStore.set(sessionName, session);
+  return sessionStore;
+}
+
+function mockAndroidTimeoutEvidenceDispatch(): void {
+  mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
+    if (command === 'snapshot') throw androidSnapshotTimeoutError();
+    if (command === 'screenshot') {
+      const screenshotPath = positionals[0];
+      expect(context?.screenshotNoStabilize).toBe(true);
+      writeSolidPng(screenshotPath);
+      return { path: screenshotPath };
+    }
+    return {};
+  });
+}
+
+function androidSnapshotTimeoutError(): AppError {
+  return new AppError(
+    'COMMAND_FAILED',
+    'Android UI hierarchy dump timed out while waiting for the UI to become idle.',
+    {
+      cmd: 'adb',
+      args: ['exec-out', 'uiautomator', 'dump', '/dev/tty'],
+      timeoutMs: 8000,
+      hint: 'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout.',
+    },
+  );
+}
+
+function expectAndroidTimeoutEvidence(
+  response: Awaited<ReturnType<typeof handleSnapshotCommands>>,
+) {
+  if (!response) throw new Error('Expected snapshot response');
+  if (response.ok) throw new Error('Expected snapshot timeout failure');
+  expect(response.error.message).toMatch(/UI hierarchy dump timed out/i);
+  expect(response.error.hint).toMatch(/Use screenshot as visual truth/i);
+  expectAndroidTimeoutEvidencePayload(response.error.details?.androidSnapshotTimeoutScreenshot);
+}
+
+function expectAndroidTimeoutEvidencePayload(evidence: unknown) {
+  if (!evidence || typeof evidence !== 'object') {
+    throw new Error('Expected Android snapshot timeout screenshot evidence');
+  }
+  const record = evidence as Record<string, unknown>;
+  expect(record.path).toEqual(expect.stringContaining('snapshot-timeout-overlay-refs.png'));
+  expect(fs.existsSync(record.path as string)).toBe(true);
+  expect(record.overlayRefsAnnotated).toBe(true);
+  expect(record.overlayRefCount).toBe(1);
+  expect(record.overlayRefs).toEqual([expect.objectContaining({ ref: 'e1', label: 'Continue' })]);
+}
+
 async function runWaitCommand(
   sessionName: string,
   device: SessionState['device'],
@@ -281,48 +351,9 @@ test('snapshot surfaces filtered-to-zero Android guidance for interactive snapsh
 });
 
 test('snapshot timeout captures Android screenshot evidence with overlay refs', async () => {
-  const sessionStore = makeSessionStore();
   const sessionName = 'android-timeout-evidence';
-  const session = makeSession(sessionName, androidDevice);
-  session.snapshot = {
-    nodes: [
-      {
-        ref: 'e1',
-        index: 0,
-        depth: 0,
-        type: 'android.widget.Button',
-        label: 'Continue',
-        hittable: true,
-        rect: { x: 20, y: 40, width: 120, height: 48 },
-      },
-    ],
-    createdAt: Date.now(),
-    backend: 'android',
-  };
-  sessionStore.set(sessionName, session);
-
-  mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
-    if (command === 'snapshot') {
-      throw new AppError(
-        'COMMAND_FAILED',
-        'Android UI hierarchy dump timed out while waiting for the UI to become idle.',
-        {
-          cmd: 'adb',
-          args: ['exec-out', 'uiautomator', 'dump', '/dev/tty'],
-          timeoutMs: 8000,
-          hint: 'Android accessibility snapshots can be blocked by busy or continuously changing app UI. Use screenshot as visual truth after this timeout.',
-        },
-      );
-    }
-    if (command === 'screenshot') {
-      const screenshotPath = positionals[0];
-      expect(context?.screenshotNoStabilize).toBe(true);
-      writeSolidPng(screenshotPath);
-      return { path: screenshotPath };
-    }
-    return {};
-  });
-
+  const sessionStore = makeAndroidTimeoutEvidenceSession(sessionName);
+  mockAndroidTimeoutEvidenceDispatch();
   const response = await handleSnapshotCommands({
     req: {
       token: 't',
@@ -335,22 +366,7 @@ test('snapshot timeout captures Android screenshot evidence with overlay refs', 
     logPath: '/tmp/daemon.log',
     sessionStore,
   });
-
-  expect(response?.ok).toBe(false);
-  if (response && !response.ok) {
-    expect(response.error.message).toMatch(/UI hierarchy dump timed out/i);
-    expect(response.error.hint).toMatch(/Use screenshot as visual truth/i);
-    const evidence = response.error.details?.androidSnapshotTimeoutScreenshot as
-      | Record<string, unknown>
-      | undefined;
-    expect(evidence?.path).toEqual(expect.stringContaining('snapshot-timeout-overlay-refs.png'));
-    expect(fs.existsSync(evidence?.path as string)).toBe(true);
-    expect(evidence?.overlayRefsAnnotated).toBe(true);
-    expect(evidence?.overlayRefCount).toBe(1);
-    expect(evidence?.overlayRefs).toEqual([
-      expect.objectContaining({ ref: 'e1', label: 'Continue' }),
-    ]);
-  }
+  expectAndroidTimeoutEvidence(response);
   expect(mockDispatch.mock.calls.map((call) => call[1])).toEqual(['snapshot', 'screenshot']);
 });
 

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -1,8 +1,13 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type { AgentDeviceBackend, BackendSnapshotResult } from '../backend.ts';
 import type { CommandSessionRecord } from '../runtime.ts';
 import { createAgentDevice } from '../runtime.ts';
 import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
-import { AppError } from '../utils/errors.ts';
+import { dispatchCommand } from '../core/dispatch.ts';
+import { AppError, normalizeError } from '../utils/errors.ts';
+import { emitDiagnostic } from '../utils/diagnostics.ts';
 import type { SnapshotDiffSummary } from '../utils/snapshot-diff.ts';
 import type { DaemonRequest, DaemonResponse, DaemonResponseData, SessionState } from './types.ts';
 import { SessionStore } from './session-store.ts';
@@ -13,8 +18,10 @@ import {
   resolveSessionDevice,
   withSessionlessRunnerCleanup,
 } from './handlers/snapshot-session.ts';
+import { contextFromFlags } from './context.ts';
 import { createDaemonRuntimePolicy } from './runtime-policy.ts';
 import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
+import { annotateScreenshotWithRefs } from './screenshot-overlay.ts';
 
 export async function dispatchSnapshotViaRuntime(params: {
   req: DaemonRequest;
@@ -125,12 +132,35 @@ async function dispatchSnapshotRuntimeCommand(
       device,
       snapshotScope: resolvedScope.scope,
     });
-    const result = await params.execute({
-      runtime,
-      sessionName,
-      req,
-      snapshotScope: resolvedScope.scope,
-    });
+    let result: Awaited<ReturnType<SnapshotRuntimeCommandParams['execute']>>;
+    try {
+      result = await params.execute({
+        runtime,
+        sessionName,
+        req,
+        snapshotScope: resolvedScope.scope,
+      });
+    } catch (error) {
+      const timeoutEvidence = await maybeCaptureAndroidSnapshotTimeoutEvidence({
+        error,
+        command: params.command,
+        logPath,
+        session,
+        device,
+      });
+      if (!timeoutEvidence) throw error;
+      const normalized = normalizeError(error);
+      return {
+        ok: false,
+        error: {
+          ...normalized,
+          details: {
+            ...(normalized.details ?? {}),
+            androidSnapshotTimeoutScreenshot: timeoutEvidence,
+          },
+        },
+      };
+    }
     recordSnapshotRuntimeAction({
       req,
       sessionName,
@@ -142,6 +172,125 @@ async function dispatchSnapshotRuntimeCommand(
       data: result.data,
     };
   });
+}
+
+async function maybeCaptureAndroidSnapshotTimeoutEvidence(params: {
+  error: unknown;
+  command: SnapshotRuntimeCommandParams['command'];
+  logPath: string;
+  session: SessionState | undefined;
+  device: SessionState['device'];
+}): Promise<Record<string, unknown> | undefined> {
+  if (params.command !== 'snapshot') return undefined;
+  if (params.device.platform !== 'android') return undefined;
+  if (!isAndroidSnapshotTimeoutError(params.error)) return undefined;
+
+  try {
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'agent-device-android-snapshot-timeout-'),
+    );
+    const screenshotPath = path.join(tempDir, 'snapshot-timeout-overlay-refs.png');
+    const data = await dispatchCommand(params.device, 'screenshot', [screenshotPath], undefined, {
+      ...contextFromFlags(
+        params.logPath,
+        { screenshotNoStabilize: true },
+        params.session?.appBundleId,
+        params.session?.trace?.outPath,
+      ),
+      surface: params.session?.surface,
+    });
+    const resolvedPath =
+      typeof data === 'object' &&
+      data !== null &&
+      typeof (data as Record<string, unknown>).path === 'string'
+        ? ((data as Record<string, unknown>).path as string)
+        : screenshotPath;
+    const evidence: Record<string, unknown> = {
+      path: resolvedPath,
+      overlayRefsRequested: true,
+      overlayRefsAnnotated: false,
+    };
+
+    if (params.session?.snapshot) {
+      try {
+        const overlayRefs = await annotateScreenshotWithRefs({
+          screenshotPath: resolvedPath,
+          snapshot: params.session.snapshot,
+        });
+        evidence.overlayRefsAnnotated = overlayRefs.length > 0;
+        evidence.overlayRefCount = overlayRefs.length;
+        evidence.overlayRefSource = 'session-snapshot';
+        evidence.overlayRefs = overlayRefs;
+      } catch (error) {
+        const normalized = normalizeError(error);
+        evidence.overlayAnnotationError = normalized.message;
+        emitDiagnostic({
+          level: 'warn',
+          phase: 'android_snapshot_timeout_screenshot_overlay_failed',
+          data: { path: resolvedPath, error: normalized.message },
+        });
+      }
+    } else {
+      evidence.overlayRefSource = 'unavailable';
+      evidence.overlayRefCount = 0;
+    }
+
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'android_snapshot_timeout_screenshot_captured',
+      data: {
+        path: resolvedPath,
+        overlayRefCount: evidence.overlayRefCount,
+        overlayRefsAnnotated: evidence.overlayRefsAnnotated,
+      },
+    });
+    return evidence;
+  } catch (error) {
+    const normalized = normalizeError(error);
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'android_snapshot_timeout_screenshot_failed',
+      data: { error: normalized.message },
+    });
+    return {
+      captureFailed: true,
+      error: normalized.message,
+    };
+  }
+}
+
+function isAndroidSnapshotTimeoutError(error: unknown): boolean {
+  const normalized = normalizeError(error);
+  if (normalized.code !== 'COMMAND_FAILED') return false;
+
+  const text = `${normalized.message}\n${normalized.hint ?? ''}`;
+  if (/Android UI hierarchy dump timed out/i.test(text)) return true;
+  if (/Stock UIAutomator fallback was skipped/i.test(text)) return true;
+  if (/Android accessibility snapshots can be blocked/i.test(text)) return true;
+
+  const details = normalized.details;
+  const helper = details?.helper;
+  if (helper && typeof helper === 'object') {
+    const helperRecord = helper as Record<string, unknown>;
+    const errorType = String(helperRecord.errorType ?? '');
+    const message = String(helperRecord.message ?? '');
+    if (/TimeoutException/i.test(errorType) || /timed out/i.test(message)) return true;
+  }
+
+  const timeoutMs = details?.timeoutMs;
+  const cmd = details?.cmd;
+  const rawArgs = details?.args;
+  const args = Array.isArray(rawArgs)
+    ? rawArgs.map(String)
+    : typeof rawArgs === 'string'
+      ? rawArgs.split(/\s+/)
+      : [];
+  return (
+    typeof timeoutMs === 'number' &&
+    cmd === 'adb' &&
+    args.includes('uiautomator') &&
+    args.includes('dump')
+  );
 }
 
 function createSnapshotRuntime(params: {

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -1,13 +1,8 @@
-import { promises as fs } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import type { AgentDeviceBackend, BackendSnapshotResult } from '../backend.ts';
 import type { CommandSessionRecord } from '../runtime.ts';
 import { createAgentDevice } from '../runtime.ts';
 import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
-import { dispatchCommand } from '../core/dispatch.ts';
-import { AppError, normalizeError } from '../utils/errors.ts';
-import { emitDiagnostic } from '../utils/diagnostics.ts';
+import { AppError } from '../utils/errors.ts';
 import type { SnapshotDiffSummary } from '../utils/snapshot-diff.ts';
 import type { DaemonRequest, DaemonResponse, DaemonResponseData, SessionState } from './types.ts';
 import { SessionStore } from './session-store.ts';
@@ -18,10 +13,9 @@ import {
   resolveSessionDevice,
   withSessionlessRunnerCleanup,
 } from './handlers/snapshot-session.ts';
-import { contextFromFlags } from './context.ts';
 import { createDaemonRuntimePolicy } from './runtime-policy.ts';
 import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
-import { annotateScreenshotWithRefs } from './screenshot-overlay.ts';
+import { maybeBuildAndroidSnapshotTimeoutFailure } from './android-snapshot-timeout-evidence.ts';
 
 export async function dispatchSnapshotViaRuntime(params: {
   req: DaemonRequest;
@@ -141,25 +135,15 @@ async function dispatchSnapshotRuntimeCommand(
         snapshotScope: resolvedScope.scope,
       });
     } catch (error) {
-      const timeoutEvidence = await maybeCaptureAndroidSnapshotTimeoutEvidence({
+      const timeoutResponse = await maybeBuildAndroidSnapshotTimeoutFailure({
         error,
         command: params.command,
         logPath,
         session,
         device,
       });
-      if (!timeoutEvidence) throw error;
-      const normalized = normalizeError(error);
-      return {
-        ok: false,
-        error: {
-          ...normalized,
-          details: {
-            ...(normalized.details ?? {}),
-            androidSnapshotTimeoutScreenshot: timeoutEvidence,
-          },
-        },
-      };
+      if (!timeoutResponse) throw error;
+      return timeoutResponse;
     }
     recordSnapshotRuntimeAction({
       req,
@@ -172,125 +156,6 @@ async function dispatchSnapshotRuntimeCommand(
       data: result.data,
     };
   });
-}
-
-async function maybeCaptureAndroidSnapshotTimeoutEvidence(params: {
-  error: unknown;
-  command: SnapshotRuntimeCommandParams['command'];
-  logPath: string;
-  session: SessionState | undefined;
-  device: SessionState['device'];
-}): Promise<Record<string, unknown> | undefined> {
-  if (params.command !== 'snapshot') return undefined;
-  if (params.device.platform !== 'android') return undefined;
-  if (!isAndroidSnapshotTimeoutError(params.error)) return undefined;
-
-  try {
-    const tempDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), 'agent-device-android-snapshot-timeout-'),
-    );
-    const screenshotPath = path.join(tempDir, 'snapshot-timeout-overlay-refs.png');
-    const data = await dispatchCommand(params.device, 'screenshot', [screenshotPath], undefined, {
-      ...contextFromFlags(
-        params.logPath,
-        { screenshotNoStabilize: true },
-        params.session?.appBundleId,
-        params.session?.trace?.outPath,
-      ),
-      surface: params.session?.surface,
-    });
-    const resolvedPath =
-      typeof data === 'object' &&
-      data !== null &&
-      typeof (data as Record<string, unknown>).path === 'string'
-        ? ((data as Record<string, unknown>).path as string)
-        : screenshotPath;
-    const evidence: Record<string, unknown> = {
-      path: resolvedPath,
-      overlayRefsRequested: true,
-      overlayRefsAnnotated: false,
-    };
-
-    if (params.session?.snapshot) {
-      try {
-        const overlayRefs = await annotateScreenshotWithRefs({
-          screenshotPath: resolvedPath,
-          snapshot: params.session.snapshot,
-        });
-        evidence.overlayRefsAnnotated = overlayRefs.length > 0;
-        evidence.overlayRefCount = overlayRefs.length;
-        evidence.overlayRefSource = 'session-snapshot';
-        evidence.overlayRefs = overlayRefs;
-      } catch (error) {
-        const normalized = normalizeError(error);
-        evidence.overlayAnnotationError = normalized.message;
-        emitDiagnostic({
-          level: 'warn',
-          phase: 'android_snapshot_timeout_screenshot_overlay_failed',
-          data: { path: resolvedPath, error: normalized.message },
-        });
-      }
-    } else {
-      evidence.overlayRefSource = 'unavailable';
-      evidence.overlayRefCount = 0;
-    }
-
-    emitDiagnostic({
-      level: 'warn',
-      phase: 'android_snapshot_timeout_screenshot_captured',
-      data: {
-        path: resolvedPath,
-        overlayRefCount: evidence.overlayRefCount,
-        overlayRefsAnnotated: evidence.overlayRefsAnnotated,
-      },
-    });
-    return evidence;
-  } catch (error) {
-    const normalized = normalizeError(error);
-    emitDiagnostic({
-      level: 'warn',
-      phase: 'android_snapshot_timeout_screenshot_failed',
-      data: { error: normalized.message },
-    });
-    return {
-      captureFailed: true,
-      error: normalized.message,
-    };
-  }
-}
-
-function isAndroidSnapshotTimeoutError(error: unknown): boolean {
-  const normalized = normalizeError(error);
-  if (normalized.code !== 'COMMAND_FAILED') return false;
-
-  const text = `${normalized.message}\n${normalized.hint ?? ''}`;
-  if (/Android UI hierarchy dump timed out/i.test(text)) return true;
-  if (/Stock UIAutomator fallback was skipped/i.test(text)) return true;
-  if (/Android accessibility snapshots can be blocked/i.test(text)) return true;
-
-  const details = normalized.details;
-  const helper = details?.helper;
-  if (helper && typeof helper === 'object') {
-    const helperRecord = helper as Record<string, unknown>;
-    const errorType = String(helperRecord.errorType ?? '');
-    const message = String(helperRecord.message ?? '');
-    if (/TimeoutException/i.test(errorType) || /timed out/i.test(message)) return true;
-  }
-
-  const timeoutMs = details?.timeoutMs;
-  const cmd = details?.cmd;
-  const rawArgs = details?.args;
-  const args = Array.isArray(rawArgs)
-    ? rawArgs.map(String)
-    : typeof rawArgs === 'string'
-      ? rawArgs.split(/\s+/)
-      : [];
-  return (
-    typeof timeoutMs === 'number' &&
-    cmd === 'adb' &&
-    args.includes('uiautomator') &&
-    args.includes('dump')
-  );
 }
 
 function createSnapshotRuntime(params: {


### PR DESCRIPTION
## Summary

Capture Android screenshot evidence when `snapshot` fails on the known UIAutomator/accessibility idle timeout path. The timeout error now keeps its existing hint and includes `details.androidSnapshotTimeoutScreenshot` with the PNG path plus overlay-ref metadata when a previous session snapshot is available.

Closes #588

Touched files: 3. Scope stayed within snapshot runtime handling, a focused Android timeout-evidence helper, and its daemon handler regression test. Review follow-ups tightened the evidence payload type, used the concrete overlay-ref type, normalized the timeout error once, verified the captured screenshot path, and made the fallback screenshot context explicit.

## Validation

Verified with `pnpm format`, `pnpm check:fallow --base origin/main`, `pnpm exec vitest run src/daemon/handlers/__tests__/snapshot-handler.test.ts`, `pnpm check:quick`, and `pnpm check:unit`. A sandboxed `pnpm check:unit` run failed because local port binding is blocked (`listen EPERM`); rerunning the same command outside the sandbox passed all 213 unit files and smoke tests.