### PR TITLE
perf(ios): make get text ~80x faster for non-editable elements

### DIFF
--- a/src/daemon/handlers/__tests__/interaction-read.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-read.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SnapshotNode } from '../../../utils/snapshot.ts';
+
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return {
+    ...actual,
+    dispatchCommand: vi.fn(async () => ({ text: 'backend-text' })),
+  };
+});
+
+import { dispatchCommand } from '../../../core/dispatch.ts';
+import { readTextForNode } from '../interaction-read.ts';
+
+const mockDispatch = vi.mocked(dispatchCommand);
+
+function node(overrides: Partial<SnapshotNode>): SnapshotNode {
+  return {
+    ref: 'e1',
+    index: 0,
+    rect: { x: 0, y: 0, width: 100, height: 40 },
+    ...overrides,
+  } as SnapshotNode;
+}
+
+const baseParams = {
+  device: { platform: 'ios' } as never,
+  flags: undefined,
+  contextFromFlags: () => ({}) as never,
+};
+
+describe('readTextForNode', () => {
+  beforeEach(() => mockDispatch.mockClear());
+
+  it('returns snapshot text without a backend read for non-editable nodes', async () => {
+    const text = await readTextForNode({ ...baseParams, node: node({ type: 'button', label: 'General' }) });
+    expect(text).toBe('General');
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('still re-reads via the backend for editable text inputs (live value may exceed snapshot)', async () => {
+    const text = await readTextForNode({ ...baseParams, node: node({ type: 'textfield', value: 'snap' }) });
+    expect(mockDispatch).toHaveBeenCalledOnce();
+    expect(text).toBe('backend-text');
+  });
+
+  it('re-reads when the snapshot node has no readable text', async () => {
+    await readTextForNode({ ...baseParams, node: node({ type: 'other' }) });
+    expect(mockDispatch).toHaveBeenCalledOnce();
+  });
+
+  it('returns snapshot text without a backend read when the node has no resolvable center', async () => {
+    const text = await readTextForNode({ ...baseParams, node: node({ type: 'button', label: 'General', rect: undefined }) });
+    expect(text).toBe('General');
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/daemon/handlers/__tests__/interaction-read.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-read.test.ts
@@ -54,4 +54,17 @@ describe('readTextForNode', () => {
     expect(text).toBe('General');
     expect(mockDispatch).not.toHaveBeenCalled();
   });
+
+  it('does NOT skip the backend read on non-iOS platforms (value-first read semantics differ)', async () => {
+    for (const platform of ['android', 'macos', 'linux'] as const) {
+      mockDispatch.mockClear();
+      const text = await readTextForNode({
+        ...baseParams,
+        device: { platform } as never,
+        node: node({ type: 'button', label: 'General' }),
+      });
+      expect(mockDispatch).toHaveBeenCalledOnce();
+      expect(text).toBe('backend-text');
+    }
+  });
 });

--- a/src/daemon/handlers/interaction-read.ts
+++ b/src/daemon/handlers/interaction-read.ts
@@ -3,6 +3,7 @@ import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { extractNodeReadText } from '../snapshot-processing.ts';
 import type { SessionState } from '../types.ts';
 import type { SnapshotNode } from '../../utils/snapshot.ts';
+import { prefersValueForReadableText } from '../../utils/text-surface.ts';
 import type { ContextFromFlags } from './interaction-common.ts';
 import { resolveRectCenter } from './interaction-targeting.ts';
 
@@ -19,6 +20,16 @@ export async function readTextForNode(params: {
   const fallbackText = extractNodeReadText(node);
   const center = resolveRectCenter(node.rect);
   if (!center) {
+    return fallbackText;
+  }
+
+  // The backend `read` re-resolves the element at a point, which on iOS XCUITest enumerates
+  // the full element tree (allElementsBoundByIndex) and is ~20x slower than the snapshot we
+  // already captured to resolve this node. That re-read only recovers fuller text for
+  // editable/expandable inputs (textField/searchField/textView/…), where the live value can
+  // exceed the snapshot. For every other element type the snapshot node text is authoritative,
+  // so return it directly and skip the expensive round-trip.
+  if (fallbackText && !prefersValueForReadableText(node.type ?? '')) {
     return fallbackText;
   }
 

--- a/src/daemon/handlers/interaction-read.ts
+++ b/src/daemon/handlers/interaction-read.ts
@@ -23,13 +23,19 @@ export async function readTextForNode(params: {
     return fallbackText;
   }
 
-  // The backend `read` re-resolves the element at a point, which on iOS XCUITest enumerates
-  // the full element tree (allElementsBoundByIndex) and is ~20x slower than the snapshot we
+  // iOS only: the XCUITest backend `read` re-resolves the element at a point by enumerating
+  // the full element tree (allElementsBoundByIndex), which is ~20x slower than the snapshot we
   // already captured to resolve this node. That re-read only recovers fuller text for
   // editable/expandable inputs (textField/searchField/textView/…), where the live value can
-  // exceed the snapshot. For every other element type the snapshot node text is authoritative,
-  // so return it directly and skip the expensive round-trip.
-  if (fallbackText && !prefersValueForReadableText(node.type ?? '')) {
+  // exceed the snapshot; for every other element type the snapshot node text is authoritative.
+  // Restricted to iOS because other backends read differently — macOS helper and Linux reads
+  // are value-first (AXValue/title/description), unlike the label-first snapshot readable text,
+  // so skipping their backend read would change the returned text.
+  if (
+    device.platform === 'ios' &&
+    fallbackText &&
+    !prefersValueForReadableText(node.type ?? '')
+  ) {
     return fallbackText;
   }
 

--- a/src/utils/text-surface.ts
+++ b/src/utils/text-surface.ts
@@ -85,7 +85,12 @@ export function normalizeType(type: string): string {
   return normalized;
 }
 
-function prefersValueForReadableText(type: string): boolean {
+/**
+ * Editable / expandable text-bearing element types whose live on-screen value can exceed
+ * the captured snapshot text. For these the readable text prefers `value`, and a backend
+ * (e.g. iOS XCUITest) re-read at the element can recover fuller text than the snapshot node.
+ */
+export function prefersValueForReadableText(type: string): boolean {
   const normalized = normalizeType(type);
   return (
     normalized.includes('textfield') ||


### PR DESCRIPTION
## What

Speeds up `get text` on iOS by **~80×** for the common case (labeled controls, static text, cells, etc.). Found via the new perf benchmark (#630), where iOS `get text` was the standout outlier — ~20× slower than `find`/`is` against the same element.

## Root cause

`get text` resolves the target from a snapshot (the same one `find`/`is` use), then `readTextForNode` dispatches a **coordinate `read`** to the XCUITest runner. On the Swift side, `readTextAt()` does:

```swift
let candidates = app.descendants(matching: .any).allElementsBoundByIndex
  .filter { $0.exists && $0.frame.contains(point) }
  .sorted { … }   // by area, then position, then type
```

`allElementsBoundByIndex` over `.any` forces a full per-element snapshot of the entire tree — the slowest XCUITest path. `find`/`is` avoid it: `find` uses a predicate `.firstMatch`, and `is` evaluates against the already-captured snapshot. So `get text` paid for a second, full-tree round-trip the others never made.

That coordinate re-read only recovers *fuller* text for **editable/expandable inputs** (`textField`/`secureTextField`/`searchField`/`textView`/`editText`/`textArea`), where the live on-screen value can exceed the captured snapshot. For every other element type the freshly-captured snapshot node text is authoritative.

## Fix

In `readTextForNode`, return the snapshot node's readable text directly for non-editable nodes with non-empty text, skipping the backend round-trip. Editable inputs keep the re-read. Mirrors the runner's own `prefersExpandedTextRead` set, so behavior for editable fields is unchanged.

```ts
if (fallbackText && !prefersValueForReadableText(node.type ?? '')) {
  return fallbackText; // snapshot node text is authoritative; skip the ~20x slower re-read
}
```

## Measured (iPhone 17 simulator, iOS 26.2)

`get text` on a labeled control (`get text 'label="General" enabled'`), steady-state:

| | before | after |
|---|---:|---:|
| get text (non-editable) | ~25s (read path; up to 91s under load) | **~0.3s** |

(Numbers are inflated by a co-resident simulator under load; the relative ~80× drop is the signal. Controlled stash/rebuild before/after on the same machine.)

## Scope / notes

- Editable text inputs are unchanged (still re-read; live value can differ from the snapshot).
- Unit test added: `interaction-read.test.ts` asserts non-editable nodes return snapshot text with **no** backend dispatch, while editable nodes and text-less nodes still dispatch.
- **Separate iOS issue, not addressed here**: `get text <selector>` on an *ambiguous* selector (every iOS Settings cell is a label/button/text triplet) can take ~13s to return `AMBIGUOUS_MATCH` even though `find` disambiguates the same selector in ~1s. Worth a follow-up — `get text` sets `disambiguateAmbiguous` but the runner-side query still rejects first.
- A deeper Swift-side fix (avoid `allElementsBoundByIndex` in `readTextAt`) would also help the editable case and other coordinate reads; deferred to keep this change small and rebuild-free.

## Stacking

Branched off `perf-harness` (#630) so the perf benchmark could verify it; PR base is `perf-harness`. Rebase onto `main` once #630 merges.
