### PR TITLE
fix: use safer in-page swipe lane

### DIFF
--- a/src/__tests__/runtime-interactions.test.ts
+++ b/src/__tests__/runtime-interactions.test.ts
@@ -609,14 +609,34 @@ test('runtime gesture swipe presets use stable viewport lanes', async () => {
     session: 'default',
   });
 
-  assert.deepEqual(pageSwipe.from, { x: 90, y: 65 });
-  assert.deepEqual(pageSwipe.to, { x: 10, y: 65 });
+  assert.deepEqual(pageSwipe.from, { x: 85, y: 65 });
+  assert.deepEqual(pageSwipe.to, { x: 15, y: 65 });
   assert.deepEqual(edgeSwipe.from, { x: 8, y: 50 });
   assert.deepEqual(edgeSwipe.to, { x: 85, y: 50 });
   assert.deepEqual(calls, [
-    { from: { x: 90, y: 65 }, to: { x: 10, y: 65 }, durationMs: 300 },
+    { from: { x: 85, y: 65 }, to: { x: 15, y: 65 }, durationMs: 300 },
     { from: { x: 8, y: 50 }, to: { x: 85, y: 50 }, durationMs: 350 },
   ]);
+});
+
+test('runtime iOS in-page swipe presets avoid edge-navigation lanes', async () => {
+  const calls: unknown[] = [];
+  const device = createInteractionDevice(snapshotWithOffscreenContent(), {
+    platform: 'ios',
+    swipe: async (_context, from, to, options) => {
+      calls.push({ from, to, durationMs: options?.durationMs });
+    },
+  });
+
+  const pageSwipe = await device.interactions.swipe({
+    preset: 'right',
+    durationMs: 300,
+    session: 'default',
+  });
+
+  assert.deepEqual(pageSwipe.from, { x: 15, y: 65 });
+  assert.deepEqual(pageSwipe.to, { x: 85, y: 65 });
+  assert.deepEqual(calls, [{ from: { x: 15, y: 65 }, to: { x: 85, y: 65 }, durationMs: 300 }]);
 });
 
 test('runtime viewport gestures reject inspect-only macOS surfaces', async () => {

--- a/src/core/__tests__/dispatch-interactions.test.ts
+++ b/src/core/__tests__/dispatch-interactions.test.ts
@@ -100,11 +100,11 @@ test('handleSwipePresetCommand resolves Android in-page swipe to content lane', 
     undefined,
   );
 
-  assert.deepEqual(calls, [[360, 520, 40, 520, 300]]);
+  assert.deepEqual(calls, [[340, 520, 60, 520, 300]]);
   assert.deepEqual(result, {
-    x1: 360,
+    x1: 340,
     y1: 520,
-    x2: 40,
+    x2: 60,
     y2: 520,
     preset: 'left',
     durationMs: 300,

--- a/src/core/scroll-gesture.ts
+++ b/src/core/scroll-gesture.ts
@@ -109,12 +109,14 @@ export function buildSwipePresetGesturePlan(
   options: { platform?: string; marginPx?: number } = {},
 ): SwipePresetGesturePlan {
   const marginPx = options.marginPx ?? 8;
-  const horizontalLanePercent = options.platform === 'android' ? 65 : 50;
+  const horizontalLanePercent = 65;
+  const inPageStartPercent = 85;
+  const inPageEndPercent = 15;
   const [startPercent, endPercent, yPercent] =
     preset === 'left'
-      ? [90, 10, horizontalLanePercent]
+      ? [inPageStartPercent, inPageEndPercent, horizontalLanePercent]
       : preset === 'right'
-        ? [10, 90, horizontalLanePercent]
+        ? [inPageEndPercent, inPageStartPercent, horizontalLanePercent]
         : preset === 'left-edge'
           ? [99, 15, 50]
           : [1, 85, 50];


### PR DESCRIPTION
## Summary

Use one consistent in-page swipe preset for native `gesture swipe left|right` and Maestro directional swipes: 15%↔85% horizontally at a lower 65% viewport lane.

This keeps in-page swipes away from the iOS edge-navigation zone without shortening the gesture so much that React Native pager/material-tab views stop advancing. Explicit edge-navigation presets (`left-edge` / `right-edge`) remain unchanged.

I also tried the more human-like 25%↔75% lane. It failed React Navigation iOS pager flows (`material-top-tabs`, `tab-view-custom-tab-bar`, `tab-view-scrollable-tab-bar`) because the 50% travel was too short. 15%↔85% was the smallest consistent lane that passed the sensitive flows locally.




## Validation

- `pnpm exec vitest run src/__tests__/runtime-interactions.test.ts src/core/__tests__/dispatch-interactions.test.ts`
- `pnpm build`
- `pnpm check:quick`
- React Navigation iOS affected swipe flows, 15%↔85%: 4/4 passed, no retries
- React Navigation Android `showcase-material-top-tabs.yml`, 15%↔85%: passed, no retries
- React Navigation iOS full Maestro suite, 15%↔85%: 38/38 passed, no retries
- React Navigation Android full Maestro suite, 15%↔85%: 37/38 passed; one unrelated launch/deep-link wait failure in `stack-float-screen-header.yml`, rerun of that flow passed in 7.6s