### PR TITLE
fix: align Maestro assertVisible timeout

### DIFF
--- a/src/compat/maestro/__tests__/replay-flow.test.ts
+++ b/src/compat/maestro/__tests__/replay-flow.test.ts
@@ -67,7 +67,7 @@ env:
       ['type', ['Ada Lovelace']],
       [
         '__maestroAssertVisible',
-        ['label="Checkout form" || text="Checkout form" || id="Checkout form"', '5000'],
+        ['label="Checkout form" || text="Checkout form" || id="Checkout form"', '7000'],
       ],
       [
         '__maestroAssertNotVisible',
@@ -368,7 +368,7 @@ test('parseMaestroReplayFlow preserves selector state and absolute swipe command
   assert.deepEqual(
     parsed.actions.map((entry) => [entry.command, entry.positionals]),
     [
-      ['__maestroAssertVisible', ['id="shipping-pickup" selected="true"', '5000']],
+      ['__maestroAssertVisible', ['id="shipping-pickup" selected="true"', '7000']],
       ['swipe', ['100', '500', '100', '200', '300']],
     ],
   );
@@ -628,7 +628,7 @@ test('parseMaestroReplayFlow keeps retry commands for runtime evaluation', () =>
     control.actions.map((entry) => [entry.command, entry.positionals, entry.flags]),
     [
       ['open', ['example://details'], {}],
-      ['__maestroAssertVisible', ['label="Article" || text="Article" || id="Article"', '5000'], {}],
+      ['__maestroAssertVisible', ['label="Article" || text="Article" || id="Article"', '7000'], {}],
     ],
   );
 });

--- a/src/compat/maestro/command-mapper.ts
+++ b/src/compat/maestro/command-mapper.ts
@@ -58,7 +58,7 @@ const MAP_COMMAND_HANDLERS: Record<string, MaestroCommandHandler> = {
   assertVisible: ({ value, context, name }) => [
     action(MAESTRO_RUNTIME_COMMAND.assertVisible, [
       maestroSelector(value, name, [], context),
-      '5000',
+      '7000',
     ]),
   ],
   assertNotVisible: ({ value, context, name }) => [

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -48,7 +48,7 @@ export async function invokeMaestroAssertVisible(params: {
 }): Promise<DaemonResponse> {
   const args = readVisibilityAssertionArgs(params.positionals, {
     command: 'assertVisible',
-    defaultTimeoutMs: 5000,
+    defaultTimeoutMs: 7000,
   });
   if (!args.ok) return args.response;
 


### PR DESCRIPTION
## Summary

Align Maestro `assertVisible` compatibility with Maestro's normal assertion wait budget by using a 7s default instead of 5s.

This lets suites rely on regular `assertVisible` for ordinary post-navigation checks instead of adding `extendedWaitUntil` timeouts for cases that should fit within the default assertion window.

## Validation

- `pnpm exec vitest run src/compat/maestro/__tests__/replay-flow.test.ts src/compat/maestro/__tests__/runtime-assertions.test.ts`
- `pnpm check:quick`