### PR TITLE
feat: stream replay test progress

### DIFF
--- a/src/__tests__/cli-network.test.ts
+++ b/src/__tests__/cli-network.test.ts
@@ -103,6 +103,7 @@ test('test command prints suite summary and exits non-zero on failures', async (
 
   assert.equal(result.code, 1);
   assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.meta?.requestProgress, 'replay-test');
   assert.match(result.stderr, /Running replay suite\.\.\./);
   assert.doesNotMatch(result.stdout, /PASS \/tmp\/01-pass\.ad/);
   assert.match(result.stdout, /FAIL \/tmp\/02-fail\.ad after 2 attempts \(5ms\)/);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -288,7 +288,11 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
             ? startDaemonLogTail(daemonPaths.logPath)
             : null;
         const client = createAgentDeviceClient(buildClientConfig(effectiveFlags, resolvedRuntime), {
-          transport: deps.sendToDaemon as AgentDeviceDaemonTransport,
+          transport: createCliDaemonTransport({
+            command,
+            flags: effectiveFlags,
+            transport: deps.sendToDaemon as AgentDeviceDaemonTransport,
+          }),
         });
         if (command === 'batch') {
           if (!parsedBatchSteps) {
@@ -477,6 +481,23 @@ function hasExplicitMetroRuntimeOverrides(explicitFlagKeys: Set<FlagKey>): boole
     }
   }
   return false;
+}
+
+function createCliDaemonTransport(options: {
+  command: string;
+  flags: CliFlags;
+  transport: AgentDeviceDaemonTransport;
+}): AgentDeviceDaemonTransport {
+  const { command, flags, transport } = options;
+  if (command !== 'test' || flags.json) return transport;
+  return async (req) =>
+    await transport({
+      ...req,
+      meta: {
+        ...req.meta,
+        requestProgress: 'replay-test',
+      },
+    });
 }
 
 function guessSessionFromArgv(argv: string[]): string | null {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -404,28 +404,41 @@ function parseLeaseCommon(
   input: unknown,
   path: string,
 ): {
-  token?: string;
-  session?: string;
+  record: Record<string, unknown>;
   leaseId?: string;
   ttlMs?: number;
 } {
   const record = expectObject(input, path);
   return {
-    token: optionalString(record, 'token', path),
-    session: optionalString(record, 'session', path),
+    record,
     leaseId: optionalString(record, 'leaseId', path),
     ttlMs: optionalInteger(record, 'ttlMs', path),
   };
 }
 
-export const leaseAllocateSchema = schema<LeaseAllocatePayload>((input, path) => {
-  const record = expectObject(input, path);
+function parseLeaseScope(
+  record: Record<string, unknown>,
+  path: string,
+): {
+  token?: string;
+  session?: string;
+  tenantId?: string;
+  tenant?: string;
+  runId?: string;
+} {
   return {
     token: optionalString(record, 'token', path),
     session: optionalString(record, 'session', path),
     tenantId: optionalString(record, 'tenantId', path),
     tenant: optionalString(record, 'tenant', path),
     runId: optionalString(record, 'runId', path),
+  };
+}
+
+export const leaseAllocateSchema = schema<LeaseAllocatePayload>((input, path) => {
+  const record = expectObject(input, path);
+  return {
+    ...parseLeaseScope(record, path),
     ttlMs: optionalInteger(record, 'ttlMs', path),
     backend: optionalEnum(
       record,
@@ -438,13 +451,8 @@ export const leaseAllocateSchema = schema<LeaseAllocatePayload>((input, path) =>
 
 export const leaseHeartbeatSchema = schema<LeaseHeartbeatPayload>((input, path) => {
   const parsed = parseLeaseCommon(input, path);
-  const record = expectObject(input, path);
   return {
-    token: parsed.token,
-    session: parsed.session,
-    tenantId: optionalString(record, 'tenantId', path),
-    tenant: optionalString(record, 'tenant', path),
-    runId: optionalString(record, 'runId', path),
+    ...parseLeaseScope(parsed.record, path),
     leaseId: parsed.leaseId,
     ttlMs: parsed.ttlMs,
   };
@@ -456,11 +464,7 @@ export const leaseReleaseSchema = schema<LeaseReleasePayload>((input, path) => {
     fail(`${path}.ttlMs`, 'Unexpected field');
   }
   return {
-    token: optionalString(record, 'token', path),
-    session: optionalString(record, 'session', path),
-    tenantId: optionalString(record, 'tenantId', path),
-    tenant: optionalString(record, 'tenant', path),
-    runId: optionalString(record, 'runId', path),
+    ...parseLeaseScope(record, path),
     leaseId: optionalString(record, 'leaseId', path),
   };
 });

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -57,6 +57,7 @@ export type DaemonRequestMeta = {
   materializationId?: string;
   lockPolicy?: DaemonLockPolicy;
   lockPlatform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple';
+  requestProgress?: 'replay-test';
 };
 
 export type DaemonRequest = {

--- a/src/daemon-client-progress.ts
+++ b/src/daemon-client-progress.ts
@@ -2,6 +2,7 @@ import http from 'node:http';
 import { AppError } from './utils/errors.ts';
 import type { DaemonRequest } from './daemon/types.ts';
 import type { RequestProgressEvent } from './daemon/request-progress.ts';
+import { consumeTextLines } from './utils/line-stream.ts';
 import {
   formatRequestProgressEvent,
   isDaemonProgressEnvelope,
@@ -77,13 +78,10 @@ export function readDaemonHttpProgressResponse(
   res.setEncoding('utf8');
   res.on('data', (chunk) => {
     if (settled) return;
-    buffer += chunk;
-    let idx = buffer.indexOf('\n');
-    while (idx !== -1) {
-      const line = buffer.slice(0, idx).trim();
-      buffer = buffer.slice(idx + 1);
+    const parsed = consumeTextLines(buffer, chunk);
+    buffer = parsed.buffer;
+    for (const line of parsed.lines) {
       if (line && handleLine(line)) return;
-      idx = buffer.indexOf('\n');
     }
   });
   res.on('end', () => {

--- a/src/daemon-client-progress.ts
+++ b/src/daemon-client-progress.ts
@@ -1,0 +1,115 @@
+import http from 'node:http';
+import { AppError } from './utils/errors.ts';
+import type { DaemonRequest } from './daemon/types.ts';
+import type { RequestProgressEvent } from './daemon/request-progress.ts';
+import {
+  formatRequestProgressEvent,
+  isDaemonProgressEnvelope,
+  isDaemonRpcResponseEnvelope,
+  shouldStreamRequestProgress,
+} from './daemon/request-progress-protocol.ts';
+
+export function writeRequestProgressEvent(event: RequestProgressEvent): void {
+  const line = formatRequestProgressEvent(event);
+  if (line) process.stderr.write(`${line}\n`);
+}
+
+export function shouldReadDaemonProgressStream(
+  req: DaemonRequest,
+  contentType: string | string[] | undefined,
+): boolean {
+  return (
+    shouldStreamRequestProgress(req) &&
+    String(Array.isArray(contentType) ? contentType.join(',') : (contentType ?? '')).includes(
+      'application/x-ndjson',
+    )
+  );
+}
+
+export function readDaemonHttpProgressResponse(
+  res: http.IncomingMessage,
+  options: {
+    req: DaemonRequest;
+    handleResponseBody: (body: string) => void;
+    reject: (error: unknown) => void;
+    clearTimeout: () => void;
+  },
+): void {
+  const { req, handleResponseBody, reject, clearTimeout } = options;
+  let buffer = '';
+  let settled = false;
+  const rejectInvalidLine = (line: string, error: unknown) => {
+    settled = true;
+    clearTimeout();
+    reject(
+      new AppError(
+        'COMMAND_FAILED',
+        'Invalid daemon response',
+        {
+          requestId: req.meta?.requestId,
+          line,
+        },
+        error instanceof Error ? error : undefined,
+      ),
+    );
+  };
+
+  const handleLine = (line: string): boolean => {
+    try {
+      const message = JSON.parse(line) as unknown;
+      if (isDaemonProgressEnvelope(message)) {
+        writeRequestProgressEvent(message.event);
+        return false;
+      }
+      if (isDaemonRpcResponseEnvelope(message)) {
+        settled = true;
+        clearTimeout();
+        handleResponseBody(JSON.stringify(message.response));
+        return true;
+      }
+      throw new Error('Missing daemon progress response envelope');
+    } catch (error) {
+      rejectInvalidLine(line, error);
+      return true;
+    }
+  };
+
+  res.setEncoding('utf8');
+  res.on('data', (chunk) => {
+    if (settled) return;
+    buffer += chunk;
+    let idx = buffer.indexOf('\n');
+    while (idx !== -1) {
+      const line = buffer.slice(0, idx).trim();
+      buffer = buffer.slice(idx + 1);
+      if (line && handleLine(line)) return;
+      idx = buffer.indexOf('\n');
+    }
+  });
+  res.on('end', () => {
+    if (settled) return;
+    const line = buffer.trim();
+    if (line && handleLine(line)) return;
+    settled = true;
+    clearTimeout();
+    reject(
+      new AppError('COMMAND_FAILED', 'Invalid daemon response', {
+        requestId: req.meta?.requestId,
+        line,
+      }),
+    );
+  });
+  res.on('error', (error) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout();
+    reject(
+      new AppError(
+        'COMMAND_FAILED',
+        'Failed to read daemon response',
+        { requestId: req.meta?.requestId },
+        error instanceof Error ? error : undefined,
+      ),
+    );
+  });
+}

--- a/src/daemon-client-progress.ts
+++ b/src/daemon-client-progress.ts
@@ -6,7 +6,7 @@ import { consumeTextLines } from './utils/line-stream.ts';
 import {
   formatRequestProgressEvent,
   isDaemonProgressEnvelope,
-  isDaemonRpcResponseEnvelope,
+  isDaemonResponseEnvelope,
   shouldStreamRequestProgress,
 } from './daemon/request-progress-protocol.ts';
 
@@ -62,7 +62,7 @@ export function readDaemonHttpProgressResponse(
         writeRequestProgressEvent(message.event);
         return false;
       }
-      if (isDaemonRpcResponseEnvelope(message)) {
+      if (isDaemonResponseEnvelope<unknown>(message)) {
         settled = true;
         clearTimeout();
         handleResponseBody(JSON.stringify(message.response));

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -28,6 +28,15 @@ import {
 import { uploadArtifact } from './upload-client.ts';
 import { computeDaemonCodeSignature } from './daemon/code-signature.ts';
 import { PUBLIC_COMMANDS } from './command-catalog.ts';
+import {
+  readDaemonHttpProgressResponse,
+  shouldReadDaemonProgressStream,
+  writeRequestProgressEvent,
+} from './daemon-client-progress.ts';
+import {
+  isDaemonProgressEnvelope,
+  isDaemonResponseEnvelope,
+} from './daemon/request-progress-protocol.ts';
 export { computeDaemonCodeSignature } from './daemon/code-signature.ts';
 export type DaemonRequest = SharedDaemonRequest;
 export type DaemonResponse = SharedDaemonResponse;
@@ -1152,28 +1161,41 @@ async function sendSocketRequest(
     socket.setEncoding('utf8');
     socket.on('data', (chunk) => {
       buffer += chunk;
-      const idx = buffer.indexOf('\n');
-      if (idx === -1) return;
-      const line = buffer.slice(0, idx).trim();
-      if (!line) return;
-      try {
-        const response = JSON.parse(line) as DaemonResponse;
-        socket.end();
-        if (timeoutHandle) clearTimeout(timeoutHandle);
-        resolve(response);
-      } catch (err) {
-        if (timeoutHandle) clearTimeout(timeoutHandle);
-        reject(
-          new AppError(
-            'COMMAND_FAILED',
-            'Invalid daemon response',
-            {
-              requestId: req.meta?.requestId,
-              line,
-            },
-            err instanceof Error ? err : undefined,
-          ),
-        );
+      let idx = buffer.indexOf('\n');
+      while (idx !== -1) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (!line) {
+          idx = buffer.indexOf('\n');
+          continue;
+        }
+        try {
+          const message = JSON.parse(line) as unknown;
+          if (isDaemonProgressEnvelope(message)) {
+            writeRequestProgressEvent(message.event);
+            idx = buffer.indexOf('\n');
+            continue;
+          }
+          const response = isDaemonResponseEnvelope(message) ? message.response : message;
+          socket.end();
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+          resolve(response as DaemonResponse);
+          return;
+        } catch (err) {
+          if (timeoutHandle) clearTimeout(timeoutHandle);
+          reject(
+            new AppError(
+              'COMMAND_FAILED',
+              'Invalid daemon response',
+              {
+                requestId: req.meta?.requestId,
+                line,
+              },
+              err instanceof Error ? err : undefined,
+            ),
+          );
+          return;
+        }
       }
     });
 
@@ -1220,6 +1242,18 @@ async function sendHttpRequest(
         headers,
       },
       (res) => {
+        if (shouldReadDaemonProgressStream(req, res.headers?.['content-type'])) {
+          readDaemonHttpProgressResponse(res, {
+            req,
+            reject,
+            clearTimeout: () => {
+              if (timeoutHandle) clearTimeout(timeoutHandle);
+            },
+            handleResponseBody: (body) =>
+              handleDaemonHttpResponseBody(body, { info, req, resolve, reject }),
+          });
+          return;
+        }
         void readNodeHttpResponseBody(res)
           .then((body) => {
             if (timeoutHandle) clearTimeout(timeoutHandle);

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { sleep } from './utils/timeouts.ts';
 import { AppError, toAppErrorCode } from './utils/errors.ts';
+import { consumeTextLines } from './utils/line-stream.ts';
 import { readNodeHttpResponseBody } from './utils/node-http.ts';
 import type {
   DaemonArtifact,
@@ -256,13 +257,21 @@ async function prepareRemoteRequest(
   const clientArtifactPaths: Record<string, string> = {};
   let uploadedArtifactId: string | undefined;
 
-  if (isRemoteDaemon(info)) {
-    flags = applyRemoteArtifactCommand(req, positionals, flags, clientArtifactPaths);
-    const remoteInstallSource = await prepareRemoteInstallSource(req, info);
-    if (remoteInstallSource) {
-      installSource = remoteInstallSource.installSource;
-      uploadedArtifactId = remoteInstallSource.uploadedArtifactId ?? uploadedArtifactId;
-    }
+  if (!isRemoteDaemon(info)) {
+    return createPreparedRemoteRequest({
+      positionals,
+      flags,
+      installSource,
+      uploadedArtifactId,
+      clientArtifactPaths,
+    });
+  }
+
+  flags = applyRemoteArtifactCommand(req, positionals, flags, clientArtifactPaths);
+  const remoteInstallSource = await prepareRemoteInstallSource(req, info);
+  if (remoteInstallSource) {
+    installSource = remoteInstallSource.installSource;
+    uploadedArtifactId = remoteInstallSource.uploadedArtifactId ?? uploadedArtifactId;
   }
 
   const baseResult = (): PreparedRemoteRequest =>
@@ -274,29 +283,50 @@ async function prepareRemoteRequest(
       clientArtifactPaths,
     });
 
-  if (!isRemoteDaemon(info) || (req.command !== 'install' && req.command !== 'reinstall')) {
-    return baseResult();
-  }
+  if (req.command !== 'install' && req.command !== 'reinstall') return baseResult();
+  const installPackageResult = await prepareRemoteInstallPackage(
+    req,
+    info,
+    positionals,
+    flags,
+    clientArtifactPaths,
+  );
+  if (installPackageResult?.prepared) return installPackageResult.prepared;
+  uploadedArtifactId = installPackageResult?.uploadedArtifactId ?? uploadedArtifactId;
+  return baseResult();
+}
 
+type RemoteInstallPackageResult = {
+  prepared?: PreparedRemoteRequest;
+  uploadedArtifactId?: string;
+};
+
+async function prepareRemoteInstallPackage(
+  req: Omit<DaemonRequest, 'token'>,
+  info: DaemonInfo,
+  positionals: string[],
+  flags: DaemonRequest['flags'] | undefined,
+  clientArtifactPaths: Record<string, string>,
+): Promise<RemoteInstallPackageResult | null> {
   const rawPath = positionals[1];
-  if (rawPath === undefined) return baseResult();
+  if (rawPath === undefined) return null;
   if (rawPath.startsWith('remote:')) {
     positionals[1] = rawPath.slice('remote:'.length);
-    return createPreparedRemoteRequest({ positionals, flags, clientArtifactPaths });
+    return { prepared: createPreparedRemoteRequest({ positionals, flags, clientArtifactPaths }) };
   }
 
   const localPath = resolveLocalInstallPath(rawPath, req.meta?.cwd);
   if (!localPath) {
-    return createPreparedRemoteRequest({ positionals, flags, clientArtifactPaths });
+    return { prepared: createPreparedRemoteRequest({ positionals, flags, clientArtifactPaths }) };
   }
 
-  uploadedArtifactId = await uploadArtifact({
+  const uploadedArtifactId = await uploadArtifact({
     localPath,
     baseUrl: info.baseUrl!,
     token: info.token,
     platform: req.flags?.platform,
   });
-  return baseResult();
+  return { uploadedArtifactId };
 }
 
 function applyRemoteArtifactCommand(
@@ -464,16 +494,44 @@ function buildRemoteTempArtifactPath(prefix: string, extension: string): string 
 }
 
 function resolveClientSettings(req: Omit<DaemonRequest, 'token'>): DaemonClientSettings {
-  const explicitStateDir = req.flags?.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR;
-  const rawRemoteBaseUrl = req.flags?.daemonBaseUrl ?? process.env.AGENT_DEVICE_DAEMON_BASE_URL;
-  const useOwnedReplayStateDir =
-    isOneShotReplayCommand(req.command) && !explicitStateDir && !rawRemoteBaseUrl;
-  const remoteBaseUrl = resolveRemoteDaemonBaseUrl(rawRemoteBaseUrl);
-  const remoteAuthToken = req.flags?.daemonAuthToken ?? process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN;
-  validateRemoteDaemonTrust(remoteBaseUrl, remoteAuthToken);
+  const explicitStateDir = resolveExplicitStateDir(req);
+  const remote = resolveRemoteClientSettings(req);
+  const transport = resolveTransportClientSettings(req, remote.remoteBaseUrl);
+  const ownedStateDir = shouldUseOwnedReplayStateDir(req, explicitStateDir, remote.rawBaseUrl);
+  const stateDir = ownedStateDir ? createOwnedReplayStateDir() : explicitStateDir;
+  return {
+    paths: resolveDaemonPaths(stateDir),
+    transportPreference: transport.preference,
+    serverMode: transport.serverMode,
+    ownedStateDir,
+    remoteBaseUrl: remote.remoteBaseUrl,
+    remoteAuthToken: remote.authToken,
+  };
+}
+
+function resolveExplicitStateDir(req: Omit<DaemonRequest, 'token'>): string | undefined {
+  return req.flags?.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR;
+}
+
+function resolveRemoteClientSettings(req: Omit<DaemonRequest, 'token'>): {
+  rawBaseUrl: string | undefined;
+  remoteBaseUrl?: string;
+  authToken?: string;
+} {
+  const rawBaseUrl = req.flags?.daemonBaseUrl ?? process.env.AGENT_DEVICE_DAEMON_BASE_URL;
+  const remoteBaseUrl = resolveRemoteDaemonBaseUrl(rawBaseUrl);
+  const authToken = req.flags?.daemonAuthToken ?? process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN;
+  validateRemoteDaemonTrust(remoteBaseUrl, authToken);
+  return { rawBaseUrl, remoteBaseUrl, authToken };
+}
+
+function resolveTransportClientSettings(
+  req: Omit<DaemonRequest, 'token'>,
+  remoteBaseUrl: string | undefined,
+): { preference: DaemonTransportPreference; serverMode: DaemonServerMode } {
   const rawTransport = req.flags?.daemonTransport ?? process.env.AGENT_DEVICE_DAEMON_TRANSPORT;
-  const transportPreference = resolveDaemonTransportPreference(rawTransport);
-  if (remoteBaseUrl && transportPreference === 'socket') {
+  const preference = resolveDaemonTransportPreference(rawTransport);
+  if (remoteBaseUrl && preference === 'socket') {
     throw new AppError(
       'INVALID_ARGS',
       'Remote daemon base URL only supports HTTP transport. Remove --daemon-transport socket.',
@@ -484,18 +542,22 @@ function resolveClientSettings(req: Omit<DaemonRequest, 'token'>): DaemonClientS
     req.flags?.daemonServerMode ??
     process.env.AGENT_DEVICE_DAEMON_SERVER_MODE ??
     (rawTransport === 'dual' ? 'dual' : undefined);
-  const serverMode = resolveDaemonServerMode(rawServerMode);
-  const stateDir = useOwnedReplayStateDir
-    ? fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-daemon-'))
-    : explicitStateDir;
   return {
-    paths: resolveDaemonPaths(stateDir),
-    transportPreference,
-    serverMode,
-    ownedStateDir: useOwnedReplayStateDir,
-    remoteBaseUrl,
-    remoteAuthToken,
+    preference,
+    serverMode: resolveDaemonServerMode(rawServerMode),
   };
+}
+
+function shouldUseOwnedReplayStateDir(
+  req: Omit<DaemonRequest, 'token'>,
+  explicitStateDir: string | undefined,
+  rawRemoteBaseUrl: string | undefined,
+): boolean {
+  return isOneShotReplayCommand(req.command) && !explicitStateDir && !rawRemoteBaseUrl;
+}
+
+function createOwnedReplayStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-daemon-'));
 }
 
 async function ensureDaemon(settings: DaemonClientSettings): Promise<EnsuredDaemon> {
@@ -1163,20 +1225,13 @@ async function sendSocketRequest(
     socket.setEncoding('utf8');
     socket.on('data', (chunk) => {
       if (settled) return;
-      buffer += chunk;
-      let idx = buffer.indexOf('\n');
-      while (idx !== -1) {
-        const line = buffer.slice(0, idx).trim();
-        buffer = buffer.slice(idx + 1);
-        if (!line) {
-          idx = buffer.indexOf('\n');
-          continue;
-        }
+      const parsed = consumeTextLines(buffer, chunk);
+      buffer = parsed.buffer;
+      for (const line of parsed.lines) {
         try {
           const message = JSON.parse(line) as unknown;
           if (isDaemonProgressEnvelope(message)) {
             writeRequestProgressEvent(message.event);
-            idx = buffer.indexOf('\n');
             continue;
           }
           const response = isDaemonResponseEnvelope(message) ? message.response : message;

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -1140,9 +1140,11 @@ async function sendSocketRequest(
     const statePaths = resolveDaemonPaths(
       req.flags?.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR,
     );
+    let settled = false;
     const timeoutHandle =
       typeof timeoutMs === 'number'
         ? setTimeout(() => {
+            settled = true;
             socket.destroy();
             reject(
               handleRequestTimeout(
@@ -1160,6 +1162,7 @@ async function sendSocketRequest(
     let buffer = '';
     socket.setEncoding('utf8');
     socket.on('data', (chunk) => {
+      if (settled) return;
       buffer += chunk;
       let idx = buffer.indexOf('\n');
       while (idx !== -1) {
@@ -1177,11 +1180,13 @@ async function sendSocketRequest(
             continue;
           }
           const response = isDaemonResponseEnvelope(message) ? message.response : message;
+          settled = true;
           socket.end();
           if (timeoutHandle) clearTimeout(timeoutHandle);
           resolve(response as DaemonResponse);
           return;
         } catch (err) {
+          settled = true;
           if (timeoutHandle) clearTimeout(timeoutHandle);
           reject(
             new AppError(
@@ -1200,6 +1205,8 @@ async function sendSocketRequest(
     });
 
     socket.on('error', (err) => {
+      if (settled) return;
+      settled = true;
       if (timeoutHandle) clearTimeout(timeoutHandle);
       reject(handleTransportError(err, req.meta?.requestId, false));
     });

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -284,49 +284,32 @@ async function prepareRemoteRequest(
     });
 
   if (req.command !== 'install' && req.command !== 'reinstall') return baseResult();
-  const installPackageResult = await prepareRemoteInstallPackage(
-    req,
-    info,
-    positionals,
-    flags,
-    clientArtifactPaths,
-  );
-  if (installPackageResult?.prepared) return installPackageResult.prepared;
-  uploadedArtifactId = installPackageResult?.uploadedArtifactId ?? uploadedArtifactId;
+  const installPackageResult = await prepareRemoteInstallPackage(req, info, positionals);
+  uploadedArtifactId = installPackageResult ?? uploadedArtifactId;
   return baseResult();
 }
-
-type RemoteInstallPackageResult = {
-  prepared?: PreparedRemoteRequest;
-  uploadedArtifactId?: string;
-};
 
 async function prepareRemoteInstallPackage(
   req: Omit<DaemonRequest, 'token'>,
   info: DaemonInfo,
   positionals: string[],
-  flags: DaemonRequest['flags'] | undefined,
-  clientArtifactPaths: Record<string, string>,
-): Promise<RemoteInstallPackageResult | null> {
+): Promise<string | undefined> {
   const rawPath = positionals[1];
-  if (rawPath === undefined) return null;
+  if (rawPath === undefined) return undefined;
   if (rawPath.startsWith('remote:')) {
     positionals[1] = rawPath.slice('remote:'.length);
-    return { prepared: createPreparedRemoteRequest({ positionals, flags, clientArtifactPaths }) };
+    return undefined;
   }
 
   const localPath = resolveLocalInstallPath(rawPath, req.meta?.cwd);
-  if (!localPath) {
-    return { prepared: createPreparedRemoteRequest({ positionals, flags, clientArtifactPaths }) };
-  }
+  if (!localPath) return undefined;
 
-  const uploadedArtifactId = await uploadArtifact({
+  return await uploadArtifact({
     localPath,
     baseUrl: info.baseUrl!,
     token: info.token,
     platform: req.flags?.platform,
   });
-  return { uploadedArtifactId };
 }
 
 function applyRemoteArtifactCommand(

--- a/src/daemon/handlers/__tests__/session-test-suite.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-suite.test.ts
@@ -150,3 +150,42 @@ test('test emits progress when attempts retry and pass', async () => {
     maxAttempts: 2,
   });
 });
+
+test('test emits skip progress without synthetic duration', async () => {
+  const sessionStore = makeSessionStore();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-suite-skip-progress-'));
+  fs.writeFileSync(path.join(root, '01-missing-platform.ad'), 'open "Demo"\n');
+  fs.writeFileSync(path.join(root, '02-android.ad'), 'context platform=android\nopen "Demo"\n');
+
+  const events: RequestProgressEvent[] = [];
+  const response = await withRequestProgressSink(
+    (event) => events.push(event),
+    async () =>
+      await handleSessionCommands({
+        req: {
+          token: 't',
+          session: 'default',
+          command: 'test',
+          positionals: [root],
+          meta: { cwd: root, requestId: 'suite-skip-progress' },
+          flags: { platform: 'android' },
+        },
+        sessionName: 'default',
+        logPath: path.join(os.tmpdir(), 'daemon.log'),
+        sessionStore,
+        invoke: async () => ({ ok: true, data: { replayed: 1, healed: 0 } }),
+      }),
+  );
+
+  const data = expectOkData(response);
+  expect(data.skipped).toBe(1);
+  expect(events.map((event) => event.status)).toEqual(['skip', 'pass']);
+  expect(events[0]).toMatchObject({
+    type: 'replay-test',
+    status: 'skip',
+    index: 1,
+    total: 2,
+    message: 'missing platform metadata for --platform android',
+  });
+  expect(events[0]?.durationMs).toBeUndefined();
+});

--- a/src/daemon/handlers/__tests__/session-test-suite.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-suite.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { handleSessionCommands } from '../session.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, DaemonResponse, DaemonResponseData } from '../../types.ts';
+import { type RequestProgressEvent, withRequestProgressSink } from '../../request-progress.ts';
 
 function makeSessionStore(): SessionStore {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-session-test-suite-'));
@@ -90,4 +91,62 @@ test('test discovers Maestro YAML suites when replay backend is set', async () =
   expect(invoked.map((req) => [req.command, req.positionals])).toEqual([['open', ['demo.app']]]);
   expect(data.passed).toBe(1);
   expect(data.failed).toBe(0);
+});
+
+test('test emits progress when attempts retry and pass', async () => {
+  const sessionStore = makeSessionStore();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-suite-progress-'));
+  fs.writeFileSync(path.join(root, '01-progress.ad'), 'context platform=ios\nopen "Demo"\n');
+
+  const events: RequestProgressEvent[] = [];
+  let attempts = 0;
+  const response = await withRequestProgressSink(
+    (event) => events.push(event),
+    async () =>
+      await handleSessionCommands({
+        req: {
+          token: 't',
+          session: 'default',
+          command: 'test',
+          positionals: [root],
+          meta: { cwd: root, requestId: 'suite-progress' },
+          flags: { retries: 1 },
+        },
+        sessionName: 'default',
+        logPath: path.join(os.tmpdir(), 'daemon.log'),
+        sessionStore,
+        invoke: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            return {
+              ok: false,
+              error: { code: 'COMMAND_FAILED', message: 'first attempt failed' },
+            };
+          }
+          return { ok: true, data: { replayed: 1, healed: 0 } };
+        },
+      }),
+  );
+
+  const data = expectOkData(response);
+  expect(data.passed).toBe(1);
+  expect(events.map((event) => event.status)).toEqual(['fail', 'pass']);
+  expect(events[0]).toMatchObject({
+    type: 'replay-test',
+    status: 'fail',
+    index: 1,
+    total: 1,
+    attempt: 1,
+    maxAttempts: 2,
+    retrying: true,
+    message: 'Replay failed at step 1 (open "Demo"): first attempt failed',
+  });
+  expect(events[1]).toMatchObject({
+    type: 'replay-test',
+    status: 'pass',
+    index: 1,
+    total: 1,
+    attempt: 2,
+    maxAttempts: 2,
+  });
 });

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -66,7 +66,6 @@ export async function runReplayTestSuite(
           status: 'skip',
           index: entryIndex + 1,
           total: entries.length,
-          durationMs: 0,
           message: entry.message,
         });
         results.push({

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -14,6 +14,7 @@ import {
   prepareReplayTestAttemptArtifacts,
   resolveReplayTestArtifactsDir,
 } from './session-test-artifacts.ts';
+import { emitRequestProgress } from '../request-progress.ts';
 import {
   buildReplayTestAttemptRequestId,
   buildReplayTestInvocationId,
@@ -57,8 +58,17 @@ export async function runReplayTestSuite(
     const suiteStartedAt = Date.now();
     let executed = 0;
 
-    for (const entry of entries) {
+    for (const [entryIndex, entry] of entries.entries()) {
       if (entry.kind === 'skip') {
+        emitRequestProgress({
+          type: 'replay-test',
+          file: entry.path,
+          status: 'skip',
+          index: entryIndex + 1,
+          total: entries.length,
+          durationMs: 0,
+          message: entry.message,
+        });
         results.push({
           file: entry.path,
           status: 'skipped',
@@ -80,6 +90,8 @@ export async function runReplayTestSuite(
         retries: resolveReplayTestRetries(req.flags?.retries, entry.metadata.retries),
         timeoutMs: resolveReplayTestTimeout(req.flags?.timeoutMs, entry.metadata.timeoutMs),
         suiteArtifactsDir,
+        suiteIndex: entryIndex + 1,
+        suiteTotal: entries.length,
         runReplay,
         cleanupSession,
       });
@@ -112,6 +124,8 @@ async function runReplayTestCase(
     retries: number;
     timeoutMs?: number;
     suiteArtifactsDir: string;
+    suiteIndex: number;
+    suiteTotal: number;
   } & ReplayTestRuntimeDependencies,
 ): Promise<Extract<ReplaySuiteTestResult, { status: 'passed' | 'failed' }>> {
   const {
@@ -124,6 +138,8 @@ async function runReplayTestCase(
     retries,
     timeoutMs,
     suiteArtifactsDir,
+    suiteIndex,
+    suiteTotal,
     runReplay,
     cleanupSession,
   } = params;
@@ -178,10 +194,33 @@ async function runReplayTestCase(
     finalSessionName = testSessionName;
     if (response.ok) break;
     if (isReplayInfrastructureFailure(response)) break;
+    if (attemptIndex >= retries) break;
+    emitRequestProgress({
+      type: 'replay-test',
+      file: entry.path,
+      status: 'fail',
+      index: suiteIndex,
+      total: suiteTotal,
+      attempt: attempts,
+      maxAttempts: retries + 1,
+      retrying: true,
+      message: response.error.message,
+    });
   }
 
   const durationMs = Date.now() - testStartedAt;
   if (finalResponse?.ok) {
+    emitRequestProgress({
+      type: 'replay-test',
+      file: entry.path,
+      status: 'pass',
+      index: suiteIndex,
+      total: suiteTotal,
+      attempt: attempts,
+      maxAttempts: retries + 1,
+      durationMs,
+      artifactsDir: testArtifactsDir,
+    });
     return {
       file: entry.path,
       session: finalSessionName,
@@ -200,6 +239,18 @@ async function runReplayTestCase(
         code: 'COMMAND_FAILED',
         message: 'Unknown replay test failure',
       });
+  emitRequestProgress({
+    type: 'replay-test',
+    file: entry.path,
+    status: 'fail',
+    index: suiteIndex,
+    total: suiteTotal,
+    attempt: attempts,
+    maxAttempts: retries + 1,
+    durationMs,
+    artifactsDir: testArtifactsDir,
+    message: error.message,
+  });
   return {
     file: entry.path,
     session: finalSessionName,

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -676,51 +676,23 @@ async function handleUpload(
   expectedToken?: string,
 ): Promise<void> {
   try {
-    // Auth: resolve token from headers and run auth hook with a synthetic context.
-    const token = resolveToken({}, req.headers);
-    const tokenError = enforceDaemonToken(token, expectedToken);
-    if (tokenError) {
-      res.statusCode = statusCodeForNormalizedError(tokenError.code);
-      res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify({ ok: false, error: tokenError.message, code: tokenError.code }));
-      return;
-    }
-    const syntheticRpc: JsonRpcRequest = {
-      jsonrpc: '2.0',
-      id: null,
-      method: 'agent_device.command',
-    };
-    const syntheticDaemon: DaemonRequest = {
-      token,
-      session: 'default',
-      command: 'upload',
-      positionals: [],
-    };
-    const authResult = await runHttpAuthHook(authHook, {
-      headers: req.headers,
-      rpcRequest: syntheticRpc,
-      daemonRequest: syntheticDaemon,
+    const auth = await authorizeAuxiliaryHttpRequest({
+      req,
+      res,
+      authHook,
+      expectedToken,
+      daemonRequest: {
+        command: 'upload',
+        positionals: [],
+      },
     });
-    if (!authResult.ok) {
-      res.statusCode = authResult.statusCode;
-      res.setHeader('content-type', 'application/json');
-      res.end(
-        JSON.stringify({
-          ok: false,
-          error:
-            authResult.response.error?.data?.message ??
-            authResult.response.error?.message ??
-            'Unauthorized',
-        }),
-      );
-      return;
-    }
+    if (!auth) return;
 
     const result = await receiveUpload(req);
     const uploadId = trackUploadedArtifact({
       artifactPath: result.artifactPath,
       tempDir: result.tempDir,
-      tenantId: authResult.tenantId,
+      tenantId: auth.tenantId,
     });
 
     res.statusCode = 200;
@@ -728,9 +700,7 @@ async function handleUpload(
     res.end(JSON.stringify({ ok: true, uploadId }));
   } catch (error) {
     const normalized = normalizeError(error);
-    res.statusCode = statusCodeForNormalizedError(normalized.code);
-    res.setHeader('content-type', 'application/json');
-    res.end(JSON.stringify({ ok: false, error: normalized.message, code: normalized.code }));
+    sendRestJsonError(res, normalized);
   }
 }
 
@@ -747,45 +717,19 @@ async function handleArtifactDownload(
     return;
   }
   try {
-    const token = resolveToken({}, req.headers);
-    const tokenError = enforceDaemonToken(token, expectedToken);
-    if (tokenError) {
-      res.statusCode = statusCodeForNormalizedError(tokenError.code);
-      res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify({ ok: false, error: tokenError.message, code: tokenError.code }));
-      return;
-    }
-    const syntheticRpc: JsonRpcRequest = {
-      jsonrpc: '2.0',
-      id: null,
-      method: 'agent_device.command',
-    };
-    const syntheticDaemon: DaemonRequest = {
-      token,
-      session: 'default',
-      command: 'download_artifact',
-      positionals: [artifactId],
-    };
-    const authResult = await runHttpAuthHook(authHook, {
-      headers: req.headers,
-      rpcRequest: syntheticRpc,
-      daemonRequest: syntheticDaemon,
+    const auth = await authorizeAuxiliaryHttpRequest({
+      req,
+      res,
+      authHook,
+      expectedToken,
+      daemonRequest: {
+        command: 'download_artifact',
+        positionals: [artifactId],
+      },
     });
-    if (!authResult.ok) {
-      res.statusCode = authResult.statusCode;
-      res.setHeader('content-type', 'application/json');
-      res.end(
-        JSON.stringify({
-          ok: false,
-          error:
-            authResult.response.error?.data?.message ??
-            authResult.response.error?.message ??
-            'Unauthorized',
-        }),
-      );
-      return;
-    }
-    const artifact = prepareDownloadableArtifact(artifactId, authResult.tenantId);
+    if (!auth) return;
+
+    const artifact = prepareDownloadableArtifact(artifactId, auth.tenantId);
     const stream = fs.createReadStream(artifact.artifactPath);
     res.statusCode = 200;
     res.setHeader('content-type', 'application/octet-stream');
@@ -812,10 +756,65 @@ async function handleArtifactDownload(
     stream.pipe(res);
   } catch (error) {
     const normalized = normalizeError(error);
-    res.statusCode = statusCodeForNormalizedError(normalized.code);
-    res.setHeader('content-type', 'application/json');
-    res.end(JSON.stringify({ ok: false, error: normalized.message, code: normalized.code }));
+    sendRestJsonError(res, normalized);
   }
+}
+
+async function authorizeAuxiliaryHttpRequest(params: {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  authHook: HttpAuthHook | null;
+  expectedToken?: string;
+  daemonRequest: Pick<DaemonRequest, 'command' | 'positionals'>;
+}): Promise<{ tenantId?: string } | null> {
+  const { req, res, authHook, expectedToken, daemonRequest } = params;
+  const token = resolveToken({}, req.headers);
+  const tokenError = enforceDaemonToken(token, expectedToken);
+  if (tokenError) {
+    sendRestJsonError(res, tokenError);
+    return null;
+  }
+
+  const syntheticRpc: JsonRpcRequest = {
+    jsonrpc: '2.0',
+    id: null,
+    method: 'agent_device.command',
+  };
+  const authResult = await runHttpAuthHook(authHook, {
+    headers: req.headers,
+    rpcRequest: syntheticRpc,
+    daemonRequest: {
+      token,
+      session: 'default',
+      command: daemonRequest.command,
+      positionals: daemonRequest.positionals,
+    },
+  });
+  if (!authResult.ok) {
+    res.statusCode = authResult.statusCode;
+    res.setHeader('content-type', 'application/json');
+    res.end(
+      JSON.stringify({
+        ok: false,
+        error:
+          authResult.response.error?.data?.message ??
+          authResult.response.error?.message ??
+          'Unauthorized',
+      }),
+    );
+    return null;
+  }
+
+  return { tenantId: authResult.tenantId };
+}
+
+function sendRestJsonError(
+  res: http.ServerResponse,
+  normalized: ReturnType<typeof normalizeError>,
+): void {
+  res.statusCode = statusCodeForNormalizedError(normalized.code);
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ ok: false, error: normalized.message, code: normalized.code }));
 }
 
 function enforceDaemonToken(

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -18,6 +18,12 @@ import {
   trackUploadedArtifact,
 } from './artifact-tracking.ts';
 import { receiveUpload } from './upload.ts';
+import { type RequestProgressEvent, withRequestProgressSink } from './request-progress.ts';
+import {
+  serializeDaemonProgressEnvelope,
+  serializeDaemonRpcResponseEnvelope,
+  shouldStreamRequestProgress,
+} from './request-progress-protocol.ts';
 
 type JsonRpcRequest = JsonRpcRequestEnvelope;
 
@@ -106,6 +112,23 @@ function sendJson(
   res.statusCode = httpCode;
   res.setHeader('content-type', 'application/json');
   res.end(JSON.stringify(response));
+}
+
+function writeProgressEnvelope(
+  res: http.ServerResponse<http.IncomingMessage>,
+  event: RequestProgressEvent,
+): void {
+  if (res.destroyed) return;
+  res.write(serializeDaemonProgressEnvelope(event));
+}
+
+function writeRpcResponseEnvelope(
+  res: http.ServerResponse<http.IncomingMessage>,
+  response: JsonRpcResponse,
+): void {
+  if (res.destroyed) return;
+  res.write(serializeDaemonRpcResponseEnvelope(response));
+  res.end();
 }
 
 function statusCodeForNormalizedError(code: string): number {
@@ -586,6 +609,30 @@ export async function createDaemonHttpServer(options: {
           };
         }
 
+        const streamProgress = shouldStreamRequestProgress(daemonRequest);
+        if (streamProgress) {
+          res.statusCode = 200;
+          res.setHeader('content-type', 'application/x-ndjson');
+          const daemonResponse = await withRequestProgressSink(
+            (event) => writeProgressEnvelope(res, event),
+            async () => await handleRequest(daemonRequest),
+          );
+          const rpcResponse = daemonResponse.ok
+            ? ({
+                jsonrpc: '2.0',
+                id: rpcRequest.id ?? null,
+                result: daemonResponse,
+              } satisfies JsonRpcResponse)
+            : createRpcError(
+                rpcRequest.id ?? null,
+                -32000,
+                daemonResponse.error.message,
+                daemonResponse.error,
+              );
+          writeRpcResponseEnvelope(res, rpcResponse);
+          return;
+        }
+
         const daemonResponse = await handleRequest(daemonRequest);
         if (daemonResponse.ok) {
           sendJson(res, { jsonrpc: '2.0', id: rpcRequest.id ?? null, result: daemonResponse });
@@ -603,6 +650,13 @@ export async function createDaemonHttpServer(options: {
         );
       } catch (error) {
         const normalized = normalizeError(error);
+        if (res.headersSent) {
+          writeRpcResponseEnvelope(
+            res,
+            createRpcError(rpcRequest.id ?? null, -32000, normalized.message, normalized),
+          );
+          return;
+        }
         sendJson(
           res,
           createRpcError(rpcRequest.id ?? null, -32000, normalized.message, normalized),

--- a/src/daemon/request-progress-protocol.ts
+++ b/src/daemon/request-progress-protocol.ts
@@ -6,14 +6,9 @@ export type DaemonProgressEnvelope = {
   event: RequestProgressEvent;
 };
 
-export type DaemonResponseEnvelope = {
+export type DaemonResponseEnvelope<TResponse = DaemonResponse> = {
   type: 'response';
-  response: DaemonResponse;
-};
-
-export type DaemonRpcResponseEnvelope = {
-  type: 'response';
-  response: unknown;
+  response: TResponse;
 };
 
 export function shouldStreamRequestProgress(req: Pick<DaemonRequest, 'meta'>): boolean {
@@ -29,17 +24,15 @@ export function isDaemonProgressEnvelope(value: unknown): value is DaemonProgres
   );
 }
 
-export function isDaemonResponseEnvelope(value: unknown): value is DaemonResponseEnvelope {
+export function isDaemonResponseEnvelope<TResponse = DaemonResponse>(
+  value: unknown,
+): value is DaemonResponseEnvelope<TResponse> {
   return (
     Boolean(value) &&
     typeof value === 'object' &&
     (value as { type?: unknown }).type === 'response' &&
     Boolean((value as { response?: unknown }).response)
   );
-}
-
-export function isDaemonRpcResponseEnvelope(value: unknown): value is DaemonRpcResponseEnvelope {
-  return isDaemonResponseEnvelope(value);
 }
 
 export function serializeDaemonProgressEnvelope(event: RequestProgressEvent): string {
@@ -51,7 +44,7 @@ export function serializeDaemonResponseEnvelope(response: DaemonResponse): strin
 }
 
 export function serializeDaemonRpcResponseEnvelope(response: unknown): string {
-  return `${JSON.stringify({ type: 'response', response } satisfies DaemonRpcResponseEnvelope)}\n`;
+  return `${JSON.stringify({ type: 'response', response } satisfies DaemonResponseEnvelope<unknown>)}\n`;
 }
 
 export function formatRequestProgressEvent(event: RequestProgressEvent): string | undefined {

--- a/src/daemon/request-progress-protocol.ts
+++ b/src/daemon/request-progress-protocol.ts
@@ -61,9 +61,14 @@ export function formatRequestProgressEvent(event: RequestProgressEvent): string 
     parts.push(`attempt=${event.attempt}/${event.maxAttempts}`);
   }
   if (event.retrying) parts.push('retry=true');
-  if (event.durationMs !== undefined) parts.push(`durationMs=${event.durationMs}`);
+  if (event.durationMs !== undefined)
+    parts.push(`duration=${formatDurationSeconds(event.durationMs)}`);
   if (event.artifactsDir && event.status === 'fail') parts.push(`artifacts=${event.artifactsDir}`);
   const message = event.message?.replace(/\s+/g, ' ').trim();
   if (message) parts.push(message);
   return parts.join(' ');
+}
+
+function formatDurationSeconds(durationMs: number): string {
+  return `${(Math.max(0, durationMs) / 1000).toFixed(2)}s`;
 }

--- a/src/daemon/request-progress-protocol.ts
+++ b/src/daemon/request-progress-protocol.ts
@@ -1,0 +1,69 @@
+import type { DaemonRequest, DaemonResponse } from './types.ts';
+import type { RequestProgressEvent } from './request-progress.ts';
+
+export type DaemonProgressEnvelope = {
+  type: 'progress';
+  event: RequestProgressEvent;
+};
+
+export type DaemonResponseEnvelope = {
+  type: 'response';
+  response: DaemonResponse;
+};
+
+export type DaemonRpcResponseEnvelope = {
+  type: 'response';
+  response: unknown;
+};
+
+export function shouldStreamRequestProgress(req: Pick<DaemonRequest, 'meta'>): boolean {
+  return req.meta?.requestProgress === 'replay-test';
+}
+
+export function isDaemonProgressEnvelope(value: unknown): value is DaemonProgressEnvelope {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'progress' &&
+    Boolean((value as { event?: unknown }).event)
+  );
+}
+
+export function isDaemonResponseEnvelope(value: unknown): value is DaemonResponseEnvelope {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'response' &&
+    Boolean((value as { response?: unknown }).response)
+  );
+}
+
+export function isDaemonRpcResponseEnvelope(value: unknown): value is DaemonRpcResponseEnvelope {
+  return isDaemonResponseEnvelope(value);
+}
+
+export function serializeDaemonProgressEnvelope(event: RequestProgressEvent): string {
+  return `${JSON.stringify({ type: 'progress', event } satisfies DaemonProgressEnvelope)}\n`;
+}
+
+export function serializeDaemonResponseEnvelope(response: DaemonResponse): string {
+  return `${JSON.stringify({ type: 'response', response } satisfies DaemonResponseEnvelope)}\n`;
+}
+
+export function serializeDaemonRpcResponseEnvelope(response: unknown): string {
+  return `${JSON.stringify({ type: 'response', response } satisfies DaemonRpcResponseEnvelope)}\n`;
+}
+
+export function formatRequestProgressEvent(event: RequestProgressEvent): string | undefined {
+  if (event.type !== 'replay-test') return undefined;
+  const parts = [event.status, `${event.index}/${event.total}`, event.file];
+  if (event.attempt !== undefined && event.maxAttempts !== undefined) {
+    parts.push(`attempt=${event.attempt}/${event.maxAttempts}`);
+  }
+  if (event.retrying) parts.push('retry=true');
+  if (event.durationMs !== undefined) parts.push(`durationMs=${event.durationMs}`);
+  if (event.artifactsDir && event.status === 'fail') parts.push(`artifacts=${event.artifactsDir}`);
+  const message = event.message?.replace(/\s+/g, ' ').trim();
+  if (message) parts.push(message);
+  return parts.join(' ');
+}

--- a/src/daemon/request-progress.ts
+++ b/src/daemon/request-progress.ts
@@ -1,0 +1,31 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type ReplayTestProgressEvent = {
+  type: 'replay-test';
+  file: string;
+  status: 'pass' | 'fail' | 'skip';
+  index: number;
+  total: number;
+  attempt?: number;
+  maxAttempts?: number;
+  durationMs?: number;
+  retrying?: boolean;
+  message?: string;
+  artifactsDir?: string;
+};
+
+export type RequestProgressEvent = ReplayTestProgressEvent;
+export type RequestProgressSink = (event: RequestProgressEvent) => void;
+
+const requestProgress = new AsyncLocalStorage<RequestProgressSink | undefined>();
+
+export async function withRequestProgressSink<T>(
+  sink: RequestProgressSink | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  return await requestProgress.run(sink, run);
+}
+
+export function emitRequestProgress(event: RequestProgressEvent): void {
+  requestProgress.getStore()?.(event);
+}

--- a/src/daemon/transport.ts
+++ b/src/daemon/transport.ts
@@ -12,6 +12,7 @@ import {
   resolveRequestTrackingId,
 } from './request-cancel.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
+import { consumeTextLines } from '../utils/line-stream.ts';
 import { sleep } from '../utils/timeouts.ts';
 import { withRequestProgressSink } from './request-progress.ts';
 import {
@@ -75,15 +76,9 @@ export function createSocketServer(
     socket.on('close', cancelInFlightRunnerSessions);
     socket.on('error', cancelInFlightRunnerSessions);
     socket.on('data', async (chunk) => {
-      buffer += chunk;
-      let idx = buffer.indexOf('\n');
-      while (idx !== -1) {
-        const line = buffer.slice(0, idx).trim();
-        buffer = buffer.slice(idx + 1);
-        if (line.length === 0) {
-          idx = buffer.indexOf('\n');
-          continue;
-        }
+      const parsed = consumeTextLines(buffer, chunk);
+      buffer = parsed.buffer;
+      for (const line of parsed.lines) {
         let response: DaemonResponse;
         inFlightRequests += 1;
         let requestIdForCleanup: string | undefined;
@@ -127,7 +122,6 @@ export function createSocketServer(
               : `${JSON.stringify(response)}\n`,
           );
         }
-        idx = buffer.indexOf('\n');
       }
     });
   });
@@ -141,21 +135,17 @@ export function createSocketServer(
 }
 
 export function listenNetServer(server: net.Server): Promise<number> {
-  return new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      server.off('error', reject);
-      const address = server.address();
-      if (typeof address === 'object' && address?.port) {
-        resolve(address.port);
-        return;
-      }
-      reject(new AppError('COMMAND_FAILED', 'Failed to bind socket server'));
-    });
-  });
+  return listenLoopbackServer(server, 'Failed to bind socket server');
 }
 
 export function listenHttpServer(server: HttpServer): Promise<number> {
+  return listenLoopbackServer(server, 'Failed to bind HTTP server');
+}
+
+function listenLoopbackServer(
+  server: net.Server | HttpServer,
+  errorMessage: string,
+): Promise<number> {
   return new Promise((resolve, reject) => {
     server.once('error', reject);
     server.listen(0, '127.0.0.1', () => {
@@ -165,7 +155,7 @@ export function listenHttpServer(server: HttpServer): Promise<number> {
         resolve(address.port);
         return;
       }
-      reject(new AppError('COMMAND_FAILED', 'Failed to bind HTTP server'));
+      reject(new AppError('COMMAND_FAILED', errorMessage));
     });
   });
 }

--- a/src/daemon/transport.ts
+++ b/src/daemon/transport.ts
@@ -13,6 +13,12 @@ import {
 } from './request-cancel.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { sleep } from '../utils/timeouts.ts';
+import { withRequestProgressSink } from './request-progress.ts';
+import {
+  serializeDaemonProgressEnvelope,
+  serializeDaemonResponseEnvelope,
+  shouldStreamRequestProgress,
+} from './request-progress-protocol.ts';
 
 const disconnectAbortPollIntervalMs = 200;
 const disconnectAbortMaxWindowMs = 15_000;
@@ -81,8 +87,10 @@ export function createSocketServer(
         let response: DaemonResponse;
         inFlightRequests += 1;
         let requestIdForCleanup: string | undefined;
+        let streamProgress = false;
         try {
           const req = JSON.parse(line) as DaemonRequest;
+          streamProgress = shouldStreamRequestProgress(req);
           requestIdForCleanup = resolveRequestTrackingId(req.meta?.requestId, 'socket');
           req.meta = {
             ...req.meta,
@@ -93,7 +101,16 @@ export function createSocketServer(
           if (isRequestCanceled(requestIdForCleanup)) {
             throw createRequestCanceledError();
           }
-          response = await handleRequest(req);
+          response = await withRequestProgressSink(
+            streamProgress
+              ? (event) => {
+                  if (!socket.destroyed) {
+                    socket.write(serializeDaemonProgressEnvelope(event));
+                  }
+                }
+              : undefined,
+            async () => await handleRequest(req),
+          );
         } catch (err) {
           response = { ok: false, error: normalizeError(err) };
         } finally {
@@ -104,7 +121,11 @@ export function createSocketServer(
           }
         }
         if (!socket.destroyed) {
-          socket.write(`${JSON.stringify(response)}\n`);
+          socket.write(
+            streamProgress
+              ? serializeDaemonResponseEnvelope(response)
+              : `${JSON.stringify(response)}\n`,
+          );
         }
         idx = buffer.indexOf('\n');
       }

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -360,6 +360,96 @@ test('sendToDaemon reuses reachable local socket daemon metadata', async (t) => 
   }
 });
 
+test('sendToDaemon prints replay test progress before the socket response', async () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-socket-progress-'));
+  let stderr = '';
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalCreateConnection = net.createConnection;
+  let createConnectionCalls = 0;
+  (net as unknown as { createConnection: typeof net.createConnection }).createConnection = ((
+    _options: unknown,
+    connectListener?: () => void,
+  ) => {
+    createConnectionCalls += 1;
+    const socket = new EventEmitter() as EventEmitter & {
+      destroy: () => void;
+      end: () => void;
+      setEncoding: () => void;
+      setTimeout: () => void;
+      write: (_chunk: string) => boolean;
+    };
+    socket.destroy = () => {
+      socket.emit('close');
+    };
+    socket.end = () => {
+      socket.emit('close');
+    };
+    socket.setEncoding = () => {};
+    socket.setTimeout = () => {};
+    socket.write = () => {
+      if (createConnectionCalls === 2) {
+        process.nextTick(() => {
+          socket.emit(
+            'data',
+            `${JSON.stringify({
+              type: 'progress',
+              event: {
+                type: 'replay-test',
+                file: '/tmp/01-login.ad',
+                status: 'fail',
+                index: 1,
+                total: 2,
+                attempt: 1,
+                maxAttempts: 2,
+                retrying: true,
+                message: 'first attempt failed',
+              },
+            })}\n`,
+          );
+          socket.emit(
+            'data',
+            `${JSON.stringify({
+              type: 'response',
+              response: { ok: true, data: { via: 'socket' } },
+            })}\n`,
+          );
+        });
+      }
+      return true;
+    };
+    process.nextTick(() => connectListener?.());
+    return socket as unknown as net.Socket;
+  }) as typeof net.createConnection;
+
+  try {
+    (process.stderr as any).write = ((chunk: unknown) => {
+      stderr += String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+
+    writeCurrentDaemonInfo(stateDir, { port: 65_530, transport: 'socket' });
+
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'test',
+      positionals: ['/tmp/replays'],
+      flags: { stateDir, daemonTransport: 'socket' },
+      meta: { requestId: 'req-progress', requestProgress: 'replay-test' },
+    });
+
+    assert.deepEqual(response, { ok: true, data: { via: 'socket' } });
+    assert.match(
+      stderr,
+      /fail 1\/2 \/tmp\/01-login\.ad attempt=1\/2 retry=true first attempt failed/,
+    );
+  } finally {
+    (net as unknown as { createConnection: typeof net.createConnection }).createConnection =
+      originalCreateConnection;
+    process.stderr.write = originalStderrWrite;
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 test('sendToDaemon reuses reachable local HTTP daemon metadata with token params', async (t) => {
   if (!(await supportsLoopbackBind())) {
     t.skip('loopback listeners are not permitted in this environment');

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -401,6 +401,7 @@ test('sendToDaemon prints replay test progress before the socket response', asyn
                 total: 2,
                 attempt: 1,
                 maxAttempts: 2,
+                durationMs: 1234,
                 retrying: true,
                 message: 'first attempt failed',
               },
@@ -440,7 +441,7 @@ test('sendToDaemon prints replay test progress before the socket response', asyn
     assert.deepEqual(response, { ok: true, data: { via: 'socket' } });
     assert.match(
       stderr,
-      /fail 1\/2 \/tmp\/01-login\.ad attempt=1\/2 retry=true first attempt failed/,
+      /fail 1\/2 \/tmp\/01-login\.ad attempt=1\/2 retry=true duration=1\.23s first attempt failed/,
     );
   } finally {
     (net as unknown as { createConnection: typeof net.createConnection }).createConnection =

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -33,6 +33,7 @@ import {
 import { findProjectRoot, readVersion } from '../version.ts';
 
 type MockHttpResponse = EventEmitter & {
+  headers?: Record<string, string>;
   statusCode?: number;
   resume: () => void;
   setEncoding: (_encoding: string) => void;
@@ -448,6 +449,104 @@ test('sendToDaemon prints replay test progress before the socket response', asyn
       originalCreateConnection;
     process.stderr.write = originalStderrWrite;
     fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('sendToDaemon prints replay test progress before the HTTP NDJSON response', async () => {
+  let stderr = '';
+  const seenPaths: string[] = [];
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalHttpRequest = http.request;
+  (http as unknown as { request: typeof http.request }).request = ((
+    options: any,
+    callback: (res: any) => void,
+  ) => {
+    const req = new EventEmitter() as EventEmitter & {
+      write: (chunk: string) => void;
+      end: () => void;
+      destroy: () => void;
+    };
+    let body = '';
+    req.write = (chunk: string) => {
+      body += chunk;
+    };
+    req.destroy = () => {
+      req.emit('close');
+    };
+    req.end = () => {
+      seenPaths.push(`${String(options.method ?? 'GET')} ${String(options.path ?? '')}`);
+      const res = new EventEmitter() as MockHttpResponse;
+      res.statusCode = 200;
+      res.resume = () => {};
+      res.setEncoding = () => {};
+      if (options.method === 'GET') {
+        process.nextTick(() => {
+          callback(res);
+          res.emit('end');
+        });
+        return;
+      }
+
+      const rpcRequest = JSON.parse(body) as { id?: string };
+      res.headers = { 'content-type': 'application/x-ndjson' };
+      process.nextTick(() => {
+        callback(res);
+        res.emit(
+          'data',
+          `${JSON.stringify({
+            type: 'progress',
+            event: {
+              type: 'replay-test',
+              file: '/tmp/02-payments.ad',
+              status: 'pass',
+              index: 2,
+              total: 3,
+              attempt: 1,
+              maxAttempts: 1,
+              durationMs: 2500,
+            },
+          })}\n`,
+        );
+        res.emit(
+          'data',
+          `${JSON.stringify({
+            type: 'response',
+            response: {
+              jsonrpc: '2.0',
+              id: rpcRequest.id,
+              result: { ok: true, data: { via: 'http-progress' } },
+            },
+          })}\n`,
+        );
+        res.emit('data', '{not-json-after-settle}\n');
+        res.emit('end');
+      });
+    };
+    return req as any;
+  }) as typeof http.request;
+
+  try {
+    (process.stderr as any).write = ((chunk: unknown) => {
+      stderr += String(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+
+    await withRemoteDaemonEnv(async () => {
+      const response = await sendToDaemon({
+        session: 'default',
+        command: 'test',
+        positionals: ['/tmp/replays'],
+        flags: {},
+        meta: { requestId: 'req-http-progress', requestProgress: 'replay-test' },
+      });
+
+      assert.deepEqual(response, { ok: true, data: { via: 'http-progress' } });
+    });
+    assert.deepEqual(seenPaths, ['GET /agent-device/health', 'POST /agent-device/rpc']);
+    assert.match(stderr, /pass 2\/3 \/tmp\/02-payments\.ad attempt=1\/1 duration=2\.50s/);
+  } finally {
+    (http as unknown as { request: typeof http.request }).request = originalHttpRequest;
+    process.stderr.write = originalStderrWrite;
   }
 });
 

--- a/src/utils/line-stream.ts
+++ b/src/utils/line-stream.ts
@@ -1,0 +1,15 @@
+export function consumeTextLines(
+  currentBuffer: string,
+  chunk: string | Buffer,
+): { lines: string[]; buffer: string } {
+  const lines: string[] = [];
+  let buffer = currentBuffer + chunk.toString();
+  let idx = buffer.indexOf('\n');
+  while (idx !== -1) {
+    const line = buffer.slice(0, idx).trim();
+    buffer = buffer.slice(idx + 1);
+    if (line) lines.push(line);
+    idx = buffer.indexOf('\n');
+  }
+  return { lines, buffer };
+}

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -346,7 +346,7 @@ agent-device replay -u ./session.ad   # Update selector drift and rewrite .ad sc
 - `test --platform <platform>` filters suite files by `context platform=...` metadata instead of overriding the script target.
 - `test --timeout <ms>` and `test --retries <n>` apply per script attempt; `context timeout=...` and `context retries=...` can be declared inside the `.ad` header. Retries are capped at `3`, duplicate metadata keys are rejected, and timeouts are cooperative.
 - `test --artifacts-dir <path>` overrides the default suite artifact root at `.agent-device/test-artifacts`.
-- `test` prints failures and flaky passed-on-retry tests by default, and prints a short `Running replay suite...` line before dispatch; add `--verbose` to print pass and skip lines too.
+- `test` prints a short `Running replay suite...` line before dispatch, then streams one-line `pass`, `fail`, or `skip` progress on stderr as each suite entry finishes or retries. Each line includes current/total suite position such as `pass 3/6 ...`. The final summary still prints failures and flaky passed-on-retry tests by default; add `--verbose` to print every final result.
 - `replay -u` updates stale recorded actions and rewrites the same script.
 - `--save-script` records a replay script on `close`; optional path is a file path and parent directories are created.
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -346,7 +346,7 @@ agent-device replay -u ./session.ad   # Update selector drift and rewrite .ad sc
 - `test --platform <platform>` filters suite files by `context platform=...` metadata instead of overriding the script target.
 - `test --timeout <ms>` and `test --retries <n>` apply per script attempt; `context timeout=...` and `context retries=...` can be declared inside the `.ad` header. Retries are capped at `3`, duplicate metadata keys are rejected, and timeouts are cooperative.
 - `test --artifacts-dir <path>` overrides the default suite artifact root at `.agent-device/test-artifacts`.
-- `test` prints a short `Running replay suite...` line before dispatch, then streams one-line `pass`, `fail`, or `skip` progress on stderr as each suite entry finishes or retries. Each line includes current/total suite position such as `pass 3/6 ...`. The final summary still prints failures and flaky passed-on-retry tests by default; add `--verbose` to print every final result.
+- `test` prints a short `Running replay suite...` line before dispatch, then streams one-line `pass`, `fail`, or `skip` progress on stderr as each suite entry finishes or retries. Each line includes current/total suite position and elapsed seconds such as `pass 3/6 ... duration=12.34s`. The final summary still prints failures and flaky passed-on-retry tests by default; add `--verbose` to print every final result.
 - `replay -u` updates stale recorded actions and rewrites the same script.
 - `--save-script` records a replay script on `close`; optional path is a file path and parent directories are created.
 

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -82,7 +82,7 @@ agent-device test ./workflows --artifacts-dir ./tmp/agent-device-artifacts
 - `context timeout=...` and `context retries=...` can be declared per script; CLI flags override metadata. Retries are capped at `3`, and duplicate keys in the context header fail fast instead of silently overriding each other.
 - By default, suite artifacts are written under `.agent-device/test-artifacts/<run-id>/...`. Each attempt writes `replay.ad` and `result.txt`; failed attempts also keep copied logs and artifact files when the replay produced them.
 - Timeouts are cooperative: the runner marks the attempt failed at the timeout boundary, then gives the underlying replay a short grace period to stop before session cleanup.
-- The default text reporter prints the suite summary, failed tests, and passed-on-retry flaky tests; use `--verbose` to print every test result.
+- The default text reporter streams one-line `pass`, `fail`, or `skip` progress on stderr as each suite entry finishes or retries. Each line includes current/total suite position such as `pass 3/6 ...`, then the final summary prints failed tests and passed-on-retry flaky tests; use `--verbose` to print every final result.
 - When `--fail-fast` and retries are both set, the current test still consumes its retries before the suite stops.
 
 ## Parametrise `.ad` scripts

--- a/website/docs/docs/replay-e2e.md
+++ b/website/docs/docs/replay-e2e.md
@@ -82,7 +82,7 @@ agent-device test ./workflows --artifacts-dir ./tmp/agent-device-artifacts
 - `context timeout=...` and `context retries=...` can be declared per script; CLI flags override metadata. Retries are capped at `3`, and duplicate keys in the context header fail fast instead of silently overriding each other.
 - By default, suite artifacts are written under `.agent-device/test-artifacts/<run-id>/...`. Each attempt writes `replay.ad` and `result.txt`; failed attempts also keep copied logs and artifact files when the replay produced them.
 - Timeouts are cooperative: the runner marks the attempt failed at the timeout boundary, then gives the underlying replay a short grace period to stop before session cleanup.
-- The default text reporter streams one-line `pass`, `fail`, or `skip` progress on stderr as each suite entry finishes or retries. Each line includes current/total suite position such as `pass 3/6 ...`, then the final summary prints failed tests and passed-on-retry flaky tests; use `--verbose` to print every final result.
+- The default text reporter streams one-line `pass`, `fail`, or `skip` progress on stderr as each suite entry finishes or retries. Each line includes current/total suite position and elapsed seconds such as `pass 3/6 ... duration=12.34s`, then the final summary prints failed tests and passed-on-retry flaky tests; use `--verbose` to print every final result.
 - When `--fail-fast` and retries are both set, the current test still consumes its retries before the suite stops.
 
 ## Parametrise `.ad` scripts


### PR DESCRIPTION
## Summary

Stream `agent-device test` progress progressively over daemon transports so CI logs show one-line `pass`, `fail`, or `skip` updates as tests finish or retry.

Progress lines include current/total position, retry state, and elapsed seconds with two decimals, for example `pass 3/6 ... duration=12.34s`, before the existing final suite summary.

Review/fallow follow-up: hardened socket progress handling after settle, added HTTP NDJSON progress coverage, removed synthetic `duration=0.00s` from skipped entries, and consolidated duplicated line-stream/auth/listener helpers flagged by Fallow.

Touched 15 files; scope stayed within replay test progress plumbing, CLI transport output, tests, docs, and cleanup required by Fallow.

## Validation

Verified with `pnpm check:fallow --base origin/main`, focused progress/client/contract tests, `pnpm format`, `pnpm check:quick`, `pnpm build`, and replay e2e runs. The macOS replay suite streamed `pass 1/1 ... attempt=1/1` progressively before the final summary, and iOS replay suite output showed per-test `pass`/`fail` progress across the suite.

Known gap: `pnpm check:unit` was attempted but hit existing environment-sensitive loopback failures (`EADDRNOTAVAIL`) unrelated to this change.