### PR TITLE
ci: gate PR preview builds

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,23 +1,14 @@
-name: Deploy PR previews
+name: Cleanup PR previews
 
 on:
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
-    paths:
-      - "website/**"
-      - ".github/actions/build-docs/action.yml"
-      - ".github/workflows/pr-preview.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
+      - closed
 
 concurrency: preview-${{ github.ref }}
 
 jobs:
-  deploy-preview:
+  cleanup-preview:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
@@ -30,12 +21,7 @@ jobs:
         with:
           persist-credentials: true
 
-      - name: Build docs
-        uses: ./.github/actions/build-docs
-        with:
-          rspress-base: /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
-
-      - name: Deploy preview
+      - name: Remove preview
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         with:
           source-dir: website/doc_build

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "website/**"
       - ".github/actions/build-docs/action.yml"
+      - ".github/actions/setup-node-pnpm/action.yml"
       - ".github/workflows/pr-preview.yml"
       - "package.json"
       - "pnpm-lock.yaml"


### PR DESCRIPTION
## Summary

Only build and deploy PR previews when docs-preview inputs change. The preview workflow now runs for opened/reopened/synchronized PRs that touch website/docs build inputs, while closed PR cleanup is handled by a separate closed-only workflow without path filters.

This keeps preview cleanup reliable and avoids the docs install/build/deploy path for code-only PRs.

Touched-file count: 2. Scope stayed within PR preview workflow plumbing.

## Validation

Validated workflow edits with `git diff --check` and local YAML parsing for both preview workflows. This PR itself is expected to run the preview workflow because it edits `.github/workflows/pr-preview.yml`; the skip behavior applies to subsequent code-only PRs after merge.