### PR TITLE
fix: normalize maestro loading ellipsis

### DIFF
--- a/src/compat/maestro/__tests__/runtime-assertions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-assertions.test.ts
@@ -158,6 +158,33 @@ test('invokeMaestroAssertVisible uses snapshot resolution for short iOS assertio
   assert.deepEqual(calls, [['snapshot', []]]);
 });
 
+test('invokeMaestroAssertVisible treats an elapsed ellipsis loading gate as already past loading', async () => {
+  vi.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValueOnce(250);
+
+  const response = await invokeMaestroAssertVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: {
+        platform: 'ios',
+        maestro: { allowAlreadyPastLoading: true },
+      },
+    },
+    positionals: ['label="Loading…" || text="Loading…" || id="Loading…"', '1000'],
+    invoke: async (): Promise<DaemonResponse> => ({
+      ok: true,
+      data: snapshot([node('Dashboard')]),
+    }),
+  });
+
+  assert.equal(response.ok, true);
+  if (response.ok) {
+    assert.ok(response.data);
+    assert.equal(response.data.alreadyPastLoading, true);
+    assert.equal(response.data.waitedMs, 250);
+  }
+});
+
 test('invokeMaestroAssertVisible dismisses React Native overlays during snapshot assertions', async () => {
   const calls: Array<[string, string[] | undefined]> = [];
   let snapshots = 0;

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -373,12 +373,12 @@ function normalizeLoadingText(value: string | null | undefined): string {
     value
       ?.trim()
       .toLowerCase()
-      .replace(/\.\.\./g, '...') ?? ''
+      .replace(/\u2026/g, '...') ?? ''
   );
 }
 
 function isLoadingText(value: string): boolean {
-  return value === 'loading' || value === 'loading...' || value === 'loading…';
+  return value === 'loading' || value === 'loading...';
 }
 
 function visibleAssertionResponse(


### PR DESCRIPTION
## Summary

Normalize Unicode ellipsis in Maestro loading text before comparing loading gates, removing the CodeQL identity replacement flagged in security alert 16.

Adds a regression test covering the elapsed `Loading…` gate path when `allowAlreadyPastLoading` is enabled.

Closes https://github.com/callstackincubator/agent-device/security/code-scanning/16

## Validation

Verified with formatting, the focused Maestro runtime assertion test, and the quick lint/typecheck bundle:

- `pnpm format`
- `pnpm exec vitest run src/compat/maestro/__tests__/runtime-assertions.test.ts --project unit`
- `pnpm check:quick`

Touched-file count: 2. Scope stayed within the Maestro compatibility assertion module and its test.