### PR TITLE
fix: improve Maestro text tap targets

### DIFF
--- a/src/compat/maestro/__tests__/runtime-geometry.test.ts
+++ b/src/compat/maestro/__tests__/runtime-geometry.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest';
+import { pointForMaestroTapOnTarget } from '../runtime-geometry.ts';
+
+test('pointForMaestroTapOnTarget biases large scroll-area text containers toward the visible label', () => {
+  const point = pointForMaestroTapOnTarget(
+    {
+      node: {
+        index: 5,
+        ref: 'e5',
+        type: 'scroll-area',
+        label: 'Article',
+        rect: { x: 0, y: 117, width: 402, height: 180 },
+      },
+      rect: { x: 0, y: 117, width: 402, height: 180 },
+      frame: { referenceWidth: 402, referenceHeight: 874 },
+    },
+    true,
+  );
+
+  expect(point).toEqual({ x: 84, y: 141 });
+});

--- a/src/compat/maestro/__tests__/runtime-interactions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-interactions.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from 'vitest';
+import type { DaemonRequest, DaemonResponse } from '../../../daemon/types.ts';
+import type { SnapshotState } from '../../../utils/snapshot.ts';
+import { invokeMaestroTapOn } from '../runtime-interactions.ts';
+
+test('invokeMaestroTapOn resolves mutating taps from the current raw snapshot', async () => {
+  const selector =
+    'label="Article by Gandalf" || text="Article by Gandalf" || id="Article by Gandalf"';
+
+  const clicks: string[][] = [];
+  let snapshots = 0;
+  const response = await invokeMaestroTapOn({
+    baseReq: {
+      token: 'test',
+      session: 'nav',
+      flags: { platform: 'ios' },
+    },
+    positionals: [selector],
+    invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
+      if (req.command === 'snapshot') {
+        snapshots += 1;
+        return { ok: true, data: currentBreadcrumbSnapshot() };
+      }
+      if (req.command === 'click') {
+        clicks.push(req.positionals ?? []);
+        return { ok: true, data: {} };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  expect(response.ok).toBe(true);
+  expect(snapshots).toBe(1);
+  expect(clicks).toEqual([['86', '89']]);
+});
+
+function currentBreadcrumbSnapshot(): SnapshotState {
+  return {
+    createdAt: Date.now(),
+    nodes: [
+      appNode(),
+      windowNode(),
+      {
+        index: 2,
+        ref: 'e3',
+        type: 'ScrollView',
+        label: 'Article by Gandalf',
+        depth: 4,
+        parentIndex: 1,
+        rect: { x: 0, y: 58.33333333333333, width: 402, height: 58.33333333333333 },
+      },
+      {
+        index: 3,
+        ref: 'e4',
+        type: 'Cell',
+        label: 'Article by Gandalf',
+        depth: 5,
+        parentIndex: 2,
+        rect: { x: 8, y: 65.33333587646484, width: 155, height: 48 },
+      },
+    ],
+  };
+}
+
+function appNode(): SnapshotState['nodes'][number] {
+  return {
+    index: 0,
+    ref: 'e1',
+    type: 'Application',
+    label: 'React Navigation Example',
+    depth: 0,
+    rect: { x: 0, y: 0, width: 402, height: 874 },
+  };
+}
+
+function windowNode(): SnapshotState['nodes'][number] {
+  return {
+    index: 1,
+    ref: 'e2',
+    type: 'Window',
+    depth: 1,
+    parentIndex: 0,
+    rect: { x: 0, y: 0, width: 402, height: 874 },
+  };
+}

--- a/src/compat/maestro/__tests__/runtime-targets.test.ts
+++ b/src/compat/maestro/__tests__/runtime-targets.test.ts
@@ -161,6 +161,95 @@ test('resolveVisibleMaestroNodeFromSnapshot requires visible text matches to be 
   });
 });
 
