### PR TITLE
ci: reduce duplicated runner work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -104,44 +104,9 @@ jobs:
       - name: Run typecheck
         run: pnpm typecheck
 
-  android-helpers:
-    name: Android Helper Packages
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup toolchain
-        uses: ./.github/actions/setup-node-pnpm
-
-      - name: Install Android SDK packages
-        run: |
-          SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
-          SDKMANAGER="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
-          if [ ! -x "$SDKMANAGER" ]; then
-            SDKMANAGER="$SDK_ROOT/cmdline-tools/bin/sdkmanager"
-          fi
-          if [ ! -x "$SDKMANAGER" ]; then
-            echo "sdkmanager not found under $SDK_ROOT" >&2
-            exit 1
-          fi
-          yes | "$SDKMANAGER" --licenses >/dev/null
-          "$SDKMANAGER" "platforms;android-36" "build-tools;36.0.0"
-
-      - name: Check Java toolchain
-        run: |
-          javac --version
-          java --version
-
-      - name: Package npm-bundled Android helpers
-        run: |
-          pnpm package:android-snapshot-helper:npm
-          pnpm package:android-multitouch-helper:npm
-
   integration:
     name: Integration Tests
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Move CI coverage and generic integration checks from macOS runners to Ubuntu runners, and remove the duplicate standalone Android helper packaging job. Android smoke still packages and validates the helper artifacts before emulator replay.

This is the first observable CI-speed slice; path gating and Apple replay cache-key changes are intentionally left for follow-up because they affect when workflows run or when cached Xcode output is reused.

Touched-file count: 1. Scope stayed within core CI workflow plumbing.

## Validation

Validated the workflow edit with `git diff --check` and a local YAML parse of `.github/workflows/ci.yml`. Did not run package checks because this worktree has no installed dependencies and the change is workflow-only.