### PR TITLE
feat: add HarmonyOS platform support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.15.3
+
+- Added HarmonyOS platform support with full device automation capabilities.
+- Added HDC (HarmonyOS Device Connector) backend for device discovery, app lifecycle, and UI automation.
+- Added `--platform harmonyos` flag to all relevant commands (devices, apps, open, close, snapshot, screenshot, press, etc.).
+- Added `--module` flag to `open` command for HarmonyOS apps that require explicit module name (e.g., Xiaohongshu needs `--module redbook`).
+- Added ArkUI hierarchy parser for HarmonyOS accessibility snapshots (dumpLayout JSON output).
+- Added HarmonyOS alert detection based on snapshot analysis (dialog/alert/popup patterns).
+- Added HarmonyOS clipboard support via uitest uiInput getClipboard/setClipboard.
+- Added HarmonyOS settings control via param tool (wifi, airplane, location, animations, bluetooth, etc.).
+- Added HarmonyOS device discovery via `hdc list targets` command.
+- Added uitest-based input actions: press, swipe, scroll, longPress, type, key events.
+- Added uitest-based screenshot capture with display id detection.
+
 ## 0.15.0
 
 - Breaking: `apps` discovery and public app-list helpers now default to user-installed apps. Use `--all` or `filter: 'all'` to include system/OEM apps.

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: agent-device
-description: Automates Apple-platform apps (iOS, tvOS, macOS) and Android devices. Use when navigating apps, taking snapshots/screenshots, tapping, typing, scrolling, extracting UI info, collecting logs/network/perf evidence, or planning agent-device CLI commands.
+description: Automates Apple-platform apps (iOS, tvOS, macOS), Android devices, and HarmonyOS devices. Use when navigating apps, taking snapshots/screenshots, tapping, typing, scrolling, rotating, keyboard interactions, extracting UI info, collecting logs/network/perf evidence, or planning agent-device CLI commands. For HarmonyOS, ALWAYS use agent-device CLI instead of raw HDC commands.
 ---
 
 # agent-device
 
 Router only. Private setup before using this skill:
