### PR TITLE
perf+fix(ios): faster text entry (readiness + typed-query field resolve) + fix fill mis-navigation

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -316,6 +316,15 @@ extension RunnerTests {
   }
 
   func clearTextInput(_ element: XCUIElement) {
+    // Nothing to clear: skip both the delete burst and the moveCaretToEnd edge-tap. The
+    // edge-tap computes a point from the element frame, which can be stale after the field
+    // repositions on focus (e.g. the Settings search bar jumps bottom->top and reveals a
+    // "Suggestions" list) — tapping there navigates away instead of clearing. Replacing into
+    // an already-empty field is a no-op, so returning early is also semantically correct.
+    let existing = editableTextValue(for: element, treatingPlaceholderAsEmpty: true) ?? ""
+    if existing.isEmpty {
+      return
+    }
 #if !os(tvOS)
     moveCaretToEnd(element: element)
 #endif

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -316,13 +316,16 @@ extension RunnerTests {
   }
 
   func clearTextInput(_ element: XCUIElement) {
-    // Nothing to clear: skip both the delete burst and the moveCaretToEnd edge-tap. The
-    // edge-tap computes a point from the element frame, which can be stale after the field
-    // repositions on focus (e.g. the Settings search bar jumps bottom->top and reveals a
-    // "Suggestions" list) — tapping there navigates away instead of clearing. Replacing into
-    // an already-empty field is a no-op, so returning early is also semantically correct.
-    let existing = editableTextValue(for: element, treatingPlaceholderAsEmpty: true) ?? ""
-    if existing.isEmpty {
+    // Skip the clear (delete burst + moveCaretToEnd edge-tap) ONLY when we can confirm the
+    // field is empty. Why skip: the edge-tap computes a point from the element frame, which can
+    // be stale after the field repositions on focus (e.g. the Settings search bar jumps
+    // bottom->top and reveals a "Suggestions" list) — tapping there navigates away instead of
+    // clearing; and replacing into an already-empty field is a no-op anyway.
+    // editableTextValue returns nil for secure (and unknown) fields, where we CANNOT confirm
+    // emptiness — those must still be cleared, or replace would concatenate stale + new text.
+    // So distinguish nil (clear) from "" (skip).
+    if let existing = editableTextValue(for: element, treatingPlaceholderAsEmpty: true),
+       existing.isEmpty {
       return
     }
 #if !os(tvOS)
@@ -425,15 +428,15 @@ extension RunnerTests {
     return target
 #else
     let latest = target
+    let keyboardVisibleAtEntry = isKeyboardVisible(app: app)
     let deadline = Date().addingTimeInterval(TextEntryTiming.focusTimeout)
     while Date() < deadline {
       if let focused = focusedTextInput(app: app) {
         return focused
       }
-      // focusedTextInput is intentionally nil on iOS, so the software keyboard becoming
-      // visible is the reliable readiness signal. Exit as soon as it is up instead of
-      // always burning the full focusTimeout.
-      if isKeyboardVisible(app: app) {
+      // focusedTextInput is intentionally nil on iOS; treat the keyboard transitioning to
+      // visible after our tap as the focus-moved signal. Don't fast-path when it was already up.
+      if keyboardBecameVisible(app: app, wasVisibleAtEntry: keyboardVisibleAtEntry) {
         return latest
       }
       sleepFor(TextEntryTiming.pollInterval)
@@ -886,6 +889,7 @@ extension RunnerTests {
   ) -> XCUIElement? {
 #if os(iOS)
     var latest = resolveTextEntryElement(app: app, target: target)
+    let keyboardVisibleAtEntry = isKeyboardVisible(app: app)
     let deadline = Date().addingTimeInterval(timeout)
     let hardwareKeyboardFallback = Date().addingTimeInterval(
       min(TextEntryTiming.hardwareKeyboardFallbackTimeout, timeout)
@@ -898,11 +902,12 @@ extension RunnerTests {
           return focused
         }
       }
-      // The software keyboard being visible is the reliable readiness signal on iOS
-      // (focusedTextInput is intentionally nil there). Once it is up the field is accepting
-      // input, so return immediately rather than burning the full readinessTimeout — the
-      // warmup-first-char echo check and post-type verify/repair remain as drop safety nets.
-      if isKeyboardVisible(app: app) {
+      // Fast-path on a keyboard hidden->visible transition: our tapped field gained focus, so
+      // return immediately instead of burning the full readinessTimeout (warmup-first-char echo
+      // + post-type verify/repair remain as drop safety nets). When the keyboard was ALREADY up
+      // (back-to-back fills), this isn't a focus signal — fall through to the settle/timeout so
+      // text isn't sent to the previously-focused field.
+      if keyboardBecameVisible(app: app, wasVisibleAtEntry: keyboardVisibleAtEntry) {
         return latest
       }
       sawSoftwareKeyboard = sawSoftwareKeyboard || keyboardElementExists(app: app)
@@ -959,6 +964,15 @@ extension RunnerTests {
 
   func isKeyboardVisible(app: XCUIApplication) -> Bool {
     return visibleKeyboardFrame(app: app) != nil
+  }
+
+  /// A focus-moved signal for iOS text entry, where `focusedTextInput` is intentionally nil.
+  /// The software keyboard TRANSITIONING from hidden (at entry) to visible means the field we
+  /// just tapped gained first-responder. If the keyboard was ALREADY up (e.g. back-to-back
+  /// fills into different fields), its visibility is not evidence focus moved to the new field,
+  /// so callers must keep waiting rather than typing into the previously-focused field.
+  private func keyboardBecameVisible(app: XCUIApplication, wasVisibleAtEntry: Bool) -> Bool {
+    return !wasVisibleAtEntry && isKeyboardVisible(app: app)
   }
 
   private func keyboardElementExists(app: XCUIApplication) -> Bool {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -337,17 +337,22 @@ extension RunnerTests {
     let point = CGPoint(x: x, y: y)
     var matched: XCUIElement?
     let exceptionMessage = RunnerObjCExceptionCatcher.catchException({
+      // Query the text-input element types directly instead of enumerating the entire tree
+      // (app.descendants(.any).allElementsBoundByIndex snapshots every element and is ~10x
+      // slower — it dominated fill latency because resolveTextEntryElement re-runs this on
+      // each verify/repair poll once the focused field reference goes stale).
       // Prefer the smallest matching field so nested editable controls win over large containers.
-      let candidates = app.descendants(matching: .any).allElementsBoundByIndex
+      let candidates = [
+        app.textFields,
+        app.secureTextFields,
+        app.searchFields,
+        app.textViews,
+      ]
+        .flatMap { $0.allElementsBoundByIndex }
         .filter { element in
           guard element.exists else { return false }
-          switch element.elementType {
-          case .textField, .secureTextField, .searchField, .textView:
-            let frame = element.frame
-            return !frame.isEmpty && frameContainsPoint(frame, point, tolerance: 2)
-          default:
-            return false
-          }
+          let frame = element.frame
+          return !frame.isEmpty && frameContainsPoint(frame, point, tolerance: 2)
         }
         .sorted { left, right in
           let leftArea = max(1, left.frame.width * left.frame.height)

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -416,6 +416,12 @@ extension RunnerTests {
       if let focused = focusedTextInput(app: app) {
         return focused
       }
+      // focusedTextInput is intentionally nil on iOS, so the software keyboard becoming
+      // visible is the reliable readiness signal. Exit as soon as it is up instead of
+      // always burning the full focusTimeout.
+      if isKeyboardVisible(app: app) {
+        return latest
+      }
       sleepFor(TextEntryTiming.pollInterval)
     }
     return latest
@@ -877,6 +883,13 @@ extension RunnerTests {
         if isKeyboardVisible(app: app) {
           return focused
         }
+      }
+      // The software keyboard being visible is the reliable readiness signal on iOS
+      // (focusedTextInput is intentionally nil there). Once it is up the field is accepting
+      // input, so return immediately rather than burning the full readinessTimeout — the
+      // warmup-first-char echo check and post-type verify/repair remain as drop safety nets.
+      if isKeyboardVisible(app: app) {
+        return latest
       }
       sawSoftwareKeyboard = sawSoftwareKeyboard || keyboardElementExists(app: app)
       if !sawSoftwareKeyboard && Date() >= hardwareKeyboardFallback && latest != nil {


### PR DESCRIPTION
Three iOS XCUITest text-entry fixes, each found and verified on-device (read-back of the field `value` + screenshots). Implements Wave-2 item #4 of the iOS perf plan.

## Summary of measured impact (iPhone 17 sim, Settings search)

| command | before | after |
|---|---:|---:|
| `type` 25 chars | 3342ms | **1379ms** (2.4×) |
| `type` 50-word lorem ipsum (313 ch) | 10.3s | **8.6s** |
| `fill` 25 chars (warm runner) | ~14.5s | **~4.5s** (3.2×) |
| `fill` into Settings search | **0/3 correct** (navigated to Developer pane) | **5–6/6 correct, stays put** |

## 1. perf: early-exit text-entry readiness on keyboard-visible (~2.4s/op)

Focus/readiness loops keyed their fast-exit on `focusedTextInput()`, which is **intentionally `nil` on iOS**. So `stabilizeTextInputBeforeTyping` always burned `focusTimeout` (0.4s) and `waitForTextEntryReadiness` burned `readinessTimeout` (2.0s) whenever the keyboard appeared. Both now return as soon as `isKeyboardVisible()` (the real readiness signal). Warmup-first-char + verify/repair safety nets unchanged; reliability 64/65 exact incl. the 50-word lorem ipsum.

## 2. fix: don't clear an already-empty field (fixes `fill` mis-navigation)

`clearTextInput` always ran `moveCaretToEnd` (an edge-tap from the element frame) + a 24-key delete burst, even on an empty field. On the Settings search bar (repositions bottom→top on focus, revealing a "Suggestions" list), the stale-frame edge-tap landed on the **Developer** suggestion → navigated away (`fill` was 0/3 correct). Skip the clear entirely when the value is already empty (placeholder treated as empty) — a no-op semantically, and it removes the stray tap.

## 3. perf: resolve text fields via typed queries, not full-tree enumeration (`fill` 3.2× faster)

This is why `fill` was ~14.5s while `type` was ~1.6s (it is **not** repair churn or "app busy" — verified). `textInputAt` used `app.descendants(.any).allElementsBoundByIndex` (snapshots **every** element). `fill` drove it repeatedly: once it has coordinates, `resolveTextEntryElement` re-runs `textInputAt` on **every verify/repair poll** when the focused-field reference goes stale (search bar repositioning). Switched to typed queries (`app.textFields/secureTextFields/searchFields/textViews`) — same matches, no whole-tree snapshot (the same primitive #632 fixed for `get text`). `fill` 25 chars warm: ~14.5s → ~4.5s, 6/6 exact.

## Diagnosis notes (for reviewers)
- The dominant per-command cost is the **first interaction after `open`/relaunch** (one-time iOS-runner startup ~10s + a per-relaunch first-AX-query settle ~4s). `type` measured fast only because a `press` preceded it; `fill` measured slow because it *was* that first interaction. (#630's harness now runs an untimed warmup after each open so benchmarks don't charge this to a measured command.)
- Warm `fill` (~4.5s) is now close to `press`+`type` (~3s). Further headroom: plan item #4b — resolve the text-entry element once per verify/repair window instead of per poll.

## Validation
Per trial: `open --relaunch` → focus → `type`/`fill <string>` (timed) → read field `value` from `snapshot --raw --json`, compare byte-for-byte → screenshot. 50-word lorem ipsum rendered exactly in the "No Results for …" header. Swift-only; needs `build:xcuitest:ios`. Branched off `main`.
