### PR TITLE
fix(ios): drive gesture pinch via two-finger synthesis (#629)

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -1510,7 +1510,27 @@ extension RunnerTests {
   }
 
   func pinch(app: XCUIApplication, scale: Double, x: Double?, y: Double?) -> RunnerInteractionOutcome {
+#if os(iOS)
+    // A coordinate tap+drag is a single-finger gesture: React Native reads it as a pan
+    // and the pinch scale never changes (#629). Drive the two-finger XCTest synthesis
+    // path (the same one transformGesture uses) with zero translation/rotation so RN's
+    // pinch recognizer actually fires.
+    let frame = interactionRoot(app: app).frame
+    let centerX = x ?? Double(frame.midX)
+    let centerY = y ?? Double(frame.midY)
+    return transformGesture(
+      app: app,
+      x: centerX,
+      y: centerY,
+      dx: 0,
+      dy: 0,
+      scale: scale,
+      degrees: 0,
+      durationMs: 300
+    )
+#else
     return performCoordinatePinch(app: app, scale: scale, x: x, y: y)
+#endif
   }
 
   func rotateGesture(app: XCUIApplication, degrees: Double, x: Double?, y: Double?, velocity: Double) -> RunnerInteractionOutcome {


### PR DESCRIPTION
## What
`gesture pinch` on iOS now uses the two-finger XCTest synthesis path instead of a single-finger coordinate drag, so React Native's pinch recognizer actually fires.

## Root cause (#629)
On iOS the runner lowered `pinch` to `performCoordinatePinch` — a `tap()` followed by a **single-finger** `press(forDuration:thenDragTo:)`. React Native reads that as a *pan*: the target translates but the pinch scale never changes. Reproduced on iPhone 17 Pro against `examples/test-app`'s gesture lab — "pinch changed no", `scale 1.00`.

## Fix
On iOS, `pinch()` delegates to `transformGesture(… dx:0, dy:0, degrees:0)` — the same private two-finger synthesis (`RunnerSynthesizedGesture`) that `gesture transform` already uses and that does change scale. macOS keeps the coordinate path; tvOS stays unsupported. 20-line Swift diff, no TS changes.

## Validation (iPhone 17 Pro, modified runner built)
- Focused pinch replay: `wait "pinch changed yes"` now **passes** (failed before the fix).
- Full `examples/test-app/replays/gesture-lab.ad` oracle: **1/1 pass** (fling ×4 / pan ×4 / pinch / rotate). It previously failed at the pinch step. No regression to the other gestures.

## Scope note
This is the one #629 gesture bug that reproduced on the current `examples/test-app`. The reported scroll/fling "miss" did **not** reproduce here (scroll/fling/pan register fine at baseline), so no gesture-duration changes are included.

Refs #629