### PR TITLE
ci: publish MCP registry metadata

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,70 @@
+name: Publish MCP Registry
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: GitHub Release tag to publish metadata for, for example v0.16.5.
+        required: true
+        type: string
+      checkout_ref:
+        description: Optional branch, tag, or commit SHA to publish from. Defaults to the selected workflow ref.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-mcp-registry:
+    name: Publish MCP Registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.checkout_ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "22"
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION="$(node -p "JSON.parse(require('node:fs').readFileSync('package.json', 'utf8')).version")"
+          SERVER_VERSION="$(node -p "JSON.parse(require('node:fs').readFileSync('server.json', 'utf8')).version")"
+          TAG_NAME="${{ github.event.release.tag_name || github.event.inputs.release_tag }}"
+          VERSION="${TAG_NAME#v}"
+          if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Release tag $TAG_NAME does not match package.json version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+          if [ "$VERSION" != "$SERVER_VERSION" ]; then
+            echo "Release tag $TAG_NAME does not match server.json version $SERVER_VERSION" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Check MCP metadata sync
+        run: node scripts/sync-mcp-metadata.mjs --check
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+        shell: bash
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish server.json

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "check:quick": "pnpm lint && pnpm typecheck",
     "sync:mcp-metadata": "node scripts/sync-mcp-metadata.mjs",
     "check:mcp-metadata": "node scripts/sync-mcp-metadata.mjs --check",
+    "version": "node scripts/sync-mcp-metadata.mjs && git add server.json",
     "check:tooling": "pnpm lint && pnpm typecheck && pnpm check:mcp-metadata && pnpm build",
     "check:unit": "pnpm test:unit && pnpm test:smoke",
     "check": "pnpm check:tooling && pnpm check:fallow && pnpm check:unit",


### PR DESCRIPTION
## Summary

Publish MCP registry metadata from the repo instead of relying on manual local `mcp-publisher` runs.

Adds a release/manual-dispatch workflow that validates the release tag against `package.json` and `server.json`, checks MCP metadata sync, authenticates with GitHub OIDC, and publishes `server.json` to the official MCP Registry.

Also hooks the package `version` lifecycle so `npm version` / `pnpm version` syncs `server.json` and stages it into the version commit.

Touched files: 2. Scope stayed within release automation and MCP metadata sync.

## Validation

Verified `server.json` metadata sync with `node scripts/sync-mcp-metadata.mjs --check` and parsed the new workflow YAML successfully with Ruby.

`pnpm install --frozen-lockfile` completed, but `pnpm format` could not run in this local checkout because `oxfmt`'s native Darwin ARM64 binding fails to load with a macOS code-signature Team ID error. No docs or skills were updated because this is release automation only.