+
+**IMPORTANT**: For HarmonyOS, always use `agent-device` CLI commands. Do NOT use raw `hdc shell uitest ...` commands. The CLI provides unified, safe interfaces; raw commands bypass safety and observability features.
 
 ```bash
 agent-device --version
@@ -34,6 +36,116 @@ agent-device help dogfood
 
 Default loop: `open -> snapshot/-i -> get/is/find or press/fill/scroll/wait -> verify -> close`.
 
+## Cognition Map
+
+Before blind testing, use `cognition` to generate a UI structure overview for AI planning:
+
+```bash
+agent-device cognition [--platform ios|macos|android|linux|apple|harmonyos] [--session <name>] [--json]
+```
+
+The cognition command analyzes the current UI and returns:
+
+- **Overview**: platform, screen resolution, total nodes, tree depth, complexity (simple/medium/complex)
+- **Structure**: layout patterns, main container count
+- **Interactions**: clickable elements, buttons, input fields, tabs
+- **Features**: scroll regions, tabs, modals, lists, forms
+- **Suggestions**: testing recommendations based on UI complexity
+- **Test Priority**: high/medium/low scoring based on complexity and interactions
+
+Example usage:
+
+```bash
+agent-device open com.example.app --platform android
+agent-device cognition --json
+```
+
+The `llmReport` field contains a formatted summary for AI planning:
+
+```
+# UI认知地图
+
+## 概览
+- 平台: android
+- 屏幕分辨率: 1080x2400
+- UI节点总数: 156
+- 树深度: 12层
+- 界面复杂度: medium
+
+## 测试优先级
+- **中等优先级**
+
+## 测试建议
+- 存在Tab导航，建议逐个Tab遍历
+- 存在滚动区域，建议测试滚动交互
+```
+
+Use this before exploratory testing to understand app structure and avoid blind navigation.
+
 Use this skill only to route into version-matched CLI help. Let `help workflow` provide exact command shapes, platform limits, and current workflow guidance.
 
 For precise location workflows, read the installed `settings` help before planning so coordinate support and platform limits come from the active CLI version.
+
+## HarmonyOS Best Practices
+
+When working with HarmonyOS devices, follow these guidelines:
+
+### App Launch
+
+- **launchAbility discovery**: `agent-device apps --platform harmonyos --device <hdc-serial> --json` returns structured rows with `launchAbility` (from device `wukong appinfo`, cached 5 minutes).
+- **Automatic open**: `open` uses wukong appinfo when `--activity` is omitted, then falls back through MainAbility, EntryAbility, and bundle-only start.
+- **Explicit override**: pass `--activity <launchAbility>` when auto-resolution is insufficient.
+- **Screen lock detection**: The CLI automatically checks and attempts to unlock the screen before launching apps
+- **System dialog handling**: Common system dialogs are automatically dismissed after app launch
+
+### System Dialogs
+
+The CLI automatically detects and handles these HarmonyOS system dialogs:
+
+- "暂无可用打开方式" (No available opening method)
+- Notification permission dialogs
+- Privacy policy dialogs
+- Update prompts
+- Common button patterns: "确定", "知道了", "同意并继续", "允许", "不允许"
+
+### Cognition Map
+
+The `cognition` command on HarmonyOS:
+
+- Auto-dismisses system dialogs before generating the UI map
+- Detects unlabeled icon buttons (like settings gear icons)
+- Provides HarmonyOS-specific testing suggestions
+
+### Known Issues and Workarounds
+
+1. **App package names**: Some system apps have different package names than expected (e.g., `com.huawei.hmos.settings` not `com.huawei.hmosSettings`)
+2. **Ability names vary**: third-party apps may use `EntryAbility`, `DcarAbility`, etc.—read `launchAbility` from `apps --json` instead of guessing
+3. **Screen unlock**: Automatic screen unlock may not work on all devices; manual intervention may be required
+
+### HarmonyOS Commands
+
+| Command | Description | Notes |
+|---------|-------------|-------|
+| `scroll up/down/left/right` | Scroll content | 方向已修复：scroll up = 内容上滚 |
+| `rotate portrait/landscape-left` | Rotate screen | 可能需要系统权限 |
+| `keyboard status` | Check keyboard visibility | 返回 `{ visible, height }` |
+| `keyboard dismiss` | Close soft keyboard | 使用 Back 键关闭 |
+| `press --double-tap` | Double tap gesture | 原生 uitest doubleClick |
+| `back` | Navigate back | 返回键导航 |
+| `home` | Go to home screen | 回到桌面 |
+
+### Example Workflow
+
+```bash
+# List apps with launchAbility (HarmonyOS)
+agent-device apps --platform harmonyos --device <hdc-serial> --json
+
+# Open without guessing ability (uses wukong appinfo)
+agent-device open com.example.app --platform harmonyos --device <hdc-serial>
+
+# Generate cognition map (auto-dismisses dialogs)
+agent-device cognition --platform harmonyos --json
+
+# Check app state
+agent-device appstate --platform harmonyos --device <hdc-serial>
+```

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -343,7 +343,45 @@ test('apps.list forwards filters and returns daemon app names', async () => {
   assert.equal(setup.calls[0]?.flags?.platform, 'ios');
   assert.equal(setup.calls[0]?.flags?.device, 'iPhone 16');
   assert.equal(setup.calls[0]?.flags?.appsFilter, 'user-installed');
-  assert.deepEqual(apps, ['Settings (com.apple.Preferences)', 'Demo (com.example.demo)']);
+  assert.deepEqual(apps, {
+    apps: ['Settings (com.apple.Preferences)', 'Demo (com.example.demo)'],
+  });
+});
+
+test('apps.list forwards HarmonyOS appDetails with launchAbility', async () => {
+  const setup = createTransport(async () => ({
+    ok: true,
+    data: {
+      apps: ['psnger (com.sdu.didi.hmos.psnger)'],
+      appDetails: [
+        {
+          id: 'com.sdu.didi.hmos.psnger',
+          bundleId: 'com.sdu.didi.hmos.psnger',
+          name: 'psnger',
+          label: 'psnger (com.sdu.didi.hmos.psnger)',
+          launchAbility: 'EntryAbility',
+        },
+      ],
+    },
+  }));
+  const client = createAgentDeviceClient(setup.config, { transport: setup.transport });
+
+  const result = await client.apps.list({
+    platform: 'harmonyos',
+    device: '22M0223824043030',
+    appsFilter: 'user-installed',
+  });
+
+  assert.deepEqual(result.apps, ['psnger (com.sdu.didi.hmos.psnger)']);
+  assert.deepEqual(result.appDetails, [
+    {
+      id: 'com.sdu.didi.hmos.psnger',
+      bundleId: 'com.sdu.didi.hmos.psnger',
+      name: 'psnger',
+      label: 'psnger (com.sdu.didi.hmos.psnger)',
+      launchAbility: 'EntryAbility',
+    },
+  ]);
 });
 
 test('materializations.release forwards materialization identity through the daemon request', async () => {

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -9,12 +9,13 @@ import type {
   SnapshotState,
 } from './utils/snapshot.ts';
 
-export type AgentDeviceBackendPlatform = 'ios' | 'android' | 'macos' | 'linux';
+export type AgentDeviceBackendPlatform = 'ios' | 'android' | 'macos' | 'linux' | 'harmonyos';
 
 export const BACKEND_CAPABILITY_NAMES = [
   'android.shell',
   'ios.runnerCommand',
   'macos.desktopScreenshot',
+  'harmonyos.hdc',
 ] as const;
 
 export type BackendCapabilityName = (typeof BACKEND_CAPABILITY_NAMES)[number];
@@ -416,12 +417,17 @@ export type BackendEscapeHatches = {
     outPath: string,
     options?: BackendScreenshotOptions,
   ): Promise<BackendScreenshotResult | void>;
+  harmonyosHdc?(
+    context: BackendCommandContext,
+    args: readonly string[],
+  ): Promise<BackendShellResult>;
 };
 
 const BACKEND_CAPABILITY_ESCAPE_HATCH_METHODS = {
   'android.shell': 'androidShell',
   'ios.runnerCommand': 'iosRunnerCommand',
   'macos.desktopScreenshot': 'macosDesktopScreenshot',
+  'harmonyos.hdc': 'harmonyosHdc',
 } as const satisfies Record<BackendCapabilityName, keyof BackendEscapeHatches>;
 
 export type AgentDeviceBackend = {

--- a/src/cli/commands/__tests__/devices-format.test.ts
+++ b/src/cli/commands/__tests__/devices-format.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { formatDeviceLine } from '../devices.ts';
+import type { AgentDeviceDevice } from '../../../client.ts';
+
+test('formatDeviceLine shows hdc serial for harmonyos devices', () => {
+  const device: AgentDeviceDevice = {
+    platform: 'harmonyos',
+    id: '22M0223824043030',
+    name: '22M0223824043030',
+    kind: 'device',
+    target: 'mobile',
+    booted: true,
+  };
+  assert.equal(
+    formatDeviceLine(device),
+    '22M0223824043030 (harmonyos device target=mobile) booted=true',
+  );
+});
+
+test('formatDeviceLine keeps human-readable name for other platforms', () => {
+  const device: AgentDeviceDevice = {
+    platform: 'android',
+    id: 'emulator-5554',
+    name: 'Pixel 9',
+    kind: 'emulator',
+    target: 'mobile',
+    booted: true,
+  };
+  assert.equal(formatDeviceLine(device), 'Pixel 9 (android emulator target=mobile) booted=true');
+});

--- a/src/cli/commands/apps.ts
+++ b/src/cli/commands/apps.ts
@@ -4,11 +4,11 @@ import type { ClientCommandHandler } from './router-types.ts';
 
 export const appsCommand: ClientCommandHandler = async ({ flags, client }) => {
   const appsFilter = assertResolvedAppsFilter(flags.appsFilter);
-  const apps = await client.apps.list({
+  const { apps, appDetails } = await client.apps.list({
     ...buildSelectionOptions(flags),
     appsFilter,
   });
-  const data = { apps };
+  const data = flags.json && appDetails && appDetails.length > 0 ? { apps: appDetails } : { apps };
   writeCommandOutput(flags, data, () => {
     if (!flags.json) {
       process.stderr.write(

--- a/src/cli/commands/client-command.ts
+++ b/src/cli/commands/client-command.ts
@@ -198,6 +198,12 @@ function formatAppState(data: AppStateCommandResult): string | null {
     if (data.activity) lines.push(`Activity: ${data.activity}`);
     return lines.join('\n');
   }
+  if (data.platform === 'harmonyos') {
+    const lines = [`Foreground app: ${data.appBundleId ?? data.package ?? 'unknown'}`];
+    if (data.state) lines.push(`State: ${data.state}`);
+    if (data.source) lines.push(`Source: ${data.source}`);
+    return lines.join('\n');
+  }
   return null;
 }
 

--- a/src/cli/commands/devices.ts
+++ b/src/cli/commands/devices.ts
@@ -10,9 +10,10 @@ export const devicesCommand: ClientCommandHandler = async ({ flags, client }) =>
   return true;
 };
 
-function formatDeviceLine(device: AgentDeviceDevice): string {
+export function formatDeviceLine(device: AgentDeviceDevice): string {
   const kind = device.kind ? ` ${device.kind}` : '';
   const target = device.target ? ` target=${device.target}` : '';
   const booted = typeof device.booted === 'boolean' ? ` booted=${device.booted}` : '';
-  return `${device.name} (${device.platform}${kind}${target})${booted}`;
+  const label = device.platform === 'harmonyos' ? device.id : device.name;
+  return `${label} (${device.platform}${kind}${target})${booted}`;
 }

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -190,6 +190,7 @@ const genericClientCommandRunners = {
     client.interactions.is(isCommandCodec.decode(positionals, flags)),
   settings: ({ client, positionals, flags }) =>
     client.settings.update(settingsCommandCodec.decode(positionals, flags)),
+  cognition: ({ client, flags }) => client.command.cognition(buildSelectionOptions(flags)),
 } satisfies Partial<Record<PublicCommandName, GenericClientCommandRunner>>;
 
 export const genericClientCommandHandlers = Object.fromEntries(

--- a/src/client-commands.ts
+++ b/src/client-commands.ts
@@ -72,6 +72,12 @@ export function createAgentDeviceCommandClient(
         positionals: [options.action],
         options,
       }),
+    cognition: async (options = {}) =>
+      await run<'cognition'>({
+        command: PUBLIC_COMMANDS.cognition,
+        positionals: [],
+        options,
+      }),
   };
 }
 

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -228,6 +228,20 @@ export type AppListOptions = AgentDeviceRequestOverrides &
     appsFilter?: AppsFilter;
   };
 
+/** Structured HarmonyOS app row returned by `apps --json`. */
+export type AppListEntry = {
+  id: string;
+  bundleId: string;
+  name?: string;
+  launchAbility?: string;
+  label?: string;
+};
+
+export type AppListResult = {
+  apps: string[];
+  appDetails?: AppListEntry[];
+};
+
 export type MaterializationReleaseOptions = AgentDeviceRequestOverrides & {
   materializationId: string;
 };
@@ -476,6 +490,42 @@ export type ReactNativeCommandOptions = ClientCommandBaseOptions & {
   action: 'dismiss-overlay';
 };
 
+export type CognitionCommandOptions = ClientCommandBaseOptions;
+
+export type CognitionCommandResult = DaemonResponseData & {
+  cognition?: {
+    overview: {
+      platform: string;
+      screenResolution: { width: number; height: number };
+      totalNodes: number;
+      treeDepth: number;
+      complexity: 'simple' | 'medium' | 'complex';
+    };
+    structure: {
+      layoutPattern: string[];
+      mainContainers: number;
+    };
+    interactions: {
+      clickableElements: number;
+      buttons: number;
+      inputFields: number;
+      tabs: number;
+    };
+    features: {
+      hasScroll: boolean;
+      hasTabs: boolean;
+      hasModal: boolean;
+      hasList: boolean;
+      hasForm: boolean;
+      hasUnlabeledIcons: boolean;
+    };
+    suggestions: string[];
+    testPriority: 'high' | 'medium' | 'low';
+  };
+  llmReport?: string;
+  message?: string;
+};
+
 export type AgentDeviceCommandClient = {
   wait: (options: WaitCommandOptions) => Promise<WaitCommandResult>;
   alert: (options?: AlertCommandOptions) => Promise<AlertCommandResult>;
@@ -487,6 +537,7 @@ export type AgentDeviceCommandClient = {
   keyboard: (options?: KeyboardCommandOptions) => Promise<KeyboardCommandResult>;
   clipboard: (options: ClipboardCommandOptions) => Promise<ClipboardCommandResult>;
   reactNative: (options: ReactNativeCommandOptions) => Promise<CommandRequestResult>;
+  cognition: (options?: CognitionCommandOptions) => Promise<CognitionCommandResult>;
 };
 
 type SelectorSnapshotCommandOptions = Pick<CaptureSnapshotOptions, 'depth' | 'scope' | 'raw'>;
@@ -848,7 +899,7 @@ export type AgentDeviceClient = {
     installFromSource: (
       options: AppInstallFromSourceOptions,
     ) => Promise<AppInstallFromSourceResult>;
-    list: (options?: AppListOptions) => Promise<string[]>;
+    list: (options?: AppListOptions) => Promise<AppListResult>;
     open: (options: AppOpenOptions) => Promise<AppOpenResult>;
     close: (options?: AppCloseOptions) => Promise<AppCloseResult>;
     push: (options: AppPushOptions) => Promise<CommandRequestResult>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,6 +41,8 @@ import type {
   AppDeployOptions,
   AppInstallFromSourceOptions,
   AppListOptions,
+  AppListEntry,
+  AppListResult,
   AppOpenOptions,
   CaptureScreenshotOptions,
   CaptureSnapshotOptions,
@@ -145,11 +147,13 @@ export function createAgentDeviceClient(
           }),
           resolveRequestSession(options),
         ),
-      list: async (options: AppListOptions = {}) => {
+      list: async (options: AppListOptions = {}): Promise<AppListResult> => {
         const data = await execute(PUBLIC_COMMANDS.apps, [], options);
-        return Array.isArray(data.apps)
+        const apps = Array.isArray(data.apps)
           ? data.apps.filter((app): app is string => typeof app === 'string')
           : [];
+        const appDetails = parseAppListDetails(data.appDetails);
+        return appDetails.length > 0 ? { apps, appDetails } : { apps };
       },
       open: async (options: AppOpenOptions) => {
         const session = resolveRequestSession(options);
@@ -524,6 +528,26 @@ function mergeClientOptions(
   options: InternalRequestOptions,
 ): InternalRequestOptions {
   return { ...config, ...options };
+}
+
+function parseAppListDetails(value: unknown): AppListEntry[] {
+  if (!Array.isArray(value)) return [];
+  const entries: AppListEntry[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const row = item as Record<string, unknown>;
+    const id = readOptionalString(row, 'id');
+    const bundleId = readOptionalString(row, 'bundleId') ?? id;
+    if (!bundleId) continue;
+    entries.push({
+      id: id ?? bundleId,
+      bundleId,
+      name: readOptionalString(row, 'name'),
+      launchAbility: readOptionalString(row, 'launchAbility'),
+      label: readOptionalString(row, 'label'),
+    });
+  }
+  return entries;
 }
 
 function normalizeLease(data: Record<string, unknown>): Lease {

--- a/src/command-catalog.ts
+++ b/src/command-catalog.ts
@@ -9,6 +9,7 @@ export const PUBLIC_COMMANDS = {
   click: 'click',
   close: 'close',
   clipboard: 'clipboard',
+  cognition: 'cognition',
   devices: 'devices',
   diff: 'diff',
   fill: 'fill',

--- a/src/commands/cognition-map.ts
+++ b/src/commands/cognition-map.ts
@@ -1,0 +1,32 @@
+/**
+ * 认知地图命令模块
+ * 为AI提供应用的UI结构概览，避免盲目测试
+ */
+
+import { PUBLIC_COMMANDS } from '../command-catalog.ts';
+import type { CommandCapability } from '../core/capabilities.ts';
+import { commandCapabilityMap, commandSchemaMap, defineCommand } from './command-definition.ts';
+
+const COGNITION_CAPABILITY = {
+  harmonyos: { device: true },
+  android: { emulator: true, device: true, unknown: true },
+  apple: { simulator: true, device: true },
+} as const satisfies CommandCapability;
+
+const cognitionCommandDefinition = defineCommand({
+  name: PUBLIC_COMMANDS.cognition,
+  schema: {
+    helpDescription:
+      'Generate a cognition map of the current UI structure. AI uses this to understand the app before blind testing.',
+    summary: 'Generate UI cognition map for AI planning',
+    positionalArgs: [],
+    allowedFlags: ['platform', 'session', 'json'],
+  },
+  capability: COGNITION_CAPABILITY,
+});
+
+export const COGNITION_COMMAND_DEFINITIONS = [cognitionCommandDefinition];
+
+export const COGNITION_COMMAND_SCHEMAS = commandSchemaMap(COGNITION_COMMAND_DEFINITIONS);
+
+export const COGNITION_COMMAND_CAPABILITIES = commandCapabilityMap(COGNITION_COMMAND_DEFINITIONS);

--- a/src/commands/command-definition.ts
+++ b/src/commands/command-definition.ts
@@ -5,6 +5,7 @@ export const ALL_DEVICE_COMMAND_CAPABILITY = {
   apple: { simulator: true, device: true },
   android: { emulator: true, device: true, unknown: true },
   linux: { device: true },
+  harmonyos: { device: true },
 } as const satisfies CommandCapability;
 
 export type CommandCodec<TOptions = unknown> = {

--- a/src/commands/react-native/definition.ts
+++ b/src/commands/react-native/definition.ts
@@ -19,6 +19,7 @@ const reactNativeCommandDefinition = defineCommand({
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: {},
+    harmonyos: { device: true },
   },
 });
 

--- a/src/commands/session-lifecycle/definition.ts
+++ b/src/commands/session-lifecycle/definition.ts
@@ -7,18 +7,21 @@ const APP_RUNTIME_CAPABILITY = {
   apple: { simulator: true, device: true },
   android: { emulator: true, device: true, unknown: true },
   linux: { device: true },
+  harmonyos: { device: true },
 } as const satisfies CommandCapability;
 
 const APP_INVENTORY_CAPABILITY = {
   apple: { simulator: true, device: true },
   android: { emulator: true, device: true, unknown: true },
   linux: {},
+  harmonyos: { device: true },
 } as const satisfies CommandCapability;
 
 const APP_INSTALL_CAPABILITY = {
   apple: { simulator: true, device: true },
   android: { emulator: true, device: true, unknown: true },
   linux: {},
+  harmonyos: { device: true },
   supports: (device) => device.platform !== 'macos',
 } as const satisfies CommandCapability;
 
@@ -29,7 +32,7 @@ const openCommandDefinition = defineCommand({
       'Boot device/simulator; optionally launch app or deep link URL (macOS also supports --surface app|frontmost-app|desktop|menubar)',
     summary: 'Open an app, deep link or URL, save replays',
     positionalArgs: ['appOrUrl?', 'url?'],
-    allowedFlags: ['activity', 'launchConsole', 'saveScript', 'relaunch', 'surface'],
+    allowedFlags: ['activity', 'module', 'launchConsole', 'saveScript', 'relaunch', 'surface'],
   },
   capability: APP_RUNTIME_CAPABILITY,
 });
@@ -90,7 +93,8 @@ const installFromSourceCommandDefinition = defineCommand({
 const appsCommandDefinition = defineCommand({
   name: PUBLIC_COMMANDS.apps,
   schema: {
-    helpDescription: 'List user-installed apps; use --all to include system/OEM apps',
+    helpDescription:
+      'List user-installed apps; use --all to include system/OEM apps. HarmonyOS --json includes launchAbility per bundle (from device wukong appinfo).',
     summary: 'List installed apps',
     positionalArgs: [],
     allowedFlags: ['appsFilter'],

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -2,7 +2,7 @@ export type { AppErrorCode } from './utils/errors.ts';
 export { defaultHintForCode, normalizeError } from './utils/errors.ts';
 
 export type SessionRuntimeHints = {
-  platform?: 'ios' | 'android';
+  platform?: 'ios' | 'android' | 'harmonyos';
   metroHost?: string;
   metroPort?: number;
   bundleUrl?: string;
@@ -56,7 +56,7 @@ export type DaemonRequestMeta = {
   materializedPathRetentionMs?: number;
   materializationId?: string;
   lockPolicy?: DaemonLockPolicy;
-  lockPlatform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple';
+  lockPlatform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple' | 'harmonyos';
 };
 
 export type DaemonRequest = {
@@ -319,7 +319,7 @@ function parseDaemonInstallSource(input: unknown, path: string): DaemonInstallSo
 export const daemonRuntimeSchema = schema<SessionRuntimeHints>((input, path) => {
   const record = expectObject(input, path);
   return {
-    platform: optionalEnum(record, 'platform', ['ios', 'android'] as const, path),
+    platform: optionalEnum(record, 'platform', ['ios', 'android', 'harmonyos'] as const, path),
     metroHost: optionalString(record, 'metroHost', path),
     metroPort: optionalInteger(record, 'metroPort', path),
     bundleUrl: optionalString(record, 'bundleUrl', path),
@@ -392,7 +392,7 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
             lockPlatform: optionalEnum(
               meta,
               'lockPlatform',
-              ['ios', 'macos', 'android', 'linux', 'apple'] as const,
+              ['ios', 'macos', 'android', 'linux', 'apple', 'harmonyos'] as const,
               `${path}.meta`,
             ),
           },

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -1,5 +1,6 @@
 import { isApplePlatform, type DeviceInfo } from '../utils/device.ts';
 import { CAPTURE_COMMAND_CAPABILITIES } from '../commands/capture-definition.ts';
+import { COGNITION_COMMAND_CAPABILITIES } from '../commands/cognition-map.ts';
 import { INTERACTION_COMMAND_CAPABILITIES } from '../commands/interactions/definition.ts';
 import { REACT_NATIVE_COMMAND_CAPABILITIES } from '../commands/react-native/definition.ts';
 import { SELECTOR_COMMAND_CAPABILITIES } from '../commands/selectors-definition.ts';
@@ -16,6 +17,7 @@ export type CommandCapability = {
   apple?: KindMatrix;
   android?: KindMatrix;
   linux?: KindMatrix;
+  harmonyos?: KindMatrix;
   supports?: (device: DeviceInfo) => boolean;
 };
 
@@ -30,6 +32,9 @@ const isMacOsOrMobileAppleSimulator = (device: DeviceInfo): boolean =>
 const LINUX_DEVICE: KindMatrix = { device: true };
 const LINUX_NONE: KindMatrix = {};
 
+// HarmonyOS supports physical devices via HDC.
+const HARMONYOS_DEVICE: KindMatrix = { device: true };
+
 const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
   // Apple simulator-only.
   alert: {
@@ -38,7 +43,11 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
-    supports: (device) => device.platform === 'android' || isMacOsOrAppleSimulator(device),
+    harmonyos: HARMONYOS_DEVICE,
+    supports: (device) =>
+      device.platform === 'android' ||
+      device.platform === 'harmonyos' ||
+      isMacOsOrAppleSimulator(device),
   },
   pinch: {
     // macOS desktop targets report kind=device, so this stays enabled here and the
@@ -46,37 +55,44 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     apple: { simulator: true, device: true },
     android: {},
     linux: LINUX_NONE,
+    harmonyos: {},
     supports: isMacOsOrMobileAppleSimulator,
   },
   'app-switcher': {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
-    supports: isNotMacOs,
+    harmonyos: HARMONYOS_DEVICE,
+    supports: (device) => isNotMacOs(device) || device.platform === 'harmonyos',
   },
   ...SESSION_LIFECYCLE_COMMAND_CAPABILITIES,
   back: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   boot: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
-    supports: isNotMacOs,
+    harmonyos: {},
+    supports: (device) => isNotMacOs(device) && device.platform !== 'harmonyos',
   },
   click: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   clipboard: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
     supports: (device) =>
       device.platform === 'android' ||
+      device.platform === 'harmonyos' ||
       device.platform === 'linux' ||
       device.platform === 'macos' ||
       device.kind === 'simulator',
@@ -86,13 +102,17 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
     supports: (device) =>
-      device.platform === 'android' || (device.platform === 'ios' && device.target !== 'tv'),
+      device.platform === 'android' ||
+      device.platform === 'harmonyos' ||
+      (device.platform === 'ios' && device.target !== 'tv'),
   },
   fill: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   ...CAPTURE_COMMAND_CAPABILITIES,
   ...SELECTOR_COMMAND_CAPABILITIES,
@@ -100,78 +120,98 @@ const COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   home: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
-    supports: isNotMacOs,
+    harmonyos: HARMONYOS_DEVICE,
+    supports: (device) => isNotMacOs(device) || device.platform === 'harmonyos',
   },
   logs: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   network: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   longpress: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   perf: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   press: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   push: {
     apple: { simulator: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
-    supports: isNotMacOs,
+    harmonyos: HARMONYOS_DEVICE,
+    supports: (device) => isNotMacOs(device) || device.platform === 'harmonyos',
   },
   record: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   ...REACT_NATIVE_COMMAND_CAPABILITIES,
+  ...COGNITION_COMMAND_CAPABILITIES,
   rotate: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
     supports: (device) =>
-      device.platform === 'android' || (device.platform === 'ios' && device.target !== 'tv'),
+      device.platform === 'android' ||
+      device.platform === 'harmonyos' ||
+      (device.platform === 'ios' && device.target !== 'tv'),
   },
   scroll: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   swipe: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_DEVICE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   settings: {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
     supports: (device) =>
-      device.platform === 'android' || device.platform === 'macos' || device.kind === 'simulator',
+      device.platform === 'android' ||
+      device.platform === 'harmonyos' ||
+      device.platform === 'macos' ||
+      device.kind === 'simulator',
   },
   'trigger-app-event': {
     apple: { simulator: true, device: true },
     android: { emulator: true, device: true, unknown: true },
     linux: LINUX_NONE,
+    harmonyos: HARMONYOS_DEVICE,
   },
   ...INTERACTION_COMMAND_CAPABILITIES,
 };
@@ -183,7 +223,9 @@ export function isCommandSupportedOnDevice(command: string, device: DeviceInfo):
     ? capability.apple
     : device.platform === 'linux'
       ? capability.linux
-      : capability.android;
+      : device.platform === 'harmonyos'
+        ? capability.harmonyos
+        : capability.android;
   if (!byPlatform) return false;
   if (capability.supports && !capability.supports(device)) return false;
   const kind = (device.kind ?? 'unknown') as keyof KindMatrix;

--- a/src/core/cognition-analyzer.ts
+++ b/src/core/cognition-analyzer.ts
@@ -1,0 +1,200 @@
+/**
+ * 认知地图核心逻辑
+ * 分析UI结构，生成AI可读的认知地图
+ */
+
+export type CognitionMap = {
+  overview: {
+    platform: string;
+    screenResolution: { width: number; height: number };
+    totalNodes: number;
+    treeDepth: number;
+    complexity: 'simple' | 'medium' | 'complex';
+  };
+  structure: {
+    layoutPattern: string[];
+    mainContainers: number;
+  };
+  interactions: {
+    clickableElements: number;
+    buttons: number;
+    inputFields: number;
+    tabs: number;
+  };
+  features: {
+    hasScroll: boolean;
+    hasTabs: boolean;
+    hasModal: boolean;
+    hasList: boolean;
+    hasForm: boolean;
+    hasUnlabeledIcons: boolean;
+  };
+  suggestions: string[];
+  testPriority: 'high' | 'medium' | 'low';
+};
+
+export function analyzeSnapshotForCognition(
+  nodes: Array<{
+    type?: string;
+    depth?: number;
+    hittable?: boolean;
+    rect?: { x: number; y: number; width: number; height: number };
+    label?: string;
+    value?: string;
+  }>,
+  platform: string,
+): CognitionMap {
+  // 计算基础统计
+  const totalNodes = nodes.length;
+  const depths = nodes.map((n) => n.depth ?? 0);
+  const maxDepth = Math.max(...depths, 0);
+  const avgDepth =
+    depths.length > 0 ? Math.round(depths.reduce((a, b) => a + b, 0) / depths.length) : 0;
+
+  // 计算复杂度
+  const complexityScore = (totalNodes * avgDepth) / 100;
+  const complexity: 'simple' | 'medium' | 'complex' =
+    complexityScore < 50 ? 'simple' : complexityScore < 100 ? 'medium' : 'complex';
+
+  // 分析节点类型
+  const nodeTypes = nodes.map((n) => n.type ?? '').filter((t) => t);
+  const uniqueTypes = [...new Set(nodeTypes)];
+
+  // 分析交互元素
+  const clickableElements = nodes.filter((n) => n.hittable).length;
+  // 按钮包括显式button类型和无label的可点击图标(Image类型且hittable)
+  const buttons = nodes.filter((n) => {
+    const type = (n.type ?? '').toLowerCase();
+    if (type.includes('button')) return true;
+    // 无label的可点击Image可能是图标按钮(如设置齿轮)
+    if (type === 'image' && n.hittable && !n.label) return true;
+    return false;
+  }).length;
+  const inputFields = nodes.filter((n) =>
+    (n.type ?? '').toLowerCase().match(/input|textfield|edittext/),
+  ).length;
+  const tabs = nodes.filter((n) => (n.type ?? '').toLowerCase().includes('tab')).length;
+
+  // 检测无label的可点击图标元素(如设置齿轮图标)
+  const unlabeledClickables = nodes.filter(
+    (n) => n.hittable && !n.label && (n.type ?? '').toLowerCase() === 'image',
+  );
+  const hasUnlabeledIcons = unlabeledClickables.length > 0;
+
+  // 分析界面特征
+  const hasScroll = uniqueTypes.some((t) => t.toLowerCase().match(/scroll|list|swiper/));
+  const hasTabs = tabs > 0 || uniqueTypes.some((t) => t.toLowerCase().includes('navigation'));
+  const hasModal = uniqueTypes.some((t) => t.toLowerCase().match(/dialog|modal|popup|alert/));
+  const hasList =
+    uniqueTypes.some((t) => t.toLowerCase().includes('list')) ||
+    nodeTypes.filter((t) => t.toLowerCase() === 'column').length > 5;
+  const hasForm = inputFields > 0;
+
+  // 确定布局模式
+  const layoutPattern: string[] = [];
+  if (uniqueTypes.some((t) => t.toLowerCase().includes('navigation')))
+    layoutPattern.push('navigation-based');
+  if (nodeTypes.filter((t) => t.toLowerCase() === 'row').length > 10)
+    layoutPattern.push('horizontal-layout');
+  if (nodeTypes.filter((t) => t.toLowerCase() === 'column').length > 10)
+    layoutPattern.push('vertical-layout');
+  if (uniqueTypes.some((t) => t.toLowerCase().includes('list'))) layoutPattern.push('list-view');
+  if (layoutPattern.length === 0) layoutPattern.push('unknown');
+
+  // 生成建议
+  const suggestions: string[] = [];
+  if (complexity === 'complex') suggestions.push('界面复杂度高，建议放慢测试速度');
+  if (clickableElements > 10) suggestions.push('交互元素多，建议分类测试');
+  if (hasTabs) suggestions.push('存在Tab导航，建议逐个Tab遍历');
+  if (hasForm) suggestions.push('存在表单，建议重点测试输入验证');
+  if (hasScroll) suggestions.push('存在滚动区域，建议测试滚动交互');
+  if (hasUnlabeledIcons)
+    suggestions.push(
+      `存在${unlabeledClickables.length}个无标签图标(如设置齿轮),建议通过坐标或raw snapshot定位`,
+    );
+
+  // 确定测试优先级
+  let testPriority: 'high' | 'medium' | 'low' = 'low';
+  if (hasForm || clickableElements > 15) testPriority = 'high';
+  else if (hasTabs || complexity === 'complex') testPriority = 'medium';
+
+  // 获取屏幕分辨率
+  const rootNode = nodes.find((n) => n.depth === 0);
+  const screenResolution = rootNode?.rect ?? { width: 1260, height: 2720 };
+
+  return {
+    overview: {
+      platform,
+      screenResolution,
+      totalNodes,
+      treeDepth: maxDepth,
+      complexity,
+    },
+    structure: {
+      layoutPattern,
+      mainContainers: nodes.filter(
+        (n) => (n.depth ?? 0) < 5 && (n.type ?? '').match(/Stack|Column|Row|Navigation/),
+      ).length,
+    },
+    interactions: {
+      clickableElements,
+      buttons,
+      inputFields,
+      tabs,
+    },
+    features: {
+      hasScroll,
+      hasTabs,
+      hasModal,
+      hasList,
+      hasForm,
+      hasUnlabeledIcons,
+    },
+    suggestions,
+    testPriority,
+  };
+}
+
+export function formatCognitionMapForLLM(map: CognitionMap): string {
+  return `
+# UI认知地图
+
+## 概览
+- 平台: ${map.overview.platform}
+- 屏幕分辨率: ${map.overview.screenResolution.width}x${map.overview.screenResolution.height}
+- UI节点总数: ${map.overview.totalNodes}
+- 树深度: ${map.overview.treeDepth}层
+- 界面复杂度: ${map.overview.complexity}
+
+## UI结构
+- 布局模式: ${map.structure.layoutPattern.join(', ')}
+- 主容器数量: ${map.structure.mainContainers}
+
+## 交互元素
+- 可点击元素: ${map.interactions.clickableElements}个
+- 按钮: ${map.interactions.buttons}个
+- 输入框: ${map.interactions.inputFields}个
+- Tab导航: ${map.interactions.tabs}个
+
+## 界面特征
+- 可滚动: ${map.features.hasScroll ? '是' : '否'}
+- 有Tab导航: ${map.features.hasTabs ? '是' : '否'}
+- 有弹窗: ${map.features.hasModal ? '是' : '否'}
+- 有列表: ${map.features.hasList ? '是' : '否'}
+- 有表单: ${map.features.hasForm ? '是' : '否'}
+- 有无标签图标: ${map.features.hasUnlabeledIcons ? '是(需通过坐标定位)' : '否'}
+
+## 测试优先级
+- **${map.testPriority === 'high' ? '高优先级' : map.testPriority === 'medium' ? '中等优先级' : '低优先级'}**
+
+## 测试建议
+${map.suggestions.length > 0 ? map.suggestions.map((s) => `- ${s}`).join('\n') : '- 界面简单，可以快速遍历'}
+
+## 大模型使用建议
+基于以上认知地图，建议：
+1. 先识别${map.interactions.clickableElements}个可点击元素的位置
+2. ${map.features.hasTabs ? '逐个Tab切换测试' : '按交互顺序测试'}
+3. ${map.features.hasForm ? '重点验证表单输入和提交' : '验证导航跳转逻辑'}
+4. 预估测试时间: ${Math.round((map.interactions.clickableElements * 2) / 60)}分钟
+`;
+}

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -19,6 +19,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   requestId?: string;
   appBundleId?: string;
   activity?: string;
+  module?: string;
   launchConsole?: string;
   verbose?: boolean;
   logPath?: string;

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -5,6 +5,7 @@ import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
 import { runMacOsPressAction, runMacOsReadTextAction } from '../platforms/ios/macos-helper.ts';
 import { rightClickLinux, middleClickLinux } from '../platforms/linux/input-actions.ts';
 import { readLinuxTextAtPoint } from '../platforms/linux/snapshot.ts';
+import { readHarmonyTextAtPoint } from '../platforms/harmonyos/input-actions.ts';
 import { successText, withSuccessText } from '../utils/success-text.ts';
 import { findMistargetedTypeRefToken } from '../utils/type-target-warning.ts';
 import { parseScrollDirection } from './scroll-gesture.ts';
@@ -588,6 +589,10 @@ export async function handleReadCommand(
   if (device.platform === 'android') {
     const text = await readAndroidTextAtPoint(device, x, y);
     return { action: 'read', text: text ?? '' };
+  }
+  if (device.platform === 'harmonyos') {
+    const text = await readHarmonyTextAtPoint(device, x, y);
+    return { action: 'read', text };
   }
   if (device.platform === 'linux') {
     const text = await readLinuxTextAtPoint(x, y, context?.surface);

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -13,6 +13,8 @@ import { ensureAdb } from '../platforms/android/adb.ts';
 import { findBootableIosSimulator, listAppleDevices } from '../platforms/ios/devices.ts';
 import { listLinuxDevices } from '../platforms/linux/devices.ts';
 import { listMacosDevices } from '../platforms/macos/devices.ts';
+import { listHarmonyDevices } from '../platforms/harmonyos/devices.ts';
+import { ensureHdc } from '../platforms/harmonyos/hdc.ts';
 import { withDiagnosticTimer } from '../utils/diagnostics.ts';
 import {
   resolveAndroidSerialAllowlist,
@@ -196,6 +198,10 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
         await ensureAdb();
       }
 
+      if (selector.platform === 'harmonyos') {
+        await ensureHdc();
+      }
+
       const devices = await listLocalDeviceInventory({
         ...selector,
         iosSimulatorSetPath,
@@ -286,6 +292,11 @@ async function listLocalDeviceInventory(request: DeviceInventoryRequest): Promis
     });
   }
 
+  if (request.platform === 'harmonyos') {
+    await ensureHdc();
+    return await listHarmonyDevices();
+  }
+
   if (request.platform) {
     return await listAppleDevices({
       simulatorSetPath: request.iosSimulatorSetPath,
@@ -311,8 +322,11 @@ async function listLocalDeviceInventory(request: DeviceInventoryRequest): Promis
       })),
     );
   } catch {}
+  try {
+    devices.push(...(await listHarmonyDevices()));
+  } catch {}
   // Linux local device is appended last so it does not displace
-  // connected Android/Apple devices in implicit auto-selection.
+  // connected Android/Apple/HarmonyOS devices in implicit auto-selection.
   try {
     devices.push(...(await listLinuxDevices()));
   } catch {}
@@ -323,7 +337,12 @@ function isAppleResolutionSelector(selector: {
   platform?: PlatformSelector;
   target?: DeviceTarget;
 }): boolean {
-  return !!selector.platform && selector.platform !== 'android' && selector.platform !== 'linux';
+  return (
+    !!selector.platform &&
+    selector.platform !== 'android' &&
+    selector.platform !== 'linux' &&
+    selector.platform !== 'harmonyos'
+  );
 }
 
 function readResolveTargetDeviceCache(cacheKey: string): DeviceInfo | undefined {

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -22,6 +22,7 @@ import { readLocationCoordinate } from '../utils/location-coordinates.ts';
 import { successText, withSuccessText } from '../utils/success-text.ts';
 import { screenshotOptionsFromFlags } from '../commands/capture-screenshot-options.ts';
 import type { DispatchContext } from './dispatch-context.ts';
+import { analyzeSnapshotForCognition, formatCognitionMapForLLM } from './cognition-analyzer.ts';
 import {
   handleFillCommand,
   handleFocusCommand,
@@ -35,6 +36,7 @@ import {
 } from './dispatch-interactions.ts';
 import { readNotificationPayload } from './dispatch-payload.ts';
 import { parseDeviceRotation } from './device-rotation.ts';
+import { dismissHarmonySystemDialogs } from '../platforms/harmonyos/alert.ts';
 
 export { resolveTargetDevice } from './dispatch-resolve.ts';
 export type { BatchStep, CommandFlags, DispatchContext } from './dispatch-context.ts';
@@ -146,6 +148,8 @@ export async function dispatchCommand(
           return handlePushCommand(device, positionals, context);
         case 'snapshot':
           return await handleSnapshotCommand(interactor, context);
+        case 'cognition':
+          return await handleCognitionCommand(interactor, device, context);
         case 'read':
           return handleReadCommand(device, positionals, context);
         default:
@@ -204,6 +208,7 @@ async function handleOpenCommand(
     }
     await interactor.open(app, {
       activity: context?.activity,
+      module: context?.module,
       appBundleId: context?.appBundleId,
       url,
     });
@@ -214,6 +219,7 @@ async function handleOpenCommand(
   }
   await interactor.open(app, {
     activity: context?.activity,
+    module: context?.module,
     appBundleId: context?.appBundleId,
     launchConsole,
   });
@@ -289,6 +295,28 @@ async function handleKeyboardCommand(
       focusedPackage: state.focusedPackage,
       focusedResourceId: state.focusedResourceId,
       inputOwner: state.inputOwner,
+    };
+  }
+  if (device.platform === 'harmonyos') {
+    const { getHarmonyKeyboardState, dismissHarmonyKeyboard } = await import(
+      '../platforms/harmonyos/input-actions.ts'
+    );
+    if (action === 'dismiss') {
+      await dismissHarmonyKeyboard(device);
+      return {
+        platform: 'harmonyos',
+        action: 'dismiss',
+        dismissed: true,
+        visible: false,
+        ...successText('Keyboard dismissed'),
+      };
+    }
+    const state = await getHarmonyKeyboardState(device);
+    return {
+      platform: 'harmonyos',
+      action: 'status',
+      visible: state.visible,
+      height: state.height,
     };
   }
   if (device.platform === 'ios') {
@@ -405,6 +433,37 @@ async function handleSnapshotCommand(
     raw: context?.snapshotRaw,
     surface: context?.surface,
   });
+}
+
+async function handleCognitionCommand(
+  interactor: Interactor,
+  device: DeviceInfo,
+  context: DispatchContext | undefined,
+): Promise<Record<string, unknown>> {
+  // For HarmonyOS, auto-dismiss system dialogs before generating cognition map
+  if (device.platform === 'harmonyos') {
+    try {
+      await dismissHarmonySystemDialogs(device, 2);
+    } catch {
+      // Proceed with cognition map generation even if dialog dismissal fails
+    }
+  }
+
+  // 获取当前UI快照
+  const snapshotResult = await interactor.snapshot({
+    appBundleId: context?.appBundleId,
+    raw: true, // 获取完整数据用于分析
+  });
+
+  // 分析UI结构生成认知地图
+  const cognitionMap = analyzeSnapshotForCognition(snapshotResult.nodes ?? [], device.platform);
+
+  // 返回结构化认知地图
+  return {
+    cognition: cognitionMap,
+    llmReport: formatCognitionMapForLLM(cognitionMap),
+    message: 'Cognition map generated for AI planning',
+  };
 }
 
 function readResultMessage(result: Record<string, unknown>): string | undefined {

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -38,13 +38,19 @@ export type SnapshotOptions = BaseSnapshotOptions & {
 
 export type SnapshotResult = Omit<BackendSnapshotResult, 'backend' | 'nodes'> & {
   nodes?: RawSnapshotNode[];
-  backend: Extract<SnapshotBackend, 'android' | 'xctest' | 'linux-atspi'>;
+  backend: Extract<SnapshotBackend, 'android' | 'xctest' | 'linux-atspi' | 'harmonyos-arkui'>;
 };
 
 export type Interactor = {
   open(
     app: string,
-    options?: { activity?: string; appBundleId?: string; launchConsole?: string; url?: string },
+    options?: {
+      activity?: string;
+      module?: string;
+      appBundleId?: string;
+      launchConsole?: string;
+      url?: string;
+    },
   ): Promise<void>;
   openDevice(): Promise<void>;
   close(app: string): Promise<void>;

--- a/src/core/interactors.ts
+++ b/src/core/interactors.ts
@@ -4,11 +4,14 @@ import type { Interactor, RunnerContext } from './interactor-types.ts';
 import { createAndroidInteractor } from './interactors/android.ts';
 import { createAppleInteractor } from './interactors/apple.ts';
 import { createLinuxInteractor } from './interactors/linux.ts';
+import { createHarmonyInteractor } from './interactors/harmonyos.ts';
 
 export function getInteractor(device: DeviceInfo, runnerContext: RunnerContext): Interactor {
   switch (device.platform) {
     case 'android':
       return createAndroidInteractor(device);
+    case 'harmonyos':
+      return createHarmonyInteractor(device);
     case 'linux':
       return createLinuxInteractor();
     case 'ios':

--- a/src/core/interactors/harmonyos.ts
+++ b/src/core/interactors/harmonyos.ts
@@ -1,0 +1,83 @@
+import { closeHarmonyApp, openHarmonyApp } from '../../platforms/harmonyos/app-lifecycle.ts';
+import {
+  fillHarmony,
+  focusHarmony,
+  longPressHarmony,
+  pressHarmony,
+  doubleTapHarmony,
+  pressBackHarmony,
+  pressHomeHarmony,
+  pressKeyHarmony,
+  scrollHarmony,
+  swipeHarmony,
+  typeHarmony,
+  rotateHarmony,
+} from '../../platforms/harmonyos/input-actions.ts';
+import { snapshotHarmony } from '../../platforms/harmonyos/snapshot.ts';
+import { screenshotHarmony } from '../../platforms/harmonyos/screenshot.ts';
+import { setHarmonySetting } from '../../platforms/harmonyos/settings.ts';
+import {
+  readHarmonyClipboardText,
+  writeHarmonyClipboardText,
+} from '../../platforms/harmonyos/clipboard.ts';
+import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import type { Interactor } from '../interactor-types.ts';
+
+export function createHarmonyInteractor(device: DeviceInfo): Interactor {
+  return {
+    open: (app, options) => openHarmonyApp(device, app, options?.activity, options?.module),
+    openDevice: async () => {
+      // HarmonyOS doesn't have a "home screen" app; just press home
+      await pressHomeHarmony(device);
+    },
+    close: (app) => closeHarmonyApp(device, app),
+    tap: (x, y) => pressHarmony(device, x, y),
+    doubleTap: (x, y) => doubleTapHarmony(device, x, y),
+    swipe: (x1, y1, x2, y2, durationMs) =>
+      swipeHarmony(device, { x: x1, y: y1 }, { x: x2, y: y2 }, durationMs),
+    longPress: (x, y, durationMs) => longPressHarmony(device, x, y, durationMs ?? 1000),
+    focus: (x, y) => focusHarmony(device, x, y),
+    type: (text, _delayMs) => typeHarmony(device, text),
+    fill: (x, y, text, delayMs) => fillHarmony(device, { x, y }, text, delayMs ?? 100),
+    scroll: (direction, options) => scrollHarmony(device, direction, options),
+    screenshot: async (outPath, _options) => {
+      await screenshotHarmony(device, outPath);
+    },
+    snapshot: async (options) => {
+      const result = await withDiagnosticTimer(
+        'snapshot_capture',
+        async () =>
+          await snapshotHarmony(device, {
+            interactiveOnly: options?.interactiveOnly,
+            compact: options?.compact,
+            depth: options?.depth,
+            scope: options?.scope,
+            raw: options?.raw,
+          }),
+        { backend: 'harmonyos-arkui' },
+      );
+      return {
+        nodes: result.nodes ?? [],
+        truncated: result.truncated ?? false,
+        backend: 'harmonyos-arkui',
+        analysis: {
+          rawNodeCount: result.rawNodeCount,
+          maxDepth: result.maxDepth,
+        },
+      };
+    },
+    back: (_mode) => pressBackHarmony(device),
+    home: () => pressHomeHarmony(device),
+    rotate: (orientation) => rotateHarmony(device, orientation),
+    appSwitcher: async () => {
+      // App switcher via recent apps key
+      await pressKeyHarmony(device, 'Recent');
+    },
+    readClipboard: async () => readHarmonyClipboardText(device),
+    writeClipboard: async (text) => writeHarmonyClipboardText(device, text),
+    setSetting: async (setting, state, appId, options) => {
+      return await setHarmonySetting(device, setting, state, appId, options);
+    },
+  };
+}

--- a/src/daemon/context.ts
+++ b/src/daemon/context.ts
@@ -20,6 +20,7 @@ export function contextFromFlags(
     requestId: effectiveRequestId,
     appBundleId,
     activity: flags?.activity,
+    module: flags?.module,
     launchConsole: flags?.launchConsole,
     verbose: flags?.verbose,
     logPath,

--- a/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
+++ b/src/daemon/handlers/__tests__/session-inventory-harmonyos.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+import { harmonyDeviceForSerial } from '../../../platforms/harmonyos/hdc.ts';
+import { handleSessionInventoryCommands } from '../session-inventory.ts';
+import { SessionStore } from '../../session-store.ts';
+import * as sessionDeviceUtils from '../session-device-utils.ts';
+import * as harmonyAppLifecycle from '../../../platforms/harmonyos/app-lifecycle.ts';
+
+vi.mock('../../../platforms/harmonyos/app-lifecycle.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../platforms/harmonyos/app-lifecycle.ts')>();
+  return {
+    ...actual,
+    listHarmonyApps: vi.fn(),
+  };
+});
+
+const listHarmonyApps = vi.mocked(harmonyAppLifecycle.listHarmonyApps);
+const HARMONY_DEVICE = harmonyDeviceForSerial('22M0223824043030');
+
+beforeEach(() => {
+  listHarmonyApps.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('apps command lists HarmonyOS bundles via listHarmonyApps', async () => {
+  listHarmonyApps.mockResolvedValue([
+    {
+      id: 'com.sdu.didi.hmos.psnger',
+      name: 'psnger',
+      bundleId: 'com.sdu.didi.hmos.psnger',
+      activity: 'EntryAbility',
+    },
+  ]);
+  vi.spyOn(sessionDeviceUtils, 'resolveCommandDevice').mockResolvedValue(HARMONY_DEVICE);
+
+  const response = await handleSessionInventoryCommands({
+    req: {
+      command: 'apps',
+      positionals: [],
+      flags: { platform: 'harmonyos', device: HARMONY_DEVICE.id, appsFilter: 'user-installed' },
+    },
+    sessionName: '',
+    sessionStore: new SessionStore('/tmp/agent-device-test-sessions'),
+  });
+
+  assert.ok(response?.ok);
+  assert.deepEqual(response?.data?.apps, ['psnger (com.sdu.didi.hmos.psnger)']);
+  assert.deepEqual(response?.data?.appDetails, [
+    {
+      id: 'com.sdu.didi.hmos.psnger',
+      bundleId: 'com.sdu.didi.hmos.psnger',
+      name: 'psnger',
+      label: 'psnger (com.sdu.didi.hmos.psnger)',
+      launchAbility: 'EntryAbility',
+    },
+  ]);
+  assert.equal(listHarmonyApps.mock.calls.length, 1);
+});

--- a/src/daemon/handlers/__tests__/session-state-harmonyos.test.ts
+++ b/src/daemon/handlers/__tests__/session-state-harmonyos.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+import { harmonyDeviceForSerial } from '../../../platforms/harmonyos/hdc.ts';
+import { handleSessionStateCommands } from '../session-state.ts';
+import { SessionStore } from '../../session-store.ts';
+import * as sessionDeviceUtils from '../session-device-utils.ts';
+import * as harmonyAppLifecycle from '../../../platforms/harmonyos/app-lifecycle.ts';
+
+vi.mock('../../../platforms/harmonyos/app-lifecycle.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../platforms/harmonyos/app-lifecycle.ts')>();
+  return {
+    ...actual,
+    getHarmonyAppState: vi.fn(),
+  };
+});
+
+const getHarmonyAppState = vi.mocked(harmonyAppLifecycle.getHarmonyAppState);
+const HARMONY_DEVICE = harmonyDeviceForSerial('22M0223824043030');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('appstate uses hdc aa dump for harmonyos instead of adb', async () => {
+  getHarmonyAppState.mockResolvedValue({
+    bundleId: 'com.xiaojukeji.didi',
+    state: 'foreground',
+  });
+  vi.spyOn(sessionDeviceUtils, 'resolveCommandDevice').mockResolvedValue(HARMONY_DEVICE);
+
+  const response = await handleSessionStateCommands({
+    req: {
+      command: 'appstate',
+      positionals: [],
+      flags: { platform: 'harmonyos', device: HARMONY_DEVICE.id },
+    },
+    sessionName: '',
+    sessionStore: new SessionStore('/tmp/agent-device-test-sessions'),
+  });
+
+  assert.ok(response?.ok);
+  assert.equal(response?.data?.platform, 'harmonyos');
+  assert.equal(response?.data?.appBundleId, 'com.xiaojukeji.didi');
+  assert.equal(getHarmonyAppState.mock.calls.length, 1);
+});

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -14,7 +14,9 @@ import {
 } from '../../utils/device-isolation.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
+import type { BackendAppInfo } from '../../backend.ts';
 import { listAndroidApps } from '../../platforms/android/app-lifecycle.ts';
+import { listHarmonyApps } from '../../platforms/harmonyos/app-lifecycle.ts';
 import { listIosApps } from '../../platforms/ios/apps.ts';
 import { requireSessionOrExplicitSelector, resolveCommandDevice } from './session-device-utils.ts';
 import { errorResponse } from './response.ts';
@@ -116,6 +118,19 @@ export async function handleSessionInventoryCommands(params: {
       };
     }
 
+    if (device.platform === 'harmonyos') {
+      const apps = await listHarmonyApps(device, appsFilter);
+      const labels = apps.map((app) => formatHarmonyAppLabel(app));
+      const appDetails = apps.map((app) => toHarmonyAppListEntry(app));
+      return {
+        ok: true,
+        data: {
+          apps: labels,
+          appDetails,
+        },
+      };
+    }
+
     const apps = await listAndroidApps(device, appsFilter);
     return {
       ok: true,
@@ -137,4 +152,26 @@ function matchesRequestedPlatform(
   if (!requestedPlatform) return true;
   if (requestedPlatform === 'apple') return isApplePlatform(device.platform);
   return device.platform === requestedPlatform;
+}
+
+function formatHarmonyAppLabel(app: BackendAppInfo): string {
+  const bundleId = app.bundleId ?? app.id;
+  return app.name && app.name !== bundleId ? `${app.name} (${bundleId})` : bundleId;
+}
+
+function toHarmonyAppListEntry(app: BackendAppInfo): {
+  id: string;
+  bundleId: string;
+  name?: string;
+  launchAbility?: string;
+  label: string;
+} {
+  const bundleId = app.bundleId ?? app.id;
+  return {
+    id: app.id,
+    bundleId,
+    name: app.name,
+    label: formatHarmonyAppLabel(app),
+    ...(app.activity ? { launchAbility: app.activity } : {}),
+  };
 }

--- a/src/daemon/handlers/session-state.ts
+++ b/src/daemon/handlers/session-state.ts
@@ -118,16 +118,38 @@ async function handleAppStateCommand(params: {
     return errorResponse('SESSION_NOT_FOUND', MACOS_APPSTATE_SESSION_REQUIRED_MESSAGE);
   }
 
-  const { getAndroidAppState } = await import('../../platforms/android/app-lifecycle.ts');
-  const state = await getAndroidAppState(device);
-  return {
-    ok: true,
-    data: {
-      platform: 'android',
-      package: state.package,
-      activity: state.activity,
-    },
-  };
+  if (device.platform === 'harmonyos') {
+    const { getHarmonyAppState } = await import('../../platforms/harmonyos/app-lifecycle.ts');
+    const state = await getHarmonyAppState(device);
+    return {
+      ok: true,
+      data: {
+        platform: 'harmonyos',
+        appBundleId: state.bundleId,
+        package: state.bundleId,
+        state: state.state,
+        source: 'device',
+      },
+    };
+  }
+
+  if (device.platform === 'android') {
+    const { getAndroidAppState } = await import('../../platforms/android/app-lifecycle.ts');
+    const state = await getAndroidAppState(device);
+    return {
+      ok: true,
+      data: {
+        platform: 'android',
+        package: state.package,
+        activity: state.activity,
+      },
+    };
+  }
+
+  return errorResponse(
+    'UNSUPPORTED_OPERATION',
+    `appstate is not supported on platform ${device.platform}`,
+  );
 }
 
 export async function handleSessionStateCommands(params: {

--- a/src/daemon/handlers/snapshot-alert.ts
+++ b/src/daemon/handlers/snapshot-alert.ts
@@ -4,6 +4,7 @@ import { sleep } from '../../utils/timeouts.ts';
 import { runIosRunnerCommand } from '../../platforms/ios/runner-client.ts';
 import { runMacOsAlertAction } from '../../platforms/ios/macos-helper.ts';
 import { handleAndroidAlert } from '../../platforms/android/alert.ts';
+import { handleHarmonyAlert } from '../../platforms/harmonyos/alert.ts';
 import { AppError } from '../../utils/errors.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
@@ -53,6 +54,15 @@ export async function handleAlertCommand(
     return recordAlertResponse(
       params,
       await handleAndroidAlert(device, action, {
+        timeoutMs,
+      }),
+    );
+  }
+  if (device.platform === 'harmonyos') {
+    const timeoutMs = parseTimeout(req.positionals?.[1]) ?? DEFAULT_TIMEOUT_MS;
+    return recordAlertResponse(
+      params,
+      await handleHarmonyAlert(device, action, {
         timeoutMs,
       }),
     );

--- a/src/platforms/harmonyos/__tests__/app-parsers.test.ts
+++ b/src/platforms/harmonyos/__tests__/app-parsers.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  lookupWukongLaunchAbility,
+  parseHarmonyBundleList,
+  parseHarmonyForegroundAbility,
+  parseWukongAppInfo,
+} from '../app-parsers.ts';
+
+describe('HarmonyOS App Parsers', () => {
+  describe('parseHarmonyBundleList', () => {
+    it('parses empty output', () => {
+      const result = parseHarmonyBundleList('');
+      assert.deepEqual(result, []);
+    });
+
+    it('parses bundle names from bm dump output', () => {
+      const output = `
+Bundle Name: com.huawei.hmos.settings
+Bundle Name: com.huawei.hmos.camera
+Bundle Name: com.example.myapp
+`;
+      const result = parseHarmonyBundleList(output);
+      assert.deepEqual(result, [
+        'com.huawei.hmos.settings',
+        'com.huawei.hmos.camera',
+        'com.example.myapp',
+      ]);
+    });
+
+    it('handles malformed output gracefully', () => {
+      const output = 'some random output without bundle names';
+      const result = parseHarmonyBundleList(output);
+      assert.deepEqual(result, []);
+    });
+  });
+
+  describe('parseWukongAppInfo', () => {
+    it('parses bundle and ability pairs from wukong appinfo', () => {
+      const output = `
+I/O error : failed to load "/system/usr/ohos_locale_config/supported_locales.xml": Permission denied
+BundleName:  com.sdu.didi.hmos.psnger
+AbilityName:  EntryAbility
+BundleName:  com.ss.dcar.auto
+AbilityName:  DcarAbility
+`;
+      const map = parseWukongAppInfo(output);
+      assert.strictEqual(map.get('com.sdu.didi.hmos.psnger'), 'EntryAbility');
+      assert.strictEqual(map.get('com.ss.dcar.auto'), 'DcarAbility');
+    });
+
+    it('keeps the first ability when a bundle appears more than once', () => {
+      const output = `
+BundleName:  com.ohos.contacts
+AbilityName:  com.ohos.contacts.EntryAbility
+BundleName:  com.ohos.contacts
+AbilityName:  com.ohos.contacts.MainAbility
+`;
+      assert.strictEqual(
+        lookupWukongLaunchAbility(output, 'com.ohos.contacts'),
+        'com.ohos.contacts.EntryAbility',
+      );
+    });
+  });
+
+  describe('parseHarmonyForegroundAbility', () => {
+    it('returns null for empty output', () => {
+      const result = parseHarmonyForegroundAbility('');
+      assert.strictEqual(result, null);
+    });
+
+    it('parses foreground ability info', () => {
+      const output = `
+# app name [com.huawei.hmos.settings]
+  main name [MainAbility]
+  app state #FOREGROUND
+`;
+      const result = parseHarmonyForegroundAbility(output);
+      assert.ok(result);
+      assert.strictEqual(result?.bundleName, 'com.huawei.hmos.settings');
+      assert.strictEqual(result?.abilityName, 'MainAbility');
+    });
+
+    it('returns null when no foreground ability', () => {
+      const output = `
+# app name [com.huawei.hmos.settings]
+  app state #BACKGROUND
+`;
+      const result = parseHarmonyForegroundAbility(output);
+      assert.strictEqual(result, null);
+    });
+  });
+});

--- a/src/platforms/harmonyos/__tests__/app-storage.test.ts
+++ b/src/platforms/harmonyos/__tests__/app-storage.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+import { harmonyDeviceForSerial } from '../hdc.ts';
+import { clearHarmonyAppStorage } from '../app-lifecycle.ts';
+import * as hdc from '../hdc.ts';
+
+const DEVICE = harmonyDeviceForSerial('22M0223824043030');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('clearHarmonyAppStorage force-stops then bm clean data and cache', async () => {
+  const runHarmonyHdc = vi.spyOn(hdc, 'runHarmonyHdc');
+  runHarmonyHdc.mockResolvedValue({ exitCode: 0, stdout: 'ok', stderr: '' });
+
+  const result = await clearHarmonyAppStorage(DEVICE, 'com.sdu.didi.hmos.psnger');
+
+  assert.deepEqual(result, {
+    bundleId: 'com.sdu.didi.hmos.psnger',
+    clearedData: true,
+    clearedCache: true,
+  });
+  assert.deepEqual(
+    runHarmonyHdc.mock.calls.map(([_, args]) => args),
+    [
+      ['shell', 'aa', 'force-stop', 'com.sdu.didi.hmos.psnger'],
+      ['shell', 'bm', 'clean', '-n', 'com.sdu.didi.hmos.psnger', '-d'],
+      ['shell', 'bm', 'clean', '-n', 'com.sdu.didi.hmos.psnger', '-c'],
+    ],
+  );
+});

--- a/src/platforms/harmonyos/__tests__/arkui-hierarchy.test.ts
+++ b/src/platforms/harmonyos/__tests__/arkui-hierarchy.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'vitest';
+import { buildArkUiSnapshot, type ArkUiTree } from '../arkui-hierarchy.ts';
+
+describe('HarmonyOS ArkUI hierarchy', () => {
+  it('filters interactiveOnly output to interactive context', () => {
+    const tree: ArkUiTree = [
+      {
+        attributes: { type: 'root' },
+        children: [
+          {
+            attributes: { type: 'Text', text: 'Title only' },
+          },
+          {
+            attributes: { type: 'List', scrollable: 'true', id: 'feed' },
+            children: [
+              {
+                attributes: { type: 'Text', text: 'Item title' },
+              },
+              {
+                attributes: { type: 'Button', text: 'Open', clickable: 'true' },
+              },
+            ],
+          },
+          {
+            attributes: { type: 'Text', text: 'Footer only' },
+          },
+        ],
+      },
+    ];
+
+    const result = buildArkUiSnapshot(tree, 100, { interactiveOnly: true });
+    const labels = result.nodes.map((node) => node.label).filter(Boolean);
+    const identifiers = result.nodes.map((node) => node.identifier).filter(Boolean);
+
+    assert.deepEqual(labels, ['Item title', 'Open']);
+    assert.deepEqual(identifiers, ['feed']);
+  });
+
+  it('when a focused modal exists, interactiveOnly scopes to it', () => {
+    const tree: ArkUiTree = [
+      {
+        attributes: { type: 'root' },
+        children: [
+          {
+            attributes: { type: 'Column' },
+            children: [
+              { attributes: { type: 'Text', text: '微信登录' } },
+              { attributes: { type: 'Text', text: '其他登录方式' } },
+              { attributes: { type: 'Button', text: '背景按钮', clickable: 'true' } },
+            ],
+          },
+          {
+            attributes: { type: 'NavDestination', focused: 'true' },
+            children: [
+              { attributes: { type: 'Text', text: '请阅读并同意以下条款' } },
+              { attributes: { type: 'Button', text: '不同意', clickable: 'true' } },
+              { attributes: { type: 'Button', text: '同意并继续', clickable: 'true' } },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = buildArkUiSnapshot(tree, 100, { interactiveOnly: true });
+    const labels = result.nodes.map((node) => node.label).filter(Boolean);
+
+    assert.ok(labels.includes('同意并继续'));
+    assert.ok(labels.includes('不同意'));
+    assert.ok(labels.includes('请阅读并同意以下条款'));
+    assert.ok(!labels.includes('背景按钮'));
+    assert.ok(!labels.includes('微信登录'));
+    assert.ok(!labels.includes('其他登录方式'));
+  });
+});

--- a/src/platforms/harmonyos/__tests__/devices.test.ts
+++ b/src/platforms/harmonyos/__tests__/devices.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { parseHarmonyDeviceList } from '../devices.ts';
+
+describe('HarmonyOS Device Discovery', () => {
+  describe('parseHarmonyDeviceList', () => {
+    it('parses empty output correctly', () => {
+      const result = parseHarmonyDeviceList('');
+      assert.deepEqual(result, []);
+    });
+
+    it('parses single device', () => {
+      const output = '192.168.1.100:5555\n';
+      const result = parseHarmonyDeviceList(output);
+      assert.deepEqual(result, ['192.168.1.100:5555']);
+    });
+
+    it('parses multiple devices', () => {
+      const output = 'device1\ndevice2\ndevice3\n';
+      const result = parseHarmonyDeviceList(output);
+      assert.deepEqual(result, ['device1', 'device2', 'device3']);
+    });
+
+    it('filters out [Empty] marker', () => {
+      const output = '[Empty]\n';
+      const result = parseHarmonyDeviceList(output);
+      assert.deepEqual(result, []);
+    });
+
+    it('handles whitespace correctly', () => {
+      const output = '  device1  \n  device2  \n\n  \n';
+      const result = parseHarmonyDeviceList(output);
+      assert.deepEqual(result, ['device1', 'device2']);
+    });
+  });
+});

--- a/src/platforms/harmonyos/__tests__/launch-abilities.test.ts
+++ b/src/platforms/harmonyos/__tests__/launch-abilities.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, test, vi } from 'vitest';
+import assert from 'node:assert/strict';
+import { harmonyDeviceForSerial } from '../hdc.ts';
+import {
+  clearHarmonyLaunchAbilityCache,
+  getHarmonyLaunchAbilities,
+  lookupHarmonyLaunchAbility,
+} from '../launch-abilities.ts';
+import * as hdc from '../hdc.ts';
+
+const DEVICE = harmonyDeviceForSerial('22M0223824043030');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearHarmonyLaunchAbilityCache();
+});
+
+test('getHarmonyLaunchAbilities parses wukong appinfo and caches per device', async () => {
+  const runHarmonyHdc = vi.spyOn(hdc, 'runHarmonyHdc');
+  runHarmonyHdc.mockResolvedValue({
+    exitCode: 0,
+    stdout: `
+BundleName:  com.sdu.didi.hmos.psnger
+AbilityName:  EntryAbility
+BundleName:  com.ss.dcar.auto
+AbilityName:  DcarAbility
+`,
+    stderr: '',
+  });
+
+  const first = await getHarmonyLaunchAbilities(DEVICE);
+  const second = await getHarmonyLaunchAbilities(DEVICE);
+
+  assert.equal(first.get('com.sdu.didi.hmos.psnger'), 'EntryAbility');
+  assert.equal(first.get('com.ss.dcar.auto'), 'DcarAbility');
+  assert.equal(runHarmonyHdc.mock.calls.length, 1);
+  assert.equal(second.get('com.sdu.didi.hmos.psnger'), 'EntryAbility');
+});
+
+test('lookupHarmonyLaunchAbility returns null when bundle is missing', async () => {
+  vi.spyOn(hdc, 'runHarmonyHdc').mockResolvedValue({
+    exitCode: 0,
+    stdout: 'BundleName:  com.example.app\nAbilityName:  EntryAbility\n',
+    stderr: '',
+  });
+
+  assert.equal(await lookupHarmonyLaunchAbility(DEVICE, 'com.missing.app'), null);
+});

--- a/src/platforms/harmonyos/__tests__/uitest-preflight.test.ts
+++ b/src/platforms/harmonyos/__tests__/uitest-preflight.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  buildHarmonyUitestBlockedHint,
+  findStuckHarmonyUitestProcess,
+} from '../uitest-preflight.ts';
+
+test('findStuckHarmonyUitestProcess detects uiRecord record', () => {
+  const stuck = findStuckHarmonyUitestProcess([
+    'shell 6151 1984 uitest uiRecord record',
+    'shell 4253 1984 snapshot_display -f /data/local/tmp/x.jpeg',
+  ]);
+  assert.match(stuck ?? '', /uiRecord record/);
+});
+
+test('buildHarmonyUitestBlockedHint mentions reboot', () => {
+  const hint = buildHarmonyUitestBlockedHint('shell 6151 uitest uiRecord record');
+  assert.match(hint, /Reboot the device/i);
+  assert.match(hint, /uiRecord record/i);
+});

--- a/src/platforms/harmonyos/alert.ts
+++ b/src/platforms/harmonyos/alert.ts
@@ -1,0 +1,458 @@
+import type { AlertAction } from '../../alert-contract.ts';
+import {
+  ALERT_ACTION_RETRY_MS,
+  ALERT_POLL_INTERVAL_MS,
+  DEFAULT_ALERT_TIMEOUT_MS,
+} from '../../alert-contract.ts';
+import { AppError } from '../../utils/errors.ts';
+import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
+import { successText } from '../../utils/success-text.ts';
+import { sleep } from '../../utils/timeouts.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import { pressBackHarmony, pressHarmony } from './input-actions.ts';
+import { snapshotHarmony } from './snapshot.ts';
+import type { SnapshotNode } from '../../utils/snapshot.ts';
+
+export type HarmonyAlertInfo = {
+  visible: boolean;
+  title?: string;
+  message?: string;
+  buttons: HarmonyAlertButton[];
+};
+
+export type HarmonyAlertButton = {
+  label: string;
+  x: number;
+  y: number;
+};
+
+export type HarmonyAlertCandidate = {
+  alert: HarmonyAlertInfo;
+  nodes: SnapshotNode[];
+};
+
+export type HarmonyAlertResult =
+  | {
+      kind: 'alertStatus';
+      platform: 'harmonyos';
+      action: 'get';
+      alert: HarmonyAlertInfo | null;
+      message?: string;
+    }
+  | {
+      kind: 'alertWait';
+      platform: 'harmonyos';
+      action: 'wait';
+      alert: HarmonyAlertInfo;
+      waitedMs: number;
+      message?: string;
+    }
+  | {
+      kind: 'alertHandled';
+      platform: 'harmonyos';
+      action: 'accept' | 'dismiss';
+      handled: true;
+      alert: HarmonyAlertInfo;
+      button: string;
+      message?: string;
+    };
+
+export async function handleHarmonyAlert(
+  device: DeviceInfo,
+  action: AlertAction,
+  options: { timeoutMs?: number } = {},
+): Promise<HarmonyAlertResult> {
+  if (action === 'wait') {
+    return await waitForHarmonyAlert(device, options.timeoutMs ?? DEFAULT_ALERT_TIMEOUT_MS);
+  }
+  if (action === 'get') {
+    const candidate = await readHarmonyAlertCandidate(device);
+    return buildHarmonyAlertStatusResponse(candidate?.alert ?? null);
+  }
+  return await handleHarmonyAlertAction(device, action);
+}
+
+async function waitForHarmonyAlert(
+  device: DeviceInfo,
+  timeoutMs: number,
+): Promise<HarmonyAlertResult> {
+  const start = Date.now();
+  const candidate = await pollHarmonyAlertCandidate(device, timeoutMs);
+  if (!candidate) {
+    throw new AppError('COMMAND_FAILED', 'alert wait timed out');
+  }
+  return {
+    kind: 'alertWait',
+    platform: 'harmonyos',
+    action: 'wait',
+    alert: candidate.alert,
+    waitedMs: Date.now() - start,
+    ...successText('Alert visible'),
+  };
+}
+
+async function handleHarmonyAlertAction(
+  device: DeviceInfo,
+  action: 'accept' | 'dismiss',
+): Promise<HarmonyAlertResult> {
+  const candidate = await pollHarmonyAlertCandidate(device, ALERT_ACTION_RETRY_MS);
+  if (!candidate) {
+    throw new AppError('COMMAND_FAILED', 'alert not found', {
+      hint: 'If a sheet is visible in snapshot but alert reports no alert, it is likely app-owned UI. Use snapshot -i and press the visible label/ref.',
+    });
+  }
+
+  const button = chooseHarmonyAlertButton(candidate.alert.buttons, action);
+  if (button) {
+    await pressHarmony(device, button.x, button.y);
+    return buildHarmonyAlertHandledResponse(action, candidate.alert, button.label);
+  }
+
+  if (action === 'dismiss') {
+    await pressBackHarmony(device);
+    return buildHarmonyAlertHandledResponse(action, candidate.alert, 'Back');
+  }
+
+  throw new AppError('COMMAND_FAILED', 'alert accept found an alert but no accept button', {
+    alert: candidate.alert,
+    hint: 'Inspect alert get --json for visible buttons, then use press by visible label/ref if needed.',
+  });
+}
+
+async function pollHarmonyAlertCandidate(
+  device: DeviceInfo,
+  timeoutMs: number,
+): Promise<HarmonyAlertCandidate | null> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const candidate = await readHarmonyAlertCandidate(device);
+    if (candidate) return candidate;
+    await sleep(ALERT_POLL_INTERVAL_MS);
+  }
+  return null;
+}
+
+async function readHarmonyAlertCandidate(
+  device: DeviceInfo,
+): Promise<HarmonyAlertCandidate | null> {
+  try {
+    const result = await withDiagnosticTimer(
+      'snapshot_capture',
+      async () => await snapshotHarmony(device, {}),
+      { backend: 'harmonyos-arkui', purpose: 'alert' },
+    );
+    return findHarmonyAlertCandidate(result.nodes);
+  } catch {
+    return null;
+  }
+}
+
+function findHarmonyAlertCandidate(nodes: SnapshotNode[]): HarmonyAlertCandidate | null {
+  // HarmonyOS alert detection: look for dialog/alert-like components
+  // Common alert patterns: Dialog, AlertDialog, Popup, Toast, Sheet
+  // System-specific patterns: "暂无可用打开方式", notification/privacy dialogs
+  const alertCandidates: SnapshotNode[] = [];
+
+  // First pass: find dialog containers
+  for (const node of nodes) {
+    const type = node.type?.toLowerCase() ?? '';
+    const label = node.label?.toLowerCase() ?? '';
+    const value = node.value?.toLowerCase() ?? '';
+
+    // Check for dialog/alert UI patterns
+    if (
+      type.includes('dialog') ||
+      type.includes('alert') ||
+      type.includes('popup') ||
+      label.includes('dialog') ||
+      label.includes('alert') ||
+      type.includes('modal') ||
+      type.includes('sheet')
+    ) {
+      alertCandidates.push(node);
+    }
+
+    // Check for system-specific dialog content patterns
+    if (
+      label.includes('暂无可用打开方式') ||
+      value.includes('暂无可用打开方式') ||
+      label.includes('打开方式') ||
+      value.includes('打开方式')
+    ) {
+      alertCandidates.push(node);
+    }
+
+    // Check for notification permission dialogs
+    if (
+      label.includes('通知') ||
+      value.includes('通知') ||
+      label.includes('权限') ||
+      value.includes('权限')
+    ) {
+      alertCandidates.push(node);
+    }
+
+    // Check for privacy policy dialogs
+    if (
+      label.includes('隐私') ||
+      value.includes('隐私') ||
+      label.includes('政策') ||
+      value.includes('政策') ||
+      label.includes('协议') ||
+      value.includes('协议')
+    ) {
+      alertCandidates.push(node);
+    }
+
+    // Check for update dialogs
+    if (
+      label.includes('更新') ||
+      value.includes('更新') ||
+      label.includes('升级') ||
+      value.includes('升级')
+    ) {
+      alertCandidates.push(node);
+    }
+  }
+
+  if (alertCandidates.length === 0) return null;
+
+  // Find buttons within alert candidates
+  const buttons: HarmonyAlertButton[] = [];
+  let title: string | undefined;
+  let message: string | undefined;
+
+  for (const candidate of alertCandidates) {
+    // Look for text content as title/message
+    if (candidate.label && !title) {
+      title = candidate.label;
+    }
+    if (candidate.value && !message) {
+      message = candidate.value;
+    }
+
+    // Look for button nodes
+    if (candidate.hittable && candidate.rect) {
+      const btnLabel = candidate.label ?? candidate.value ?? '';
+      const btnLabelLower = btnLabel.toLowerCase();
+      const isButton =
+        // English patterns
+        btnLabelLower.includes('ok') ||
+        btnLabelLower.includes('cancel') ||
+        btnLabelLower.includes('confirm') ||
+        btnLabelLower.includes('dismiss') ||
+        btnLabelLower.includes('yes') ||
+        btnLabelLower.includes('no') ||
+        btnLabelLower.includes('allow') ||
+        btnLabelLower.includes('deny') ||
+        btnLabelLower.includes('accept') ||
+        btnLabelLower.includes('reject') ||
+        btnLabelLower.includes('continue') ||
+        btnLabelLower.includes('close') ||
+        btnLabelLower.includes('got it') ||
+        // Chinese patterns (common in HarmonyOS)
+        btnLabel.includes('确定') ||
+        btnLabel.includes('确认') ||
+        btnLabel.includes('取消') ||
+        btnLabel.includes('是') ||
+        btnLabel.includes('否') ||
+        btnLabel.includes('允许') ||
+        btnLabel.includes('不允许') ||
+        btnLabel.includes('同意') ||
+        btnLabel.includes('拒绝') ||
+        btnLabel.includes('知道了') ||
+        btnLabel.includes('同意并继续') ||
+        btnLabel.includes('继续') ||
+        btnLabel.includes('关闭') ||
+        btnLabel.includes('稍后') ||
+        btnLabel.includes('暂不') ||
+        btnLabel.includes('下次再说') ||
+        btnLabel.includes('跳过') ||
+        candidate.type?.toLowerCase().includes('button');
+
+      if (isButton) {
+        const centerX = (candidate.rect.x ?? 0) + (candidate.rect.width ?? 0) / 2;
+        const centerY = (candidate.rect.y ?? 0) + (candidate.rect.height ?? 0) / 2;
+        buttons.push({
+          label: btnLabel,
+          x: centerX,
+          y: centerY,
+        });
+      }
+    }
+  }
+
+  if (buttons.length === 0) return null;
+
+  return {
+    alert: {
+      visible: true,
+      title,
+      message,
+      buttons,
+    },
+    nodes: alertCandidates,
+  };
+}
+
+function chooseHarmonyAlertButton(
+  buttons: HarmonyAlertButton[],
+  action: 'accept' | 'dismiss',
+): HarmonyAlertButton | null {
+  if (buttons.length === 0) return null;
+
+  const acceptPatterns = [
+    // English
+    'ok',
+    'confirm',
+    'yes',
+    'accept',
+    'allow',
+    'continue',
+    'got it',
+    'close',
+    'agree',
+    // Chinese
+    '确定',
+    '确认',
+    '是',
+    '允许',
+    '同意',
+    '同意并继续',
+    '继续',
+    '知道了',
+    '关闭',
+    '跳过',
+  ];
+  const dismissPatterns = [
+    // English
+    'cancel',
+    'dismiss',
+    'no',
+    'reject',
+    'deny',
+    'later',
+    'skip',
+    'not now',
+    // Chinese
+    '取消',
+    '否',
+    '不允许',
+    '拒绝',
+    '暂不',
+    '稍后',
+    '下次再说',
+    '跳过',
+  ];
+
+  const patterns = action === 'accept' ? acceptPatterns : dismissPatterns;
+
+  // First pass: exact match (preferred)
+  for (const button of buttons) {
+    const label = button.label.toLowerCase();
+    for (const pattern of patterns) {
+      if (label === pattern || label.includes(pattern)) {
+        return button;
+      }
+    }
+  }
+
+  // Fallback: first button for accept, last for dismiss
+  if (action === 'accept') {
+    return buttons[0];
+  }
+  return buttons[buttons.length - 1] ?? null;
+}
+
+function buildHarmonyAlertStatusResponse(alert: HarmonyAlertInfo | null): HarmonyAlertResult {
+  return {
+    kind: 'alertStatus',
+    platform: 'harmonyos',
+    action: 'get',
+    alert,
+    ...(alert ? successText('Alert visible') : successText('No alert visible')),
+  };
+}
+
+function buildHarmonyAlertHandledResponse(
+  action: 'accept' | 'dismiss',
+  alert: HarmonyAlertInfo,
+  button: string,
+): HarmonyAlertResult {
+  return {
+    kind: 'alertHandled',
+    platform: 'harmonyos',
+    action,
+    handled: true,
+    alert,
+    button,
+    ...successText(`Alert ${action}ed`),
+  };
+}
+
+/**
+ * Auto-dismiss common HarmonyOS system dialogs that appear during app launch.
+ * This handles:
+ * - "暂无可用打开方式" (No available opening method)
+ * - Notification permission dialogs
+ * - Privacy policy dialogs
+ * - Update prompts
+ *
+ * @param device Device info
+ * @param maxAttempts Maximum number of attempts to dismiss dialogs
+ * @returns Number of dialogs dismissed
+ */
+export async function dismissHarmonySystemDialogs(
+  device: DeviceInfo,
+  maxAttempts: number = 3,
+): Promise<number> {
+  let dismissedCount = 0;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const candidate = await readHarmonyAlertCandidate(device);
+    if (!candidate) {
+      // No dialog visible
+      break;
+    }
+
+    const { alert } = candidate;
+    const title = (alert.title ?? '').toLowerCase();
+    const message = (alert.message ?? '').toLowerCase();
+
+    // Check for known system dialog patterns
+    const isSystemDialog =
+      title.includes('暂无可用打开方式') ||
+      message.includes('暂无可用打开方式') ||
+      title.includes('打开方式') ||
+      message.includes('打开方式') ||
+      title.includes('通知') ||
+      message.includes('通知') ||
+      title.includes('权限') ||
+      message.includes('权限') ||
+      title.includes('隐私') ||
+      message.includes('隐私') ||
+      title.includes('更新') ||
+      message.includes('更新');
+
+    if (!isSystemDialog) {
+      // Not a system dialog, stop
+      break;
+    }
+
+    // Try to dismiss by accepting (most system dialogs have "确定" or "知道了")
+    const button = chooseHarmonyAlertButton(alert.buttons, 'accept');
+    if (button) {
+      await pressHarmony(device, button.x, button.y);
+      dismissedCount++;
+      // Small delay to let dialog dismiss
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    } else {
+      // No button found, try back
+      await pressBackHarmony(device);
+      dismissedCount++;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+
+  return dismissedCount;
+}

--- a/src/platforms/harmonyos/app-lifecycle.ts
+++ b/src/platforms/harmonyos/app-lifecycle.ts
@@ -1,0 +1,358 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import type { BackendAppInfo, BackendAppState } from '../../backend.ts';
+import type { AppsFilter } from '../../commands/app-inventory-contract.ts';
+import { runHarmonyHdc } from './hdc.ts';
+import { parseHarmonyBundleList, parseHarmonyForegroundAbility } from './app-parsers.ts';
+import { dismissHarmonySystemDialogs } from './alert.ts';
+import { lookupHarmonyLaunchAbility, getHarmonyLaunchAbilities } from './launch-abilities.ts';
+
+export async function listHarmonyApps(
+  device: DeviceInfo,
+  _filter: AppsFilter,
+): Promise<readonly BackendAppInfo[]> {
+  const result = await runHarmonyHdc(device, ['shell', 'bm', 'dump', '-a'], {
+    allowFailure: false,
+    timeoutMs: 15_000,
+  });
+
+  const bundles = parseHarmonyBundleList(result.stdout);
+  const launchAbilities = await getHarmonyLaunchAbilities(device);
+
+  return bundles.map((bundle) => {
+    const launchAbility = launchAbilities.get(bundle);
+    return {
+      id: bundle,
+      name: bundle.split('.').pop() ?? bundle,
+      bundleId: bundle,
+      ...(launchAbility ? { activity: launchAbility } : {}),
+    };
+  });
+}
+
+export async function openHarmonyApp(
+  device: DeviceInfo,
+  bundleName: string,
+  abilityName?: string,
+  moduleName?: string,
+): Promise<void> {
+  // Check for screen lock first
+  await checkAndHandleScreenLock(device);
+
+  const resolved = await resolveHarmonyApp(device, bundleName);
+
+  // Strategy 1: Try with specified ability if provided
+  if (abilityName) {
+    const success = await tryOpenWithAbility(device, resolved, abilityName, moduleName);
+    if (success) {
+      await handlePostLaunchDialogs(device);
+      return;
+    }
+  }
+
+  // Strategy 2: Resolve launch ability via wukong appinfo (DevEco / device catalog)
+  const wukongAbility = await lookupHarmonyLaunchAbility(device, resolved);
+  if (wukongAbility) {
+    const successWukong = await tryOpenWithAbility(device, resolved, wukongAbility, moduleName);
+    if (successWukong) {
+      await handlePostLaunchDialogs(device);
+      return;
+    }
+  }
+
+  // Strategy 3: Try with MainAbility (common default)
+  const successMain = await tryOpenWithAbility(device, resolved, 'MainAbility', moduleName);
+  if (successMain) {
+    await handlePostLaunchDialogs(device);
+    return;
+  }
+
+  // Strategy 4: Try EntryAbility (common for third-party apps)
+  const successEntry = await tryOpenWithAbility(device, resolved, 'EntryAbility', moduleName);
+  if (successEntry) {
+    await handlePostLaunchDialogs(device);
+    return;
+  }
+
+  // Strategy 5: Try without specifying ability (let system decide)
+  const successDefault = await tryOpenWithoutAbility(device, resolved, moduleName);
+  if (successDefault) {
+    await handlePostLaunchDialogs(device);
+    return;
+  }
+
+  throw new AppError('COMMAND_FAILED', `Failed to open app ${resolved} after multiple attempts`);
+}
+
+async function tryOpenWithAbility(
+  device: DeviceInfo,
+  bundleName: string,
+  abilityName: string,
+  moduleName?: string,
+): Promise<boolean> {
+  // Try with the provided ability name
+  let success = await attemptStartAbility(device, bundleName, abilityName, moduleName);
+  if (success) return true;
+
+  // If ability name doesn't include a dot, try with full qualified name
+  if (!abilityName.includes('.')) {
+    const fullAbilityName = `${bundleName}.${abilityName}`;
+    success = await attemptStartAbility(device, bundleName, fullAbilityName, moduleName);
+    if (success) return true;
+  }
+
+  return false;
+}
+
+async function attemptStartAbility(
+  device: DeviceInfo,
+  bundleName: string,
+  abilityName: string,
+  moduleName?: string,
+): Promise<boolean> {
+  const args = ['shell', 'aa', 'start', '-b', bundleName, '-a', abilityName];
+  if (moduleName) {
+    args.push('-m', moduleName);
+  }
+
+  try {
+    const result = await runHarmonyHdc(device, args, { allowFailure: true, timeoutMs: 10_000 });
+    if (result.exitCode === 0) {
+      // Verify app is in foreground
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const state = await getHarmonyAppState(device);
+      if (state.state === 'foreground' && state.bundleId === bundleName) {
+        return true;
+      }
+    }
+  } catch {
+    // Ignore errors, will try next strategy
+  }
+  return false;
+}
+
+async function tryOpenWithoutAbility(
+  device: DeviceInfo,
+  bundleName: string,
+  moduleName?: string,
+): Promise<boolean> {
+  const args = ['shell', 'aa', 'start', '-b', bundleName];
+  if (moduleName) {
+    args.push('-m', moduleName);
+  }
+
+  try {
+    const result = await runHarmonyHdc(device, args, { allowFailure: true, timeoutMs: 10_000 });
+    if (result.exitCode === 0) {
+      // Verify app is in foreground
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const state = await getHarmonyAppState(device);
+      if (state.state === 'foreground' && state.bundleId === bundleName) {
+        return true;
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+  return false;
+}
+
+async function handlePostLaunchDialogs(device: DeviceInfo): Promise<void> {
+  // Small delay to let any system dialogs appear
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  // Auto-dismiss common system dialogs
+  await dismissHarmonySystemDialogs(device, 3);
+}
+
+async function checkAndHandleScreenLock(device: DeviceInfo): Promise<void> {
+  try {
+    // Check screen lock state via PowerManagerService
+    const result = await runHarmonyHdc(
+      device,
+      ['shell', 'hidumper', '-s', 'PowerManagerService', '-a', '-s'],
+      { allowFailure: true, timeoutMs: 5000 },
+    );
+
+    if (result.exitCode === 0) {
+      const output = result.stdout.toLowerCase();
+      if (output.includes('screen state: off') || output.includes('lock state: locked')) {
+        // Try to wake up screen
+        await runHarmonyHdc(device, ['shell', 'power-shell', 'wakeup'], { allowFailure: true });
+        // Try to unlock (swipe up)
+        await runHarmonyHdc(
+          device,
+          ['shell', 'uitest', 'ui-input', 'swipe', '540', '2000', '540', '800', '300'],
+          { allowFailure: true },
+        );
+        // Wait for screen to wake
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // Check again
+        const recheck = await runHarmonyHdc(
+          device,
+          ['shell', 'hidumper', '-s', 'PowerManagerService', '-a', '-s'],
+          { allowFailure: true, timeoutMs: 5000 },
+        );
+        if (recheck.stdout.toLowerCase().includes('lock state: locked')) {
+          throw new AppError(
+            'COMMAND_FAILED',
+            'Device screen is locked and could not be automatically unlocked. Please unlock the device manually.',
+          );
+        }
+      }
+    }
+  } catch (error) {
+    if (error instanceof AppError && error.code === 'COMMAND_FAILED') {
+      throw error;
+    }
+    // If we can't check screen lock, proceed anyway
+  }
+}
+
+export async function closeHarmonyApp(device: DeviceInfo, bundleName: string): Promise<void> {
+  const resolved = await resolveHarmonyApp(device, bundleName);
+
+  await runHarmonyHdc(device, ['shell', 'aa', 'force-stop', resolved], {
+    allowFailure: true,
+  });
+}
+
+export async function getHarmonyAppState(device: DeviceInfo): Promise<BackendAppState> {
+  try {
+    const result = await runHarmonyHdc(device, ['shell', 'aa', 'dump', '-l'], {
+      allowFailure: true,
+      timeoutMs: 10_000,
+    });
+
+    if (result.exitCode !== 0) {
+      return { state: 'unknown' };
+    }
+
+    const foreground = parseHarmonyForegroundAbility(result.stdout);
+    if (foreground) {
+      return {
+        bundleId: foreground.bundleName,
+        state: 'foreground',
+      };
+    }
+
+    return { state: 'unknown' };
+  } catch {
+    return { state: 'unknown' };
+  }
+}
+
+async function resolveHarmonyApp(device: DeviceInfo, app: string): Promise<string> {
+  // Known system app aliases
+  const aliases: Record<string, string> = {
+    settings: 'com.huawei.hmos.settings',
+    'com.huawei.hmos.settings': 'com.huawei.hmos.settings',
+    camera: 'com.huawei.hmos.camera',
+    browser: 'com.huawei.hmos.browser',
+    photos: 'com.huawei.hmos.photos',
+    files: 'com.huawei.hmos.filemanager',
+    notes: 'com.huawei.hmos.notes',
+    calculator: 'com.huawei.hmos.calculator',
+    clock: 'com.huawei.hmos.clock',
+    weather: 'com.huawei.hmos.weather',
+    calendar: 'com.huawei.hmos.calendar',
+    contacts: 'com.huawei.hmos.contacts',
+    phone: 'com.huawei.hmos.phone',
+    messages: 'com.huawei.hmos.mms',
+    appstore: 'com.huawei.hmos.appstore',
+    callsetting: 'com.huawei.hmos.callsetting',
+    communicationsetting: 'com.huawei.hmos.communicationsetting',
+  };
+
+  const lowerApp = app.toLowerCase();
+
+  // Check aliases first
+  if (aliases[lowerApp]) {
+    return aliases[lowerApp];
+  }
+
+  // If it looks like a full bundle name, use it directly
+  if (app.includes('.') && !app.includes(' ')) {
+    return app;
+  }
+
+  // Try fuzzy match against installed bundles
+  try {
+    const result = await runHarmonyHdc(device, ['shell', 'bm', 'dump', '-a'], {
+      allowFailure: true,
+      timeoutMs: 10_000,
+    });
+
+    if (result.exitCode === 0) {
+      const bundles = parseHarmonyBundleList(result.stdout);
+      const lower = lowerApp;
+
+      // Try substring match
+      const match = bundles.find(
+        (b) => b.toLowerCase().includes(lower) || b.toLowerCase().endsWith('.' + lower),
+      );
+
+      if (match) return match;
+    }
+  } catch {
+    // Fall through to error
+  }
+
+  throw new AppError('APP_NOT_FOUND', `Could not resolve HarmonyOS app: ${app}`);
+}
+
+export async function installHarmonyApp(device: DeviceInfo, hapPath: string): Promise<void> {
+  const result = await runHarmonyHdc(device, ['install', hapPath], {
+    allowFailure: false,
+    timeoutMs: 120_000,
+  });
+
+  if (result.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', `Failed to install app: ${result.stderr}`);
+  }
+}
+
+export async function uninstallHarmonyApp(device: DeviceInfo, bundleName: string): Promise<void> {
+  await runHarmonyHdc(device, ['uninstall', bundleName], {
+    allowFailure: true,
+  });
+}
+
+/** Wipe app data/cache via `bm clean` (resets first-run state such as privacy consent). */
+export async function clearHarmonyAppStorage(
+  device: DeviceInfo,
+  bundleName: string,
+  options?: { data?: boolean; cache?: boolean },
+): Promise<{ bundleId: string; clearedData: boolean; clearedCache: boolean }> {
+  const resolved = await resolveHarmonyApp(device, bundleName);
+  const clearData = options?.data !== false;
+  const clearCache = options?.cache !== false;
+
+  await runHarmonyHdc(device, ['shell', 'aa', 'force-stop', resolved], {
+    allowFailure: true,
+    timeoutMs: 10_000,
+  });
+
+  if (clearData) {
+    const dataResult = await runHarmonyHdc(device, ['shell', 'bm', 'clean', '-n', resolved, '-d'], {
+      allowFailure: false,
+      timeoutMs: 30_000,
+    });
+    if (dataResult.exitCode !== 0) {
+      throw new AppError(
+        'COMMAND_FAILED',
+        `Failed to clear HarmonyOS app data for ${resolved}: ${dataResult.stderr}`,
+      );
+    }
+  }
+
+  if (clearCache) {
+    await runHarmonyHdc(device, ['shell', 'bm', 'clean', '-n', resolved, '-c'], {
+      allowFailure: true,
+      timeoutMs: 30_000,
+    });
+  }
+
+  return { bundleId: resolved, clearedData: clearData, clearedCache: clearCache };
+}

--- a/src/platforms/harmonyos/app-parsers.ts
+++ b/src/platforms/harmonyos/app-parsers.ts
@@ -1,0 +1,119 @@
+export function parseHarmonyBundleList(rawOutput: string): string[] {
+  const bundles: string[] = [];
+  for (const line of rawOutput.split('\n')) {
+    const trimmed = line.trim();
+    // Match "Bundle Name: com.example.app" or just lines with bundle patterns
+    const match = trimmed.match(/Bundle\s+Name\s*[:=]\s*(\S+)/i);
+    if (match) {
+      bundles.push(match[1]);
+    } else if (trimmed.includes('.') && !trimmed.startsWith('#') && trimmed.length > 0) {
+      // Fallback: if line contains dots (like a bundle ID) and isn't a comment
+      bundles.push(trimmed);
+    }
+  }
+  return bundles;
+}
+
+export function parseHarmonyForegroundAbility(rawOutput: string): {
+  bundleName: string;
+  abilityName: string;
+} | null {
+  const lines = rawOutput.split('\n');
+  let currentBundle: string | null = null;
+  let currentAbility: string | null = null;
+  let currentAppState: string | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Look for "app name [bundleName]" pattern
+    const appMatch = trimmed.match(/app\s+name\s+\[(\S+)\]/i);
+    if (appMatch) {
+      currentBundle = appMatch[1];
+    }
+
+    // Look for "bundle name [bundleName]" pattern
+    const bundleMatch = trimmed.match(/bundle\s+name\s+\[(\S+)\]/i);
+    if (bundleMatch) {
+      currentBundle = bundleMatch[1];
+    }
+
+    // Look for "main name [abilityName]" pattern
+    const abilityMatch = trimmed.match(/main\s+name\s+\[(\S+)\]/i);
+    if (abilityMatch) {
+      currentAbility = abilityMatch[1];
+    }
+
+    // Look for "app state #FOREGROUND" pattern
+    const stateMatch = trimmed.match(/app\s+state\s+#(\S+)/i);
+    if (stateMatch) {
+      currentAppState = stateMatch[1];
+    }
+
+    // When we find a complete entry, check if it's foreground
+    if (currentBundle && currentAbility && currentAppState) {
+      if (currentAppState === 'FOREGROUND') {
+        return { bundleName: currentBundle, abilityName: currentAbility };
+      }
+      // Reset for next entry
+      currentBundle = null;
+      currentAbility = null;
+      currentAppState = null;
+    }
+  }
+
+  return null;
+}
+
+/** Parse `hdc shell wukong appinfo` bundle → launch ability pairs. */
+export function parseWukongAppInfo(rawOutput: string): Map<string, string> {
+  const abilities = new Map<string, string>();
+  let pendingBundle: string | null = null;
+
+  for (const line of rawOutput.split('\n')) {
+    const trimmed = line.trim();
+    const bundleMatch = trimmed.match(/^BundleName:\s+(\S+)/i);
+    if (bundleMatch) {
+      pendingBundle = bundleMatch[1];
+      continue;
+    }
+
+    const abilityMatch = trimmed.match(/^AbilityName:\s+(\S+)/i);
+    if (abilityMatch && pendingBundle && !abilities.has(pendingBundle)) {
+      abilities.set(pendingBundle, abilityMatch[1]);
+      pendingBundle = null;
+    }
+  }
+
+  return abilities;
+}
+
+export function lookupWukongLaunchAbility(rawOutput: string, bundleName: string): string | null {
+  return parseWukongAppInfo(rawOutput).get(bundleName) ?? null;
+}
+
+export function parseHarmonyRunningAbilities(rawOutput: string): Array<{
+  bundleName: string;
+  abilityName: string;
+}> {
+  const abilities: Array<{ bundleName: string; abilityName: string }> = [];
+  const lines = rawOutput.split('\n');
+  let currentBundle = '';
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const bundleMatch = trimmed.match(/bundle\s*[:=]\s*(\S+)/i);
+    if (bundleMatch) {
+      currentBundle = bundleMatch[1];
+    }
+    const abilityMatch = trimmed.match(/ability\s*[:=]\s*(\S+)/i);
+    if (abilityMatch && currentBundle) {
+      abilities.push({
+        bundleName: currentBundle,
+        abilityName: abilityMatch[1],
+      });
+    }
+  }
+
+  return abilities;
+}

--- a/src/platforms/harmonyos/arkui-hierarchy.ts
+++ b/src/platforms/harmonyos/arkui-hierarchy.ts
@@ -1,0 +1,290 @@
+import type { Rect, RawSnapshotNode, SnapshotOptions } from '../../utils/snapshot.ts';
+
+export type ArkUiAttributes = {
+  type?: string;
+  text?: string;
+  originalText?: string;
+  description?: string;
+  hint?: string;
+  accessibilityId?: string;
+  id?: string;
+  key?: string;
+  bounds?: string;
+  clickable?: string;
+  enabled?: string;
+  visible?: string;
+  scrollable?: string;
+  checkable?: string;
+  checked?: string;
+  selected?: string;
+  focused?: string;
+  longClickable?: string;
+  bundleName?: string;
+  abilityName?: string;
+  pagePath?: string;
+  [key: string]: string | undefined;
+};
+
+export type ArkUiNode = {
+  attributes: ArkUiAttributes;
+  children?: ArkUiNode[];
+};
+
+export type ArkUiTree = ArkUiNode[];
+
+export type ArkUiHierarchyResult = {
+  nodes: RawSnapshotNode[];
+  truncated?: boolean;
+  rawNodeCount: number;
+  maxDepth: number;
+  bundleName?: string;
+  abilityName?: string;
+};
+
+export function parseArkUiTree(json: string): ArkUiTree {
+  const parsed = JSON.parse(json);
+  // ArkUI dumpLayout can output either an array or a single root object
+  if (Array.isArray(parsed)) {
+    return parsed as ArkUiTree;
+  }
+  // If it's a single object, wrap it in an array
+  if (parsed && typeof parsed === 'object' && parsed.attributes) {
+    return [parsed as ArkUiNode];
+  }
+  throw new Error('ArkUI dumpLayout output must be a JSON array or root object');
+}
+
+export function buildArkUiSnapshot(
+  tree: ArkUiTree,
+  maxNodes: number,
+  options: SnapshotOptions,
+): ArkUiHierarchyResult {
+  let nodeIndex = 0;
+  let rawNodeCount = 0;
+  let maxDepth = 0;
+  let truncated = false;
+  let bundleName: string | undefined;
+  let abilityName: string | undefined;
+  const interactiveDescendantMemo = new WeakMap<ArkUiNode, boolean>();
+
+  const nodes: RawSnapshotNode[] = [];
+
+  function walk(
+    node: ArkUiNode,
+    depth: number,
+    parentIndex: number | null,
+    ancestorInteractive: boolean,
+  ): void {
+    rawNodeCount++;
+    if (depth > maxDepth) maxDepth = depth;
+
+    const attrs = node.attributes;
+    const type = attrs.type ?? '';
+    const isRoot = type === 'root' || type === 'WindowScene';
+
+    // Extract bundle info from root-level nodes
+    if (attrs.bundleName) bundleName = attrs.bundleName;
+    if (attrs.abilityName) abilityName = attrs.abilityName;
+
+    // Skip invisible nodes unless in raw mode
+    if (!options.raw && attrs.visible === 'false' && !isRoot) {
+      if (node.children) {
+        for (const child of node.children) {
+          walk(child, depth + 1, parentIndex, ancestorInteractive);
+        }
+      }
+      return;
+    }
+
+    // Skip empty root/WindowScene wrapper nodes, walk their children directly
+    if (isRoot && node.children) {
+      for (const child of node.children) {
+        walk(child, depth + 1, parentIndex, ancestorInteractive);
+      }
+      return;
+    }
+
+    const rect = parseArkUiBounds(attrs.bounds ?? '');
+    const hittable = attrs.clickable === 'true' || attrs.longClickable === 'true';
+    const scrollable = attrs.scrollable === 'true';
+    const text = attrs.text || attrs.originalText || '';
+    const description = attrs.description || '';
+    const label = text || description || attrs.hint || '';
+    const identifier = attrs.accessibilityId || attrs.id || attrs.key || '';
+    const enabled = attrs.enabled !== 'false';
+    const visible = attrs.visible !== 'false';
+    const descendantInteractive = hasInteractiveDescendant(node, interactiveDescendantMemo);
+
+    const shouldInclude = shouldIncludeNode(
+      {
+        type,
+        text,
+        description,
+        label,
+        identifier,
+        hittable,
+        visible,
+        scrollable,
+        ancestorInteractive,
+        descendantInteractive,
+      },
+      options,
+    );
+
+    if (!shouldInclude) {
+      if (node.children) {
+        for (const child of node.children) {
+          walk(child, depth + 1, parentIndex, ancestorInteractive || hittable || scrollable);
+        }
+      }
+      return;
+    }
+
+    const currentIndex = nodeIndex;
+    if (nodeIndex >= maxNodes) {
+      truncated = true;
+      return;
+    }
+
+    nodes.push({
+      index: currentIndex,
+      type,
+      label: label || undefined,
+      value: text || undefined,
+      identifier: identifier || undefined,
+      rect,
+      enabled,
+      hittable,
+      selected: attrs.selected === 'true' || attrs.checked === 'true',
+      focused: attrs.focused === 'true',
+      depth,
+      parentIndex: parentIndex ?? undefined,
+      bundleId: bundleName,
+    });
+
+    nodeIndex++;
+
+    if (node.children) {
+      for (const child of node.children) {
+        walk(child, depth + 1, currentIndex, ancestorInteractive || hittable || scrollable);
+      }
+    }
+  }
+
+  const scopeRoot =
+    options.raw || !options.interactiveOnly
+      ? null
+      : findBestFocusedInteractiveRoot(tree, interactiveDescendantMemo);
+
+  const roots = scopeRoot ? [scopeRoot] : tree;
+  for (const rootNode of roots) {
+    // If we're scoping to a focused modal subtree, treat it as an interactive context
+    // so proxy label nodes inside the modal are kept for targeting/verification.
+    walk(rootNode, 0, null, scopeRoot !== null);
+  }
+
+  return {
+    nodes,
+    truncated: truncated || nodeIndex >= maxNodes,
+    rawNodeCount,
+    maxDepth,
+    bundleName,
+    abilityName,
+  };
+}
+
+function shouldIncludeNode(
+  node: {
+    type: string;
+    text: string;
+    description: string;
+    label: string;
+    identifier: string;
+    hittable: boolean;
+    visible: boolean;
+    scrollable: boolean;
+    ancestorInteractive: boolean;
+    descendantInteractive: boolean;
+  },
+  options: SnapshotOptions,
+): boolean {
+  if (options.raw) return true;
+
+  if (options.interactiveOnly) {
+    if (node.hittable) return true;
+    if (node.scrollable) return true;
+    // Keep proxy label/id nodes only when they are close to interactive controls.
+    if (node.label && node.label.length > 0 && node.ancestorInteractive) return true;
+    if (node.identifier && node.identifier.length > 0 && node.descendantInteractive) return true;
+    return false;
+  }
+
+  if (options.compact) {
+    if (node.hittable) return true;
+    if (node.label && node.label.length > 0) return true;
+    if (node.identifier && node.identifier.length > 0) return true;
+    return false;
+  }
+
+  // Default: include everything that is visible
+  return node.visible;
+}
+
+function findBestFocusedInteractiveRoot(
+  tree: ArkUiTree,
+  interactiveDescendantMemo: WeakMap<ArkUiNode, boolean>,
+): ArkUiNode | null {
+  let best: { node: ArkUiNode; depth: number } | null = null;
+  const stack: Array<{ node: ArkUiNode; depth: number }> = tree.map((node) => ({ node, depth: 0 }));
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) break;
+    const { node, depth } = current;
+    const focused = node.attributes.focused === 'true';
+    if (focused && hasInteractiveDescendant(node, interactiveDescendantMemo)) {
+      if (!best || depth > best.depth) best = { node, depth };
+    }
+    for (const child of node.children ?? []) {
+      stack.push({ node: child, depth: depth + 1 });
+    }
+  }
+  return best?.node ?? null;
+}
+
+function hasInteractiveDescendant(node: ArkUiNode, memo: WeakMap<ArkUiNode, boolean>): boolean {
+  const cached = memo.get(node);
+  if (cached !== undefined) return cached;
+  const attrs = node.attributes;
+  const selfInteractive =
+    attrs.clickable === 'true' || attrs.longClickable === 'true' || attrs.scrollable === 'true';
+  if (selfInteractive) {
+    memo.set(node, true);
+    return true;
+  }
+  for (const child of node.children ?? []) {
+    if (hasInteractiveDescendant(child, memo)) {
+      memo.set(node, true);
+      return true;
+    }
+  }
+  memo.set(node, false);
+  return false;
+}
+
+const BOUNDS_RE = /^\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]$/;
+
+export function parseArkUiBounds(bounds: string): Rect | undefined {
+  if (!bounds) return undefined;
+  const match = bounds.match(BOUNDS_RE);
+  if (!match) return undefined;
+  const x1 = Number(match[1]);
+  const y1 = Number(match[2]);
+  const x2 = Number(match[3]);
+  const y2 = Number(match[4]);
+  return {
+    x: x1,
+    y: y1,
+    width: x2 - x1,
+    height: y2 - y1,
+  };
+}

--- a/src/platforms/harmonyos/clipboard.ts
+++ b/src/platforms/harmonyos/clipboard.ts
@@ -1,0 +1,48 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+/**
+ * Read clipboard text from HarmonyOS device.
+ * HarmonyOS doesn't have a direct hdc clipboard command.
+ * This implementation tries multiple approaches.
+ */
+export async function readHarmonyClipboardText(device: DeviceInfo): Promise<string> {
+  // Try using uitest clipboard API
+  const result = await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'getClipboard'], {
+    allowFailure: true,
+    timeoutMs: 10_000,
+  });
+
+  if (result.exitCode === 0 && result.stdout.trim()) {
+    return result.stdout.trim();
+  }
+
+  // Fallback: return empty string (clipboard access requires app-level implementation)
+  return '';
+}
+
+/**
+ * Write text to HarmonyOS device clipboard.
+ * HarmonyOS doesn't have a direct hdc clipboard command.
+ * This implementation tries uitest clipboard API.
+ */
+export async function writeHarmonyClipboardText(device: DeviceInfo, text: string): Promise<void> {
+  // Try using uitest clipboard API
+  const result = await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'setClipboard', text], {
+    allowFailure: true,
+    timeoutMs: 10_000,
+  });
+
+  if (result.exitCode !== 0) {
+    // Clipboard operations may require specific permissions or app context
+    throw new AppError(
+      'COMMAND_FAILED',
+      `Failed to write to HarmonyOS clipboard. Clipboard operations may require app-level implementation.`,
+      {
+        stderr: result.stderr,
+        text: text.slice(0, 100),
+      },
+    );
+  }
+}

--- a/src/platforms/harmonyos/devices.ts
+++ b/src/platforms/harmonyos/devices.ts
@@ -1,0 +1,80 @@
+import type { DeviceInfo, DeviceTarget } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import { runCmd } from '../../utils/exec.ts';
+import { harmonyDeviceForSerial } from './hdc.ts';
+
+export type HarmonyDeviceDiscoveryOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export async function listHarmonyDevices(
+  options?: HarmonyDeviceDiscoveryOptions,
+): Promise<DeviceInfo[]> {
+  const result = await runCmd('hdc', ['list', 'targets'], {
+    allowFailure: true,
+    signal: options?.signal,
+    timeoutMs: options?.timeoutMs ?? 30_000,
+  });
+
+  if (result.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', `hdc list targets failed: ${result.stderr}`);
+  }
+
+  const serials = parseHarmonyDeviceList(result.stdout);
+  const devices: DeviceInfo[] = [];
+
+  for (const serial of serials) {
+    const device = await probeHarmonyDevice(serial);
+    devices.push(device);
+  }
+
+  return devices;
+}
+
+export function parseHarmonyDeviceList(rawOutput: string): string[] {
+  return rawOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && line !== '[Empty]');
+}
+
+async function probeHarmonyDevice(serial: string): Promise<DeviceInfo> {
+  let target: DeviceTarget | undefined;
+
+  try {
+    const typeResult = await runCmd(
+      'hdc',
+      ['-t', serial, 'shell', 'param', 'get', 'const.build.characteristics'],
+      { allowFailure: true, timeoutMs: 10_000 },
+    );
+    if (typeResult.exitCode === 0) {
+      const characteristics = typeResult.stdout.trim().toLowerCase();
+      if (characteristics.includes('tv')) {
+        target = 'tv';
+      }
+    }
+  } catch {
+    // Default to mobile if probe fails
+  }
+
+  return {
+    ...harmonyDeviceForSerial(serial),
+    // Keep hdc target serial as the canonical selector (matches `hdc list targets`).
+    name: serial,
+    target: target ?? 'mobile',
+  };
+}
+
+export async function isHarmonyDeviceBooted(serial: string): Promise<boolean> {
+  try {
+    const result = await runCmd(
+      'hdc',
+      ['-t', serial, 'shell', 'param', 'get', 'const.sys.boot_completed'],
+      { allowFailure: true, timeoutMs: 5_000 },
+    );
+    return result.exitCode === 0 && result.stdout.trim() === 'true';
+  } catch {
+    return false;
+  }
+}

--- a/src/platforms/harmonyos/hdc-executor.ts
+++ b/src/platforms/harmonyos/hdc-executor.ts
@@ -1,0 +1,124 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { DeviceInfo } from '../../utils/device.ts';
+import {
+  runCmd,
+  withCommandExecutorOverride,
+  withoutCommandExecutorOverride,
+  type CommandExecutorOverride,
+  type ExecOptions,
+  type ExecResult,
+} from '../../utils/exec.ts';
+
+export type HarmonyHdcExecutorOptions = Pick<
+  ExecOptions,
+  'allowFailure' | 'timeoutMs' | 'binaryStdout' | 'stdin' | 'signal'
+>;
+
+export type HarmonyHdcExecutorResult = Pick<
+  ExecResult,
+  'exitCode' | 'stdout' | 'stderr' | 'stdoutBuffer'
+>;
+
+/**
+ * Runs device-scoped hdc arguments after the device serial has been selected.
+ */
+export type HarmonyHdcExecutor = (
+  args: string[],
+  options?: HarmonyHdcExecutorOptions,
+) => Promise<HarmonyHdcExecutorResult>;
+
+export type HarmonyHdcProvider = {
+  exec: HarmonyHdcExecutor;
+};
+
+export type HarmonyHdcProviderScopeOptions = {
+  serial: string;
+};
+
+type HarmonyHdcProviderScope = {
+  provider: HarmonyHdcProvider;
+  serial: string;
+};
+
+const harmonyHdcProviderScope = new AsyncLocalStorage<HarmonyHdcProviderScope>();
+
+export function createDeviceHdcExecutor(device: DeviceInfo): HarmonyHdcExecutor {
+  return createSerialHdcExecutor(device.id);
+}
+
+function createSerialHdcExecutor(serial: string): HarmonyHdcExecutor {
+  return async (args, options) =>
+    await withoutCommandExecutorOverride(
+      async () => await runCmd('hdc', ['-t', serial, ...args], options),
+    );
+}
+
+export function createLocalHarmonyHdcProvider(device: DeviceInfo): HarmonyHdcProvider {
+  return {
+    exec: createDeviceHdcExecutor(device),
+  };
+}
+
+export function resolveHarmonyHdcExecutor(
+  device: DeviceInfo,
+  executor?: HarmonyHdcExecutor,
+): HarmonyHdcExecutor {
+  const scoped = harmonyHdcProviderScope.getStore();
+  if (executor) return executor;
+  if (scoped?.serial === device.id) return scoped.provider.exec;
+  return createDeviceHdcExecutor(device);
+}
+
+export function resolveHarmonyHdcProvider(
+  device: DeviceInfo,
+  provider?: HarmonyHdcProvider | HarmonyHdcExecutor,
+): HarmonyHdcProvider {
+  if (provider) return normalizeHarmonyHdcProvider(provider);
+  const scoped = harmonyHdcProviderScope.getStore();
+  return scoped?.serial === device.id
+    ? normalizeHarmonyHdcProvider(scoped.provider)
+    : createLocalHarmonyHdcProvider(device);
+}
+
+export async function withHarmonyHdcProvider<T>(
+  provider: HarmonyHdcProvider | HarmonyHdcExecutor | undefined,
+  options: HarmonyHdcProviderScopeOptions,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!provider) return await fn();
+  const normalized = typeof provider === 'function' ? { exec: provider } : provider;
+  const scope = { provider: normalized, serial: options.serial };
+  const override = createHarmonyCommandExecutorOverride(scope);
+  return await harmonyHdcProviderScope.run(
+    scope,
+    async () => await withCommandExecutorOverride(override, fn),
+  );
+}
+
+function createHarmonyCommandExecutorOverride(
+  scope: HarmonyHdcProviderScope,
+): CommandExecutorOverride {
+  return (cmd, args, options) => {
+    if (cmd !== 'hdc') return undefined;
+    const providerArgs = stripHdcSerialArgs(args, scope.serial);
+    if (!providerArgs) return undefined;
+    return withoutCommandExecutorOverride(
+      async () => await scope.provider.exec(providerArgs, options),
+    );
+  };
+}
+
+function stripHdcSerialArgs(args: string[], expectedSerial: string): string[] | undefined {
+  if (args[0] !== '-t' || !args[1]) return undefined;
+  if (args[1] !== expectedSerial) return undefined;
+  return args.slice(2);
+}
+
+function normalizeHarmonyHdcProvider(
+  provider: HarmonyHdcProvider | HarmonyHdcExecutor,
+): HarmonyHdcProvider {
+  if (typeof provider === 'function') {
+    return { exec: provider };
+  }
+  return provider;
+}

--- a/src/platforms/harmonyos/hdc.ts
+++ b/src/platforms/harmonyos/hdc.ts
@@ -1,0 +1,27 @@
+import { whichCmd } from '../../utils/exec.ts';
+import { AppError } from '../../utils/errors.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import { resolveHarmonyHdcExecutor } from './hdc-executor.ts';
+
+export async function runHarmonyHdc(
+  device: DeviceInfo,
+  args: string[],
+  options?: import('./hdc-executor.ts').HarmonyHdcExecutorOptions,
+): Promise<import('./hdc-executor.ts').HarmonyHdcExecutorResult> {
+  return await resolveHarmonyHdcExecutor(device)(args, options);
+}
+
+export function harmonyDeviceForSerial(serial: string): DeviceInfo {
+  return {
+    platform: 'harmonyos',
+    id: serial,
+    name: serial,
+    kind: 'device',
+    booted: true,
+  };
+}
+
+export async function ensureHdc(): Promise<void> {
+  const hdcAvailable = await whichCmd('hdc');
+  if (!hdcAvailable) throw new AppError('TOOL_MISSING', 'hdc not found in PATH');
+}

--- a/src/platforms/harmonyos/input-actions.ts
+++ b/src/platforms/harmonyos/input-actions.ts
@@ -1,0 +1,263 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import type { Point } from '../../utils/snapshot.ts';
+import { runHarmonyHdc } from './hdc.ts';
+import { buildScrollGesturePlan, type ScrollDirection } from '../../core/scroll-gesture.ts';
+import { AppError } from '../../utils/errors.ts';
+import type { DeviceRotation } from '../../core/device-rotation.ts';
+
+export async function pressHarmony(device: DeviceInfo, x: number, y: number): Promise<void> {
+  await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'click', String(x), String(y)]);
+}
+
+export async function doubleTapHarmony(device: DeviceInfo, x: number, y: number): Promise<void> {
+  // Use uitest native doubleClick command
+  await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'doubleClick', String(x), String(y)]);
+}
+
+export async function rotateHarmony(device: DeviceInfo, orientation: DeviceRotation): Promise<void> {
+  // HarmonyOS rotation via hidumper setting to DisplayManagerService
+  // Orientation values: 0 = portrait, 1 = landscape-left, 2 = portrait-upside-down, 3 = landscape-right
+  const rotationValue = mapRotationToValue(orientation);
+
+  // Try using hidumper to set rotation
+  const result = await runHarmonyHdc(
+    device,
+    ['shell', 'hidumper', '-s', 'DisplayManagerService', '-a', `SetScreenRotation ${rotationValue}`],
+    { allowFailure: true, timeoutMs: 10_000 },
+  );
+
+  if (result.exitCode !== 0 || result.stderr.includes('error')) {
+    // Fallback: try param set
+    const paramResult = await runHarmonyHdc(
+      device,
+      ['shell', 'param', 'set', 'persist.sys.display.orientation', String(rotationValue)],
+      { allowFailure: true, timeoutMs: 10_000 },
+    );
+
+    if (paramResult.exitCode !== 0) {
+      throw new AppError(
+        'UNSUPPORTED_OPERATION',
+        'HarmonyOS screen rotation requires system-level permissions. Rotation control is not available via HDC.',
+      );
+    }
+  }
+}
+
+function mapRotationToValue(orientation: DeviceRotation): number {
+  switch (orientation) {
+    case 'portrait':
+      return 0;
+    case 'landscape-left':
+      return 1;
+    case 'portrait-upside-down':
+      return 2;
+    case 'landscape-right':
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+export async function getHarmonyKeyboardState(
+  device: DeviceInfo,
+): Promise<{ visible: boolean; height?: number }> {
+  // Check keyboard visibility via WindowManagerService dump
+  const result = await runHarmonyHdc(
+    device,
+    ['shell', 'hidumper', '-s', 'WindowManagerService', '-a', '-a'],
+    { allowFailure: true, timeoutMs: 10_000 },
+  );
+
+  if (result.exitCode !== 0) {
+    return { visible: false };
+  }
+
+  // Look for softKeyboard window with non-zero height
+  const lines = result.stdout.split('\n');
+  for (const line of lines) {
+    if (line.includes('softKeyboard') || line.includes('Keyboard')) {
+      // Parse the window rect [ x y w h ]
+      const rectMatch = line.match(/\[\s*\d+\s+\d+\s+\d+\s+(\d+)\s*\]/);
+      if (rectMatch) {
+        const height = Number(rectMatch[1]);
+        if (height > 0) {
+          return { visible: true, height };
+        }
+      }
+    }
+  }
+
+  return { visible: false };
+}
+
+export async function dismissHarmonyKeyboard(device: DeviceInfo): Promise<void> {
+  // Dismiss keyboard by pressing Back key
+  await pressBackHarmony(device);
+}
+
+export async function longPressHarmony(
+  device: DeviceInfo,
+  x: number,
+  y: number,
+  durationMs: number = 1000,
+): Promise<void> {
+  // Long press = swipe to same point with duration
+  await runHarmonyHdc(device, [
+    'shell',
+    'uitest',
+    'uiInput',
+    'swipe',
+    String(x),
+    String(y),
+    String(x),
+    String(y),
+    String(durationMs),
+  ]);
+}
+
+export async function swipeHarmony(
+  device: DeviceInfo,
+  from: Point,
+  to: Point,
+  durationMs?: number,
+): Promise<void> {
+  const args = [
+    'shell',
+    'uitest',
+    'uiInput',
+    'swipe',
+    String(from.x),
+    String(from.y),
+    String(to.x),
+    String(to.y),
+  ];
+  if (durationMs !== undefined) {
+    args.push(String(durationMs));
+  }
+  await runHarmonyHdc(device, args);
+}
+
+export async function typeHarmony(device: DeviceInfo, text: string): Promise<void> {
+  await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'text', text]);
+}
+
+export async function fillHarmony(
+  device: DeviceInfo,
+  point: Point,
+  text: string,
+  delayMs: number = 100,
+): Promise<void> {
+  // Tap to focus, then type
+  await pressHarmony(device, point.x, point.y);
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+  await typeHarmony(device, text);
+}
+
+export async function scrollHarmony(
+  device: DeviceInfo,
+  direction: ScrollDirection,
+  options?: { amount?: number; pixels?: number },
+): Promise<Record<string, unknown>> {
+  const size = await getHarmonyScreenSize(device);
+  const plan = buildScrollGesturePlan({
+    direction,
+    amount: options?.amount,
+    pixels: options?.pixels,
+    referenceWidth: size.width,
+    referenceHeight: size.height,
+  });
+
+  await swipeHarmony(device, { x: plan.x1, y: plan.y1 }, { x: plan.x2, y: plan.y2 }, 300);
+  return plan;
+}
+
+export async function getHarmonyScreenSize(
+  device: DeviceInfo,
+): Promise<{ width: number; height: number }> {
+  // Method 1: Try to get display resolution via param get
+  const paramResult = await runHarmonyHdc(
+    device,
+    ['shell', 'param', 'get', 'const.display.resolution'],
+    { allowFailure: true, timeoutMs: 10_000 },
+  );
+
+  if (paramResult.exitCode === 0 && paramResult.stdout.trim()) {
+    const match = paramResult.stdout.match(/(\d+)\s*[x*]\s*(\d+)/);
+    if (match) {
+      return { width: Number(match[1]), height: Number(match[2]) };
+    }
+  }
+
+  // Method 2: Try getWindowInfo for screen dimensions
+  const windowResult = await runHarmonyHdc(
+    device,
+    ['shell', 'uitest', 'getWindowInfo'],
+    { allowFailure: true, timeoutMs: 10_000 },
+  );
+
+  if (windowResult.exitCode === 0 && windowResult.stdout.trim()) {
+    try {
+      const info = JSON.parse(windowResult.stdout);
+      if (info.width && info.height) {
+        return { width: info.width, height: info.height };
+      }
+      // Some versions may have windowRect
+      if (info.windowRect) {
+        const rect = info.windowRect;
+        return { width: rect.right - rect.left, height: rect.bottom - rect.top };
+      }
+    } catch {
+      // JSON parse failed, continue to next method
+    }
+  }
+
+  // Method 3: Parse from snapshot dumpLayout root bounds
+  const { snapshotHarmony } = await import('./snapshot.ts');
+  const snapshot = await snapshotHarmony(device, { raw: true, maxNodes: 1 });
+
+  // Find the root node with the largest bounds (typically full screen)
+  let maxWidth = 0;
+  let maxHeight = 0;
+  for (const node of snapshot.nodes ?? []) {
+    const rect = node.rect;
+    if (rect && rect.width > maxWidth && rect.height > maxHeight) {
+      maxWidth = rect.width;
+      maxHeight = rect.height;
+    }
+  }
+
+  if (maxWidth > 0 && maxHeight > 0) {
+    return { width: maxWidth, height: maxHeight };
+  }
+
+  throw new AppError(
+    'COMMAND_FAILED',
+    'Unable to read HarmonyOS screen size. Please ensure device is connected and accessible.',
+  );
+}
+
+export async function pressBackHarmony(device: DeviceInfo): Promise<void> {
+  await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'keyEvent', 'Back']);
+}
+
+export async function pressHomeHarmony(device: DeviceInfo): Promise<void> {
+  await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'keyEvent', 'Home']);
+}
+
+export async function pressKeyHarmony(device: DeviceInfo, key: string): Promise<void> {
+  await runHarmonyHdc(device, ['shell', 'uitest', 'uiInput', 'keyEvent', key]);
+}
+
+export async function focusHarmony(device: DeviceInfo, x: number, y: number): Promise<void> {
+  await pressHarmony(device, x, y);
+}
+
+export async function readHarmonyTextAtPoint(
+  _device: DeviceInfo,
+  _x: number,
+  _y: number,
+): Promise<string> {
+  // HarmonyOS doesn't have a direct text read API via uitest
+  // Return empty string for now - text reading would require snapshot parsing
+  return '';
+}

--- a/src/platforms/harmonyos/launch-abilities.ts
+++ b/src/platforms/harmonyos/launch-abilities.ts
@@ -1,0 +1,51 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import { parseWukongAppInfo } from './app-parsers.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+const LAUNCH_ABILITY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type LaunchAbilityCacheEntry = {
+  fetchedAt: number;
+  abilities: Map<string, string>;
+};
+
+const launchAbilityCache = new Map<string, LaunchAbilityCacheEntry>();
+
+export function clearHarmonyLaunchAbilityCache(deviceId?: string): void {
+  if (deviceId) {
+    launchAbilityCache.delete(deviceId);
+    return;
+  }
+  launchAbilityCache.clear();
+}
+
+export async function getHarmonyLaunchAbilities(device: DeviceInfo): Promise<Map<string, string>> {
+  const cached = launchAbilityCache.get(device.id);
+  if (cached && Date.now() - cached.fetchedAt < LAUNCH_ABILITY_CACHE_TTL_MS) {
+    return cached.abilities;
+  }
+
+  const result = await runHarmonyHdc(device, ['shell', 'wukong', 'appinfo'], {
+    allowFailure: true,
+    timeoutMs: 15_000,
+  });
+
+  if (result.exitCode !== 0) {
+    return cached?.abilities ?? new Map();
+  }
+
+  const abilities = parseWukongAppInfo(result.stdout);
+  launchAbilityCache.set(device.id, {
+    fetchedAt: Date.now(),
+    abilities,
+  });
+  return abilities;
+}
+
+export async function lookupHarmonyLaunchAbility(
+  device: DeviceInfo,
+  bundleName: string,
+): Promise<string | null> {
+  const abilities = await getHarmonyLaunchAbilities(device);
+  return abilities.get(bundleName) ?? null;
+}

--- a/src/platforms/harmonyos/logcat.ts
+++ b/src/platforms/harmonyos/logcat.ts
@@ -1,0 +1,43 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+export type HarmonyLogOptions = {
+  level?: 'D' | 'I' | 'W' | 'E' | 'F';
+  tag?: string;
+  clear?: boolean;
+  lines?: number;
+  signal?: AbortSignal;
+};
+
+export async function readHarmonyLogs(
+  device: DeviceInfo,
+  options?: HarmonyLogOptions,
+): Promise<string> {
+  if (options?.clear) {
+    await runHarmonyHdc(device, ['shell', 'hilog', '-c'], { allowFailure: true });
+  }
+
+  const args = ['shell', 'hilog'];
+
+  if (options?.lines) {
+    args.push('-n', String(options.lines));
+  }
+  if (options?.level) {
+    args.push('-L', options.level);
+  }
+  if (options?.tag) {
+    args.push('-t', options.tag);
+  }
+
+  const result = await runHarmonyHdc(device, args, {
+    allowFailure: false,
+    timeoutMs: 10_000,
+    signal: options?.signal,
+  });
+
+  return result.stdout;
+}
+
+export async function clearHarmonyLogs(device: DeviceInfo): Promise<void> {
+  await runHarmonyHdc(device, ['shell', 'hilog', '-c'], { allowFailure: true });
+}

--- a/src/platforms/harmonyos/perf.ts
+++ b/src/platforms/harmonyos/perf.ts
@@ -1,0 +1,51 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+export type HarmonyPerfResult = {
+  cpu?: string;
+  memory?: string;
+  processes?: string;
+  raw?: Record<string, string>;
+};
+
+export async function measureHarmonyPerf(device: DeviceInfo): Promise<HarmonyPerfResult> {
+  const result: HarmonyPerfResult = { raw: {} };
+
+  // CPU info
+  try {
+    const cpuResult = await runHarmonyHdc(device, ['shell', 'hidumper', '-c', 'cpudump'], {
+      allowFailure: true,
+      timeoutMs: 10_000,
+    });
+    result.cpu = cpuResult.stdout;
+    result.raw!.cpu = cpuResult.stdout;
+  } catch {
+    // CPU dump not available
+  }
+
+  // Memory info
+  try {
+    const memResult = await runHarmonyHdc(device, ['shell', 'hidumper', '-m'], {
+      allowFailure: true,
+      timeoutMs: 10_000,
+    });
+    result.memory = memResult.stdout;
+    result.raw!.memory = memResult.stdout;
+  } catch {
+    // Memory dump not available
+  }
+
+  // Process list
+  try {
+    const psResult = await runHarmonyHdc(device, ['shell', 'ps', '-ef'], {
+      allowFailure: true,
+      timeoutMs: 10_000,
+    });
+    result.processes = psResult.stdout;
+    result.raw!.processes = psResult.stdout;
+  } catch {
+    // Process list not available
+  }
+
+  return result;
+}

--- a/src/platforms/harmonyos/recording.ts
+++ b/src/platforms/harmonyos/recording.ts
@@ -1,0 +1,36 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+export async function startHarmonyRecording(device: DeviceInfo, remotePath: string): Promise<void> {
+  // HarmonyOS screen recording via hdc shell screenrecord
+  // This command may not be available on all devices
+  await runHarmonyHdc(device, ['shell', 'screenrecord', '--output', remotePath], {
+    allowFailure: true,
+    timeoutMs: 5_000,
+  });
+}
+
+export async function stopHarmonyRecording(
+  device: DeviceInfo,
+  remotePath: string,
+  localPath: string,
+): Promise<void> {
+  // Stop recording (kill the screenrecord process)
+  await runHarmonyHdc(device, ['shell', 'aa', 'force-stop', 'com.ohos.screenrecorder'], {
+    allowFailure: true,
+  });
+
+  // Pull the recording file
+  try {
+    await runHarmonyHdc(device, ['file', 'recv', remotePath, localPath], {
+      allowFailure: false,
+      timeoutMs: 30_000,
+    });
+  } catch {
+    throw new AppError('COMMAND_FAILED', 'Failed to retrieve recording file');
+  }
+
+  // Cleanup remote
+  await runHarmonyHdc(device, ['shell', 'rm', '-f', remotePath], { allowFailure: true });
+}

--- a/src/platforms/harmonyos/screenshot.ts
+++ b/src/platforms/harmonyos/screenshot.ts
@@ -1,0 +1,38 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import type { DeviceInfo } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+export async function screenshotHarmony(device: DeviceInfo, outPath: string): Promise<void> {
+  const uuid = randomUUID();
+  const remotePath = `/data/local/tmp/hd-screen-${uuid}.jpeg`;
+
+  // Step 1: Capture screenshot on device
+  const captureResult = await runHarmonyHdc(
+    device,
+    ['shell', 'snapshot_display', '-f', remotePath],
+    { allowFailure: false, timeoutMs: 15_000 },
+  );
+
+  if (captureResult.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', `snapshot_display failed: ${captureResult.stderr}`);
+  }
+
+  // Step 2: Pull to local
+  await runHarmonyHdc(device, ['file', 'recv', remotePath, outPath], {
+    allowFailure: false,
+    timeoutMs: 15_000,
+  });
+
+  // Step 3: Cleanup remote file
+  await runHarmonyHdc(device, ['shell', 'rm', '-f', remotePath], {
+    allowFailure: true,
+  });
+
+  // Verify JPEG signature
+  const buffer = await fs.readFile(outPath);
+  if (buffer.length < 3 || buffer[0] !== 0xff || buffer[1] !== 0xd8 || buffer[2] !== 0xff) {
+    throw new AppError('COMMAND_FAILED', 'Screenshot data is not a valid JPEG');
+  }
+}

--- a/src/platforms/harmonyos/settings.ts
+++ b/src/platforms/harmonyos/settings.ts
@@ -1,0 +1,217 @@
+import { AppError } from '../../utils/errors.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import {
+  parsePermissionAction,
+  parsePermissionTarget,
+  type SettingOptions,
+} from '../permission-utils.ts';
+import { parseAppearanceAction } from '../appearance.ts';
+import { parseSettingState } from '../setting-state.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+export async function setHarmonySetting(
+  device: DeviceInfo,
+  setting: string,
+  state: string,
+  appPackage?: string,
+  options?: SettingOptions,
+): Promise<Record<string, unknown> | void> {
+  const normalized = setting.toLowerCase();
+  switch (normalized) {
+    case 'wifi': {
+      const enabled = parseSettingState(state);
+      // HarmonyOS uses param to control network settings
+      await runHarmonyHdc(device, [
+        'shell',
+        'param',
+        'set',
+        'persist.sys.wifi.enabled',
+        enabled ? 'true' : 'false',
+      ]);
+      return;
+    }
+    case 'airplane': {
+      const enabled = parseSettingState(state);
+      await runHarmonyHdc(device, [
+        'shell',
+        'param',
+        'set',
+        'persist.sys.airplane_mode',
+        enabled ? 'true' : 'false',
+      ]);
+      return;
+    }
+    case 'location': {
+      const enabled = parseSettingState(state);
+      await runHarmonyHdc(device, [
+        'shell',
+        'param',
+        'set',
+        'persist.sys.location.enabled',
+        enabled ? 'true' : 'false',
+      ]);
+      return;
+    }
+    case 'animations': {
+      const enabled = parseSettingState(state);
+      const scale = enabled ? '1' : '0';
+      await runHarmonyHdc(device, ['shell', 'param', 'set', 'persist.sys.animation.scale', scale]);
+      return { scale };
+    }
+    case 'appearance': {
+      const target = await resolveHarmonyAppearanceTarget(device, state);
+      await runHarmonyHdc(device, ['shell', 'param', 'set', 'persist.sys.appearance.mode', target]);
+      return;
+    }
+    case 'permission': {
+      if (!appPackage) {
+        throw new AppError('INVALID_ARGS', 'permission setting requires an active app in session');
+      }
+      const action = parsePermissionAction(state);
+      const target = parseHarmonyPermissionTarget(options?.permissionTarget);
+      await setHarmonyPermission(device, appPackage, action, target);
+      return;
+    }
+    case 'bluetooth': {
+      const enabled = parseSettingState(state);
+      await runHarmonyHdc(device, [
+        'shell',
+        'param',
+        'set',
+        'persist.sys.bluetooth.enabled',
+        enabled ? 'true' : 'false',
+      ]);
+      return;
+    }
+    case 'volume': {
+      const level = Math.max(0, Math.min(100, Number.parseInt(state, 10)));
+      if (!Number.isFinite(level)) {
+        throw new AppError('INVALID_ARGS', `Invalid volume level: ${state}. Use 0-100.`);
+      }
+      await runHarmonyHdc(device, [
+        'shell',
+        'param',
+        'set',
+        'persist.sys.volume.media',
+        String(level),
+      ]);
+      return { level };
+    }
+    case 'brightness': {
+      const level = Math.max(0, Math.min(100, Number.parseInt(state, 10)));
+      if (!Number.isFinite(level)) {
+        throw new AppError('INVALID_ARGS', `Invalid brightness level: ${state}. Use 0-100.`);
+      }
+      await runHarmonyHdc(device, [
+        'shell',
+        'param',
+        'set',
+        'persist.sys.brightness',
+        String(level),
+      ]);
+      return { level };
+    }
+    default:
+      throw new AppError('INVALID_ARGS', `Unsupported HarmonyOS setting: ${setting}`);
+  }
+}
+
+async function resolveHarmonyAppearanceTarget(device: DeviceInfo, state: string): Promise<string> {
+  const action = parseAppearanceAction(state);
+  if (action !== 'toggle') return action;
+
+  const currentResult = await runHarmonyHdc(
+    device,
+    ['shell', 'param', 'get', 'persist.sys.appearance.mode'],
+    { allowFailure: true },
+  );
+
+  if (currentResult.exitCode !== 0) {
+    // Default to dark if we can't read current state
+    return 'dark';
+  }
+
+  const current = currentResult.stdout.trim().toLowerCase();
+  return current === 'dark' ? 'light' : 'dark';
+}
+
+function parseHarmonyPermissionTarget(permissionTarget: string | undefined): string {
+  const normalized = parsePermissionTarget(permissionTarget);
+  // HarmonyOS permission names differ from Android
+  const harmonyPermissions: Record<string, string> = {
+    camera: 'ohos.permission.CAMERA',
+    microphone: 'ohos.permission.MICROPHONE',
+    photos: 'ohos.permission.READ_MEDIA',
+    contacts: 'ohos.permission.READ_CONTACTS',
+    notifications: 'ohos.permission.NOTIFICATION_CONTROLLER',
+  };
+
+  const permission = harmonyPermissions[normalized];
+  if (!permission) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Unsupported permission target on HarmonyOS: ${permissionTarget}. Use camera|microphone|photos|contacts|notifications.`,
+    );
+  }
+  return permission;
+}
+
+async function setHarmonyPermission(
+  device: DeviceInfo,
+  appPackage: string,
+  action: 'grant' | 'deny' | 'reset',
+  permission: string,
+): Promise<void> {
+  // HarmonyOS permission management uses different commands than Android
+  // This is a simplified implementation - actual HarmonyOS may need specific APIs
+  if (action === 'reset') {
+    throw new AppError(
+      'UNSUPPORTED_OPERATION',
+      'HarmonyOS permission reset is not yet implemented',
+    );
+  }
+
+  // Try using bm tool for permission management (if available)
+  const result = await runHarmonyHdc(
+    device,
+    ['shell', 'bm', 'grant-permission', '-n', appPackage, '-p', permission],
+    { allowFailure: true },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new AppError('COMMAND_FAILED', `Failed to set HarmonyOS permission: ${result.stderr}`, {
+      appPackage,
+      permission,
+      action,
+    });
+  }
+}
+
+export async function getHarmonySetting(device: DeviceInfo, setting: string): Promise<string> {
+  const normalized = setting.toLowerCase();
+  const paramMap: Record<string, string> = {
+    wifi: 'persist.sys.wifi.enabled',
+    airplane: 'persist.sys.airplane_mode',
+    location: 'persist.sys.location.enabled',
+    animations: 'persist.sys.animation.scale',
+    appearance: 'persist.sys.appearance.mode',
+    bluetooth: 'persist.sys.bluetooth.enabled',
+    volume: 'persist.sys.volume.media',
+    brightness: 'persist.sys.brightness',
+  };
+
+  const paramKey = paramMap[normalized];
+  if (!paramKey) {
+    throw new AppError('INVALID_ARGS', `Unsupported HarmonyOS setting: ${setting}`);
+  }
+
+  const result = await runHarmonyHdc(device, ['shell', 'param', 'get', paramKey], {
+    allowFailure: true,
+  });
+
+  if (result.exitCode !== 0) {
+    return '';
+  }
+
+  return result.stdout.trim();
+}

