### PR TITLE
fix: preserve remote config for interaction commands

### DIFF
--- a/src/__tests__/cli-config.test.ts
+++ b/src/__tests__/cli-config.test.ts
@@ -134,6 +134,51 @@ test('command-specific config defaults are ignored for commands that do not supp
   fs.rmSync(root, { recursive: true, force: true });
 });
 
+test('interaction commands preserve remote config defaults', async () => {
+  const { root, home, project } = makeTempWorkspace();
+  fs.mkdirSync(path.join(home, '.agent-device'), { recursive: true });
+  fs.writeFileSync(
+    path.join(project, 'agent-device.json'),
+    JSON.stringify({
+      daemonBaseUrl: 'https://daemon.example.test',
+      daemonAuthToken: 'token-123',
+      daemonTransport: 'http',
+      tenant: 'tenant-123',
+      runId: 'run-123',
+      leaseId: 'lease-123',
+      platform: 'ios',
+    }),
+    'utf8',
+  );
+
+  const commands = [
+    ['press', '10', '20'],
+    ['click', '10', '20'],
+    ['fill', '10', '20', 'hello'],
+    ['longpress', '10', '20'],
+    ['get', 'text', '@e1'],
+  ];
+
+  for (const command of commands) {
+    const result = await runCliCapture([...command, '--json'], {
+      cwd: project,
+      env: { HOME: home },
+    });
+
+    assert.equal(result.code, null, command.join(' '));
+    assert.equal(result.calls.length, 1, command.join(' '));
+    assert.equal(result.calls[0]?.flags?.daemonBaseUrl, 'https://daemon.example.test');
+    assert.equal(result.calls[0]?.flags?.daemonAuthToken, 'token-123');
+    assert.equal(result.calls[0]?.flags?.daemonTransport, 'http');
+    assert.equal(result.calls[0]?.flags?.tenant, 'tenant-123');
+    assert.equal(result.calls[0]?.flags?.runId, 'run-123');
+    assert.equal(result.calls[0]?.flags?.leaseId, 'lease-123');
+    assert.equal(result.calls[0]?.flags?.platform, 'ios');
+  }
+
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
 test('explicit --config path overrides default config discovery', async () => {
   const { root, home, project } = makeTempWorkspace();
   fs.mkdirSync(path.join(home, '.agent-device'), { recursive: true });

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -437,7 +437,7 @@ export function optionalEnum<const T extends readonly string[]>(
 export function commonToClientOptions(
   input: CommonCommandInput,
 ): AgentDeviceRequestOverrides & AgentDeviceSelectionOptions {
-  return {
+  return compactRecord({
     session: input.session,
     platform: input.platform,
     target: input.deviceTarget,
@@ -453,7 +453,7 @@ export function commonToClientOptions(
     leaseId: input.leaseId,
     cwd: input.cwd,
     debug: input.debug,
-  };
+  }) as AgentDeviceRequestOverrides & AgentDeviceSelectionOptions;
 }
 
 export function toClientInteractionTarget(target: InteractionTargetInput): InteractionTarget {


### PR DESCRIPTION
## Summary

PR #593 introduced structured command definitions for the CLI/MCP path. Interaction commands (`press`, `click`, `fill`, `longpress`, `get`) now parse CLI input into structured input, then convert that back into client options with `commonToClientOptions()`.

That conversion returned remote fields even when they were absent from the command input:

```ts
{ daemonBaseUrl: undefined, daemonAuthToken: undefined, tenant: undefined, runId: undefined }
```

Because per-command options are merged over the configured client defaults, those explicit `undefined` values erased the remote daemon fields loaded from `--config`. This showed up in remote-device environments that run through a generated config file. Read-only commands still reached the remote daemon, but interaction commands fell back to local daemon metadata and failed before dispatch:

```sh
agent-device --config remote-dev-infra/agent-device.json press @e13
# Error: Daemon HTTP endpoint is unavailable
```

This PR wraps `commonToClientOptions()` in `compactRecord()`. `compactRecord()` removes entries whose value is `undefined`, so absent per-command fields are omitted instead of overwriting the configured remote defaults. Regression coverage now checks `press`, `click`, `fill`, `longpress`, and `get` with remote config defaults.

## Validation

- Local E2E before/after: started a local HTTP daemon and ran `press` through `--config`. The current broken CLI failed with `Daemon HTTP endpoint is unavailable`; CLI with these changes reached the daemon and failed later with `SESSION_NOT_FOUND`