### PR TITLE
fix: stabilize android perf harness setup

### DIFF
--- a/scripts/perf/harness.ts
+++ b/scripts/perf/harness.ts
@@ -126,6 +126,10 @@ function buildMeasurement(
   };
 }
 
+function setupMeasurementFailed(measurement: Measurement): boolean {
+  return measurement.samples.some((sample) => !sample.ok);
+}
+
 // Boot the device once and time it. Runs WITHOUT --session so no session lock policy
 // applies and the device selectors are honored (selectors are rejected on locked sessions).
 function bootOnce(ctx: IsolationContext): Measurement {
@@ -163,6 +167,10 @@ export function runScenario(ctx: IsolationContext, cfg: PerfConfig): Measurement
 
   const boot = bootOnce(ctx);
   const establish = establishSession(ctx);
+  if (setupMeasurementFailed(boot) || setupMeasurementFailed(establish)) {
+    log('setup failed; skipping timed tour');
+    return [boot, establish];
+  }
   // Absorb the one-time runner startup before any round so it isn't charged to a measurement.
   warmRunner(ctx);
 

--- a/scripts/perf/platform-profiles.ts
+++ b/scripts/perf/platform-profiles.ts
@@ -2,10 +2,10 @@ import type { PerfConfig } from './config.ts';
 import type { Platform } from './types.ts';
 
 // Local-convenience defaults for ad-hoc runs; CI always overrides them (--device / --serial).
-// The iOS UDID is a specific local "iPhone 17" sim; the Android serial is a dedicated emulator
-// port. Pass --udid/--device/--serial to target your own device.
+// The iOS UDID is a specific local "iPhone 17" sim; the Android default is an AVD name that
+// `boot` can launch. Pass --udid/--device/--serial to target your own device.
 const DEFAULT_IOS_UDID = 'D74E0B66-57EB-4EC1-92DC-DA0A30581FE7';
-const DEFAULT_ANDROID_SERIAL = 'emulator-5556';
+const DEFAULT_ANDROID_AVD = 'Pixel_9_Pro_XL_API_37';
 
 export type ProfileSelectors = {
   // A row on the Settings root that pushes a large sub-screen (big a11y tree).
@@ -57,13 +57,16 @@ export function resolveProfile(cfg: PerfConfig): ResolvedProfile {
       },
     };
   }
-  const serial = cfg.serial ?? DEFAULT_ANDROID_SERIAL;
+  const avdName = cfg.device ?? DEFAULT_ANDROID_AVD;
+  const serialFlags = cfg.serial
+    ? ['--serial', cfg.serial, '--android-device-allowlist', cfg.serial]
+    : [];
   return {
     platform: 'android',
-    deviceName: cfg.serial ? `android (${serial})` : 'Pixel_9_Pro_XL_API_37',
-    serial,
+    deviceName: cfg.serial ? `android (${cfg.serial})` : avdName,
+    serial: cfg.serial,
     platformFlags: ['--platform', 'android'],
-    selectorFlags: ['--serial', serial, '--android-device-allowlist', serial],
+    selectorFlags: ['--device', avdName, ...serialFlags],
     appTarget: 'com.android.settings',
     selectors: {
       deepScreen: 'text="Network & internet"',


### PR DESCRIPTION
## Summary

Android perf runs now default to an AVD name that `boot` can launch instead of a hardcoded emulator serial, while still honoring explicit `--serial` selectors when provided.

The perf harness also stops after failed setup measurements, so boot/open failures no longer cascade into misleading timed tour failures.

## Validation

Verified with `pnpm check:quick` and `git diff --check`.