--- a/src/platforms/harmonyos/snapshot.ts
+++ b/src/platforms/harmonyos/snapshot.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type { DeviceInfo } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import type { SnapshotOptions } from '../../utils/snapshot.ts';
+import { attachRefs, type SnapshotNode } from '../../utils/snapshot.ts';
+import { runHarmonyHdc } from './hdc.ts';
+import {
+  parseArkUiTree,
+  buildArkUiSnapshot,
+  type ArkUiHierarchyResult,
+} from './arkui-hierarchy.ts';
+import { ensureHarmonyUitestReady } from './uitest-preflight.ts';
+
+const DEFAULT_MAX_NODES = 5000;
+
+export type HarmonySnapshotResult = ArkUiHierarchyResult & {
+  nodes: SnapshotNode[];
+  backend: 'harmonyos-arkui';
+};
+
+export async function snapshotHarmony(
+  device: DeviceInfo,
+  options: SnapshotOptions & { maxNodes?: number },
+): Promise<HarmonySnapshotResult> {
+  const maxNodes = options.maxNodes ?? DEFAULT_MAX_NODES;
+  const uuid = randomUUID();
+  const remotePath = `/data/local/tmp/hd-layout-${uuid}.json`;
+  const localDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hd-snapshot-'));
+  const localPath = path.join(localDir, `layout-${uuid}.json`);
+
+  try {
+    await ensureHarmonyUitestReady(device);
+
+    // Step 1: Dump layout on device
+    const dumpResult = await runHarmonyHdc(
+      device,
+      ['shell', 'uitest', 'dumpLayout', '-p', remotePath],
+      { allowFailure: false, timeoutMs: 30_000 },
+    );
+
+    if (dumpResult.exitCode !== 0) {
+      throw new AppError('COMMAND_FAILED', `uitest dumpLayout failed: ${dumpResult.stderr}`);
+    }
+
+    // Step 2: Pull file to local
+    await runHarmonyHdc(device, ['file', 'recv', remotePath, localPath], {
+      allowFailure: false,
+      timeoutMs: 15_000,
+    });
+
+    // Step 3: Cleanup remote file
+    await runHarmonyHdc(device, ['shell', 'rm', '-f', remotePath], {
+      allowFailure: true,
+    });
+
+    // Step 4: Parse the JSON file
+    const jsonContent = await fs.readFile(localPath, 'utf-8');
+    const tree = parseArkUiTree(jsonContent);
+    const result = buildArkUiSnapshot(tree, maxNodes, options);
+
+    // Step 5: Attach refs (@e1, @e2, etc.)
+    const nodesWithRefs = attachRefs(result.nodes);
+
+    return {
+      ...result,
+      nodes: nodesWithRefs,
+      backend: 'harmonyos-arkui',
+    };
+  } finally {
+    await fs.rm(localDir, { recursive: true, force: true });
+  }
+}

