### PR TITLE
feat: forward --launch-args to adb shell am start on Android

### DIFF
--- a/src/commands/client-command-contracts.ts
+++ b/src/commands/client-command-contracts.ts
@@ -81,7 +81,9 @@ export const clientCommandDefinitions = [
       surface: enumField(SURFACE_VALUES),
       activity: stringField('Android activity name.'),
       launchConsole: stringField('Launch console mode.'),
-      launchArgs: stringArrayField('iOS launch arguments forwarded verbatim to the app process.'),
+      launchArgs: stringArrayField(
+        'Launch arguments forwarded verbatim to the platform launch command.',
+      ),
       relaunch: booleanField('Force relaunch.'),
       saveScript: jsonSchemaField<boolean | string>({ oneOf: [booleanSchema(), stringSchema()] }),
       noRecord: booleanField('Do not record this action.'),

--- a/src/core/__tests__/dispatch-open.test.ts
+++ b/src/core/__tests__/dispatch-open.test.ts
@@ -4,6 +4,7 @@ import { dispatchCommand } from '../dispatch.ts';
 import { AppError } from '../../utils/errors.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { clearIosSimulatorAppState, openIosApp } from '../../platforms/ios/apps.ts';
+import { openAndroidApp } from '../../platforms/android/app-lifecycle.ts';
 import { IOS_SIMULATOR } from '../../__tests__/test-utils/device-fixtures.ts';
 
 vi.mock('../../platforms/ios/apps.ts', async (importOriginal) => {
@@ -18,12 +19,23 @@ vi.mock('../../platforms/ios/apps.ts', async (importOriginal) => {
   };
 });
 
+vi.mock('../../platforms/android/app-lifecycle.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../platforms/android/app-lifecycle.ts')>();
+  return {
+    ...actual,
+    openAndroidApp: vi.fn(async () => {}),
+  };
+});
+
 const mockClearIosSimulatorAppState = vi.mocked(clearIosSimulatorAppState);
 const mockOpenIosApp = vi.mocked(openIosApp);
+const mockOpenAndroidApp = vi.mocked(openAndroidApp);
 
 beforeEach(() => {
   mockClearIosSimulatorAppState.mockClear();
   mockOpenIosApp.mockClear();
+  mockOpenAndroidApp.mockClear();
 });
 
 test('dispatch open rejects URL as first argument when second URL is provided', async () => {
@@ -46,7 +58,7 @@ test('dispatch open rejects URL as first argument when second URL is provided', 
   );
 });
 
