### PR TITLE
chore: update Glama MCP metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![npm version](https://img.shields.io/npm/v/agent-device.svg)](https://www.npmjs.com/package/agent-device)
 [![CI](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml/badge.svg)](https://github.com/callstackincubator/agent-device/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-black.svg)](LICENSE)
+[![Glama MCP server](https://glama.ai/mcp/servers/callstackincubator/agent-device/badges/score.svg)](https://glama.ai/mcp/servers/callstackincubator/agent-device)
 
 Mobile app verification for AI agents.
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["thymikee"]
+}

--- a/website/docs/docs/agent-setup.md
+++ b/website/docs/docs/agent-setup.md
@@ -86,7 +86,7 @@ No global install variant. Pin a user- or project-selected package version for u
 }
 ```
 
-Registry metadata uses MCP name `io.github.callstackincubator/agent-device`, npm package `agent-device`, stdio transport, `mcpName` package verification, `server.json`, and `smithery.yaml`.
+Registry metadata uses MCP name `io.github.callstackincubator/agent-device`, npm package `agent-device`, stdio transport, `mcpName` package verification, `server.json`, `glama.json`, and `smithery.yaml`. Glama lists the server at [callstackincubator/agent-device](https://glama.ai/mcp/servers/callstackincubator/agent-device).
 
 ## Cursor
 


### PR DESCRIPTION
## Summary

Update Glama-facing MCP metadata so the organization-owned server can be claimed and evaluated, including `glama.json`, a Glama README badge, and docs metadata alignment.

Touched files: 3. Scope stayed within MCP/registry metadata and docs.

## Validation

Verified metadata sync with `pnpm check:mcp-metadata`. Earlier on this branch, also verified `pnpm build`, JSON metadata parsing, and a built stdio MCP `tools/list` smoke request before the later scope trims.