--- a/src/platforms/harmonyos/uitest-preflight.ts
+++ b/src/platforms/harmonyos/uitest-preflight.ts
@@ -1,0 +1,55 @@
+import type { DeviceInfo } from '../../utils/device.ts';
+import { AppError } from '../../utils/errors.ts';
+import { runHarmonyHdc } from './hdc.ts';
+
+const UITEST_DAEMON_TOKEN = 'agent-device';
+
+export async function listHarmonyUitestProcesses(device: DeviceInfo): Promise<string[]> {
+  const result = await runHarmonyHdc(device, ['shell', 'ps', '-ef'], {
+    allowFailure: true,
+    timeoutMs: 10_000,
+  });
+  if (result.exitCode !== 0) return [];
+  return result.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /uitest/i.test(line));
+}
+
+export function findStuckHarmonyUitestProcess(lines: readonly string[]): string | null {
+  for (const line of lines) {
+    if (/uitest\s+uiRecord\s+record/i.test(line)) {
+      return line;
+    }
+  }
+  return null;
+}
+
+export function buildHarmonyUitestBlockedHint(stuckLine?: string): string {
+  const detail = stuckLine ? ` Detected: ${stuckLine.trim()}` : '';
+  return (
+    'HarmonyOS uitest is blocked, so dumpLayout/snapshot cannot run.' +
+    ' Reboot the device to clear stuck uitest uiRecord sessions.' +
+    ' Avoid leaving `hdc shell uitest uiRecord record` running in the background.' +
+    detail
+  );
+}
+
+export async function ensureHarmonyUitestReady(device: DeviceInfo): Promise<void> {
+  const lines = await listHarmonyUitestProcesses(device);
+  const stuck = findStuckHarmonyUitestProcess(lines);
+  if (stuck) {
+    throw new AppError(
+      'COMMAND_FAILED',
+      'HarmonyOS uitest is blocked by a stuck uiRecord session',
+      {
+        hint: buildHarmonyUitestBlockedHint(stuck),
+      },
+    );
+  }
+
+  await runHarmonyHdc(device, ['shell', 'uitest', 'start-daemon', UITEST_DAEMON_TOKEN], {
+    allowFailure: true,
+    timeoutMs: 5_000,
+  });
+}