-test('dispatch open rejects Android launch arguments instead of dropping them', async () => {
+test('dispatch open forwards Android launch arguments to openAndroidApp', async () => {
   const device: DeviceInfo = {
     platform: 'android',
     id: 'emulator-5554',
@@ -55,18 +67,16 @@ test('dispatch open rejects Android launch arguments instead of dropping them', 
     booted: true,
   };
 
-  await assert.rejects(
-    () =>
-      dispatchCommand(device, 'open', ['com.example.app'], undefined, {
-        launchArgs: ['--fixture', 'demo'],
-      }),
-    (error: unknown) => {
-      assert.equal(error instanceof AppError, true);
-      assert.equal((error as AppError).code, 'UNSUPPORTED_OPERATION');
-      assert.match((error as AppError).message, /Apple platforms/i);
-      return true;
-    },
-  );
+  await dispatchCommand(device, 'open', ['com.example.app'], undefined, {
+    launchArgs: ['--es', 'KEY', 'value'],
+  });
+
+  assert.equal(mockOpenAndroidApp.mock.calls.length, 1);
+  assert.equal(mockOpenAndroidApp.mock.calls[0]?.[0], device);
+  assert.equal(mockOpenAndroidApp.mock.calls[0]?.[1], 'com.example.app');
+  const optionsArg = mockOpenAndroidApp.mock.calls[0]?.[2];
+  assert.ok(optionsArg && typeof optionsArg === 'object', 'expected options object');
+  assert.deepEqual(optionsArg.launchArgs, ['--es', 'KEY', 'value']);
 });
 
 test('dispatch open clears Maestro iOS simulator state and launches once', async () => {

--- a/src/core/__tests__/dispatch-open.test.ts
+++ b/src/core/__tests__/dispatch-open.test.ts
@@ -20,8 +20,7 @@ vi.mock('../../platforms/ios/apps.ts', async (importOriginal) => {
 });
 
 vi.mock('../../platforms/android/app-lifecycle.ts', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('../../platforms/android/app-lifecycle.ts')>();
+  const actual = await importOriginal<typeof import('../../platforms/android/app-lifecycle.ts')>();
   return {
     ...actual,
     openAndroidApp: vi.fn(async () => {}),
@@ -58,6 +57,18 @@ test('dispatch open rejects URL as first argument when second URL is provided', 
   );
 });
 
+test('dispatch open rejects launch arguments without an app target', async () => {
+  await assert.rejects(
+    () => dispatchCommand(IOS_SIMULATOR, 'open', [], undefined, { launchArgs: ['-Flag'] }),
+    (error: unknown) => {
+      assert.equal(error instanceof AppError, true);
+      assert.equal((error as AppError).code, 'INVALID_ARGS');
+      assert.match((error as AppError).message, /requires an app target/i);
+      return true;
+    },
+  );
+});
+
 test('dispatch open forwards Android launch arguments to openAndroidApp', async () => {
   const device: DeviceInfo = {
     platform: 'android',
@@ -77,6 +88,29 @@ test('dispatch open forwards Android launch arguments to openAndroidApp', async 
   const optionsArg = mockOpenAndroidApp.mock.calls[0]?.[2];
   assert.ok(optionsArg && typeof optionsArg === 'object', 'expected options object');
   assert.deepEqual(optionsArg.launchArgs, ['--es', 'KEY', 'value']);
+});
+
+test('dispatch open rejects launch arguments on Linux', async () => {
+  const device: DeviceInfo = {
+    platform: 'linux',
+    id: 'linux-local',
+    name: 'Linux',
+    kind: 'device',
+    booted: true,
+  };
+
+  await assert.rejects(
+    () =>
+      dispatchCommand(device, 'open', ['org.example.App'], undefined, {
+        launchArgs: ['--fixture', 'demo'],
+      }),
+    (error: unknown) => {
+      assert.equal(error instanceof AppError, true);
+      assert.equal((error as AppError).code, 'UNSUPPORTED_OPERATION');
+      assert.match((error as AppError).message, /Linux/i);
+      return true;
+    },
+  );
 });
 
 test('dispatch open clears Maestro iOS simulator state and launches once', async () => {

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -218,12 +218,6 @@ async function handleOpenCommand(
   if (launchConsole && isDeepLinkTarget(app)) {
     throw new AppError('INVALID_ARGS', LAUNCH_CONSOLE_DIRECT_APP_ONLY_MESSAGE);
   }
-  if (device.platform === 'android' && context?.launchArgs && context.launchArgs.length > 0) {
-    throw new AppError(
-      'UNSUPPORTED_OPERATION',
-      'Launch arguments are currently supported only on Apple platforms.',
-    );
-  }
   if (context?.clearAppState) {
     if (isDeepLinkTarget(app)) {
       throw new AppError(

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -181,6 +181,7 @@ async function handleOpenCommand(
   const app = positionals[0];
   const url = positionals[1];
   const launchConsole = context?.launchConsole;
+  const launchArgs = context?.launchArgs;
   if (positionals.length > 2) {
     throw new AppError('INVALID_ARGS', 'open accepts at most two arguments: <app|url> [url]');
   }
@@ -188,11 +189,17 @@ async function handleOpenCommand(
     if (launchConsole) {
       throw new AppError('INVALID_ARGS', '--launch-console requires an app target');
     }
+    if (launchArgs && launchArgs.length > 0) {
+      throw new AppError('INVALID_ARGS', '--launch-args requires an app target');
+    }
     await interactor.openDevice();
     return { app: null, ...successText('Opened device') };
   }
   if (launchConsole && (device.platform !== 'ios' || device.kind !== 'simulator')) {
     throw new AppError('UNSUPPORTED_OPERATION', LAUNCH_CONSOLE_IOS_SIMULATOR_ONLY_MESSAGE);
+  }
+  if (device.platform === 'linux' && launchArgs && launchArgs.length > 0) {
+    throw new AppError('UNSUPPORTED_OPERATION', '--launch-args is not supported on Linux.');
   }
   if (url !== undefined) {
     if (isDeepLinkTarget(app)) {
@@ -210,7 +217,7 @@ async function handleOpenCommand(
     await interactor.open(app, {
       activity: context?.activity,
       appBundleId: context?.appBundleId,
-      launchArgs: context?.launchArgs,
+      launchArgs,
       url,
     });
     return { app, url, ...successText(`Opened: ${app}`) };
@@ -237,7 +244,7 @@ async function handleOpenCommand(
     activity: context?.activity,
     appBundleId: context?.appBundleId,
     launchConsole,
-    launchArgs: context?.launchArgs,
+    launchArgs,
   });
   return { app, ...(launchConsole ? { launchConsole } : {}), ...successText(`Opened: ${app}`) };
 }

--- a/src/core/interactors/android.ts
+++ b/src/core/interactors/android.ts
@@ -38,6 +38,7 @@ export function createAndroidInteractor(device: DeviceInfo): Interactor {
       openAndroidApp(device, app, {
         activity: options?.activity,
         appBundleId: options?.appBundleId,
+        launchArgs: options?.launchArgs,
         url: options?.url,
       }),
     openDevice: () => openAndroidDevice(device),

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -66,6 +66,24 @@ async function withMockedAdb(
   }
 }
 
+function androidOpenAdbScript(): string {
+  return [
+    '#!/bin/sh',
+    'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+    'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+    'if [ "$1" = "-s" ]; then',
+    '  shift',
+    '  shift',
+    'fi',
+    'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
+    '  echo "Status: ok"',
+    '  exit 0',
+    'fi',
+    'exit 0',
+    '',
+  ].join('\n');
+}
+
 test('parseUiHierarchy reads double-quoted Android node attributes', () => {
   const xml =
     '<hierarchy><node class="android.widget.TextView" text="Hello" content-desc="Greeting" resource-id="com.demo:id/title" bounds="[10,20][110,60]" clickable="true" enabled="true"/></hierarchy>';
@@ -1121,25 +1139,7 @@ test('installAndroidInstallablePath invalidates cached display-name package matc
 test('openAndroidApp default launch uses -p package flag', async () => {
   await withMockedAdb(
     'agent-device-android-open-default-',
-    [
-      '#!/bin/sh',
-      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'if [ "$1" = "-s" ]; then',
-      '  shift',
-      '  shift',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
-      '  echo "package:com.example.app"',
-      '  exit 0',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
-      '  echo "Status: ok"',
-      '  exit 0',
-      'fi',
-      'exit 0',
-      '',
-    ].join('\n'),
+    androidOpenAdbScript(),
     async ({ argsLogPath, device }) => {
       await openAndroidApp(device, 'com.example.app');
       const logged = await fs.readFile(argsLogPath, 'utf8');
@@ -1152,25 +1152,7 @@ test('openAndroidApp default launch uses -p package flag', async () => {
 test('openAndroidApp appends launchArgs to am start when launching by package', async () => {
   await withMockedAdb(
     'agent-device-android-open-launch-args-',
-    [
-      '#!/bin/sh',
-      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'if [ "$1" = "-s" ]; then',
-      '  shift',
-      '  shift',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
-      '  echo "package:com.example.app"',
-      '  exit 0',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
-      '  echo "Status: ok"',
-      '  exit 0',
-      'fi',
-      'exit 0',
-      '',
-    ].join('\n'),
+    androidOpenAdbScript(),
     async ({ argsLogPath, device }) => {
       await openAndroidApp(device, 'com.example.app', {
         launchArgs: ['--es', 'screen', 'home', '--ez', 'fresh', 'true'],
@@ -1184,31 +1166,14 @@ test('openAndroidApp appends launchArgs to am start when launching by package', 
 test('openAndroidApp appends launchArgs to am start when activity override is set', async () => {
   await withMockedAdb(
     'agent-device-android-open-launch-args-activity-',
-    [
-      '#!/bin/sh',
-      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'if [ "$1" = "-s" ]; then',
-      '  shift',
-      '  shift',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
-      '  echo "Status: ok"',
-      '  exit 0',
-      'fi',
-      'exit 0',
-      '',
-    ].join('\n'),
+    androidOpenAdbScript(),
     async ({ argsLogPath, device }) => {
       await openAndroidApp(device, 'com.example.app', {
         activity: '.MainActivity',
         launchArgs: ['--es', 'mode', 'debug'],
       });
       const logged = await fs.readFile(argsLogPath, 'utf8');
-      assert.match(
-        logged,
-        /-n\ncom\.example\.app\/\.MainActivity\n--es\nmode\ndebug/,
-      );
+      assert.match(logged, /-n\ncom\.example\.app\/\.MainActivity\n--es\nmode\ndebug/);
     },
   );
 });
@@ -1216,30 +1181,13 @@ test('openAndroidApp appends launchArgs to am start when activity override is se
 test('openAndroidApp appends launchArgs to am start for deep link URL opens', async () => {
   await withMockedAdb(
     'agent-device-android-open-launch-args-url-',
-    [
-      '#!/bin/sh',
-      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'if [ "$1" = "-s" ]; then',
-      '  shift',
-      '  shift',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
-      '  echo "Status: ok"',
-      '  exit 0',
-      'fi',
-      'exit 0',
-      '',
-    ].join('\n'),
+    androidOpenAdbScript(),
     async ({ argsLogPath, device }) => {
       await openAndroidApp(device, 'myapp://item/42', {
         launchArgs: ['--es', 'ref', 'campaign'],
       });
       const logged = await fs.readFile(argsLogPath, 'utf8');
-      assert.match(
-        logged,
-        /-d\nmyapp:\/\/item\/42\n--es\nref\ncampaign/,
-      );
+      assert.match(logged, /-d\nmyapp:\/\/item\/42\n--es\nref\ncampaign/);
     },
   );
 });
@@ -1247,25 +1195,7 @@ test('openAndroidApp appends launchArgs to am start for deep link URL opens', as
 test('openAndroidApp appends launchArgs to am start for app-bound URL opens', async () => {
   await withMockedAdb(
     'agent-device-android-open-launch-args-app-bound-url-',
-    [
-      '#!/bin/sh',
-      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'if [ "$1" = "-s" ]; then',
-      '  shift',
-      '  shift',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
-      '  echo "package:com.example.app"',
-      '  exit 0',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
-      '  echo "Status: ok"',
-      '  exit 0',
-      'fi',
-      'exit 0',
-      '',
-    ].join('\n'),
+    androidOpenAdbScript(),
     async ({ argsLogPath, device }) => {
       await openAndroidApp(device, 'com.example.app', {
         url: 'https://example.com/promo',
@@ -1283,25 +1213,7 @@ test('openAndroidApp appends launchArgs to am start for app-bound URL opens', as
 test('openAndroidApp shell-quotes launchArgs containing JSON or shell metacharacters', async () => {
   await withMockedAdb(
     'agent-device-android-open-launch-args-quoting-',
-    [
-      '#!/bin/sh',
-      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
-      'if [ "$1" = "-s" ]; then',
-      '  shift',
-      '  shift',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
-      '  echo "package:com.example.app"',
-      '  exit 0',
-      'fi',
-      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
-      '  echo "Status: ok"',
-      '  exit 0',
-      'fi',
-      'exit 0',
-      '',
-    ].join('\n'),
+    androidOpenAdbScript(),
     async ({ argsLogPath, device }) => {
       // Value contains characters the device shell would otherwise re-interpret:
       // `#` (comment), `;` (statement separator), `&` (background), `*` (glob),
@@ -1313,10 +1225,7 @@ test('openAndroidApp shell-quotes launchArgs containing JSON or shell metacharac
       const logged = await fs.readFile(argsLogPath, 'utf8');
       // `--es` and the safe extra key pass through unquoted; the JSON value
       // is single-quoted so `adb shell` re-tokenisation preserves it.
-      assert.match(
-        logged,
-        /--es\nEXTRA_CONFIG\n'\{"a":"x #y;z&w","b":"path\/\*"\}'/,
-      );
+      assert.match(logged, /--es\nEXTRA_CONFIG\n'\{"a":"x #y;z&w","b":"path\/\*"\}'/);
     },
   );
 });

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -1149,6 +1149,178 @@ test('openAndroidApp default launch uses -p package flag', async () => {
   );
 });
 
+test('openAndroidApp appends launchArgs to am start when launching by package', async () => {
+  await withMockedAdb(
+    'agent-device-android-open-launch-args-',
+    [
+      '#!/bin/sh',
+      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'if [ "$1" = "-s" ]; then',
+      '  shift',
+      '  shift',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
+      '  echo "package:com.example.app"',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
+      '  echo "Status: ok"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    async ({ argsLogPath, device }) => {
+      await openAndroidApp(device, 'com.example.app', {
+        launchArgs: ['--es', 'screen', 'home', '--ez', 'fresh', 'true'],
+      });
+      const logged = await fs.readFile(argsLogPath, 'utf8');
+      assert.match(logged, /-p\ncom\.example\.app\n--es\nscreen\nhome\n--ez\nfresh\ntrue/);
+    },
+  );
+});
+
+test('openAndroidApp appends launchArgs to am start when activity override is set', async () => {
+  await withMockedAdb(
+    'agent-device-android-open-launch-args-activity-',
+    [
+      '#!/bin/sh',
+      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'if [ "$1" = "-s" ]; then',
+      '  shift',
+      '  shift',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
+      '  echo "Status: ok"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    async ({ argsLogPath, device }) => {
+      await openAndroidApp(device, 'com.example.app', {
+        activity: '.MainActivity',
+        launchArgs: ['--es', 'mode', 'debug'],
+      });
+      const logged = await fs.readFile(argsLogPath, 'utf8');
+      assert.match(
+        logged,
+        /-n\ncom\.example\.app\/\.MainActivity\n--es\nmode\ndebug/,
+      );
+    },
+  );
+});
+
+test('openAndroidApp appends launchArgs to am start for deep link URL opens', async () => {
+  await withMockedAdb(
+    'agent-device-android-open-launch-args-url-',
+    [
+      '#!/bin/sh',
+      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'if [ "$1" = "-s" ]; then',
+      '  shift',
+      '  shift',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
+      '  echo "Status: ok"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    async ({ argsLogPath, device }) => {
+      await openAndroidApp(device, 'myapp://item/42', {
+        launchArgs: ['--es', 'ref', 'campaign'],
+      });
+      const logged = await fs.readFile(argsLogPath, 'utf8');
+      assert.match(
+        logged,
+        /-d\nmyapp:\/\/item\/42\n--es\nref\ncampaign/,
+      );
+    },
+  );
+});
+
+test('openAndroidApp appends launchArgs to am start for app-bound URL opens', async () => {
+  await withMockedAdb(
+    'agent-device-android-open-launch-args-app-bound-url-',
+    [
+      '#!/bin/sh',
+      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'if [ "$1" = "-s" ]; then',
+      '  shift',
+      '  shift',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
+      '  echo "package:com.example.app"',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
+      '  echo "Status: ok"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    async ({ argsLogPath, device }) => {
+      await openAndroidApp(device, 'com.example.app', {
+        url: 'https://example.com/promo',
+        launchArgs: ['--es', 'ref', 'campaign'],
+      });
+      const logged = await fs.readFile(argsLogPath, 'utf8');
+      assert.match(
+        logged,
+        /-d\nhttps:\/\/example\.com\/promo\n-p\ncom\.example\.app\n--es\nref\ncampaign/,
+      );
+    },
+  );
+});
+
+test('openAndroidApp shell-quotes launchArgs containing JSON or shell metacharacters', async () => {
+  await withMockedAdb(
+    'agent-device-android-open-launch-args-quoting-',
+    [
+      '#!/bin/sh',
+      'printf "__CMD__\\n" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'printf "%s\\n" "$@" >> "$AGENT_DEVICE_TEST_ARGS_FILE"',
+      'if [ "$1" = "-s" ]; then',
+      '  shift',
+      '  shift',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "pm" ] && [ "$3" = "list" ]; then',
+      '  echo "package:com.example.app"',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "shell" ] && [ "$2" = "am" ] && [ "$3" = "start" ]; then',
+      '  echo "Status: ok"',
+      '  exit 0',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+    async ({ argsLogPath, device }) => {
+      // Value contains characters the device shell would otherwise re-interpret:
+      // `#` (comment), `;` (statement separator), `&` (background), `*` (glob),
+      // ` ` (word separator), `\` (escape).
+      const jsonPayload = '{"a":"x #y;z&w","b":"path/*"}';
+      await openAndroidApp(device, 'com.example.app', {
+        launchArgs: ['--es', 'EXTRA_CONFIG', jsonPayload],
+      });
+      const logged = await fs.readFile(argsLogPath, 'utf8');
+      // `--es` and the safe extra key pass through unquoted; the JSON value
+      // is single-quoted so `adb shell` re-tokenisation preserves it.
+      assert.match(
+        logged,
+        /--es\nEXTRA_CONFIG\n'\{"a":"x #y;z&w","b":"path\/\*"\}'/,
+      );
+    },
+  );
+});
+
 test('openAndroidApp normalizes missing package launch failures into APP_NOT_INSTALLED', async () => {
   await withMockedAdb(
     'agent-device-android-open-missing-package-',

--- a/src/platforms/android/app-lifecycle.ts
+++ b/src/platforms/android/app-lifecycle.ts
@@ -433,10 +433,7 @@ async function openAndroidPackageActivity(
     ? activity
     : `${packageName}/${activity.startsWith('.') ? activity : `.${activity}`}`;
   try {
-    await runAndroidAdb(
-      device,
-      buildAndroidActivityLaunchArgs(component, launchCategory, options),
-    );
+    await runAndroidAdb(device, buildAndroidActivityLaunchArgs(component, launchCategory, options));
   } catch (error) {
     await maybeRethrowAndroidMissingPackageError(device, packageName, error);
     throw error;
@@ -481,10 +478,7 @@ async function openAndroidPackage(
       stderr: primaryResult.stderr,
     });
   }
-  await runAndroidAdb(
-    device,
-    buildAndroidActivityLaunchArgs(component, launchCategory, options),
-  );
+  await runAndroidAdb(device, buildAndroidActivityLaunchArgs(component, launchCategory, options));
 }
 
 function buildAndroidActivityLaunchArgs(

--- a/src/platforms/android/app-lifecycle.ts
+++ b/src/platforms/android/app-lifecycle.ts
@@ -295,8 +295,24 @@ async function ensureAndroidLocalhostReverse(device: DeviceInfo, target: string)
 export type OpenAndroidAppOptions = {
   activity?: string;
   appBundleId?: string;
+  launchArgs?: string[];
   url?: string;
 };
+
+// `adb shell` joins its argv with spaces and feeds the result to a device
+// shell, which re-tokenises. The other `am start` arguments (action, category,
+// component, etc.) are well-known and never contain shell-significant
+// characters, so they round-trip untouched. Launch arguments are user-supplied
+// and may contain JSON, spaces, `#`, etc.; each is single-quoted unless it
+// consists entirely of safe shell characters.
+function quoteAndroidShellArg(arg: string): string {
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+function androidLaunchArgs(options: OpenAndroidAppOptions): string[] {
+  return (options.launchArgs ?? []).map(quoteAndroidShellArg);
+}
 
 export async function openAndroidApp(
   device: DeviceInfo,
@@ -320,14 +336,14 @@ export async function openAndroidApp(
   const resolved = await resolveAndroidApp(device, app);
   const launchCategory = resolveAndroidLauncherCategory(device);
   if (resolved.type === 'intent') {
-    await openAndroidIntent(device, resolved.value, activity);
+    await openAndroidIntent(device, resolved.value, options);
     return;
   }
   if (activity) {
-    await openAndroidPackageActivity(device, resolved.value, activity, launchCategory);
+    await openAndroidPackageActivity(device, resolved.value, activity, launchCategory, options);
     return;
   }
-  await openAndroidPackage(device, resolved.value, launchCategory);
+  await openAndroidPackage(device, resolved.value, launchCategory, options);
 }
 
 async function openAndroidDeepLink(
@@ -352,6 +368,7 @@ async function openAndroidDeepLink(
     '-d',
     target,
     ...androidDeepLinkPackageArgs(options.appBundleId),
+    ...androidLaunchArgs(options),
   ]);
 }
 
@@ -382,18 +399,27 @@ async function openAndroidAppBoundDeepLink(
     deepLinkUrl,
     '-p',
     resolved,
+    ...androidLaunchArgs(options),
   ]);
 }
 
 async function openAndroidIntent(
   device: DeviceInfo,
   intent: string,
-  activity: string | undefined,
+  options: OpenAndroidAppOptions,
 ): Promise<void> {
-  if (activity) {
+  if (options.activity) {
     throw new AppError('INVALID_ARGS', 'Activity override requires a package name, not an intent');
   }
-  await runAndroidAdb(device, ['shell', 'am', 'start', '-W', '-a', intent]);
+  await runAndroidAdb(device, [
+    'shell',
+    'am',
+    'start',
+    '-W',
+    '-a',
+    intent,
+    ...androidLaunchArgs(options),
+  ]);
 }
 
 async function openAndroidPackageActivity(
@@ -401,12 +427,16 @@ async function openAndroidPackageActivity(
   packageName: string,
   activity: string,
   launchCategory: string,
+  options: OpenAndroidAppOptions,
 ): Promise<void> {
   const component = activity.includes('/')
     ? activity
     : `${packageName}/${activity.startsWith('.') ? activity : `.${activity}`}`;
   try {
-    await runAndroidAdb(device, buildAndroidActivityLaunchArgs(component, launchCategory));
+    await runAndroidAdb(
+      device,
+      buildAndroidActivityLaunchArgs(component, launchCategory, options),
+    );
   } catch (error) {
     await maybeRethrowAndroidMissingPackageError(device, packageName, error);
     throw error;
@@ -417,6 +447,7 @@ async function openAndroidPackage(
   device: DeviceInfo,
   packageName: string,
   launchCategory: string,
+  options: OpenAndroidAppOptions,
 ): Promise<void> {
   const primaryResult = await runAndroidAdb(
     device,
@@ -433,6 +464,7 @@ async function openAndroidPackage(
       launchCategory,
       '-p',
       packageName,
+      ...androidLaunchArgs(options),
     ],
     { allowFailure: true },
   );
@@ -449,10 +481,17 @@ async function openAndroidPackage(
       stderr: primaryResult.stderr,
     });
   }
-  await runAndroidAdb(device, buildAndroidActivityLaunchArgs(component, launchCategory));
+  await runAndroidAdb(
+    device,
+    buildAndroidActivityLaunchArgs(component, launchCategory, options),
+  );
 }
 
-function buildAndroidActivityLaunchArgs(component: string, launchCategory: string): string[] {
+function buildAndroidActivityLaunchArgs(
+  component: string,
+  launchCategory: string,
+  options: OpenAndroidAppOptions,
+): string[] {
   return [
     'shell',
     'am',
@@ -466,6 +505,7 @@ function buildAndroidActivityLaunchArgs(component: string, launchCategory: strin
     launchCategory,
     '-n',
     component,
+    ...androidLaunchArgs(options),
   ];
 }
 

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -331,6 +331,7 @@ test('usageForCommand documents open --launch-args', () => {
   if (help === null) throw new Error('Expected open help text');
   assert.match(help, /--launch-args <arg>/);
   assert.match(help, /forwarded verbatim/);
+  assert.match(help, /Linux and macOS reject the flag/);
 });
 
 test('parseArgs accepts install-from-source GitHub Actions artifact flag', () => {

--- a/src/utils/cli-flags.ts
+++ b/src/utils/cli-flags.ts
@@ -506,7 +506,7 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     multiple: true,
     usageLabel: '--launch-args <arg>',
     usageDescription:
-      'open: repeatable launch argument forwarded verbatim to the iOS launch command (simctl launch positional args for simulators; devicectl process launch positional args for devices, after `--`). Currently supported only on iOS; Android and macOS reject the flag.',
+      'open: repeatable launch argument forwarded verbatim to the platform launch command (iOS app process args; Android adb shell am start args). Linux and macOS reject the flag.',
   },
   {
     key: 'header',


### PR DESCRIPTION
> 🚧 **Draft, stacked on top of #598.** The branch is based on #598's branch, so until #598 merges this diff includes its changes too. Will rebase onto `main` once #598 lands and the diff will narrow to the Android-only changes summarised below.

## Summary

Extends the `--launch-args` flag added in #598 to Android, removing the `UNSUPPORTED_OPERATION` guard that landed with the Maestro work and forwarding launch arguments verbatim to `adb shell am start`.

Opening this as a separate PR so the Android-specific design decisions (shell-quoting model, threading across the five Android open helpers, app-bound URL path) get their own review thread.

## What this PR does

| Layer | Change |
| --- | --- |
| `src/core/dispatch.ts` | Removes the `device.platform === 'android'` rejection for `launchArgs`. |
| `src/core/interactors/android.ts` | Forwards `options.launchArgs` into `openAndroidApp`. |
| `src/platforms/android/app-lifecycle.ts` | Adds `launchArgs?: string[]` to `OpenAndroidAppOptions`; threads the args through **all five** Android open helpers (`openAndroidPackage`, `openAndroidPackageActivity`, `openAndroidIntent`, `openAndroidDeepLink`, `openAndroidAppBoundDeepLink`); adds a `quoteAndroidShellArg` helper applied to launch arg values. |
| `src/utils/command-schema.ts` | Updates the `--launch-args` help text to describe the Android shape (`--es key value` for typed Intent extras); macOS remains the only rejected platform. |

## Why shell-quoting

`adb shell` joins its argv with spaces and sends the result as a single string to a shell on the device, which then re-tokenises before invoking `am start`. The well-known `am start` flags (`-a`, `-c`, `-n`, `-p`, `-d`, etc.) and the values we generate for them never contain shell-significant characters, so they round-trip untouched. **Launch arguments are user-supplied** and routinely contain JSON, spaces, `#`, `;`, `&`, etc., which the device shell would otherwise re-interpret as comments, separators, or backgrounding operators.

Helper:

```ts
function quoteAndroidShellArg(arg: string): string {
  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
  return `'${arg.replace(/'/g, `'\\''`)}'`;
}
```

Safe-ASCII args pass through unquoted (keeps `adb` and `am start` logs readable); anything else is single-quoted with the standard `'\''` escape for embedded single quotes. The same shape long used by ADB-driven tooling for the same reason.

## Per-path argv shapes

```
# Package launch
adb shell am start -W -a MAIN -c DEFAULT -c LAUNCHER -p <package> <launchArgs...>

# Activity override
adb shell am start -W -a MAIN -c DEFAULT -c LAUNCHER -n <package/component> <launchArgs...>

# Bare intent
adb shell am start -W -a <intent> <launchArgs...>

# Deep-link URL (with optional appBundleId)
adb shell am start -W -a VIEW -d <url> [-p <package>] <launchArgs...>

# App-bound deep-link URL
adb shell am start -W -a VIEW -d <url> -p <resolved-package> <launchArgs...>
```

## Tests

- **`src/platforms/android/__tests__/index.test.ts`** — five new tests cover:
  - Package launch with typed extras (`--es`, `--ez`)
  - Activity-override launch with extras
  - Deep-link URL launch with extras
  - App-bound URL launch with extras
  - **Shell-quoting**: a JSON value containing `:`, `/`, `#` is single-quoted on the way to the device
- **`src/core/__tests__/dispatch-open.test.ts`** — the previous "rejects Android launch arguments" test is inverted into a forwarding test that asserts `openAndroidApp` receives the args.

## Manual validation

Verified end-to-end on a Pixel emulator running a debug build whose launcher activity reads an Intent extra to bootstrap test configuration:

```bash
agent-device open com.example.app --platform android \
  --activity com.example.app/com.example.app.bootstrap.SyncActivity \
  --launch-args --es \
  --launch-args EXTRA_CONFIG \
  --launch-args '{"mode":"debug","path":"a/b","note":"x #y"}'
```

The JSON value (containing `#`, `/`, `:` — all shell-significant on the device side) survived single-quoted transit through `adb shell`, arrived at the activity as an Intent extra, and was consumed by the app's bootstrap code unchanged.

`pnpm check` passes locally on top of #598's branch.