+test('resolveMaestroNodeFromSnapshot infers missing selected tab slot from tab-strip children', () => {
+  const snapshot: SnapshotState = {
+    createdAt: Date.now(),
+    nodes: [
+      {
+        index: 1,
+        ref: 'e1',
+        type: 'ScrollView',
+        label: 'Chat',
+        rect: { x: 0, y: 116.66666412353516, width: 402, height: 48 },
+        depth: 3,
+      },
+      {
+        index: 2,
+        ref: 'e2',
+        type: 'Cell',
+        label: 'Contacts',
+        rect: { x: 134, y: 116.66666412353516, width: 134, height: 48 },
+        depth: 4,
+        parentIndex: 1,
+      },
+      {
+        index: 3,
+        ref: 'e3',
+        type: 'Cell',
+        label: 'Albums',
+        rect: { x: 268, y: 116.66666412353516, width: 134, height: 48 },
+        depth: 4,
+        parentIndex: 1,
+      },
+    ],
+  };
+
+  const target = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="Chat" || text="Chat" || id="Chat"',
+    {},
+    'ios',
+    { referenceWidth: 402, referenceHeight: 874 },
+    { promoteTapTarget: true },
+  );
+
+  expect(target).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 1 }),
+    rect: { x: 0, y: 116.66666412353516, width: 134, height: 48 },
+  });
+});
+
+test('resolveMaestroNodeFromSnapshot keeps concrete child matches over tab-strip inference', () => {
+  const snapshot: SnapshotState = {
+    createdAt: Date.now(),
+    nodes: [
+      {
+        index: 1,
+        ref: 'e1',
+        type: 'ScrollView',
+        label: 'Article by Gandalf',
+        rect: { x: 0, y: 58.33333333333333, width: 402, height: 58.33333333333333 },
+        depth: 4,
+      },
+      {
+        index: 2,
+        ref: 'e2',
+        type: 'Cell',
+        label: 'Article by Gandalf',
+        rect: { x: 8, y: 65.33333587646484, width: 155, height: 48 },
+        depth: 5,
+        parentIndex: 1,
+      },
+    ],
+  };
+
+  const target = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="Article by Gandalf" || text="Article by Gandalf" || id="Article by Gandalf"',
+    {},
+    'ios',
+    { referenceWidth: 402, referenceHeight: 874 },
+    { promoteTapTarget: true },
+  );
+
+  expect(target).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 2 }),
+    rect: { x: 8, y: 65.33333587646484, width: 155, height: 48 },
+  });
+});
+
 function makeReactNativeOverlaySnapshot(): SnapshotState {
   return {
     createdAt: Date.now(),

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -6,7 +6,6 @@ import { sleep } from '../../utils/timeouts.ts';
 import {
   captureMaestroRawSnapshot,
   errorResponse,
-  rememberMaestroSnapshot,
   readSnapshotState,
   type MaestroRuntimeInvoke,
   type ReplayBaseRequest,
@@ -57,7 +56,6 @@ export async function invokeMaestroAssertVisible(params: {
         getSnapshotReferenceFrame(snapshot),
       );
       if (target.ok) {
-        rememberMaestroSnapshot(params.scope, response.data, selector);
         return {
           ok: true,
           data: {

--- a/src/compat/maestro/runtime-geometry.ts
+++ b/src/compat/maestro/runtime-geometry.ts
@@ -1,4 +1,5 @@
 import type { Rect, SnapshotNode } from '../../utils/snapshot.ts';
+import { normalizeType } from '../../utils/snapshot-processing.ts';
 import type { MaestroSnapshotTarget } from './runtime-targets.ts';
 
 const MAESTRO_GEOMETRY_POLICY = {
@@ -108,14 +109,13 @@ function shouldBiasMaestroVisibleTextTap(
   rect: Rect,
 ): boolean {
   if (!isVisibleTextSelector) return false;
-  if (
-    rect.height < MAESTRO_GEOMETRY_POLICY.largeTextContainerBias.minHeight ||
-    rect.width < MAESTRO_GEOMETRY_POLICY.largeTextContainerBias.minWidth
-  ) {
+  if (rect.width < MAESTRO_GEOMETRY_POLICY.largeTextContainerBias.minWidth) {
     return false;
   }
-  const type = node.type?.toLowerCase();
-  return type === 'cell' || type === 'other' || type === 'scrollview';
+  const type = normalizeType(node.type ?? '');
+  const scrollableTextContainer = type === 'scrollview' || type === 'scroll-area';
+  if (rect.height < MAESTRO_GEOMETRY_POLICY.largeTextContainerBias.minHeight) return false;
+  return type === 'cell' || type === 'other' || scrollableTextContainer;
 }
 
 function interiorCoordinate(origin: number, size: number): number {

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -5,7 +5,6 @@ import { sleep } from '../../utils/timeouts.ts';
 import { pointForMaestroTapOnTarget, swipeCoordinatesFromTarget } from './runtime-geometry.ts';
 import {
   captureMaestroRawSnapshot,
-  consumeMaestroSnapshot,
   errorResponse,
   readCachedMaestroReferenceFrame,
   readSnapshotState,
@@ -471,14 +470,6 @@ async function resolveMaestroSnapshotTarget(
   commandLabel: string,
   resolutionOptions: { promoteTapTarget: boolean },
 ): Promise<{ ok: true; target: MaestroSnapshotTarget } | { ok: false; response: DaemonResponse }> {
-  const cachedTarget = resolveCachedMaestroSnapshotTarget(
-    params,
-    selector,
-    options,
-    resolutionOptions,
-  );
-  if (cachedTarget.ok) return cachedTarget;
-
   const snapshotResponse = await captureMaestroRawSnapshot(params);
   if (!snapshotResponse.ok) return { ok: false, response: snapshotResponse };
 
@@ -541,37 +532,6 @@ async function resolveMaestroSnapshotTarget(
       frame,
     },
   };
-}
-
-function resolveCachedMaestroSnapshotTarget(
-  params: {
-    baseReq: ReplayBaseRequest;
-    scope?: ReplayVarScope;
-  },
-  selector: string,
-  options: MaestroTapOnOptions,
-  resolutionOptions: { promoteTapTarget: boolean },
-): { ok: true; target: MaestroSnapshotTarget } | { ok: false } {
-  const cached = consumeMaestroSnapshot(params.scope, selector);
-  if (!cached) return { ok: false };
-  const resolution = resolveMaestroNodeFromSnapshot(
-    cached.snapshot,
-    selector,
-    options,
-    readMaestroSelectorPlatform(params.baseReq.flags),
-    cached.frame,
-    resolutionOptions,
-  );
-  return resolution.ok
-    ? {
-        ok: true,
-        target: {
-          node: resolution.node,
-          rect: resolution.rect,
-          frame: cached.frame,
-        },
-      }
-    : { ok: false };
 }
 
 function readMaestroTapOnOptions(

--- a/src/compat/maestro/runtime-support.ts
+++ b/src/compat/maestro/runtime-support.ts
@@ -20,10 +20,6 @@ export type MaestroRuntimeInvoke = (req: DaemonRequest) => Promise<DaemonRespons
 export type FailedDaemonResponse = Extract<DaemonResponse, { ok: false }>;
 
 const maestroReferenceFrameCache = new WeakMap<ReplayVarScope, TouchReferenceFrame>();
-const maestroSnapshotCache = new WeakMap<
-  ReplayVarScope,
-  { snapshot: SnapshotState; frame: TouchReferenceFrame | undefined; selector: string }
->();
 
 export function errorResponse(
   code: string,
@@ -71,31 +67,6 @@ export function readCachedMaestroReferenceFrame(
   scope: ReplayVarScope | undefined,
 ): TouchReferenceFrame | undefined {
   return scope ? maestroReferenceFrameCache.get(scope) : undefined;
-}
-
-export function rememberMaestroSnapshot(
-  scope: ReplayVarScope | undefined,
-  data: unknown,
-  selector: string,
-): void {
-  if (!scope) return;
-  const snapshot = readSnapshotState(data);
-  if (!snapshot) return;
-  maestroSnapshotCache.set(scope, {
-    snapshot,
-    frame: getSnapshotReferenceFrame(snapshot),
-    selector,
-  });
-}
-
-export function consumeMaestroSnapshot(
-  scope: ReplayVarScope | undefined,
-  selector: string,
-): { snapshot: SnapshotState; frame: TouchReferenceFrame | undefined } | undefined {
-  if (!scope) return undefined;
-  const cached = maestroSnapshotCache.get(scope);
-  maestroSnapshotCache.delete(scope);
-  return cached?.selector === selector ? cached : undefined;
 }
 
 function rememberMaestroReferenceFrame(scope: ReplayVarScope, data: unknown): void {

--- a/src/compat/maestro/runtime-targets.ts
+++ b/src/compat/maestro/runtime-targets.ts
@@ -327,34 +327,65 @@ function selectMaestroSnapshotMatch(
   promoteTapTarget = false,
 ): { node: SnapshotNode; rect: Rect } | null {
   const nodeByIndex = buildSnapshotNodeByIndex(nodes);
-  const resolved = matches
-    .map((node) => {
-      const match = resolveNodeRect(nodes, node, nodeByIndex);
-      return match ? { node, rect: match.rect, inheritedRect: match.inherited } : null;
-    })
-    .filter((candidate): candidate is MaestroResolvedSnapshotMatch => Boolean(candidate));
-  const candidates =
-    visibleTextQuery && index === undefined
-      ? preferOnScreenMatches(resolved, frame, requireOnScreen)
-      : resolved;
-  if (index !== undefined) {
-    return promoteMaestroSnapshotMatch(
-      nodes,
-      candidates[index] ?? null,
-      nodeByIndex,
-      promoteTapTarget,
-      frame,
-    );
-  }
-  const sorted = candidates.sort((left, right) =>
-    compareMaestroSnapshotMatches(left, right, visibleTextQuery),
-  );
-  return promoteMaestroSnapshotMatch(
+  const candidates = resolveMaestroSnapshotMatchCandidates(
     nodes,
-    sorted[0] ?? null,
+    matches,
     nodeByIndex,
-    promoteTapTarget,
+    visibleTextQuery,
+    index,
     frame,
+    requireOnScreen,
+  );
+  const target = chooseMaestroSnapshotMatch(nodes, candidates, index, visibleTextQuery, promoteTapTarget);
+  return promoteMaestroSnapshotMatch(nodes, target, nodeByIndex, promoteTapTarget, frame);
+}
+
+function resolveMaestroSnapshotMatchCandidates(
+  nodes: SnapshotState['nodes'],
+  matches: SnapshotNode[],
+  nodeByIndex: SnapshotNodeByIndex,
+  visibleTextQuery: string | null,
+  index: number | undefined,
+  frame: TouchReferenceFrame | undefined,
+  requireOnScreen: boolean,
+): MaestroResolvedSnapshotMatch[] {
+  const resolved = matches
+    .map((node) => resolveMaestroSnapshotMatch(nodes, node, nodeByIndex))
+    .filter((candidate): candidate is MaestroResolvedSnapshotMatch => Boolean(candidate));
+  if (!visibleTextQuery || index !== undefined) return resolved;
+  return preferOnScreenMatches(resolved, frame, requireOnScreen);
+}
+
+function resolveMaestroSnapshotMatch(
+  nodes: SnapshotState['nodes'],
+  node: SnapshotNode,
+  nodeByIndex: SnapshotNodeByIndex,
+): MaestroResolvedSnapshotMatch | null {
+  const match = resolveNodeRect(nodes, node, nodeByIndex);
+  return match ? { node, rect: match.rect, inheritedRect: match.inherited } : null;
+}
+
+function chooseMaestroSnapshotMatch(
+  nodes: SnapshotState['nodes'],
+  candidates: MaestroResolvedSnapshotMatch[],
+  index: number | undefined,
+  visibleTextQuery: string | null,
+  promoteTapTarget: boolean,
+): MaestroResolvedSnapshotMatch | null {
+  if (index !== undefined) return candidates[index] ?? null;
+  const best = selectBestMaestroSnapshotMatch(candidates, visibleTextQuery);
+  if (!promoteTapTarget || !visibleTextQuery || !best) return best;
+  return inferMaestroMissingTabSlotMatch(nodes, best, visibleTextQuery) ?? best;
+}
+
+function selectBestMaestroSnapshotMatch(
+  candidates: MaestroResolvedSnapshotMatch[],
+  visibleTextQuery: string | null,
+): MaestroResolvedSnapshotMatch | null {
+  return (
+    candidates.sort((left, right) =>
+      compareMaestroSnapshotMatches(left, right, visibleTextQuery),
+    )[0] ?? null
   );
 }
 
@@ -437,6 +468,99 @@ function rectArea(rect: Rect): number {
 
 function maestroTapTargetTypeRank(node: SnapshotNode): number {
   return MAESTRO_TAP_TARGET_TYPE_RANK.get(normalizeType(node.type ?? '')) ?? 3;
+}
+
+function inferMaestroMissingTabSlotMatch(
+  nodes: SnapshotState['nodes'],
+  match: MaestroResolvedSnapshotMatch,
+  query: string,
+): MaestroResolvedSnapshotMatch | null {
+  if (!isMaestroTabStripContainerMatch(match, query)) return null;
+  const children: Array<SnapshotNode & { rect: Rect }> = [];
+  for (const node of nodes) {
+    if (node.parentIndex !== match.node.index || !node.rect) continue;
+    const candidate = node as SnapshotNode & { rect: Rect };
+    if (isMaestroTabStripChildCandidate(candidate, match.rect, query)) {
+      children.push(candidate);
+    }
+  }
+  children.sort((left, right) => left.rect.x - right.rect.x);
+  if (children.length === 0) return null;
+  const medianChildWidth = median(children.map((child) => child.rect.width));
+  const gaps = resolveHorizontalGaps(
+    match.rect,
+    children.map((child) => child.rect),
+  ).filter((gap) => isPlausibleMissingTabSlot(gap.width, medianChildWidth));
+  if (gaps.length !== 1) return null;
+  const gap = gaps[0];
+  if (!gap) return null;
+  return {
+    ...match,
+    rect: {
+      x: gap.x,
+      y: match.rect.y,
+      width: gap.width,
+      height: match.rect.height,
+    },
+  };
+}
+
+function isMaestroTabStripContainerMatch(
+  match: MaestroResolvedSnapshotMatch,
+  query: string,
+): boolean {
+  const type = normalizeType(match.node.type ?? '');
+  if (type !== 'other' && type !== 'scrollview' && type !== 'scroll-area') return false;
+  if (match.rect.width < 120 || match.rect.height < 32 || match.rect.height > 80) return false;
+  return maestroVisibleTextMatchRank(match.node, query) <= 1;
+}
+
+function isMaestroTabStripChildCandidate(
+  node: SnapshotNode & { rect: Rect },
+  container: Rect,
+  query: string,
+): boolean {
+  const type = normalizeType(node.type ?? '');
+  if (type !== 'button' && type !== 'cell' && type !== 'other') return false;
+  if (maestroVisibleTextMatchRank(node, query) <= 1) return false;
+  if (node.rect.width < 16 || node.rect.height < 16) return false;
+  if (!rectContains(container, node.rect)) return false;
+  return verticalOverlapRatio(container, node.rect) >= 0.5;
+}
+
+function resolveHorizontalGaps(
+  container: Rect,
+  occupied: Rect[],
+): Array<{ x: number; width: number }> {
+  const gaps: Array<{ x: number; width: number }> = [];
+  let cursor = container.x;
+  const containerRight = container.x + container.width;
+  for (const rect of occupied) {
+    const start = Math.max(container.x, rect.x);
+    const end = Math.min(containerRight, rect.x + rect.width);
+    if (start > cursor) gaps.push({ x: cursor, width: start - cursor });
+    cursor = Math.max(cursor, end);
+  }
+  if (containerRight > cursor) gaps.push({ x: cursor, width: containerRight - cursor });
+  return gaps;
+}
+
+function isPlausibleMissingTabSlot(gapWidth: number, medianChildWidth: number): boolean {
+  if (gapWidth < 24 || medianChildWidth < 24) return false;
+  return gapWidth >= medianChildWidth * 0.4 && gapWidth <= medianChildWidth * 1.6;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted[middle] ?? 0;
+}
+
+function verticalOverlapRatio(a: Rect, b: Rect): number {
+  const top = Math.max(a.y, b.y);
+  const bottom = Math.min(a.y + a.height, b.y + b.height);
+  const overlap = Math.max(0, bottom - top);
+  return overlap / Math.max(1, Math.min(a.height, b.height));
 }
 
 function promoteMaestroSnapshotMatch(

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -820,10 +820,10 @@ test('runReplayScriptFile promotes Maestro id tapOn to an actionable ancestor', 
   );
 });
 
-test('runReplayScriptFile reuses successful Maestro visibility snapshot for following tapOn', async () => {
+test('runReplayScriptFile captures a fresh Maestro snapshot for tapOn after assertVisible', async () => {
   let snapshots = 0;
   const { response, calls } = await runReplayFixture({
-    label: 'maestro-assert-visible-tap-cache',
+    label: 'maestro-assert-visible-tap-fresh-snapshot',
     script: ['appId: demo.app', '---', '- assertVisible: Open feed', '- tapOn: Open feed', ''].join(
       '\n',
     ),
@@ -854,6 +854,11 @@ test('runReplayScriptFile reuses successful Maestro visibility snapshot for foll
                       label: 'AppStack.tsx (42:7)',
                       rect: { x: 28, y: 1304, width: 1025, height: 44 },
                     },
+                    {
+                      index: 2,
+                      label: 'Open feed',
+                      rect: { x: 40, y: 240, width: 200, height: 48 },
+                    },
                   ],
           },
         };
@@ -863,11 +868,13 @@ test('runReplayScriptFile reuses successful Maestro visibility snapshot for foll
   });
 
   assert.equal(response.ok, true);
+  assert.equal(snapshots, 2);
   assert.deepEqual(
     calls.map((call) => [call.command, call.positionals]),
     [
       ['snapshot', []],
-      ['click', ['110', '204']],
+      ['snapshot', []],
+      ['click', ['140', '264']],
     ],
   );
 });


### PR DESCRIPTION
## Summary

Make Maestro `tapOn` target resolution safer for React Native/iOS tab surfaces.

- resolve mutating Maestro interactions from a fresh raw snapshot instead of assertion-cached snapshots
- remove the now-dead Maestro assertion snapshot cache API and cache writes
- infer the missing selected tab slot when iOS exposes the active tab only as a tab-strip container label and exposes sibling tabs as children
- keep concrete child matches preferred over inference, and keep large-container bias scoped to genuinely large text containers

## Validation

- `pnpm exec vitest run --project unit src/daemon/handlers/__tests__/session-replay-vars.test.ts src/compat/maestro/__tests__/runtime-targets.test.ts src/compat/maestro/__tests__/runtime-interactions.test.ts src/compat/maestro/__tests__/runtime-geometry.test.ts`
- `pnpm check:fallow --base 99e97c873e17d6438a57c8e3a143e1f930e815a7`
- `pnpm check:quick`
- `pnpm build`
- `pnpm test:coverage`
- Local React Navigation iPhone 17 Pro validation with patched CLI: 5/5 tab/material-tab repro flows passed (`material-top-tabs.yml`, `tab-view-auto-width-tab-bar.yml`, `tab-view-coverflow.yml`, `tab-view-scroll-adapter.yml`, `tab-view-scrollable-tab-bar.yml`).

Note: `navigator-layout.yml` still fails locally and is intentionally left for a separate root-cause pass; speculative top-edge guards were removed from this PR.