--- a/src/remote-config-schema.ts
+++ b/src/remote-config-schema.ts
@@ -27,7 +27,7 @@ export type RemoteConfigProfile = RemoteConfigMetroOptions & {
   runId?: string;
   leaseId?: string;
   leaseBackend?: 'ios-simulator' | 'ios-instance' | 'android-instance';
-  platform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple';
+  platform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple' | 'harmonyos';
   target?: 'mobile' | 'tv' | 'desktop';
   device?: string;
   udid?: string;
@@ -73,7 +73,11 @@ export const REMOTE_CONFIG_FIELD_SPECS = [
     type: 'enum',
     enumValues: ['ios-simulator', 'ios-instance', 'android-instance'],
   },
-  { key: 'platform', type: 'enum', enumValues: ['ios', 'macos', 'android', 'linux', 'apple'] },
+  {
+    key: 'platform',
+    type: 'enum',
+    enumValues: ['ios', 'macos', 'android', 'linux', 'apple', 'harmonyos'],
+  },
   { key: 'target', type: 'enum', enumValues: ['mobile', 'tv', 'desktop'] },
   { key: 'device', type: 'string' },
   { key: 'udid', type: 'string' },

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -20,6 +20,7 @@ const REPLAY_METADATA_PLATFORMS = new Set<ReplayScriptPlatform>([
   'android',
   'macos',
   'linux',
+  'harmonyos',
 ]);
 const REPLAY_METADATA_TARGETS = new Set<DeviceTarget>(['mobile', 'tv', 'desktop']);
 

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -911,6 +911,8 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /Discovery is not enough when the task asks to open\/start/);
   assert.match(help, /If the task says install, use install/);
   assert.match(help, /Do not open artifact paths or invent package ids/);
