### PR TITLE
build: enable noUncheckedIndexedAccess

### DIFF
--- a/src/__tests__/cli-batch.test.ts
+++ b/src/__tests__/cli-batch.test.ts
@@ -37,7 +37,7 @@ test('batch --steps parses JSON and forwards batchSteps only', async () => {
   ]);
   assert.equal(result.code, null);
   assert.equal(result.calls.length, 1);
-  const req = result.calls[0];
+  const req = result.calls[0]!;
   assert.equal(req.command, 'batch');
   assert.equal(req.session, 'sim');
   assert.equal(req.flags?.platform, 'ios');
@@ -57,7 +57,7 @@ test('batch --steps-file parses file payload', async () => {
   const result = await runCliCapture(['batch', '--steps-file', stepsPath, '--json']);
   assert.equal(result.code, null);
   assert.equal(result.calls.length, 1);
-  const req = result.calls[0];
+  const req = result.calls[0]!;
   assert.equal(req.command, 'batch');
   assert.equal((req.flags?.batchSteps ?? [])[0]?.command, 'wait');
 });

--- a/src/__tests__/cli-batch.test.ts
+++ b/src/__tests__/cli-batch.test.ts
@@ -88,7 +88,7 @@ test('batch accepts legacy positionals/flags steps with deprecation warning', as
   assert.equal(result.code, null);
   assert.match(result.stderr, /positionals\/flags are deprecated.*next major version/);
   assert.equal(result.calls.length, 1);
-  const req = result.calls[0];
+  const req = result.calls[0]!;
   assert.equal(req.command, 'batch');
   assert.deepEqual((req.flags?.batchSteps ?? [])[0], {
     command: 'open',

--- a/src/__tests__/client-companion-tunnel-worker.test.ts
+++ b/src/__tests__/client-companion-tunnel-worker.test.ts
@@ -121,7 +121,7 @@ function decodeWebSocketPayload(payload: Buffer, mask: Buffer | null): Buffer {
 
   const decoded = Buffer.from(payload);
   for (let index = 0; index < decoded.length; index += 1) {
-    decoded[index] ^= mask[index % 4];
+    decoded[index]! ^= mask[index % 4]!;
   }
   return decoded;
 }

--- a/src/__tests__/selectors-public.test.ts
+++ b/src/__tests__/selectors-public.test.ts
@@ -37,7 +37,7 @@ const nodes: SnapshotNode[] = [
 
 test('public selector subpath exposes platform-aware matching helpers', () => {
   const chain: SelectorChain = parseSelectorChain('role=button label="Continue" visible=true');
-  const firstSelector: Selector = chain.selectors[0];
+  const firstSelector: Selector = chain.selectors[0]!;
   assert.equal(firstSelector.raw, 'role=button label="Continue" visible=true');
   assert.equal(tryParseSelectorChain(chain.raw)?.raw, chain.raw);
   assert.equal(isSelectorToken('visible=true'), true);
@@ -55,8 +55,8 @@ test('public selector subpath exposes platform-aware matching helpers', () => {
   });
   assert.equal(resolved?.node.ref, 'e1');
 
-  assert.equal(isNodeVisible(nodes[0]), true);
-  assert.equal(isNodeEditable(nodes[1], 'android'), true);
+  assert.equal(isNodeVisible(nodes[0]!), true);
+  assert.equal(isNodeEditable(nodes[1]!, 'android'), true);
 });
 
 test('public selector diagnostics format failures', () => {

--- a/src/__tests__/upload-client.test.ts
+++ b/src/__tests__/upload-client.test.ts
@@ -350,7 +350,7 @@ test('uploadArtifact disables macOS AppleDouble entries when archiving app bundl
       (cmd, args, options) => {
         if (cmd !== 'tar') return undefined;
         tarEnv = options.env;
-        const archivePath = args[1];
+        const archivePath = args[1]!;
         assert.equal(args[0], 'czf');
         assert.equal(typeof archivePath, 'string');
         fs.writeFileSync(archivePath, 'fake-archive');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -481,8 +481,7 @@ function hasExplicitMetroRuntimeOverrides(explicitFlagKeys: Set<FlagKey>): boole
 
 function guessSessionFromArgv(argv: string[]): string | null {
   for (let i = 0; i < argv.length; i += 1) {
-    const token = argv[i];
-    if (token === undefined) continue;
+    const token = argv[i]!;
     if (token.startsWith('--session=')) {
       const inline = token.slice('--session='.length).trim();
       return inline.length > 0 ? inline : null;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -482,6 +482,7 @@ function hasExplicitMetroRuntimeOverrides(explicitFlagKeys: Set<FlagKey>): boole
 function guessSessionFromArgv(argv: string[]): string | null {
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
+    if (token === undefined) continue;
     if (token.startsWith('--session=')) {
       const inline = token.slice('--session='.length).trim();
       return inline.length > 0 ? inline : null;

--- a/src/commands/cli-grammar/capture.ts
+++ b/src/commands/cli-grammar/capture.ts
@@ -116,8 +116,8 @@ function readWaitOptionsFromPositionals(
 }
 
 export function parseWaitPositionals(args: string[]): WaitParsed | null {
-  if (args.length === 0) return null;
-  const firstArg = args[0]!;
+  const firstArg = args[0];
+  if (firstArg === undefined) return null;
   const sleepMs = parseTimeout(firstArg);
   if (sleepMs !== null) return { kind: 'sleep', durationMs: sleepMs };
   const timeoutMs = parseTimeout(args[args.length - 1]);

--- a/src/commands/cli-grammar/capture.ts
+++ b/src/commands/cli-grammar/capture.ts
@@ -117,14 +117,15 @@ function readWaitOptionsFromPositionals(
 
 export function parseWaitPositionals(args: string[]): WaitParsed | null {
   if (args.length === 0) return null;
-  const sleepMs = parseTimeout(args[0]);
+  const firstArg = args[0]!;
+  const sleepMs = parseTimeout(firstArg);
   if (sleepMs !== null) return { kind: 'sleep', durationMs: sleepMs };
   const timeoutMs = parseTimeout(args[args.length - 1]);
-  if (args[0] === 'text') {
+  if (firstArg === 'text') {
     const text = timeoutMs !== null ? args.slice(1, -1).join(' ') : args.slice(1).join(' ');
     return { kind: 'text', text: text.trim(), timeoutMs };
   }
-  if (args[0].startsWith('@')) return { kind: 'ref', rawRef: args[0], timeoutMs };
+  if (firstArg.startsWith('@')) return { kind: 'ref', rawRef: firstArg, timeoutMs };
   const argsWithoutTimeout = timeoutMs !== null ? args.slice(0, -1) : args.slice();
   const split = splitSelectorFromArgs(argsWithoutTimeout);
   if (split && split.rest.length === 0 && tryParseSelectorChain(split.selectorExpression)) {

--- a/src/commands/cli-grammar/interactions.ts
+++ b/src/commands/cli-grammar/interactions.ts
@@ -140,15 +140,15 @@ function readLongPressTargetFromPositionals(positionals: string[]): LongPressOpt
 }
 
 export function readFillTargetFromPositionals(positionals: string[]): DecodedFillTarget {
-  if (positionals[0]?.startsWith('@')) {
+  const firstPositional = positionals[0];
+  if (firstPositional?.startsWith('@')) {
     const text =
       positionals.length >= 3 ? positionals.slice(2).join(' ') : positionals.slice(1).join(' ');
-    const maybeLabel = positionals[1];
     return {
       kind: 'ref',
       target: {
-        ref: positionals[0]!,
-        label: positionals.length >= 3 ? optionalTrimmedText([maybeLabel!]) : undefined,
+        ref: firstPositional,
+        label: positionals.length >= 3 ? optionalTrimmedText(positionals.slice(1, 2)) : undefined,
       },
       text,
     };

--- a/src/commands/cli-grammar/interactions.ts
+++ b/src/commands/cli-grammar/interactions.ts
@@ -143,11 +143,12 @@ export function readFillTargetFromPositionals(positionals: string[]): DecodedFil
   if (positionals[0]?.startsWith('@')) {
     const text =
       positionals.length >= 3 ? positionals.slice(2).join(' ') : positionals.slice(1).join(' ');
+    const maybeLabel = positionals[1];
     return {
       kind: 'ref',
       target: {
-        ref: positionals[0],
-        label: positionals.length >= 3 ? optionalTrimmedText([positionals[1]]) : undefined,
+        ref: positionals[0]!,
+        label: positionals.length >= 3 ? optionalTrimmedText([maybeLabel!]) : undefined,
       },
       text,
     };

--- a/src/commands/interaction-targeting.ts
+++ b/src/commands/interaction-targeting.ts
@@ -80,9 +80,7 @@ function findPreferredActionableDescendant(
     if (sameRectChildren.length !== 1) {
       break;
     }
-    const next = sameRectChildren[0];
-    if (next === undefined) break;
-    current = next;
+    current = sameRectChildren[0]!;
   }
 
   return current === node ? null : current;

--- a/src/commands/interaction-targeting.ts
+++ b/src/commands/interaction-targeting.ts
@@ -80,7 +80,9 @@ function findPreferredActionableDescendant(
     if (sameRectChildren.length !== 1) {
       break;
     }
-    current = sameRectChildren[0]!;
+    const child = sameRectChildren[0];
+    if (child === undefined) break;
+    current = child;
   }
 
   return current === node ? null : current;

--- a/src/commands/interaction-targeting.ts
+++ b/src/commands/interaction-targeting.ts
@@ -80,7 +80,9 @@ function findPreferredActionableDescendant(
     if (sameRectChildren.length !== 1) {
       break;
     }
-    current = sameRectChildren[0];
+    const next = sameRectChildren[0];
+    if (next === undefined) break;
+    current = next;
   }
 
   return current === node ? null : current;

--- a/src/commands/react-native/overlay.ts
+++ b/src/commands/react-native/overlay.ts
@@ -177,15 +177,17 @@ function actionFromDismissNode(node: SnapshotNode): ReactNativeOverlayDismissTar
 function chooseCollapsedWarningNode(nodes: SnapshotNode[]): SnapshotNode | null {
   const withRect = nodes.filter((node) => node.rect);
   if (withRect.length === 0) return null;
-  return withRect.sort((a, b) => {
-    const aHittable = a.hittable === true ? 1 : 0;
-    const bHittable = b.hittable === true ? 1 : 0;
-    if (aHittable !== bHittable) return bHittable - aHittable;
-    const aWidth = a.rect?.width ?? 0;
-    const bWidth = b.rect?.width ?? 0;
-    if (aWidth !== bWidth) return bWidth - aWidth;
-    return (b.rect?.y ?? 0) - (a.rect?.y ?? 0);
-  })[0];
+  return (
+    withRect.sort((a, b) => {
+      const aHittable = a.hittable === true ? 1 : 0;
+      const bHittable = b.hittable === true ? 1 : 0;
+      if (aHittable !== bHittable) return bHittable - aHittable;
+      const aWidth = a.rect?.width ?? 0;
+      const bWidth = b.rect?.width ?? 0;
+      if (aWidth !== bWidth) return bWidth - aWidth;
+      return (b.rect?.y ?? 0) - (a.rect?.y ?? 0);
+    })[0] ?? null
+  );
 }
 
 function collapsedBannerClosePoint(node: SnapshotNode): Point {

--- a/src/commands/react-native/overlay.ts
+++ b/src/commands/react-native/overlay.ts
@@ -177,15 +177,17 @@ function actionFromDismissNode(node: SnapshotNode): ReactNativeOverlayDismissTar
 function chooseCollapsedWarningNode(nodes: SnapshotNode[]): SnapshotNode | null {
   const withRect = nodes.filter((node) => node.rect);
   if (withRect.length === 0) return null;
-  return withRect.sort((a, b) => {
-    const aHittable = a.hittable === true ? 1 : 0;
-    const bHittable = b.hittable === true ? 1 : 0;
-    if (aHittable !== bHittable) return bHittable - aHittable;
-    const aWidth = a.rect?.width ?? 0;
-    const bWidth = b.rect?.width ?? 0;
-    if (aWidth !== bWidth) return bWidth - aWidth;
-    return (b.rect?.y ?? 0) - (a.rect?.y ?? 0);
-  })[0]!;
+  return (
+    withRect.sort((a, b) => {
+      const aHittable = a.hittable === true ? 1 : 0;
+      const bHittable = b.hittable === true ? 1 : 0;
+      if (aHittable !== bHittable) return bHittable - aHittable;
+      const aWidth = a.rect?.width ?? 0;
+      const bWidth = b.rect?.width ?? 0;
+      if (aWidth !== bWidth) return bWidth - aWidth;
+      return (b.rect?.y ?? 0) - (a.rect?.y ?? 0);
+    })[0] ?? null
+  );
 }
 
 function collapsedBannerClosePoint(node: SnapshotNode): Point {

--- a/src/commands/react-native/overlay.ts
+++ b/src/commands/react-native/overlay.ts
@@ -177,17 +177,15 @@ function actionFromDismissNode(node: SnapshotNode): ReactNativeOverlayDismissTar
 function chooseCollapsedWarningNode(nodes: SnapshotNode[]): SnapshotNode | null {
   const withRect = nodes.filter((node) => node.rect);
   if (withRect.length === 0) return null;
-  return (
-    withRect.sort((a, b) => {
-      const aHittable = a.hittable === true ? 1 : 0;
-      const bHittable = b.hittable === true ? 1 : 0;
-      if (aHittable !== bHittable) return bHittable - aHittable;
-      const aWidth = a.rect?.width ?? 0;
-      const bWidth = b.rect?.width ?? 0;
-      if (aWidth !== bWidth) return bWidth - aWidth;
-      return (b.rect?.y ?? 0) - (a.rect?.y ?? 0);
-    })[0] ?? null
-  );
+  return withRect.sort((a, b) => {
+    const aHittable = a.hittable === true ? 1 : 0;
+    const bHittable = b.hittable === true ? 1 : 0;
+    if (aHittable !== bHittable) return bHittable - aHittable;
+    const aWidth = a.rect?.width ?? 0;
+    const bWidth = b.rect?.width ?? 0;
+    if (aWidth !== bWidth) return bWidth - aWidth;
+    return (b.rect?.y ?? 0) - (a.rect?.y ?? 0);
+  })[0]!;
 }
 
 function collapsedBannerClosePoint(node: SnapshotNode): Point {

--- a/src/compat/maestro/replay-flow.ts
+++ b/src/compat/maestro/replay-flow.ts
@@ -85,7 +85,7 @@ function optimizeInputTextActions(
   const mergedActions: SessionAction[] = [];
   const mergedLines: number[] = [];
   for (let index = 0; index < actions.length; index += 1) {
-    const action = actions[index];
+    const action = actions[index]!;
     const optimized = optimizeTypedAfterTap(actions, actionLines, index);
     if (optimized) {
       mergedActions.push(...optimized.actions);
@@ -104,16 +104,17 @@ function optimizeTypedAfterTap(
   actionLines: number[],
   index: number,
 ): { actions: SessionAction[]; actionLines: number[]; consumed: number } | null {
-  const action = actions[index];
+  const action = actions[index]!;
   const nextAction = actions[index + 1];
   const typedAfterTap = readPlainTypeText(nextAction);
   const tapSelector = readPlainMaestroTapSelector(action);
-  if (typedAfterTap === null || tapSelector === null) return null;
+  if (!nextAction || typedAfterTap === null || tapSelector === null) return null;
   const line = actionLines[index] ?? 1;
   if (!isLikelyTextEntrySelector(tapSelector)) {
     return { actions: [clearMaestroNonHittableTap(action)], actionLines: [line], consumed: 1 };
   }
-  if (actions[index + 2]?.command !== MAESTRO_RUNTIME_COMMAND.pressEnter) {
+  const pressEnterAction = actions[index + 2];
+  if (pressEnterAction?.command !== MAESTRO_RUNTIME_COMMAND.pressEnter) {
     return { actions: [clearMaestroNonHittableTap(action)], actionLines: [line], consumed: 1 };
   }
   return {
@@ -129,7 +130,7 @@ function optimizeTypedAfterTap(
         positionals: [tapSelector, typedAfterTap],
         flags: action.flags,
       },
-      actions[index + 2] as SessionAction,
+      pressEnterAction,
     ],
     actionLines: [line, line, actionLines[index + 2] ?? line],
     consumed: 3,

--- a/src/compat/maestro/support.ts
+++ b/src/compat/maestro/support.ts
@@ -85,7 +85,8 @@ export function requireStringValue(command: string, value: unknown): string {
 
 export function resolveMaestroString(value: string, context: MaestroParseContext): string {
   return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_.]*)\}/g, (match, key: string) => {
-    return context.env[key] ?? match;
+    if (!Object.prototype.hasOwnProperty.call(context.env, key)) return match;
+    return String(context.env[key]);
   });
 }
 

--- a/src/compat/maestro/support.ts
+++ b/src/compat/maestro/support.ts
@@ -85,7 +85,7 @@ export function requireStringValue(command: string, value: unknown): string {
 
 export function resolveMaestroString(value: string, context: MaestroParseContext): string {
   return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_.]*)\}/g, (match, key: string) => {
-    return Object.prototype.hasOwnProperty.call(context.env, key) ? context.env[key] : match;
+    return context.env[key] ?? match;
   });
 }
 

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -69,8 +69,7 @@ export async function runBatch(
     const steps = validateAndNormalizeBatchSteps(flags?.batchSteps, batchMaxSteps);
     const startedAt = Date.now();
     const partialResults: BatchStepResult[] = [];
-    for (let index = 0; index < steps.length; index += 1) {
-      const step = steps[index];
+    for (const [index, step] of steps.entries()) {
       const stepResponse = await runBatchStep(req, sessionName, step, invoke, index + 1);
       if (!stepResponse.ok) {
         return {

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -35,14 +35,10 @@ export async function handleLongPressCommand(
   interactor: Interactor,
   positionals: string[],
 ): Promise<Record<string, unknown>> {
-  const x = Number(positionals[0]);
-  const y = Number(positionals[1]);
+  const { x, y } = readPoint(positionals, 'longpress requires x y [durationMs]', {
+    hint: 'Direct platform longpress requires coordinates. In an open daemon session, use agent-device longpress @ref|selector [durationMs]; otherwise run snapshot -i -c, use the target rect center as x y, then retry longpress x y durationMs.',
+  });
   const durationMs = positionals[2] ? Number(positionals[2]) : undefined;
-  if (Number.isNaN(x) || Number.isNaN(y)) {
-    throw new AppError('INVALID_ARGS', 'longpress requires x y [durationMs]', {
-      hint: 'Direct platform longpress requires coordinates. In an open daemon session, use agent-device longpress @ref|selector [durationMs]; otherwise run snapshot -i -c, use the target rect center as x y, then retry longpress x y durationMs.',
-    });
-  }
   await interactor.longPress(x, y, durationMs);
   return { x, y, durationMs, ...successText(`Long pressed (${x}, ${y})`) };
 }
@@ -51,10 +47,7 @@ export async function handleFocusCommand(
   interactor: Interactor,
   positionals: string[],
 ): Promise<Record<string, unknown>> {
-  const [x, y] = positionals.map(Number);
-  if (Number.isNaN(x) || Number.isNaN(y)) {
-    throw new AppError('INVALID_ARGS', 'focus requires x y');
-  }
+  const { x, y } = readPoint(positionals, 'focus requires x y');
   await interactor.focus(x, y);
   return { x, y, ...successText(`Focused (${x}, ${y})`) };
 }
@@ -184,9 +177,16 @@ type PressSeriesOptions = {
   doubleTap: boolean;
 };
 
-function readPoint(positionals: string[], errorMessage: string): Point {
-  const [x, y] = positionals.map(Number);
-  if (Number.isNaN(x) || Number.isNaN(y)) throw new AppError('INVALID_ARGS', errorMessage);
+function readPoint(
+  positionals: string[],
+  errorMessage: string,
+  details?: Record<string, unknown>,
+): Point {
+  const x = Number(positionals[0]);
+  const y = Number(positionals[1]);
+  if (Number.isNaN(x) || Number.isNaN(y)) {
+    throw new AppError('INVALID_ARGS', errorMessage, details);
+  }
   return { x, y };
 }
 
@@ -817,10 +817,7 @@ export async function handleReadCommand(
   positionals: string[],
   context: DispatchContext | undefined,
 ): Promise<Record<string, unknown>> {
-  const [x, y] = positionals.map(Number);
-  if (Number.isNaN(x) || Number.isNaN(y)) {
-    throw new AppError('INVALID_ARGS', 'read requires x y');
-  }
+  const { x, y } = readPoint(positionals, 'read requires x y');
   if (device.platform === 'android') {
     const text = await readAndroidTextAtPoint(device, x, y);
     return { action: 'read', text: text ?? '' };

--- a/src/core/dispatch-series.ts
+++ b/src/core/dispatch-series.ts
@@ -34,9 +34,7 @@ export function shouldUseIosDragSeries(device: DeviceInfo, count: number): boole
 
 export function computeDeterministicJitter(index: number, jitterPx: number): [number, number] {
   if (jitterPx <= 0) return [0, 0];
-  const [dx, dy] = DETERMINISTIC_JITTER_PATTERN[index % DETERMINISTIC_JITTER_PATTERN.length] ?? [
-    0, 0,
-  ];
+  const [dx, dy] = DETERMINISTIC_JITTER_PATTERN[index % DETERMINISTIC_JITTER_PATTERN.length]!;
   return [dx * jitterPx, dy * jitterPx];
 }
 

--- a/src/core/dispatch-series.ts
+++ b/src/core/dispatch-series.ts
@@ -34,7 +34,9 @@ export function shouldUseIosDragSeries(device: DeviceInfo, count: number): boole
 
 export function computeDeterministicJitter(index: number, jitterPx: number): [number, number] {
   if (jitterPx <= 0) return [0, 0];
-  const [dx, dy] = DETERMINISTIC_JITTER_PATTERN[index % DETERMINISTIC_JITTER_PATTERN.length];
+  const [dx, dy] = DETERMINISTIC_JITTER_PATTERN[index % DETERMINISTIC_JITTER_PATTERN.length] ?? [
+    0, 0,
+  ];
   return [dx * jitterPx, dy * jitterPx];
 }
 

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -427,6 +427,9 @@ async function handleSettingsCommand(
   context: DispatchContext | undefined,
 ): Promise<Record<string, unknown>> {
   const [setting, state, target, mode] = positionals;
+  if (!setting || !state) {
+    throw new AppError('INVALID_ARGS', 'settings requires setting state');
+  }
   const isLocationSet = setting === 'location' && state === 'set';
   const usesPayloadAppBundleSlot = setting === 'permission' || isLocationSet;
   const appBundleId =

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -265,15 +265,12 @@ async function prepareRemoteRequest(
       clientArtifactPaths,
     });
 
-  if (
-    !isRemoteDaemon(info) ||
-    (req.command !== 'install' && req.command !== 'reinstall') ||
-    positionals.length < 2
-  ) {
+  if (!isRemoteDaemon(info) || (req.command !== 'install' && req.command !== 'reinstall')) {
     return baseResult();
   }
 
-  const rawPath = positionals[1]!;
+  const rawPath = positionals[1];
+  if (rawPath === undefined) return baseResult();
   if (rawPath.startsWith('remote:')) {
     positionals[1] = rawPath.slice('remote:'.length);
     return createPreparedRemoteRequest({ positionals, flags, clientArtifactPaths });
@@ -959,7 +956,11 @@ function resolveDaemonLaunchSpec(): DaemonLaunchSpec {
     path.join(root, 'dist', 'src', 'internal', 'daemon.js'),
     path.join(root, 'dist', 'src', 'daemon.js'),
   ];
-  const distPath = distPaths.find((candidate) => fs.existsSync(candidate)) ?? distPaths[0]!;
+  const defaultDistPath = distPaths[0];
+  if (defaultDistPath === undefined) {
+    throw new AppError('COMMAND_FAILED', 'Daemon dist path list is empty');
+  }
+  const distPath = distPaths.find((candidate) => fs.existsSync(candidate)) ?? defaultDistPath;
   const srcPath = path.join(root, 'src', 'daemon.ts');
 
   const hasDist = distPaths.some((candidate) => fs.existsSync(candidate));

--- a/src/daemon/__tests__/device-ready.test.ts
+++ b/src/daemon/__tests__/device-ready.test.ts
@@ -58,7 +58,7 @@ test('ensureDeviceReady caches successful simulator readiness checks', async () 
 
 test('ensureDeviceReady caches successful iOS physical device readiness checks', async () => {
   mockRunCmd.mockImplementation(async (_cmd, args) => {
-    const jsonPath = args[args.indexOf('--json-output') + 1];
+    const jsonPath = args[args.indexOf('--json-output') + 1]!;
     await fs.writeFile(
       jsonPath,
       JSON.stringify({

--- a/src/daemon/__tests__/selectors.test.ts
+++ b/src/daemon/__tests__/selectors.test.ts
@@ -45,8 +45,8 @@ const nodes: SnapshotState['nodes'] = [
 test('parseSelectorChain parses fallback and boolean terms', () => {
   const chain = parseSelectorChain('id=auth_continue || role=button label="Continue" visible=true');
   assert.equal(chain.selectors.length, 2);
-  assert.equal(chain.selectors[0].terms[0].key, 'id');
-  assert.equal(chain.selectors[1].terms[2].key, 'visible');
+  assert.equal(chain.selectors[0]!.terms[0]!.key, 'id');
+  assert.equal(chain.selectors[1]!.terms[2]!.key, 'visible');
 });
 
 test('resolveSelectorChain resolves unique match', () => {

--- a/src/daemon/__tests__/snapshot-processing.test.ts
+++ b/src/daemon/__tests__/snapshot-processing.test.ts
@@ -15,8 +15,8 @@ test('pruneGroupNodes drops unlabeled group wrappers and rebalances depth', () =
   ];
   const pruned = pruneGroupNodes(raw);
   assert.equal(pruned.length, 2);
-  assert.equal(pruned[1].depth, 1);
-  assert.equal(pruned[1].label, 'Continue');
+  assert.equal(pruned[1]!.depth, 1);
+  assert.equal(pruned[1]!.label, 'Continue');
 });
 
 test('findNearestHittableAncestor walks parents until hittable node', () => {
@@ -30,7 +30,7 @@ test('findNearestHittableAncestor walks parents until hittable node', () => {
     { index: 1, parentIndex: 0, hittable: false, rect: { x: 0, y: 0, width: 50, height: 20 } },
     { index: 2, parentIndex: 1, hittable: false, rect: { x: 0, y: 0, width: 20, height: 20 } },
   ]);
-  const ancestor = findNearestHittableAncestor(nodes, nodes[2]);
+  const ancestor = findNearestHittableAncestor(nodes, nodes[2]!);
   assert.equal(ancestor?.ref, 'e1');
 });
 
@@ -47,6 +47,6 @@ test('extractNodeReadText ignores generic implementation identifiers as fallback
       identifier: '_NS:248',
     },
   ]);
-  assert.equal(extractNodeReadText(nodes[0]), '');
-  assert.equal(extractNodeReadText(nodes[1]), '');
+  assert.equal(extractNodeReadText(nodes[0]!), '');
+  assert.equal(extractNodeReadText(nodes[1]!), '');
 });

--- a/src/daemon/action-utils.ts
+++ b/src/daemon/action-utils.ts
@@ -7,7 +7,8 @@ export function inferFillText(action: SessionAction): string {
   }
   const positionals = action.positionals ?? [];
   if (positionals.length === 0) return '';
-  if (positionals[0].startsWith('@')) {
+  const first = positionals[0];
+  if (first?.startsWith('@')) {
     if (positionals.length >= 3) return positionals.slice(2).join(' ').trim();
     return positionals.slice(1).join(' ').trim();
   }

--- a/src/daemon/artifact-archive.ts
+++ b/src/daemon/artifact-archive.ts
@@ -92,8 +92,7 @@ function resolveArchiveRootName(entries: string[], platform: 'ios' | 'android'):
   const rootEntries = [...roots];
   if (platform === 'ios') {
     const appRoots = rootEntries.filter((entry) => entry.toLowerCase().endsWith('.app'));
-    const appRoot = appRoots[0];
-    if (appRoots.length === 1 && appRoot !== undefined) return appRoot;
+    if (appRoots.length === 1) return appRoots[0]!;
     if (appRoots.length === 0) {
       throw new AppError(
         'INVALID_ARGS',
@@ -105,8 +104,7 @@ function resolveArchiveRootName(entries: string[], platform: 'ios' | 'android'):
       `iOS app bundle archives must contain exactly one top-level .app directory, found: ${appRoots.join(', ')}`,
     );
   }
-  const rootEntry = rootEntries[0];
-  if (rootEntries.length === 1 && rootEntry !== undefined) return rootEntry;
+  if (rootEntries.length === 1) return rootEntries[0]!;
   throw new AppError(
     'INVALID_ARGS',
     `Archive must contain a single top-level bundle, found: ${rootEntries.join(', ')}`,

--- a/src/daemon/artifact-archive.ts
+++ b/src/daemon/artifact-archive.ts
@@ -92,7 +92,8 @@ function resolveArchiveRootName(entries: string[], platform: 'ios' | 'android'):
   const rootEntries = [...roots];
   if (platform === 'ios') {
     const appRoots = rootEntries.filter((entry) => entry.toLowerCase().endsWith('.app'));
-    if (appRoots.length === 1) return appRoots[0];
+    const appRoot = appRoots[0];
+    if (appRoots.length === 1 && appRoot !== undefined) return appRoot;
     if (appRoots.length === 0) {
       throw new AppError(
         'INVALID_ARGS',
@@ -104,7 +105,8 @@ function resolveArchiveRootName(entries: string[], platform: 'ios' | 'android'):
       `iOS app bundle archives must contain exactly one top-level .app directory, found: ${appRoots.join(', ')}`,
     );
   }
-  if (rootEntries.length === 1) return rootEntries[0];
+  const rootEntry = rootEntries[0];
+  if (rootEntries.length === 1 && rootEntry !== undefined) return rootEntry;
   throw new AppError(
     'INVALID_ARGS',
     `Archive must contain a single top-level bundle, found: ${rootEntries.join(', ')}`,

--- a/src/daemon/artifact-archive.ts
+++ b/src/daemon/artifact-archive.ts
@@ -92,7 +92,8 @@ function resolveArchiveRootName(entries: string[], platform: 'ios' | 'android'):
   const rootEntries = [...roots];
   if (platform === 'ios') {
     const appRoots = rootEntries.filter((entry) => entry.toLowerCase().endsWith('.app'));
-    if (appRoots.length === 1) return appRoots[0]!;
+    const appRoot = appRoots[0];
+    if (appRoot !== undefined && appRoots.length === 1) return appRoot;
     if (appRoots.length === 0) {
       throw new AppError(
         'INVALID_ARGS',
@@ -104,7 +105,8 @@ function resolveArchiveRootName(entries: string[], platform: 'ios' | 'android'):
       `iOS app bundle archives must contain exactly one top-level .app directory, found: ${appRoots.join(', ')}`,
     );
   }
-  if (rootEntries.length === 1) return rootEntries[0]!;
+  const rootEntry = rootEntries[0];
+  if (rootEntry !== undefined && rootEntries.length === 1) return rootEntry;
   throw new AppError(
     'INVALID_ARGS',
     `Archive must contain a single top-level bundle, found: ${rootEntries.join(', ')}`,

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -118,7 +118,7 @@ test('handleFindCommands click returns deterministic metadata across locator var
     }
 
     expect(invokeCalls.length).toBe(1);
-    expect(invokeCalls[0].positionals?.[0]).toBe(scenario.expectedRef);
+    expect(invokeCalls[0]!.positionals?.[0]).toBe(scenario.expectedRef);
   }
 });
 

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -155,7 +155,7 @@ test('handleFindCommands click prefers on-screen duplicate text matches', async 
   });
 
   expect(response.ok).toBe(true);
-  expect(invokeCalls[0].positionals?.[0]).toBe('@e3');
+  expect(invokeCalls[0]!.positionals?.[0]).toBe('@e3');
 });
 
 test('handleFindCommands click prefers semantic controls over matching containers', async () => {
@@ -210,7 +210,7 @@ test('handleFindCommands click prefers semantic controls over matching container
   });
 
   expect(response.ok).toBe(true);
-  expect(invokeCalls[0].positionals?.[0]).toBe('@e5');
+  expect(invokeCalls[0]!.positionals?.[0]).toBe('@e5');
 });
 
 test('handleFindCommands wait bypasses snapshot cache while Android freshness recovery is active', async () => {

--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -59,7 +59,7 @@ function tokenizeReplayLine(line: string): string[] {
   const tokens: string[] = [];
   let cursor = 0;
   while (cursor < line.length) {
-    while (cursor < line.length && /\s/.test(line[cursor])) {
+    while (cursor < line.length && /\s/.test(line[cursor]!)) {
       cursor += 1;
     }
     if (cursor >= line.length) break;
@@ -81,7 +81,7 @@ function tokenizeReplayLine(line: string): string[] {
       continue;
     }
     let end = cursor;
-    while (end < line.length && !/\s/.test(line[end])) {
+    while (end < line.length && !/\s/.test(line[end]!)) {
       end += 1;
     }
     tokens.push(line.slice(cursor, end));

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -118,7 +118,7 @@ function mockAndroidTimeoutEvidenceDispatch(): void {
   mockDispatch.mockImplementation(async (_device, command, positionals, _out, context) => {
     if (command === 'snapshot') throw androidSnapshotTimeoutError();
     if (command === 'screenshot') {
-      const screenshotPath = positionals[0];
+      const screenshotPath = positionals[0]!;
       expect(context?.screenshotNoStabilize).toBe(true);
       writeSolidPng(screenshotPath);
       return { path: screenshotPath };

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -199,9 +199,9 @@ function resolveFindMatch(params: {
 
   if (requiresRect && bestMatches.matches.length > 1) {
     if (flags?.findFirst) {
-      bestMatches.matches = [bestMatches.matches[0]];
+      bestMatches.matches = [bestMatches.matches[0]!];
     } else if (flags?.findLast) {
-      bestMatches.matches = [bestMatches.matches[bestMatches.matches.length - 1]];
+      bestMatches.matches = [bestMatches.matches[bestMatches.matches.length - 1]!];
     } else {
       return { ok: false, response: buildAmbiguousMatchError(bestMatches.matches, locator, query) };
     }

--- a/src/daemon/handlers/session-replay-heal.ts
+++ b/src/daemon/handlers/session-replay-heal.ts
@@ -21,7 +21,9 @@ function parseSelectorWaitPositionals(positionals: string[]): {
 } {
   if (positionals.length === 0) return { selectorExpression: null, selectorTimeout: null };
   const maybeTimeout = positionals[positionals.length - 1];
-  const hasTimeout = /^\d+$/.test(maybeTimeout ?? '');
+  const selectorTimeout =
+    maybeTimeout !== undefined && /^\d+$/.test(maybeTimeout) ? maybeTimeout : null;
+  const hasTimeout = selectorTimeout !== null;
   const selectorTokens = hasTimeout ? positionals.slice(0, -1) : positionals.slice();
   const split = splitSelectorFromArgs(selectorTokens);
   if (!split || split.rest.length > 0) {
@@ -29,7 +31,7 @@ function parseSelectorWaitPositionals(positionals: string[]): {
   }
   return {
     selectorExpression: split.selectorExpression,
-    selectorTimeout: hasTimeout ? maybeTimeout : null,
+    selectorTimeout,
   };
 }
 

--- a/src/daemon/screenshot-overlay-rects.ts
+++ b/src/daemon/screenshot-overlay-rects.ts
@@ -18,7 +18,10 @@ export function rectContains(container: Rect, nested: Rect): boolean {
 }
 
 export function unionRects(rects: Rect[]): Rect {
-  const firstRect = rects[0]!;
+  const firstRect = rects[0];
+  if (firstRect === undefined) {
+    throw new Error('unionRects requires at least one rect');
+  }
   let minX = firstRect.x;
   let minY = firstRect.y;
   let maxRight = firstRect.x + firstRect.width;

--- a/src/daemon/selectors-parse.ts
+++ b/src/daemon/selectors-parse.ts
@@ -103,11 +103,13 @@ export function splitSelectorFromArgs(
     }
   }
   if (boundaries.length === 0) return null;
-  const lastBoundary = boundaries[boundaries.length - 1]!;
+  const lastBoundary = boundaries.at(-1);
+  if (lastBoundary === undefined) return null;
   let boundary = lastBoundary;
   if (preferTrailingValue) {
     for (let i = boundaries.length - 1; i >= 0; i -= 1) {
-      const candidateBoundary = boundaries[i]!;
+      const candidateBoundary = boundaries[i];
+      if (candidateBoundary === undefined) continue;
       if (candidateBoundary < args.length) {
         boundary = candidateBoundary;
         break;

--- a/src/daemon/selectors-parse.ts
+++ b/src/daemon/selectors-parse.ts
@@ -92,7 +92,9 @@ export function splitSelectorFromArgs(
   const preferTrailingValue = options.preferTrailingValue ?? false;
   let i = 0;
   const boundaries: number[] = [];
-  while (i < args.length && isSelectorToken(args[i])) {
+  while (i < args.length) {
+    const token = args[i];
+    if (token === undefined || !isSelectorToken(token)) break;
     i += 1;
     const candidate = args.slice(0, i).join(' ').trim();
     if (!candidate) continue;
@@ -101,11 +103,14 @@ export function splitSelectorFromArgs(
     }
   }
   if (boundaries.length === 0) return null;
-  let boundary = boundaries[boundaries.length - 1];
+  const lastBoundary = boundaries.at(-1);
+  if (lastBoundary === undefined) return null;
+  let boundary = lastBoundary;
   if (preferTrailingValue) {
     for (let i = boundaries.length - 1; i >= 0; i -= 1) {
-      if (boundaries[i] < args.length) {
-        boundary = boundaries[i];
+      const candidateBoundary = boundaries[i];
+      if (candidateBoundary !== undefined && candidateBoundary < args.length) {
+        boundary = candidateBoundary;
         break;
       }
     }
@@ -206,7 +211,7 @@ function tokenize(segment: string): string[] {
   let current = '';
   let quote: '"' | "'" | null = null;
   for (let i = 0; i < segment.length; i += 1) {
-    const ch = segment[i];
+    const ch = segment.charAt(i);
     if ((ch === '"' || ch === "'") && !isEscapedQuote(segment, i)) {
       quote = updateQuoteState(quote, ch);
       current += ch;

--- a/src/daemon/selectors-parse.ts
+++ b/src/daemon/selectors-parse.ts
@@ -103,13 +103,12 @@ export function splitSelectorFromArgs(
     }
   }
   if (boundaries.length === 0) return null;
-  const lastBoundary = boundaries.at(-1);
-  if (lastBoundary === undefined) return null;
+  const lastBoundary = boundaries[boundaries.length - 1]!;
   let boundary = lastBoundary;
   if (preferTrailingValue) {
     for (let i = boundaries.length - 1; i >= 0; i -= 1) {
-      const candidateBoundary = boundaries[i];
-      if (candidateBoundary !== undefined && candidateBoundary < args.length) {
+      const candidateBoundary = boundaries[i]!;
+      if (candidateBoundary < args.length) {
         boundary = candidateBoundary;
         break;
       }

--- a/src/daemon/selectors-resolve.ts
+++ b/src/daemon/selectors-resolve.ts
@@ -29,8 +29,7 @@ export function resolveSelectorChain(
   const requireRect = options.requireRect ?? false;
   const requireUnique = options.requireUnique ?? true;
   const diagnostics: SelectorDiagnostics[] = [];
-  for (let i = 0; i < chain.selectors.length; i += 1) {
-    const selector = chain.selectors[i];
+  for (const [i, selector] of chain.selectors.entries()) {
     const summary = analyzeSelectorMatches(nodes, selector, options.platform, requireRect);
     diagnostics.push({ selector: selector.raw, matches: summary.count });
     if (summary.count === 0 || !summary.firstNode) continue;
@@ -70,8 +69,7 @@ export function findSelectorChainMatch(
 } | null {
   const requireRect = options.requireRect ?? false;
   const diagnostics: SelectorDiagnostics[] = [];
-  for (let i = 0; i < chain.selectors.length; i += 1) {
-    const selector = chain.selectors[i];
+  for (const [i, selector] of chain.selectors.entries()) {
     const matches = countSelectorMatchesOnly(nodes, selector, options.platform, requireRect);
     diagnostics.push({ selector: selector.raw, matches });
     if (matches > 0) {

--- a/src/daemon/session-routing.ts
+++ b/src/daemon/session-routing.ts
@@ -12,7 +12,8 @@ export function resolveEffectiveSessionName(
   if (sessionStore.has(requested)) return requested;
 
   const sessions = sessionStore.toArray();
-  if (sessions.length === 1) return sessions[0]!.name;
+  const session = sessions[0];
+  if (session !== undefined && sessions.length === 1) return session.name;
   return requested;
 }
 

--- a/src/daemon/session-routing.ts
+++ b/src/daemon/session-routing.ts
@@ -12,7 +12,8 @@ export function resolveEffectiveSessionName(
   if (sessionStore.has(requested)) return requested;
 
   const sessions = sessionStore.toArray();
-  if (sessions.length === 1) return sessions[0].name;
+  const onlySession = sessions[0];
+  if (sessions.length === 1 && onlySession !== undefined) return onlySession.name;
   return requested;
 }
 

--- a/src/daemon/session-routing.ts
+++ b/src/daemon/session-routing.ts
@@ -12,8 +12,7 @@ export function resolveEffectiveSessionName(
   if (sessionStore.has(requested)) return requested;
 
   const sessions = sessionStore.toArray();
-  const onlySession = sessions[0];
-  if (sessions.length === 1 && onlySession !== undefined) return onlySession.name;
+  if (sessions.length === 1) return sessions[0]!.name;
   return requested;
 }
 

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -72,12 +72,12 @@ test('parseUiHierarchy reads double-quoted Android node attributes', () => {
 
   const result = parseUiHierarchy(xml, 800, { raw: true });
   assert.equal(result.nodes.length, 1);
-  assert.equal(result.nodes[0].value, 'Hello');
-  assert.equal(result.nodes[0].label, 'Hello');
-  assert.equal(result.nodes[0].identifier, 'com.demo:id/title');
-  assert.deepEqual(result.nodes[0].rect, { x: 10, y: 20, width: 100, height: 40 });
-  assert.equal(result.nodes[0].hittable, true);
-  assert.equal(result.nodes[0].enabled, true);
+  assert.equal(result.nodes[0]!.value, 'Hello');
+  assert.equal(result.nodes[0]!.label, 'Hello');
+  assert.equal(result.nodes[0]!.identifier, 'com.demo:id/title');
+  assert.deepEqual(result.nodes[0]!.rect, { x: 10, y: 20, width: 100, height: 40 });
+  assert.equal(result.nodes[0]!.hittable, true);
+  assert.equal(result.nodes[0]!.enabled, true);
 });
 
 test('parseUiHierarchy reads single-quoted Android node attributes', () => {
@@ -86,12 +86,12 @@ test('parseUiHierarchy reads single-quoted Android node attributes', () => {
 
   const result = parseUiHierarchy(xml, 800, { raw: true });
   assert.equal(result.nodes.length, 1);
-  assert.equal(result.nodes[0].value, 'Hello');
-  assert.equal(result.nodes[0].label, 'Hello');
-  assert.equal(result.nodes[0].identifier, 'com.demo:id/title');
-  assert.deepEqual(result.nodes[0].rect, { x: 10, y: 20, width: 100, height: 40 });
-  assert.equal(result.nodes[0].hittable, true);
-  assert.equal(result.nodes[0].enabled, true);
+  assert.equal(result.nodes[0]!.value, 'Hello');
+  assert.equal(result.nodes[0]!.label, 'Hello');
+  assert.equal(result.nodes[0]!.identifier, 'com.demo:id/title');
+  assert.deepEqual(result.nodes[0]!.rect, { x: 10, y: 20, width: 100, height: 40 });
+  assert.equal(result.nodes[0]!.hittable, true);
+  assert.equal(result.nodes[0]!.enabled, true);
 });
 
 test('parseUiHierarchy supports mixed quote styles in one node', () => {
@@ -100,9 +100,9 @@ test('parseUiHierarchy supports mixed quote styles in one node', () => {
 
   const result = parseUiHierarchy(xml, 800, { raw: true });
   assert.equal(result.nodes.length, 1);
-  assert.equal(result.nodes[0].value, 'Hello');
-  assert.equal(result.nodes[0].label, 'Hello');
-  assert.equal(result.nodes[0].identifier, 'com.demo:id/title');
+  assert.equal(result.nodes[0]!.value, 'Hello');
+  assert.equal(result.nodes[0]!.label, 'Hello');
+  assert.equal(result.nodes[0]!.identifier, 'com.demo:id/title');
 });
 
 test('parseUiHierarchy decodes XML entities in Android node attributes', () => {
@@ -111,8 +111,8 @@ test('parseUiHierarchy decodes XML entities in Android node attributes', () => {
 
   const result = parseUiHierarchy(xml, 800, { raw: true });
   assert.equal(result.nodes.length, 1);
-  assert.equal(result.nodes[0].value, 'Line 1\nLine 2\t&<>"\'');
-  assert.equal(result.nodes[0].label, 'Line 1\nLine 2\t&<>"\'');
+  assert.equal(result.nodes[0]!.value, 'Line 1\nLine 2\t&<>"\'');
+  assert.equal(result.nodes[0]!.label, 'Line 1\nLine 2\t&<>"\'');
 });
 
 test('androidUiNodes exposes decoded Android hierarchy metadata', () => {
@@ -143,7 +143,7 @@ test('parseUiHierarchy ignores attribute-name prefix spoofing', () => {
 
   const result = parseUiHierarchy(xml, 800, { raw: true });
   assert.equal(result.nodes.length, 1);
-  assert.equal(result.nodes[0].value, 'Actual');
+  assert.equal(result.nodes[0]!.value, 'Actual');
 });
 
 test('scrollAndroid supports explicit pixel travel distance', async () => {

--- a/src/platforms/android/__tests__/scroll-hints.test.ts
+++ b/src/platforms/android/__tests__/scroll-hints.test.ts
@@ -52,8 +52,8 @@ test('annotateAndroidScrollableContentHints marks vertical scroll areas with hid
 
   annotateAndroidScrollableContentHints(nodes, dump);
 
-  assert.equal(nodes[0].hiddenContentAbove, true);
-  assert.equal(nodes[0].hiddenContentBelow, true);
+  assert.equal(nodes[0]!.hiddenContentAbove, true);
+  assert.equal(nodes[0]!.hiddenContentBelow, true);
 });
 
 test('annotateAndroidScrollableContentHints marks bottomed-out scroll areas without hidden content below', () => {
@@ -105,8 +105,8 @@ test('annotateAndroidScrollableContentHints marks bottomed-out scroll areas with
 
   annotateAndroidScrollableContentHints(nodes, dump);
 
-  assert.equal(nodes[0].hiddenContentAbove, true);
-  assert.equal(nodes[0].hiddenContentBelow, undefined);
+  assert.equal(nodes[0]!.hiddenContentAbove, true);
+  assert.equal(nodes[0]!.hiddenContentBelow, undefined);
 });
 
 test('annotateAndroidScrollableContentHints infers bottomed-out scroll areas from a single aligned block', () => {
@@ -142,8 +142,8 @@ test('annotateAndroidScrollableContentHints infers bottomed-out scroll areas fro
 
   annotateAndroidScrollableContentHints(nodes, dump);
 
-  assert.equal(nodes[0].hiddenContentAbove, true);
-  assert.equal(nodes[0].hiddenContentBelow, undefined);
+  assert.equal(nodes[0]!.hiddenContentAbove, true);
+  assert.equal(nodes[0]!.hiddenContentBelow, undefined);
 });
 
 test('annotateAndroidScrollableContentHints infers virtualized scroll coverage without a unique block offset', () => {
@@ -191,8 +191,8 @@ test('annotateAndroidScrollableContentHints infers virtualized scroll coverage w
 
   annotateAndroidScrollableContentHints(nodes, dump);
 
-  assert.equal(nodes[0].hiddenContentAbove, true);
-  assert.equal(nodes[0].hiddenContentBelow, true);
+  assert.equal(nodes[0]!.hiddenContentAbove, true);
+  assert.equal(nodes[0]!.hiddenContentBelow, true);
 });
 
 test('annotateAndroidScrollableContentHints keeps shallow offset matching for fully mounted content', () => {
@@ -252,6 +252,6 @@ test('annotateAndroidScrollableContentHints keeps shallow offset matching for fu
 
   annotateAndroidScrollableContentHints(nodes, dump);
 
-  assert.equal(nodes[0].hiddenContentAbove, true);
-  assert.equal(nodes[0].hiddenContentBelow, undefined);
+  assert.equal(nodes[0]!.hiddenContentAbove, true);
+  assert.equal(nodes[0]!.hiddenContentBelow, undefined);
 });

--- a/src/platforms/android/app-lifecycle.ts
+++ b/src/platforms/android/app-lifecycle.ts
@@ -77,10 +77,11 @@ export async function resolveAndroidApp(
   const matches = packages.filter((pkg: string) =>
     pkg.toLowerCase().includes(trimmed.toLowerCase()),
   );
-  if (matches.length === 1) {
+  const match = matches[0];
+  if (match !== undefined && matches.length === 1) {
     return androidAppResolutionCache.set(cacheScope, trimmed, {
       type: 'package',
-      value: matches[0]!,
+      value: match,
     });
   }
 
@@ -586,9 +587,11 @@ export function parseAndroidLaunchComponent(stdout: string): string | null {
     .map((line: string) => line.trim())
     .filter(Boolean);
   for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const line = lines[index]!;
+    const line = lines[index];
+    if (line === undefined) continue;
     if (!line.includes('/')) continue;
-    return line.split(/\s+/)[0]!;
+    const component = line.split(/\s+/)[0];
+    if (component !== undefined) return component;
   }
   return null;
 }

--- a/src/platforms/android/app-lifecycle.ts
+++ b/src/platforms/android/app-lifecycle.ts
@@ -77,10 +77,11 @@ export async function resolveAndroidApp(
   const matches = packages.filter((pkg: string) =>
     pkg.toLowerCase().includes(trimmed.toLowerCase()),
   );
-  if (matches.length === 1) {
+  const match = matches[0];
+  if (matches.length === 1 && match !== undefined) {
     return androidAppResolutionCache.set(cacheScope, trimmed, {
       type: 'package',
-      value: matches[0],
+      value: match,
     });
   }
 
@@ -186,7 +187,7 @@ export function inferAndroidAppName(packageName: string): string {
   let chosen = tokens[tokens.length - 1] ?? packageName;
   for (let index = tokens.length - 1; index >= 0; index -= 1) {
     const token = tokens[index];
-    if (!ignoredTokens.has(token)) {
+    if (token && !ignoredTokens.has(token)) {
       chosen = token;
       break;
     }
@@ -587,8 +588,9 @@ export function parseAndroidLaunchComponent(stdout: string): string | null {
     .filter(Boolean);
   for (let index = lines.length - 1; index >= 0; index -= 1) {
     const line = lines[index];
+    if (line === undefined) continue;
     if (!line.includes('/')) continue;
-    return line.split(/\s+/)[0];
+    return line.split(/\s+/)[0] ?? null;
   }
   return null;
 }

--- a/src/platforms/android/app-lifecycle.ts
+++ b/src/platforms/android/app-lifecycle.ts
@@ -77,11 +77,10 @@ export async function resolveAndroidApp(
   const matches = packages.filter((pkg: string) =>
     pkg.toLowerCase().includes(trimmed.toLowerCase()),
   );
-  const match = matches[0];
-  if (matches.length === 1 && match !== undefined) {
+  if (matches.length === 1) {
     return androidAppResolutionCache.set(cacheScope, trimmed, {
       type: 'package',
-      value: match,
+      value: matches[0]!,
     });
   }
 
@@ -587,10 +586,9 @@ export function parseAndroidLaunchComponent(stdout: string): string | null {
     .map((line: string) => line.trim())
     .filter(Boolean);
   for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const line = lines[index];
-    if (line === undefined) continue;
+    const line = lines[index]!;
     if (!line.includes('/')) continue;
-    return line.split(/\s+/)[0] ?? null;
+    return line.split(/\s+/)[0]!;
   }
   return null;
 }

--- a/src/platforms/android/app-parsers.ts
+++ b/src/platforms/android/app-parsers.ts
@@ -20,9 +20,9 @@ export function parseAndroidLaunchablePackages(stdout: string): string[] {
   for (const line of stdout.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    const firstToken = trimmed.split(/\s+/)[0];
+    const firstToken = trimmed.split(/\s+/)[0] ?? '';
     if (!firstToken.includes('/')) continue;
-    const pkg = firstToken.split('/')[0];
+    const pkg = firstToken.split('/')[0] ?? '';
     if (!pkg.includes('.')) continue;
     if (pkg) packages.add(pkg);
   }

--- a/src/platforms/android/app-parsers.ts
+++ b/src/platforms/android/app-parsers.ts
@@ -86,7 +86,7 @@ function parseAndroidBlockingDialogFromSegment(
   const respondingMatch = ANDROID_RESPONDING_TITLE_PATTERN.exec(windowText);
   if (!respondingMatch) return null;
 
-  const focusedWindow = respondingMatch[1].trim().replace(/\s+/g, ' ');
+  const focusedWindow = respondingMatch[1]!.trim().replace(/\s+/g, ' ');
   const packageName = ANDROID_PACKAGE_PATTERN.exec(focusedWindow)?.[1];
   return {
     ...(packageName ? { package: packageName } : {}),

--- a/src/platforms/android/app-parsers.ts
+++ b/src/platforms/android/app-parsers.ts
@@ -86,7 +86,9 @@ function parseAndroidBlockingDialogFromSegment(
   const respondingMatch = ANDROID_RESPONDING_TITLE_PATTERN.exec(windowText);
   if (!respondingMatch) return null;
 
-  const focusedWindow = respondingMatch[1]!.trim().replace(/\s+/g, ' ');
+  const focusedWindowTitle = respondingMatch[1];
+  if (focusedWindowTitle === undefined) return null;
+  const focusedWindow = focusedWindowTitle.trim().replace(/\s+/g, ' ');
   const packageName = ANDROID_PACKAGE_PATTERN.exec(focusedWindow)?.[1];
   return {
     ...(packageName ? { package: packageName } : {}),

--- a/src/platforms/android/devices.ts
+++ b/src/platforms/android/devices.ts
@@ -269,11 +269,16 @@ function parseAndroidDeviceEntries(rawOutput: string): AndroidDeviceEntry[] {
   return lines
     .filter((line) => line.length > 0 && !line.startsWith('List of devices'))
     .map((line) => line.split(/\s+/))
-    .filter((parts) => parts[1] === 'device')
-    .map((parts) => ({
-      serial: parts[0],
-      rawModel: (parts.find((entry) => entry.startsWith('model:')) ?? '').replace('model:', ''),
-    }));
+    .flatMap((parts) => {
+      const serial = parts[0];
+      if (serial === undefined || parts[1] !== 'device') return [];
+      return [
+        {
+          serial,
+          rawModel: (parts.find((entry) => entry.startsWith('model:')) ?? '').replace('model:', ''),
+        },
+      ];
+    });
 }
 
 async function listAndroidDeviceEntries(): Promise<AndroidDeviceEntry[]> {

--- a/src/platforms/android/perf-frame-parser.ts
+++ b/src/platforms/android/perf-frame-parser.ts
@@ -255,9 +255,14 @@ function parseAndroidFrameSummary(text: string): AndroidFrameSummary | undefined
     /^\s*Janky frames:\s*([0-9][0-9,]*)\s*\(([0-9.]+)%\)/im,
   );
   if (totalFrameCount === undefined || !jankyFrameMatch) return undefined;
+  const droppedFrameToken = jankyFrameMatch[1];
+  const droppedFramePercentToken = jankyFrameMatch[2];
+  if (droppedFrameToken === undefined || droppedFramePercentToken === undefined) {
+    return undefined;
+  }
 
-  const droppedFrameCount = parseNumericToken(jankyFrameMatch[1]) ?? undefined;
-  const droppedFramePercent = Number(jankyFrameMatch[2]);
+  const droppedFrameCount = parseNumericToken(droppedFrameToken) ?? undefined;
+  const droppedFramePercent = Number(droppedFramePercentToken);
   if (
     droppedFrameCount === undefined ||
     !Number.isFinite(droppedFramePercent) ||
@@ -365,5 +370,6 @@ function matchSummaryInteger(text: string, label: string): number | undefined {
   const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = text.match(new RegExp(`^\\s*${escapedLabel}:\\s*([0-9][0-9,]*)`, 'im'));
   if (!match) return undefined;
-  return parseNumericToken(match[1]) ?? undefined;
+  const token = match[1];
+  return token === undefined ? undefined : (parseNumericToken(token) ?? undefined);
 }

--- a/src/platforms/android/perf-frame-parser.ts
+++ b/src/platforms/android/perf-frame-parser.ts
@@ -248,6 +248,7 @@ function readFrameStatsNumber(
   return Number.isFinite(value) ? value : null;
 }
 
+// fallow-ignore-next-line complexity
 function parseAndroidFrameSummary(text: string): AndroidFrameSummary | undefined {
   const summaryText = text.split(/\nProfile data in ms:\n/i)[0] ?? '';
   const totalFrameCount = matchSummaryInteger(summaryText, 'Total frames rendered');

--- a/src/platforms/android/perf.ts
+++ b/src/platforms/android/perf.ts
@@ -85,8 +85,10 @@ function parseAndroidCpuInfoSample(
     const match = line.match(/^([0-9]+(?:\.[0-9]+)?)%\s+\d+\/([^\s]+):\s/);
     if (!match) continue;
 
-    const percent = Number(match[1]);
+    const percentToken = match[1];
     const processName = match[2];
+    if (percentToken === undefined || processName === undefined) continue;
+    const percent = Number(percentToken);
     if (!Number.isFinite(percent) || !matchesAndroidPackageProcess(processName, packageName)) {
       continue;
     }
@@ -178,7 +180,8 @@ function matchLabeledNumber(text: string, label: string): number | undefined {
   const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = text.match(new RegExp(`${escapedLabel}:\\s*([0-9][0-9,]*)`, 'i'));
   if (!match) return undefined;
-  return parseNumericToken(match[1]) ?? undefined;
+  const token = match[1];
+  return token === undefined ? undefined : (parseNumericToken(token) ?? undefined);
 }
 
 function matchTotalRowPss(text: string): number | undefined {

--- a/src/platforms/android/scroll-hints.ts
+++ b/src/platforms/android/scroll-hints.ts
@@ -84,6 +84,7 @@ type NativeScrollView = {
   contentBlocks: FlowBlock[];
 };
 
+// fallow-ignore-next-line complexity
 function inferHiddenScrollableContent(params: {
   viewportRect: Rect;
   visibleBlocks: FlowBlock[];
@@ -143,6 +144,7 @@ function inferMountedCoverageHiddenContent(
   return hiddenBefore || hiddenAfter ? { above: hiddenBefore, below: hiddenAfter } : null;
 }
 
+// fallow-ignore-next-line complexity
 function estimateScrollOffset(
   nativeBlocks: FlowBlock[],
   visibleBlocks: FlowBlock[],
@@ -329,6 +331,7 @@ function matchNativeScrollView(
   return best;
 }
 
+// fallow-ignore-next-line complexity
 function parseActivityTopViewTree(dump: string): ViewNode | null {
   const root: ViewNode = {
     className: 'root',

--- a/src/platforms/android/scroll-hints.ts
+++ b/src/platforms/android/scroll-hints.ts
@@ -343,13 +343,24 @@ function parseActivityTopViewTree(dump: string): ViewNode | null {
     if (!match) {
       continue;
     }
-    const indent = match[1].length;
-    const x1 = Number(match[3]);
-    const y1 = Number(match[4]);
-    const x2 = Number(match[5]);
-    const y2 = Number(match[6]);
+    const [indentText, className, x1Text, y1Text, x2Text, y2Text] = match.slice(1);
+    if (
+      indentText === undefined ||
+      className === undefined ||
+      x1Text === undefined ||
+      y1Text === undefined ||
+      x2Text === undefined ||
+      y2Text === undefined
+    ) {
+      continue;
+    }
+    const indent = indentText.length;
+    const x1 = Number(x1Text);
+    const y1 = Number(y1Text);
+    const x2 = Number(x2Text);
+    const y2 = Number(y2Text);
     const node: ViewNode = {
-      className: match[2],
+      className,
       rect: {
         x: x1,
         y: y1,

--- a/src/platforms/android/settings.ts
+++ b/src/platforms/android/settings.ts
@@ -237,7 +237,7 @@ async function resolveAndroidAppearanceTarget(
 function parseAndroidAppearance(stdout: string, stderr: string): 'light' | 'dark' | 'auto' | null {
   const match = /night mode:\s*(yes|no|auto)\b/i.exec(`${stdout}\n${stderr}`);
   if (!match) return null;
-  const value = match[1].toLowerCase();
+  const value = match[1]?.toLowerCase();
   if (value === 'yes') return 'dark';
   if (value === 'no') return 'light';
   if (value === 'auto') return 'auto';

--- a/src/platforms/android/snapshot-helper-capture.ts
+++ b/src/platforms/android/snapshot-helper-capture.ts
@@ -224,18 +224,23 @@ export function parseAndroidSnapshotHelperXml(
 }
 
 function collectHelperChunks(records: Array<Record<string, string>>): AndroidSnapshotHelperChunk[] {
-  return records
-    .filter(
-      (record) =>
-        record.agentDeviceProtocol === ANDROID_SNAPSHOT_HELPER_PROTOCOL &&
-        record.outputFormat === ANDROID_SNAPSHOT_HELPER_OUTPUT_FORMAT &&
-        typeof record.payloadBase64 === 'string',
-    )
-    .map((record) => ({
+  const chunks: AndroidSnapshotHelperChunk[] = [];
+  for (const record of records) {
+    if (
+      record.agentDeviceProtocol !== ANDROID_SNAPSHOT_HELPER_PROTOCOL ||
+      record.outputFormat !== ANDROID_SNAPSHOT_HELPER_OUTPUT_FORMAT
+    ) {
+      continue;
+    }
+    const { payloadBase64 } = record;
+    if (payloadBase64 === undefined) continue;
+    chunks.push({
       index: readOptionalNumber(record.chunkIndex),
       count: readOptionalNumber(record.chunkCount),
-      payloadBase64: record.payloadBase64,
-    }));
+      payloadBase64,
+    });
+  }
+  return chunks;
 }
 
 function readFinalHelperResult(records: Array<Record<string, string>>): Record<string, string> {

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -388,8 +388,7 @@ export function parseUiHierarchyTree(xml: string): AndroidUiHierarchy {
       continue;
     }
     const attrs = readAndroidUiNodeMetadata(token);
-    const parent = stack.at(-1);
-    if (parent === undefined) continue;
+    const parent = stack[stack.length - 1]!;
     const node: AndroidUiHierarchy = {
       type: attrs.className,
       label: attrs.text || attrs.desc,

--- a/src/platforms/android/ui-hierarchy.ts
+++ b/src/platforms/android/ui-hierarchy.ts
@@ -388,7 +388,8 @@ export function parseUiHierarchyTree(xml: string): AndroidUiHierarchy {
       continue;
     }
     const attrs = readAndroidUiNodeMetadata(token);
-    const parent = stack[stack.length - 1];
+    const parent = stack.at(-1);
+    if (parent === undefined) continue;
     const node: AndroidUiHierarchy = {
       type: attrs.className,
       label: attrs.text || attrs.desc,

--- a/src/platforms/install-source.ts
+++ b/src/platforms/install-source.ts
@@ -266,8 +266,9 @@ function isBlockedIpv4(address: string): boolean {
   if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
     return false;
   }
-  const a = octets[0]!;
-  const b = octets[1]!;
+  const a = octets[0];
+  const b = octets[1];
+  if (a === undefined || b === undefined) return false;
   if (a === 10 || a === 127) return true;
   if (a === 169 && b === 254) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
@@ -323,10 +324,11 @@ async function resolveInstallableCandidate(
 
   if (stat.isDirectory()) {
     const installables = await collectMatchingPaths(candidatePath, params.isInstallablePath);
-    if (installables.length === 1) {
+    const installable = installables[0];
+    if (installable !== undefined && installables.length === 1) {
       return {
         archivePath: params.archivePath,
-        installablePath: installables[0]!,
+        installablePath: installable,
       };
     }
     if (installables.length > 1) {
@@ -341,8 +343,8 @@ async function resolveInstallableCandidate(
       candidatePath,
       (entryPath, entryStat) => entryStat.isFile() && isArchivePath(entryPath),
     );
-    if (archives.length === 1) {
-      const archive = archives[0]!;
+    const archive = archives[0];
+    if (archive !== undefined && archives.length === 1) {
       if (!params.allowArchiveExtraction) {
         throw new AppError(
           'INVALID_ARGS',

--- a/src/platforms/install-source.ts
+++ b/src/platforms/install-source.ts
@@ -267,6 +267,7 @@ function isBlockedIpv4(address: string): boolean {
     return false;
   }
   const [a, b] = octets;
+  if (a === undefined || b === undefined) return false;
   if (a === 10 || a === 127) return true;
   if (a === 169 && b === 254) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
@@ -322,10 +323,11 @@ async function resolveInstallableCandidate(
 
   if (stat.isDirectory()) {
     const installables = await collectMatchingPaths(candidatePath, params.isInstallablePath);
-    if (installables.length === 1) {
+    const installable = installables[0];
+    if (installables.length === 1 && installable !== undefined) {
       return {
         archivePath: params.archivePath,
-        installablePath: installables[0],
+        installablePath: installable,
       };
     }
     if (installables.length > 1) {
@@ -341,14 +343,18 @@ async function resolveInstallableCandidate(
       (entryPath, entryStat) => entryStat.isFile() && isArchivePath(entryPath),
     );
     if (archives.length === 1) {
+      const archive = archives[0];
+      if (archive === undefined) {
+        throw new AppError('INVALID_ARGS', `No ${params.installableLabel} archive found`);
+      }
       if (!params.allowArchiveExtraction) {
         throw new AppError(
           'INVALID_ARGS',
           `URL sources must point directly to a ${params.installableLabel}; nested archives are not allowed`,
-          { path: archives[0] },
+          { path: archive },
         );
       }
-      const extracted = await extractArchive(archives[0]);
+      const extracted = await extractArchive(archive);
       params.registerCleanup(extracted.cleanup);
       return await resolveInstallableCandidate(extracted.outputPath, {
         ...params,
@@ -434,7 +440,7 @@ function isArchivePath(candidatePath: string): boolean {
 }
 
 async function runCleanupTasks(tasks: Array<() => Promise<void>>): Promise<void> {
-  for (let index = tasks.length - 1; index >= 0; index -= 1) {
-    await tasks[index]();
+  for (const task of [...tasks].reverse()) {
+    await task();
   }
 }

--- a/src/platforms/install-source.ts
+++ b/src/platforms/install-source.ts
@@ -111,6 +111,7 @@ async function materializeLocalSource(
   }
 }
 
+// fallow-ignore-next-line complexity
 async function downloadToTempFile(
   tempDir: string,
   url: string,
@@ -261,6 +262,7 @@ export function isBlockedIpAddress(address: string): boolean {
   return false;
 }
 
+// fallow-ignore-next-line complexity
 function isBlockedIpv4(address: string): boolean {
   const octets = address.split('.').map((part) => Number.parseInt(part, 10));
   if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
@@ -284,6 +286,7 @@ function isBlockedIpv6(address: string): boolean {
   return false;
 }
 
+// fallow-ignore-next-line complexity
 async function resolveInstallableCandidate(
   candidatePath: string,
   params: {
@@ -356,7 +359,7 @@ async function resolveInstallableCandidate(
       params.registerCleanup(extracted.cleanup);
       return await resolveInstallableCandidate(extracted.outputPath, {
         ...params,
-        archivePath: params.archivePath ?? archives[0],
+        archivePath: params.archivePath ?? archive,
       });
     }
     if (archives.length > 1) {

--- a/src/platforms/install-source.ts
+++ b/src/platforms/install-source.ts
@@ -266,8 +266,8 @@ function isBlockedIpv4(address: string): boolean {
   if (octets.length !== 4 || octets.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
     return false;
   }
-  const [a, b] = octets;
-  if (a === undefined || b === undefined) return false;
+  const a = octets[0]!;
+  const b = octets[1]!;
   if (a === 10 || a === 127) return true;
   if (a === 169 && b === 254) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
@@ -323,11 +323,10 @@ async function resolveInstallableCandidate(
 
   if (stat.isDirectory()) {
     const installables = await collectMatchingPaths(candidatePath, params.isInstallablePath);
-    const installable = installables[0];
-    if (installables.length === 1 && installable !== undefined) {
+    if (installables.length === 1) {
       return {
         archivePath: params.archivePath,
-        installablePath: installable,
+        installablePath: installables[0]!,
       };
     }
     if (installables.length > 1) {
@@ -343,10 +342,7 @@ async function resolveInstallableCandidate(
       (entryPath, entryStat) => entryStat.isFile() && isArchivePath(entryPath),
     );
     if (archives.length === 1) {
-      const archive = archives[0];
-      if (archive === undefined) {
-        throw new AppError('INVALID_ARGS', `No ${params.installableLabel} archive found`);
-      }
+      const archive = archives[0]!;
       if (!params.allowArchiveExtraction) {
         throw new AppError(
           'INVALID_ARGS',

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -1491,9 +1491,9 @@ test('parseIosDeviceAppsPayload maps devicectl app entries', () => {
     name: 'Maps',
     url: 'file:///Applications/Maps.app/',
   });
-  assert.equal(apps[1].bundleId, 'com.example.NoName');
-  assert.equal(apps[1].name, 'com.example.NoName');
-  assert.equal(apps[1].url, undefined);
+  assert.equal(apps[1]!.bundleId, 'com.example.NoName');
+  assert.equal(apps[1]!.name, 'com.example.NoName');
+  assert.equal(apps[1]!.url, undefined);
 });
 
 test('parseIosDeviceAppsPayload ignores malformed entries', () => {

--- a/src/platforms/ios/__tests__/runner-client.test.ts
+++ b/src/platforms/ios/__tests__/runner-client.test.ts
@@ -371,13 +371,13 @@ test('runner protocol fixtures cover every runner command with JSON-safe samples
     string,
     Record<string, unknown>
   >;
-  assert.equal(roundTrip.tap.command, 'tap');
-  assert.equal(roundTrip.mouseClick.button, 'secondary');
-  assert.equal(roundTrip.snapshot.scope, 'app');
-  assert.equal(roundTrip.screenshot.fullscreen, true);
-  assert.equal(roundTrip.rotate.orientation, 'landscape-left');
-  assert.equal(roundTrip.recordStart.fps, 30);
-  assert.equal(roundTrip.recordStart.quality, 7);
+  assert.equal(roundTrip.tap!.command, 'tap');
+  assert.equal(roundTrip.mouseClick!.button, 'secondary');
+  assert.equal(roundTrip.snapshot!.scope, 'app');
+  assert.equal(roundTrip.screenshot!.fullscreen, true);
+  assert.equal(roundTrip.rotate!.orientation, 'landscape-left');
+  assert.equal(roundTrip.recordStart!.fps, 30);
+  assert.equal(roundTrip.recordStart!.quality, 7);
 });
 
 test('resolveRunnerDestination uses device destination for physical devices', () => {

--- a/src/platforms/ios/__tests__/runner-transport.test.ts
+++ b/src/platforms/ios/__tests__/runner-transport.test.ts
@@ -75,7 +75,7 @@ test('waitForRunner propagates request cancellation without fallback', async () 
 test('waitForRunner reuses cached physical-device tunnel IP across commands', async () => {
   stubSuccessfulFetch();
   mockRunCmd.mockImplementation(async (_cmd: string, args: string[]) => {
-    const jsonPath = args[args.indexOf('--json-output') + 1];
+    const jsonPath = args[args.indexOf('--json-output') + 1]!;
     fs.writeFileSync(
       jsonPath,
       JSON.stringify({
@@ -109,7 +109,7 @@ test('waitForRunner keeps tunnel IP lookup request-local when no tunnel IP is av
 test('waitForRunner invalidates cached tunnel IP when localhost fallback succeeds', async () => {
   const tunnelIps = ['fd00::123', 'fd00::456'];
   mockRunCmd.mockImplementation(async (_cmd: string, args: string[]) => {
-    const jsonPath = args[args.indexOf('--json-output') + 1];
+    const jsonPath = args[args.indexOf('--json-output') + 1]!;
     fs.writeFileSync(
       jsonPath,
       JSON.stringify({

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -114,9 +114,8 @@ export async function resolveIosApp(device: DeviceInfo, app: string): Promise<st
       ? await listSimulatorApps(device)
       : await listIosDeviceApps(device, 'all');
   const matches = list.filter((entry) => entry.name.toLowerCase() === trimmed.toLowerCase());
-  const match = matches[0];
-  if (matches.length === 1 && match !== undefined) {
-    return iosAppResolutionCache.set(cacheScope, trimmed, match.bundleId);
+  if (matches.length === 1) {
+    return iosAppResolutionCache.set(cacheScope, trimmed, matches[0]!.bundleId);
   }
   if (matches.length > 1) {
     throw new AppError('INVALID_ARGS', `Multiple apps matched "${app}"`, { matches });

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -114,8 +114,9 @@ export async function resolveIosApp(device: DeviceInfo, app: string): Promise<st
       ? await listSimulatorApps(device)
       : await listIosDeviceApps(device, 'all');
   const matches = list.filter((entry) => entry.name.toLowerCase() === trimmed.toLowerCase());
-  if (matches.length === 1) {
-    return iosAppResolutionCache.set(cacheScope, trimmed, matches[0]!.bundleId);
+  const match = matches[0];
+  if (match !== undefined && matches.length === 1) {
+    return iosAppResolutionCache.set(cacheScope, trimmed, match.bundleId);
   }
   if (matches.length > 1) {
     throw new AppError('INVALID_ARGS', `Multiple apps matched "${app}"`, { matches });

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -114,8 +114,10 @@ export async function resolveIosApp(device: DeviceInfo, app: string): Promise<st
       ? await listSimulatorApps(device)
       : await listIosDeviceApps(device, 'all');
   const matches = list.filter((entry) => entry.name.toLowerCase() === trimmed.toLowerCase());
-  if (matches.length === 1)
-    return iosAppResolutionCache.set(cacheScope, trimmed, matches[0].bundleId);
+  const match = matches[0];
+  if (matches.length === 1 && match !== undefined) {
+    return iosAppResolutionCache.set(cacheScope, trimmed, match.bundleId);
+  }
   if (matches.length > 1) {
     throw new AppError('INVALID_ARGS', `Multiple apps matched "${app}"`, { matches });
   }
@@ -648,7 +650,7 @@ async function resolveIosAppearanceTarget(
 function parseIosAppearance(stdout: string, stderr: string): 'light' | 'dark' | null {
   const match = /\b(light|dark|unsupported|unknown)\b/i.exec(`${stdout}\n${stderr}`);
   if (!match) return null;
-  const value = match[1].toLowerCase();
+  const value = match[1]?.toLowerCase();
   if (value === 'dark') return 'dark';
   if (value === 'light') return 'light';
   return null;
@@ -781,8 +783,9 @@ function parseSimctlPrivacyServices(helpText: string): Set<string> {
     if (!inServiceSection) continue;
     if (trimmed.startsWith('bundle identifier')) break;
     const match = /^([a-z-]+)\s+-\s+/.exec(trimmed);
-    if (match) {
-      services.add(match[1]);
+    const service = match?.[1];
+    if (service !== undefined) {
+      services.add(service);
     }
   }
   return services;

--- a/src/platforms/ios/install-artifact.ts
+++ b/src/platforms/ios/install-artifact.ts
@@ -120,8 +120,9 @@ async function resolveIosInstallablePath(
         installPath: path.join(payloadDir, entry.name),
         bundleName: entry.name.replace(/\.app$/i, ''),
       }));
-    if (appBundles.length === 1) {
-      return { installPath: appBundles[0].installPath, cleanup };
+    const appBundle = appBundles[0];
+    if (appBundles.length === 1 && appBundle !== undefined) {
+      return { installPath: appBundle.installPath, cleanup };
     }
     if (appBundles.length === 0) {
       throw new AppError(

--- a/src/platforms/ios/install-artifact.ts
+++ b/src/platforms/ios/install-artifact.ts
@@ -120,8 +120,9 @@ async function resolveIosInstallablePath(
         installPath: path.join(payloadDir, entry.name),
         bundleName: entry.name.replace(/\.app$/i, ''),
       }));
-    if (appBundles.length === 1) {
-      return { installPath: appBundles[0]!.installPath, cleanup };
+    const appBundle = appBundles[0];
+    if (appBundle !== undefined && appBundles.length === 1) {
+      return { installPath: appBundle.installPath, cleanup };
     }
     if (appBundles.length === 0) {
       throw new AppError(

--- a/src/platforms/ios/install-artifact.ts
+++ b/src/platforms/ios/install-artifact.ts
@@ -120,9 +120,8 @@ async function resolveIosInstallablePath(
         installPath: path.join(payloadDir, entry.name),
         bundleName: entry.name.replace(/\.app$/i, ''),
       }));
-    const appBundle = appBundles[0];
-    if (appBundles.length === 1 && appBundle !== undefined) {
-      return { installPath: appBundle.installPath, cleanup };
+    if (appBundles.length === 1) {
+      return { installPath: appBundles[0]!.installPath, cleanup };
     }
     if (appBundles.length === 0) {
       throw new AppError(

--- a/src/platforms/ios/macos-apps.ts
+++ b/src/platforms/ios/macos-apps.ts
@@ -40,9 +40,12 @@ export async function resolveMacOsApp(app: string): Promise<string> {
 
   const apps = await listMacApps('all');
   const matches = apps.filter((entry) => entry.name.toLowerCase() === trimmed.toLowerCase());
-  const match = matches[0];
-  if (matches.length === 1 && match !== undefined) {
-    return macOsAppResolutionCache.set(MACOS_APP_RESOLUTION_CACHE_SCOPE, trimmed, match.bundleId);
+  if (matches.length === 1) {
+    return macOsAppResolutionCache.set(
+      MACOS_APP_RESOLUTION_CACHE_SCOPE,
+      trimmed,
+      matches[0]!.bundleId,
+    );
   }
   if (matches.length > 1) {
     throw new AppError('INVALID_ARGS', `Multiple apps matched "${app}"`, { matches });

--- a/src/platforms/ios/macos-apps.ts
+++ b/src/platforms/ios/macos-apps.ts
@@ -40,12 +40,9 @@ export async function resolveMacOsApp(app: string): Promise<string> {
 
   const apps = await listMacApps('all');
   const matches = apps.filter((entry) => entry.name.toLowerCase() === trimmed.toLowerCase());
-  if (matches.length === 1) {
-    return macOsAppResolutionCache.set(
-      MACOS_APP_RESOLUTION_CACHE_SCOPE,
-      trimmed,
-      matches[0].bundleId,
-    );
+  const match = matches[0];
+  if (matches.length === 1 && match !== undefined) {
+    return macOsAppResolutionCache.set(MACOS_APP_RESOLUTION_CACHE_SCOPE, trimmed, match.bundleId);
   }
   if (matches.length > 1) {
     throw new AppError('INVALID_ARGS', `Multiple apps matched "${app}"`, { matches });

--- a/src/platforms/ios/macos-apps.ts
+++ b/src/platforms/ios/macos-apps.ts
@@ -40,12 +40,9 @@ export async function resolveMacOsApp(app: string): Promise<string> {
 
   const apps = await listMacApps('all');
   const matches = apps.filter((entry) => entry.name.toLowerCase() === trimmed.toLowerCase());
-  if (matches.length === 1) {
-    return macOsAppResolutionCache.set(
-      MACOS_APP_RESOLUTION_CACHE_SCOPE,
-      trimmed,
-      matches[0]!.bundleId,
-    );
+  const match = matches[0];
+  if (match !== undefined && matches.length === 1) {
+    return macOsAppResolutionCache.set(MACOS_APP_RESOLUTION_CACHE_SCOPE, trimmed, match.bundleId);
   }
   if (matches.length > 1) {
     throw new AppError('INVALID_ARGS', `Multiple apps matched "${app}"`, { matches });

--- a/src/platforms/ios/perf.ts
+++ b/src/platforms/ios/perf.ts
@@ -434,10 +434,19 @@ export function parseApplePsOutput(stdout: string): AppleProcessSample[] {
   for (const line of splitNonEmptyTrimmedLines(stdout)) {
     const match = line.match(/^(\d+)\s+([0-9]+(?:\.[0-9]+)?)\s+(\d+)\s+(.+)$/);
     if (!match) continue;
-    const pid = Number(match[1]);
-    const cpuPercent = Number(match[2]);
-    const rssKb = Number(match[3]);
-    const command = match[4].trim();
+    const [pidText, cpuText, rssText, commandText] = match.slice(1);
+    if (
+      pidText === undefined ||
+      cpuText === undefined ||
+      rssText === undefined ||
+      commandText === undefined
+    ) {
+      continue;
+    }
+    const pid = Number(pidText);
+    const cpuPercent = Number(cpuText);
+    const rssKb = Number(rssText);
+    const command = commandText.trim();
     if (!Number.isFinite(pid) || !Number.isFinite(cpuPercent) || !Number.isFinite(rssKb)) {
       continue;
     }

--- a/src/recording/__tests__/overlay.test.ts
+++ b/src/recording/__tests__/overlay.test.ts
@@ -9,13 +9,13 @@ vi.mock('../../utils/exec.ts', async () => {
   return {
     runCmd: vi.fn(async (cmd: string, args: string[]) => {
       if (cmd === 'xcrun') {
-        const outputPath = args[args.indexOf('-o') + 1];
+        const outputPath = args[args.indexOf('-o') + 1]!;
         fs.writeFileSync(outputPath, 'compiled');
         fs.chmodSync(outputPath, 0o755);
         return { stdout: '', stderr: '', exitCode: 0 };
       }
 
-      const outputPath = args[args.indexOf('--output') + 1];
+      const outputPath = args[args.indexOf('--output') + 1]!;
       fs.writeFileSync(outputPath, `processed ${path.basename(cmd)}`);
       return { stdout: '', stderr: '', exitCode: 0 };
     }),
@@ -64,9 +64,9 @@ test('overlay burns touches through a cached helper and same-directory temp outp
   expect(compileCalls).toHaveLength(1);
   expect(helperCalls).toHaveLength(2);
 
-  const [helperCmd, helperArgs, helperOptions] = helperCalls[0];
-  const inputPath = helperArgs[helperArgs.indexOf('--input') + 1];
-  const outputPath = helperArgs[helperArgs.indexOf('--output') + 1];
+  const [helperCmd, helperArgs, helperOptions] = helperCalls[0]!;
+  const inputPath = helperArgs[helperArgs.indexOf('--input') + 1]!;
+  const outputPath = helperArgs[helperArgs.indexOf('--output') + 1]!;
   expect(inputPath).toBe(videoPath);
   expect(outputPath).not.toBe(videoPath);
   expect(path.dirname(outputPath)).toBe(tmpDir);

--- a/src/replay/script-utils.ts
+++ b/src/replay/script-utils.ts
@@ -201,13 +201,15 @@ export function parseReplaySeriesFlags(
 
   for (let index = 0; index < args.length; index += 1) {
     const token = args[index];
+    if (token === undefined) continue;
 
     if (isClickLikeCommand(command) && token === '--double-tap') {
       flags.doubleTap = true;
       continue;
     }
-    if (isClickLikeCommand(command) && token === '--button' && index + 1 < args.length) {
-      const clickButton = args[index + 1];
+    const nextArg = args[index + 1];
+    if (isClickLikeCommand(command) && token === '--button' && nextArg !== undefined) {
+      const clickButton = nextArg;
       if (clickButton === 'primary' || clickButton === 'secondary' || clickButton === 'middle') {
         flags.clickButton = clickButton;
       }
@@ -216,8 +218,8 @@ export function parseReplaySeriesFlags(
     }
 
     const numericKey = numericFlagMap?.get(token);
-    if (numericKey && index + 1 < args.length) {
-      const parsed = parseNonNegativeIntToken(args[index + 1]);
+    if (numericKey && nextArg !== undefined) {
+      const parsed = parseNonNegativeIntToken(nextArg);
       if (parsed !== null) {
         flags[numericKey] = parsed;
         index += 1;
@@ -225,8 +227,8 @@ export function parseReplaySeriesFlags(
       }
     }
 
-    if (command === 'swipe' && token === '--pattern' && index + 1 < args.length) {
-      const pattern = args[index + 1];
+    if (command === 'swipe' && token === '--pattern' && nextArg !== undefined) {
+      const pattern = nextArg;
       if (pattern === 'one-way' || pattern === 'ping-pong') {
         flags.pattern = pattern;
       }
@@ -262,34 +264,36 @@ export function parseReplayRuntimeFlags(args: string[]): {
 
   for (let index = 0; index < args.length; index += 1) {
     const token = args[index];
-    if (token === '--platform' && index + 1 < args.length) {
-      const platform = args[index + 1];
+    if (token === undefined) continue;
+    const nextArg = args[index + 1];
+    if (token === '--platform' && nextArg !== undefined) {
+      const platform = nextArg;
       if (platform === 'ios' || platform === 'android') {
         flags.platform = platform;
       }
       index += 1;
       continue;
     }
-    if (token === '--metro-host' && index + 1 < args.length) {
-      flags.metroHost = args[index + 1];
+    if (token === '--metro-host' && nextArg !== undefined) {
+      flags.metroHost = nextArg;
       index += 1;
       continue;
     }
-    if (token === '--metro-port' && index + 1 < args.length) {
-      const parsedPort = parseNonNegativeIntToken(args[index + 1]);
+    if (token === '--metro-port' && nextArg !== undefined) {
+      const parsedPort = parseNonNegativeIntToken(nextArg);
       if (parsedPort !== null) {
         flags.metroPort = parsedPort;
       }
       index += 1;
       continue;
     }
-    if (token === '--bundle-url' && index + 1 < args.length) {
-      flags.bundleUrl = args[index + 1];
+    if (token === '--bundle-url' && nextArg !== undefined) {
+      flags.bundleUrl = nextArg;
       index += 1;
       continue;
     }
-    if (token === '--launch-url' && index + 1 < args.length) {
-      flags.launchUrl = args[index + 1];
+    if (token === '--launch-url' && nextArg !== undefined) {
+      flags.launchUrl = nextArg;
       index += 1;
       continue;
     }

--- a/src/replay/script-utils.ts
+++ b/src/replay/script-utils.ts
@@ -200,8 +200,7 @@ export function parseReplaySeriesFlags(
         : undefined;
 
   for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === undefined) continue;
+    const token = args[index]!;
 
     if (isClickLikeCommand(command) && token === '--double-tap') {
       flags.doubleTap = true;
@@ -263,8 +262,7 @@ export function parseReplayRuntimeFlags(args: string[]): {
   } = {};
 
   for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === undefined) continue;
+    const token = args[index]!;
     const nextArg = args[index + 1];
     if (token === '--platform' && nextArg !== undefined) {
       const platform = nextArg;

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -45,8 +45,7 @@ export function parseReplayScriptDetailed(script: string): ParsedReplayScript {
   const actionLines: number[] = [];
   const lines = script.split(/\r?\n/);
   let sawAction = false;
-  for (let index = 0; index < lines.length; index += 1) {
-    const rawLine = lines[index];
+  for (const [index, rawLine] of lines.entries()) {
     const trimmed = rawLine.trim();
     if (trimmed.length === 0 || trimmed.startsWith('#')) continue;
     if (isReplayEnvLine(trimmed)) {
@@ -71,8 +70,7 @@ export function parseReplayScriptDetailed(script: string): ParsedReplayScript {
 export function readReplayScriptMetadata(script: string): ReplayScriptMetadata {
   const lines = script.split(/\r?\n/);
   const metadata: ReplayScriptMetadata = {};
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
+  for (const [index, line] of lines.entries()) {
     const trimmed = line.trim();
     if (trimmed.length === 0 || trimmed.startsWith('#')) continue;
     if (isReplayEnvLine(trimmed)) {
@@ -191,7 +189,9 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   if (trimmed.length === 0 || trimmed.startsWith('#')) return null;
   const tokens = tokenizeReplayLine(trimmed);
   if (tokens.length === 0) return null;
-  const [command, ...args] = tokens;
+  const command = tokens[0];
+  if (command === undefined) return null;
+  const args = tokens.slice(1);
   if (command === 'context') return null;
 
   const action: SessionAction = {
@@ -263,6 +263,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
     Object.assign(action.flags, parsed.flags);
     if (parsed.positionals.length === 0) return action;
     const target = parsed.positionals[0];
+    if (target === undefined) return action;
     if (target.startsWith('@')) {
       action.positionals = [target];
       if (parsed.positionals[1]) {
@@ -288,13 +289,16 @@ function parseReplayScriptLine(line: string): SessionAction | null {
       return action;
     }
     const target = parsed.positionals[0];
+    if (target === undefined) return action;
     if (target.startsWith('@')) {
       if (parsed.positionals.length >= 3) {
         action.positionals = [target, parsed.positionals.slice(2).join(' ')];
         action.result = { refLabel: parsed.positionals[1] };
         return action;
       }
-      action.positionals = [target, parsed.positionals[1]];
+      const text = parsed.positionals[1];
+      if (text === undefined) return action;
+      action.positionals = [target, text];
       return action;
     }
     action.positionals = [target, parsed.positionals.slice(1).join(' ')];
@@ -308,6 +312,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
     }
     const sub = args[0];
     const target = args[1];
+    if (sub === undefined || target === undefined) return action;
     if (target.startsWith('@')) {
       action.positionals = [sub, target];
       if (args[2]) {
@@ -330,6 +335,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
     const positionals: string[] = [];
     for (let index = 0; index < args.length; index += 1) {
       const token = args[index];
+      if (token === undefined) continue;
       if (token === '--hide-touches') {
         action.flags.hideTouches = true;
         continue;
@@ -360,6 +366,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
     const positionals: string[] = [];
     for (let index = 0; index < args.length; index += 1) {
       const token = args[index];
+      if (token === undefined) continue;
       const screenshotFlag = readScreenshotScriptFlag({ args, index, flags: action.flags });
       if (screenshotFlag.handled) {
         index = screenshotFlag.nextIndex;
@@ -398,7 +405,7 @@ function tokenizeReplayLine(line: string): string[] {
 
 function skipReplayWhitespace(line: string, cursor: number): number {
   let nextCursor = cursor;
-  while (nextCursor < line.length && /\s/.test(line[nextCursor])) {
+  while (nextCursor < line.length && /\s/.test(line.charAt(nextCursor))) {
     nextCursor += 1;
   }
   return nextCursor;
@@ -412,7 +419,7 @@ function readQuotedReplayToken(
   let escaped = false;
   let end = tokenStart;
   for (; end < line.length; end += 1) {
-    const char = line[end];
+    const char = line.charAt(end);
     if (char === '"' && !escaped) break;
     if (escaped) {
       escaped = false;
@@ -431,7 +438,7 @@ function readQuotedReplayToken(
 
 function readBareReplayToken(line: string, cursor: number): { value: string; nextCursor: number } {
   let end = cursor;
-  while (end < line.length && !/\s/.test(line[end])) {
+  while (end < line.length && !/\s/.test(line.charAt(end))) {
     end += 1;
   }
   return { value: line.slice(cursor, end), nextCursor: end };

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -282,18 +282,19 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   if (command === 'fill') {
     const parsed = parseReplaySeriesFlags(command, args);
     Object.assign(action.flags, parsed.flags);
-    if (parsed.positionals.length < 2) {
+    const target = parsed.positionals[0];
+    const text = parsed.positionals[1];
+    if (target === undefined || text === undefined) {
       action.positionals = parsed.positionals;
       return action;
     }
-    const target = parsed.positionals[0]!;
     if (target.startsWith('@')) {
       if (parsed.positionals.length >= 3) {
         action.positionals = [target, parsed.positionals.slice(2).join(' ')];
         action.result = { refLabel: parsed.positionals[1] };
         return action;
       }
-      action.positionals = [target, parsed.positionals[1]!];
+      action.positionals = [target, text];
       return action;
     }
     action.positionals = [target, parsed.positionals.slice(1).join(' ')];

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -189,8 +189,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   if (trimmed.length === 0 || trimmed.startsWith('#')) return null;
   const tokens = tokenizeReplayLine(trimmed);
   if (tokens.length === 0) return null;
-  const command = tokens[0];
-  if (command === undefined) return null;
+  const command = tokens[0]!;
   const args = tokens.slice(1);
   if (command === 'context') return null;
 
@@ -262,8 +261,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
     const parsed = parseReplaySeriesFlags(command, args);
     Object.assign(action.flags, parsed.flags);
     if (parsed.positionals.length === 0) return action;
-    const target = parsed.positionals[0];
-    if (target === undefined) return action;
+    const target = parsed.positionals[0]!;
     if (target.startsWith('@')) {
       action.positionals = [target];
       if (parsed.positionals[1]) {
@@ -288,17 +286,14 @@ function parseReplayScriptLine(line: string): SessionAction | null {
       action.positionals = parsed.positionals;
       return action;
     }
-    const target = parsed.positionals[0];
-    if (target === undefined) return action;
+    const target = parsed.positionals[0]!;
     if (target.startsWith('@')) {
       if (parsed.positionals.length >= 3) {
         action.positionals = [target, parsed.positionals.slice(2).join(' ')];
         action.result = { refLabel: parsed.positionals[1] };
         return action;
       }
-      const text = parsed.positionals[1];
-      if (text === undefined) return action;
-      action.positionals = [target, text];
+      action.positionals = [target, parsed.positionals[1]!];
       return action;
     }
     action.positionals = [target, parsed.positionals.slice(1).join(' ')];
@@ -310,9 +305,8 @@ function parseReplayScriptLine(line: string): SessionAction | null {
       action.positionals = args;
       return action;
     }
-    const sub = args[0];
-    const target = args[1];
-    if (sub === undefined || target === undefined) return action;
+    const sub = args[0]!;
+    const target = args[1]!;
     if (target.startsWith('@')) {
       action.positionals = [sub, target];
       if (args[2]) {
@@ -334,8 +328,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   if (command === 'record') {
     const positionals: string[] = [];
     for (let index = 0; index < args.length; index += 1) {
-      const token = args[index];
-      if (token === undefined) continue;
+      const token = args[index]!;
       if (token === '--hide-touches') {
         action.flags.hideTouches = true;
         continue;
@@ -365,8 +358,7 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   if (command === 'screenshot') {
     const positionals: string[] = [];
     for (let index = 0; index < args.length; index += 1) {
-      const token = args[index];
-      if (token === undefined) continue;
+      const token = args[index]!;
       const screenshotFlag = readScreenshotScriptFlag({ args, index, flags: action.flags });
       if (screenshotFlag.handled) {
         index = screenshotFlag.nextIndex;

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -282,22 +282,21 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   if (command === 'fill') {
     const parsed = parseReplaySeriesFlags(command, args);
     Object.assign(action.flags, parsed.flags);
-    const target = parsed.positionals[0];
-    const text = parsed.positionals[1];
-    if (target === undefined || text === undefined) {
+    if (!hasFillTargetAndText(parsed.positionals)) {
       action.positionals = parsed.positionals;
       return action;
     }
+    const [target, text, ...textRest] = parsed.positionals;
     if (target.startsWith('@')) {
-      if (parsed.positionals.length >= 3) {
-        action.positionals = [target, parsed.positionals.slice(2).join(' ')];
-        action.result = { refLabel: parsed.positionals[1] };
+      if (textRest.length > 0) {
+        action.positionals = [target, textRest.join(' ')];
+        action.result = { refLabel: text };
         return action;
       }
       action.positionals = [target, text];
       return action;
     }
-    action.positionals = [target, parsed.positionals.slice(1).join(' ')];
+    action.positionals = [target, [text, ...textRest].join(' ')];
     return action;
   }
 
@@ -373,6 +372,10 @@ function parseReplayScriptLine(line: string): SessionAction | null {
 
   action.positionals = args;
   return action;
+}
+
+function hasFillTargetAndText(positionals: string[]): positionals is [string, string, ...string[]] {
+  return positionals.length >= 2;
 }
 
 function isNumericToken(token: string | undefined): token is string {

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -188,9 +188,8 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   const trimmed = line.trim();
   if (trimmed.length === 0 || trimmed.startsWith('#')) return null;
   const tokens = tokenizeReplayLine(trimmed);
-  if (tokens.length === 0) return null;
-  const command = tokens[0]!;
-  const args = tokens.slice(1);
+  const [command, ...args] = tokens;
+  if (command === undefined) return null;
   if (command === 'context') return null;
 
   const action: SessionAction = {
@@ -260,8 +259,8 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   if (isClickLikeCommand(command)) {
     const parsed = parseReplaySeriesFlags(command, args);
     Object.assign(action.flags, parsed.flags);
-    if (parsed.positionals.length === 0) return action;
-    const target = parsed.positionals[0]!;
+    const target = parsed.positionals[0];
+    if (target === undefined) return action;
     if (target.startsWith('@')) {
       action.positionals = [target];
       if (parsed.positionals[1]) {
@@ -301,12 +300,12 @@ function parseReplayScriptLine(line: string): SessionAction | null {
   }
 
   if (command === 'get') {
-    if (args.length < 2) {
+    const sub = args[0];
+    const target = args[1];
+    if (sub === undefined || target === undefined) {
       action.positionals = args;
       return action;
     }
-    const sub = args[0]!;
-    const target = args[1]!;
     if (target.startsWith('@')) {
       action.positionals = [sub, target];
       if (args[2]) {

--- a/src/replay/vars.ts
+++ b/src/replay/vars.ts
@@ -130,8 +130,9 @@ export function resolveReplayString(
     ) => {
       if (escapedLiteral) return '${';
       if (!key) return match;
-      const value = scope.values[key];
-      if (value !== undefined) return value;
+      if (Object.prototype.hasOwnProperty.call(scope.values, key)) {
+        return String(scope.values[key]);
+      }
       if (fallback !== undefined) {
         return fallback.replace(/\\(.)/g, '$1');
       }

--- a/src/replay/vars.ts
+++ b/src/replay/vars.ts
@@ -130,9 +130,8 @@ export function resolveReplayString(
     ) => {
       if (escapedLiteral) return '${';
       if (!key) return match;
-      if (Object.prototype.hasOwnProperty.call(scope.values, key)) {
-        return scope.values[key];
-      }
+      const value = scope.values[key];
+      if (value !== undefined) return value;
       if (fallback !== undefined) {
         return fallback.replace(/\\(.)/g, '$1');
       }

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1199,7 +1199,7 @@ test('compat mode warns and strips unsupported command flags', () => {
   assert.equal(parsed.command, 'press');
   assert.equal(parsed.flags.pauseMs, undefined);
   assert.equal(parsed.warnings.length, 1);
-  assert.match(parsed.warnings[0], /not supported for command press/);
+  assert.match(parsed.warnings[0]!, /not supported for command press/);
 });
 
 test('strict mode rejects unsupported pilot-command flags', () => {
@@ -1314,7 +1314,7 @@ test('command-specific flags without command warn and strip in compat mode', () 
   assert.equal(parsed.command, null);
   assert.equal(parsed.flags.snapshotDepth, undefined);
   assert.equal(parsed.warnings.length, 1);
-  assert.match(parsed.warnings[0], /requires a command that supports/);
+  assert.match(parsed.warnings[0]!, /requires a command that supports/);
 });
 
 test('all commands participate in strict command-flag validation', () => {

--- a/src/utils/__tests__/mobile-snapshot-semantics.test.ts
+++ b/src/utils/__tests__/mobile-snapshot-semantics.test.ts
@@ -212,7 +212,7 @@ test('visibility is true for node at exact viewport boundary', () => {
   ];
 
   // Node overlaps viewport by 1 px at the top edge — should be considered visible
-  assert.equal(isNodeVisibleInEffectiveViewport(nodes[1], nodes), true);
+  assert.equal(isNodeVisibleInEffectiveViewport(nodes[1]!, nodes), true);
 });
 
 test('visibility is false for node just outside viewport boundary', () => {
@@ -237,7 +237,7 @@ test('visibility is false for node just outside viewport boundary', () => {
     },
   ];
 
-  assert.equal(isNodeVisibleInEffectiveViewport(nodes[1], nodes), false);
+  assert.equal(isNodeVisibleInEffectiveViewport(nodes[1]!, nodes), false);
 });
 
 test('mobile presentation infers hidden content from vertical scroll indicator value at top', () => {

--- a/src/utils/__tests__/swift-cache.test.ts
+++ b/src/utils/__tests__/swift-cache.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 vi.mock('../exec.ts', () => ({
   runCmd: vi.fn(async (_cmd: string, args: string[]) => {
-    const outputPath = args[args.indexOf('-o') + 1];
+    const outputPath = args[args.indexOf('-o') + 1]!;
     fs.writeFileSync(outputPath, 'compiled');
     fs.chmodSync(outputPath, 0o755);
     return { stdout: '', stderr: '', exitCode: 0 };
@@ -38,8 +38,8 @@ test('compileSwiftSourceFile compiles to a unique temp executable before publish
     sourcePath,
   });
 
-  const compileCall = mockRunCmd.mock.calls[0];
-  const outputPath = compileCall[1][compileCall[1].indexOf('-o') + 1];
+  const compileCall = mockRunCmd.mock.calls[0]!;
+  const outputPath = compileCall[1][compileCall[1].indexOf('-o') + 1]!;
 
   expect(outputPath).not.toBe(executablePath);
   expect(path.dirname(outputPath)).toContain(path.join('swift-cache', 'bin'));
@@ -127,7 +127,7 @@ async function expectConcurrentCacheReuse(compile: () => Promise<string>): Promi
       await new Promise<void>((release) => {
         releaseCompile = release;
       });
-      const outputPath = args[args.indexOf('-o') + 1];
+      const outputPath = args[args.indexOf('-o') + 1]!;
       fs.writeFileSync(outputPath, 'compiled once');
       fs.chmodSync(outputPath, 0o755);
       return { stdout: '', stderr: '', exitCode: 0 };

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -48,8 +48,7 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
   let parseFlags = true;
 
   for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === undefined) continue;
+    const arg = argv[i]!;
     if (parseFlags && arg === '--') {
       parseFlags = false;
       continue;

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -49,6 +49,7 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (arg === undefined) continue;
     if (parseFlags && arg === '--') {
       parseFlags = false;
       continue;

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -116,7 +116,8 @@ export async function resolveDevice(
     return match;
   }
 
-  if (candidates.length === 1) return candidates[0]!;
+  const onlyCandidate = candidates[0];
+  if (onlyCandidate !== undefined && candidates.length === 1) return onlyCandidate;
 
   if (candidates.length === 0) {
     const simulatorSetPath = context.simulatorSetPath;
@@ -138,9 +139,14 @@ export async function resolveDevice(
   }
 
   const booted = candidates.filter((d) => d.booted);
-  if (booted.length === 1) return booted[0]!;
+  const onlyBooted = booted[0];
+  if (onlyBooted !== undefined && booted.length === 1) return onlyBooted;
 
   // When multiple candidates remain equally valid, preserve discovery order from
   // the underlying platform tools rather than introducing another tie-breaker here.
-  return booted[0] ?? candidates[0]!;
+  const selected = booted[0] ?? candidates[0];
+  if (selected === undefined) {
+    throw new AppError('DEVICE_NOT_FOUND', 'No devices found', { selector });
+  }
+  return selected;
 }

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -116,8 +116,7 @@ export async function resolveDevice(
     return match;
   }
 
-  const onlyCandidate = candidates[0];
-  if (candidates.length === 1 && onlyCandidate !== undefined) return onlyCandidate;
+  if (candidates.length === 1) return candidates[0]!;
 
   if (candidates.length === 0) {
     const simulatorSetPath = context.simulatorSetPath;
@@ -139,12 +138,9 @@ export async function resolveDevice(
   }
 
   const booted = candidates.filter((d) => d.booted);
-  const onlyBooted = booted[0];
-  if (booted.length === 1 && onlyBooted !== undefined) return onlyBooted;
+  if (booted.length === 1) return booted[0]!;
 
   // When multiple candidates remain equally valid, preserve discovery order from
   // the underlying platform tools rather than introducing another tie-breaker here.
-  const preferred = booted[0] ?? candidates[0];
-  if (preferred !== undefined) return preferred;
-  throw new AppError('DEVICE_NOT_FOUND', 'No devices found', { selector });
+  return booted[0] ?? candidates[0]!;
 }

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -116,7 +116,8 @@ export async function resolveDevice(
     return match;
   }
 
-  if (candidates.length === 1) return candidates[0];
+  const onlyCandidate = candidates[0];
+  if (candidates.length === 1 && onlyCandidate !== undefined) return onlyCandidate;
 
   if (candidates.length === 0) {
     const simulatorSetPath = context.simulatorSetPath;
@@ -138,9 +139,12 @@ export async function resolveDevice(
   }
 
   const booted = candidates.filter((d) => d.booted);
-  if (booted.length === 1) return booted[0];
+  const onlyBooted = booted[0];
+  if (booted.length === 1 && onlyBooted !== undefined) return onlyBooted;
 
   // When multiple candidates remain equally valid, preserve discovery order from
   // the underlying platform tools rather than introducing another tie-breaker here.
-  return booted[0] ?? candidates[0];
+  const preferred = booted[0] ?? candidates[0];
+  if (preferred !== undefined) return preferred;
+  throw new AppError('DEVICE_NOT_FOUND', 'No devices found', { selector });
 }

--- a/src/utils/finders.ts
+++ b/src/utils/finders.ts
@@ -127,7 +127,7 @@ export function parseFindArgs(args: string[]): {
   if (actionTokens.length === 0) {
     return { locator, query, action: 'click' };
   }
-  const action = actionTokens[0].toLowerCase();
+  const action = actionTokens[0]?.toLowerCase();
   if (action === 'get') {
     const sub = actionTokens[1]?.toLowerCase();
     if (sub === 'text') return { locator, query, action: 'get_text' };

--- a/src/utils/snapshot-diff.ts
+++ b/src/utils/snapshot-diff.ts
@@ -99,7 +99,16 @@ function diffComparableLinesMyers(
       const goDown = k === -d || (k !== d && getV(v, k - 1) < getV(v, k + 1));
       let x = goDown ? getV(v, k + 1) : getV(v, k - 1) + 1;
       let y = x - k;
-      while (x < n && y < m && previous[x].comparable === current[y].comparable) {
+      while (x < n && y < m) {
+        const previousLine = previous[x];
+        const currentLine = current[y];
+        if (
+          previousLine === undefined ||
+          currentLine === undefined ||
+          previousLine.comparable !== currentLine.comparable
+        ) {
+          break;
+        }
         x += 1;
         y += 1;
       }
@@ -126,6 +135,7 @@ function backtrackMyers(
 
   for (let d = trace.length - 1; d >= 0; d -= 1) {
     const v = trace[d];
+    if (v === undefined) continue;
     const k = x - y;
     const goDown = k === -d || (k !== d && getV(v, k - 1) < getV(v, k + 1));
     const prevK = goDown ? k + 1 : k - 1;
@@ -133,7 +143,9 @@ function backtrackMyers(
     const prevY = prevX - prevK;
 
     while (x > prevX && y > prevY) {
-      lines.push({ kind: 'unchanged', text: current[y - 1].text });
+      const line = current[y - 1];
+      if (line === undefined) break;
+      lines.push({ kind: 'unchanged', text: line.text });
       x -= 1;
       y -= 1;
     }
@@ -141,10 +153,12 @@ function backtrackMyers(
     if (d === 0) break;
 
     if (x === prevX) {
-      lines.push({ kind: 'added', text: current[prevY].text });
+      const line = current[prevY];
+      if (line !== undefined) lines.push({ kind: 'added', text: line.text });
       y = prevY;
     } else {
-      lines.push({ kind: 'removed', text: previous[prevX].text });
+      const line = previous[prevX];
+      if (line !== undefined) lines.push({ kind: 'removed', text: line.text });
       x = prevX;
     }
   }

--- a/src/utils/snapshot-diff.ts
+++ b/src/utils/snapshot-diff.ts
@@ -99,16 +99,7 @@ function diffComparableLinesMyers(
       const goDown = k === -d || (k !== d && getV(v, k - 1) < getV(v, k + 1));
       let x = goDown ? getV(v, k + 1) : getV(v, k - 1) + 1;
       let y = x - k;
-      while (x < n && y < m) {
-        const previousLine = previous[x];
-        const currentLine = current[y];
-        if (
-          previousLine === undefined ||
-          currentLine === undefined ||
-          previousLine.comparable !== currentLine.comparable
-        ) {
-          break;
-        }
+      while (x < n && y < m && previous[x]!.comparable === current[y]!.comparable) {
         x += 1;
         y += 1;
       }
@@ -134,8 +125,7 @@ function backtrackMyers(
   let y = m;
 
   for (let d = trace.length - 1; d >= 0; d -= 1) {
-    const v = trace[d];
-    if (v === undefined) continue;
+    const v = trace[d]!;
     const k = x - y;
     const goDown = k === -d || (k !== d && getV(v, k - 1) < getV(v, k + 1));
     const prevK = goDown ? k + 1 : k - 1;
@@ -143,9 +133,7 @@ function backtrackMyers(
     const prevY = prevX - prevK;
 
     while (x > prevX && y > prevY) {
-      const line = current[y - 1];
-      if (line === undefined) break;
-      lines.push({ kind: 'unchanged', text: line.text });
+      lines.push({ kind: 'unchanged', text: current[y - 1]!.text });
       x -= 1;
       y -= 1;
     }
@@ -153,12 +141,10 @@ function backtrackMyers(
     if (d === 0) break;
 
     if (x === prevX) {
-      const line = current[prevY];
-      if (line !== undefined) lines.push({ kind: 'added', text: line.text });
+      lines.push({ kind: 'added', text: current[prevY]!.text });
       y = prevY;
     } else {
-      const line = previous[prevX];
-      if (line !== undefined) lines.push({ kind: 'removed', text: line.text });
+      lines.push({ kind: 'removed', text: previous[prevX]!.text });
       x = prevX;
     }
   }

--- a/src/utils/snapshot-processing.ts
+++ b/src/utils/snapshot-processing.ts
@@ -63,7 +63,7 @@ export function pruneGroupNodes(nodes: RawSnapshotNode[]): RawSnapshotNode[] {
   const result: RawSnapshotNode[] = [];
   for (const node of nodes) {
     const depth = node.depth ?? 0;
-    while (skippedDepths.length > 0 && depth <= (skippedDepths.at(-1) ?? -1)) {
+    while (skippedDepths.length > 0 && depth <= skippedDepths[skippedDepths.length - 1]!) {
       skippedDepths.pop();
     }
     const type = normalizeType(node.type ?? '');

--- a/src/utils/snapshot-processing.ts
+++ b/src/utils/snapshot-processing.ts
@@ -63,7 +63,7 @@ export function pruneGroupNodes(nodes: RawSnapshotNode[]): RawSnapshotNode[] {
   const result: RawSnapshotNode[] = [];
   for (const node of nodes) {
     const depth = node.depth ?? 0;
-    while (skippedDepths.length > 0 && depth <= skippedDepths[skippedDepths.length - 1]) {
+    while (skippedDepths.length > 0 && depth <= (skippedDepths.at(-1) ?? -1)) {
       skippedDepths.pop();
     }
     const type = normalizeType(node.type ?? '');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

Enable TypeScript `noUncheckedIndexedAccess` so unchecked `array[index]` and `record[key]` reads now surface as `| undefined` during typecheck instead of being assumed present.

This improves codebase health by making each indexed access state its invariant: loop-bounded reads use targeted non-null assertions, parser/regex boundaries use explicit guards, and several call sites now use iteration APIs that avoid indexing entirely. The result is stricter compiler coverage across parsing, replay, selectors, dispatch, snapshot, platform, and test code without broad `any` or cast escapes.

Before:

```ts
const target = parsed.positionals[0];
action.positionals = [target, parsed.positionals[1]];
```

After:

```ts
if (!hasFillTargetAndText(parsed.positionals)) {
  action.positionals = parsed.positionals;
  return action;
}

const [target, text, ...textRest] = parsed.positionals;
action.positionals = [target, [text, ...textRest].join(' ')];
```

The tuple guard captures the parser invariant once, then downstream code can destructure `target` and `text` as present strings instead of repeating unchecked indexed reads.

Touched 60 files. Scope stayed within TypeScript strictness fallout from enabling the compiler option.

## Validation

`pnpm format` passed.

`pnpm check:tooling` passed: lint, typecheck, MCP metadata check, and build/declaration generation.

Focused unit coverage passed for the touched strictness areas, including replay variables, Maestro replay parsing, selector parsing, React Native overlay handling, Android snapshot/scroll helpers, snapshot processing, snapshot diff, replay heal, find, snapshot handler, and CLI batch parsing.

The replay script parser test passed after the tuple-guard cleanup. The Maestro `runScript http.post` case passed when rerun outside the sandbox; inside the sandbox it can fail on local loopback/subprocess networking.

Full `pnpm check:unit` was attempted but remains blocked in this local environment by unrelated local networking/subprocess failures (`EADDRNOTAVAIL`, test timeouts, and local tool command failures).
