### PR TITLE
ci: stop waiting for preview pages build

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -27,4 +27,3 @@ jobs:
           source-dir: website/doc_build
           preview-branch: gh-pages
           qr-code: true
-          wait-for-pages-deployment: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -42,4 +42,3 @@ jobs:
           source-dir: website/doc_build
           preview-branch: gh-pages
           qr-code: true
-          wait-for-pages-deployment: true


### PR DESCRIPTION
## Summary

Stop waiting for the asynchronous GitHub Pages deployment in PR preview deploy and cleanup workflows. The preview action still updates gh-pages, but the check no longer fails or waits on the separate Pages build after the git operation has succeeded.

This addresses the false-red preview checks observed after PR #603 merged: deploy/remove pushed successfully, then failed while waiting for Pages build status.

Touched-file count: 2. Scope stayed within PR preview workflow options.

## Validation

Validated with `git diff --check` and local YAML parsing for both preview workflows. This PR should still run deploy-preview because it changes preview workflow files; the expected behavior is that it completes after gh-pages update without waiting for the Pages build.