+  assert.match(help, /HarmonyOS discovery and launch:/);
+  assert.match(help, /launchAbility via wukong appinfo/);
   assert.match(help, /agent-device get attrs @e4/);
   assert.match(help, /Ambiguous find: add --first or --last/);
   assert.match(help, /report that gap instead of typing\/searching\/navigating/);

--- a/src/utils/__tests__/device.test.ts
+++ b/src/utils/__tests__/device.test.ts
@@ -223,3 +223,33 @@ test('resolveDevice returns physical device when it is the only candidate (no si
   assert.equal(result.id, 'phys-1');
   assert.equal(result.kind, 'device');
 });
+
+test('resolveDevice returns harmony device when explicitly selected by hdc serial', async () => {
+  const harmony: DeviceInfo = {
+    platform: 'harmonyos',
+    id: '22M0223824043030',
+    name: '22M0223824043030',
+    kind: 'device',
+    booted: true,
+  };
+  const result = await resolveDevice([harmony], {
+    platform: 'harmonyos',
+    deviceName: '22M0223824043030',
+  });
+  assert.equal(result.id, '22M0223824043030');
+});
+
+test('resolveDevice returns harmony device when --serial is used', async () => {
+  const harmony: DeviceInfo = {
+    platform: 'harmonyos',
+    id: '23E0223A12009511',
+    name: '23E0223A12009511',
+    kind: 'device',
+    booted: true,
+  };
+  const result = await resolveDevice([harmony], {
+    platform: 'harmonyos',
+    serial: '23E0223A12009511',
+  });
+  assert.equal(result.id, '23E0223A12009511');
+});

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -10,6 +10,7 @@ import {
   SELECTOR_SNAPSHOT_FLAGS,
 } from '../commands/selectors-definition.ts';
 import { SESSION_LIFECYCLE_COMMAND_SCHEMAS } from '../commands/session-lifecycle/definition.ts';
