### PR TITLE
ci: skip core CI for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,14 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "website/**"
+      - "README.md"
+      - ".github/actions/build-docs/action.yml"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/pr-preview.yml"
+      - ".github/workflows/pr-preview-cleanup.yml"
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Skip the core CI workflow on PRs that only change docs, website, or preview/deploy workflow files, matching the existing platform smoke gating. Pushes to `main` still run full CI.

Touched files: 1; scope stayed workflow-only.

## Validation

Verified `.github/workflows/ci.yml` parses as YAML and `git diff --check` passed. No runtime tests were run because this only changes workflow trigger paths.