### PR TITLE
ci: skip platform smoke for docs-only PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,14 @@ name: Android
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "website/**"
+      - "README.md"
+      - ".github/actions/build-docs/action.yml"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/pr-preview.yml"
+      - ".github/workflows/pr-preview-cleanup.yml"
   push:
     branches:
       - main

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,6 +2,14 @@ name: iOS
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "website/**"
+      - "README.md"
+      - ".github/actions/build-docs/action.yml"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/pr-preview.yml"
+      - ".github/workflows/pr-preview-cleanup.yml"
   push:
     branches:
       - main

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,14 @@ name: Linux
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "website/**"
+      - "README.md"
+      - ".github/actions/build-docs/action.yml"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/pr-preview.yml"
+      - ".github/workflows/pr-preview-cleanup.yml"
   push:
     branches:
       - main

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,14 @@ name: macOS
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "website/**"
+      - "README.md"
+      - ".github/actions/build-docs/action.yml"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/pr-preview.yml"
+      - ".github/workflows/pr-preview-cleanup.yml"
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Skip Android, iOS, macOS, and Linux smoke workflows on pull requests that only change docs/website or docs-preview/deploy workflow inputs. Pushes to main still run the platform smoke workflows.

This keeps platform validation for source, package, platform workflow, shared action, runner, and replay changes while avoiding emulator/simulator/desktop smoke work for docs-only PRs.

Touched-file count: 4. Scope stayed within platform smoke workflow triggers.

## Validation

Validated workflow edits with `git diff --check` and local YAML parsing for the four platform workflows. This PR itself is expected to run platform smoke because it edits those platform workflow files; the skip behavior applies to subsequent docs-only PRs after merge.