+import { COGNITION_COMMAND_SCHEMAS } from '../commands/cognition-map.ts';
 import {
   SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS,
   type ScreenshotRequestFlags,
@@ -35,7 +36,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     sessionLock?: 'reject' | 'strip';
     sessionLocked?: boolean;
     sessionLockConflicts?: 'reject' | 'strip';
-    platform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple';
+    platform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple' | 'harmonyos';
     target?: 'mobile' | 'tv' | 'desktop';
     device?: string;
     udid?: string;
@@ -74,6 +75,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     pauseMs?: number;
     pattern?: 'one-way' | 'ping-pong';
     activity?: string;
+    module?: string;
     launchConsole?: string;
     header?: string[];
     githubActionsArtifact?: string;
@@ -216,6 +218,7 @@ const EXAMPLE_LINES = [
   'agent-device fill @e3 "test@example.com"',
   'agent-device replay ./session.ad',
   'agent-device test ./suite --platform android',
+  'agent-device open com.example.app --platform harmonyos --device <hdc-serial>',
 ] as const;
 
 const HELP_TOPICS = {
@@ -250,6 +253,14 @@ Bootstrap:
   If app id is unknown, plan devices, apps, then open <discovered-app-id>. Discovery is not enough when the task asks to open/start the app.
   Install arguments are app/package id then artifact path. If the task says install, use install; use reinstall only when explicitly requested. Fresh runtime state is open --relaunch after install.
   Do not open artifact paths or invent package ids. If apps lookup misses the target and no URL/artifact is provided, ask or stop.
+
+HarmonyOS discovery and launch:
+  agent-device devices --platform harmonyos
+  agent-device apps --platform harmonyos --device <hdc-serial> --json
+  jq -r '.data.apps[] | select(.bundleId=="com.example.app") | .launchAbility'
+  agent-device open com.example.app --platform harmonyos --device <hdc-serial>
+  open resolves launchAbility via wukong appinfo when --activity is omitted; apps --json exposes the same field for planning.
+  Use --activity <launchAbility> only when auto-resolution is insufficient.
 
 Snapshots and refs:
   snapshot reads visible state. snapshot -i gets current interactive refs only; it is the fast path when the next step is an interaction.
@@ -786,8 +797,8 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     key: 'platform',
     names: ['--platform'],
     type: 'enum',
-    enumValues: ['ios', 'macos', 'android', 'linux', 'apple'],
-    usageLabel: '--platform ios|macos|android|linux|apple',
+    enumValues: ['ios', 'macos', 'android', 'linux', 'apple', 'harmonyos'],
+    usageLabel: '--platform ios|macos|android|linux|apple|harmonyos',
     usageDescription: 'Platform to target (`apple` aliases the Apple automation backend)',
   },
   {
@@ -980,7 +991,14 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     names: ['--activity'],
     type: 'string',
     usageLabel: '--activity <component>',
-    usageDescription: 'Android app launch activity (package/Activity); not for URL opens',
+    usageDescription: 'Android/HarmonyOS app launch activity (package/Activity); not for URL opens',
+  },
+  {
+    key: 'module',
+    names: ['--module'],
+    type: 'string',
+    usageLabel: '--module <name>',
+    usageDescription: 'HarmonyOS app launch module name (for apps requiring explicit module)',
   },
   {
     key: 'launchConsole',
@@ -1473,6 +1491,7 @@ const COMMAND_SCHEMAS: Record<string, CommandSchema> = {
     allowedFlags: ['headless'],
   },
   ...SESSION_LIFECYCLE_COMMAND_SCHEMAS,
+  ...COGNITION_COMMAND_SCHEMAS,
   connect: {
     usageOverride:
       'connect [--remote-config <path>] [--tenant <id>] [--run-id <id>] [--lease-backend <backend>] [--force] [--no-login]',
@@ -1911,7 +1930,7 @@ function buildCommandListUsage(commandName: string, schema: CommandSchema): stri
 function renderUsageText(): string {
   const header = `agent-device <command> [args] [--json]
 
-CLI to control iOS and Android devices for AI agents.
+CLI to control iOS, Android, and HarmonyOS devices for AI agents.
 `;
 
   const commands = getCliCommandNames().map((name) => {

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,7 +1,7 @@
 import { AppError } from './errors.ts';
 
 export type ApplePlatform = 'ios' | 'macos';
-export type Platform = ApplePlatform | 'android' | 'linux';
+export type Platform = ApplePlatform | 'android' | 'linux' | 'harmonyos';
 export type PlatformSelector = Platform | 'apple';
 export type DeviceKind = 'simulator' | 'emulator' | 'device';
 export type DeviceTarget = 'mobile' | 'tv' | 'desktop';
@@ -101,15 +101,23 @@ export async function resolveDevice(
   }
 
   if (selector.serial) {
-    const match = candidates.find((d) => d.id === selector.serial && d.platform === 'android');
-    if (!match)
-      throw new AppError('DEVICE_NOT_FOUND', `No Android device with serial ${selector.serial}`);
+    const match = candidates.find(
+      (d) => d.id === selector.serial && (d.platform === 'android' || d.platform === 'harmonyos'),
+    );
+    if (!match) {
+      throw new AppError(
+        'DEVICE_NOT_FOUND',
+        `No Android or HarmonyOS device with serial ${selector.serial}`,
+      );
+    }
     return match;
   }
 
   if (selector.deviceName) {
     const target = normalize(selector.deviceName);
-    const match = candidates.find((d) => normalize(d.name) === target);
+    const match =
+      candidates.find((d) => normalize(d.name) === target) ??
+      candidates.find((d) => d.platform === 'harmonyos' && d.id === selector.deviceName);
     if (!match) {
       throw new AppError('DEVICE_NOT_FOUND', `No device named ${selector.deviceName}`);
     }

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -112,7 +112,11 @@ function parseFiniteNumber(value: unknown): number | undefined {
 }
 
 function parsePlatform(value: unknown): Platform | undefined {
-  return value === 'ios' || value === 'macos' || value === 'android' || value === 'linux'
+  return value === 'ios' ||
+    value === 'macos' ||
+    value === 'android' ||
+    value === 'linux' ||
+    value === 'harmonyos'
     ? value
     : undefined;
 }

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -60,7 +60,12 @@ export type SnapshotNode = RawSnapshotNode & {
   ref: string;
 };
 
-export type SnapshotBackend = 'xctest' | 'android' | 'macos-helper' | 'linux-atspi';
+export type SnapshotBackend =
+  | 'xctest'
+  | 'android'
+  | 'macos-helper'
+  | 'linux-atspi'
+  | 'harmonyos-arkui';
 
 export type SnapshotState = {
   nodes: SnapshotNode[];


### PR DESCRIPTION
## Summary

Add HarmonyOS (鸿蒙) as a first-class platform alongside iOS, Android, macOS, and Linux. This enables agent-device to automate HarmonyOS devices via HDC (HarmonyOS Device Connector).

### Platform implementation (`src/platforms/harmonyos/`, 17 new files)

- **Device management**: device discovery via `hdc list targets`
- **App lifecycle**: open, close, app state with automatic `launchAbility` resolution via `wukong appinfo`
- **UI snapshot**: ArkUI hierarchy parsing with interactive-only filtering (`snapshot -i`)
- **Input actions**: scroll (4 directions), rotate, keyboard dismiss, double-tap, long-press
- **System dialog handling**: auto-dismiss privacy policy, notification permission, and update prompts
- **Screen lock**: detection and auto-unlock
- **uitest preflight**: health checks for stuck uitest processes
- **Clipboard, logcat, perf, recording, screenshot** support

### Core changes

- Register `harmonyos` in backend capabilities, dispatch, interactor, and command schema
- Add `cognition` command for UI structure analysis (cross-platform)
- Extend client types, contracts, and CLI commands for HarmonyOS
- Update `apps` command to return structured data with app details
- 6 new test files for HarmonyOS platform layer

### Test plan

- [x] All 221 test files pass (1827 tests), including 6 new HarmonyOS platform tests
- [x] `pnpm build` succeeds
- [x] No `console.log`/`console.warn` debug leftovers (matches existing codebase style)
- [x] Tested on Huawei Mate 60 Pro (HarmonyOS NEXT) with real apps (小红书, 滴滴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)