### PR TITLE
refactor: add iOS runner lifecycle protocol

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -27,7 +27,7 @@ extension RunnerTests {
 
   func execute(command: Command) throws -> Response {
     if command.command == .status {
-      return try executeDispatched(command: command)
+      return executeStatus(command: command)
     }
     commandJournal.accept(command: command)
     commandJournal.start(command: command)
@@ -39,6 +39,17 @@ extension RunnerTests {
       commandJournal.fail(command: command, error: error)
       throw error
     }
+  }
+
+  private func executeStatus(command: Command) -> Response {
+    guard
+      let statusCommandId = command.statusCommandId?
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+      !statusCommandId.isEmpty
+    else {
+      return Response(ok: false, error: ErrorPayload(message: "status requires statusCommandId"))
+    }
+    return Response(ok: true, data: commandJournal.status(commandId: statusCommandId))
   }
 
   private func executeDispatched(command: Command) throws -> Response {
@@ -200,14 +211,7 @@ extension RunnerTests {
 
     switch command.command {
     case .status:
-      guard
-        let statusCommandId = command.statusCommandId?
-          .trimmingCharacters(in: .whitespacesAndNewlines),
-        !statusCommandId.isEmpty
-      else {
-        return Response(ok: false, error: ErrorPayload(message: "status requires statusCommandId"))
-      }
-      return Response(ok: true, data: commandJournal.status(commandId: statusCommandId))
+      return executeStatus(command: command)
     case .shutdown:
       stopRecordingIfNeeded()
       return Response(ok: true, data: DataPayload(message: "shutdown"))

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -26,6 +26,9 @@ extension RunnerTests {
   }
 
   func execute(command: Command) throws -> Response {
+    if command.command == .status {
+      return try executeDispatched(command: command)
+    }
     commandJournal.accept(command: command)
     commandJournal.start(command: command)
     do {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -26,6 +26,19 @@ extension RunnerTests {
   }
 
   func execute(command: Command) throws -> Response {
+    commandJournal.accept(command: command)
+    commandJournal.start(command: command)
+    do {
+      let response = try executeDispatched(command: command)
+      commandJournal.finish(command: command, response: response)
+      return response
+    } catch {
+      commandJournal.fail(command: command, error: error)
+      throw error
+    }
+  }
+
+  private func executeDispatched(command: Command) throws -> Response {
     if Thread.isMainThread {
       return try executeOnMainSafely(command: command)
     }
@@ -183,6 +196,15 @@ extension RunnerTests {
     }
 
     switch command.command {
+    case .status:
+      guard
+        let statusCommandId = command.statusCommandId?
+          .trimmingCharacters(in: .whitespacesAndNewlines),
+        !statusCommandId.isEmpty
+      else {
+        return Response(ok: false, error: ErrorPayload(message: "status requires statusCommandId"))
+      }
+      return Response(ok: true, data: commandJournal.status(commandId: statusCommandId))
     case .shutdown:
       stopRecordingIfNeeded()
       return Response(ok: true, data: DataPayload(message: "shutdown"))

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
@@ -11,7 +11,8 @@ struct RunnerCommandJournalEntry {
   let commandId: String
   let command: String
   var state: RunnerCommandLifecycleState
-  var response: Response?
+  var responseOk: Bool?
+  var responseJson: String?
   var error: ErrorPayload?
   var updatedAtMs: Double
 }
@@ -19,6 +20,7 @@ struct RunnerCommandJournalEntry {
 final class RunnerCommandJournal {
   private let lock = NSLock()
   private let maxEntries = 64
+  private let maxResponseJsonBytes = 16 * 1024
   private var entries: [String: RunnerCommandJournalEntry] = [:]
   private var order: [String] = []
 
@@ -30,7 +32,8 @@ final class RunnerCommandJournal {
       commandId: commandId,
       command: command.command.rawValue,
       state: .accepted,
-      response: nil,
+      responseOk: nil,
+      responseJson: nil,
       error: nil,
       updatedAtMs: currentTimeMs()
     )
@@ -40,14 +43,15 @@ final class RunnerCommandJournal {
   }
 
   func start(command: Command) {
-    update(command: command, state: .started, response: nil, error: nil)
+    update(command: command, state: .started, responseOk: nil, responseJson: nil, error: nil)
   }
 
   func finish(command: Command, response: Response) {
     update(
       command: command,
       state: response.ok ? .completed : .failed,
-      response: response,
+      responseOk: response.ok,
+      responseJson: encodeResponseJson(response),
       error: response.error
     )
   }
@@ -56,7 +60,8 @@ final class RunnerCommandJournal {
     update(
       command: command,
       state: .failed,
-      response: nil,
+      responseOk: nil,
+      responseJson: nil,
       error: ErrorPayload(message: error.localizedDescription)
     )
   }
@@ -75,8 +80,8 @@ final class RunnerCommandJournal {
       commandId: entry.commandId,
       lifecycleState: entry.state.rawValue,
       lifecycleCommand: entry.command,
-      lifecycleResponseOk: entry.response?.ok,
-      lifecycleResponseJson: encodeResponseJson(entry.response),
+      lifecycleResponseOk: entry.responseOk,
+      lifecycleResponseJson: entry.responseJson,
       lifecycleErrorCode: entry.error?.code,
       lifecycleErrorMessage: entry.error?.message,
       lifecycleErrorHint: entry.error?.hint
@@ -86,7 +91,8 @@ final class RunnerCommandJournal {
   private func update(
     command: Command,
     state: RunnerCommandLifecycleState,
-    response: Response?,
+    responseOk: Bool?,
+    responseJson: String?,
     error: ErrorPayload?
   ) {
     guard let commandId = normalizedCommandId(command.commandId) else { return }
@@ -96,12 +102,14 @@ final class RunnerCommandJournal {
       commandId: commandId,
       command: command.command.rawValue,
       state: .accepted,
-      response: nil,
+      responseOk: nil,
+      responseJson: nil,
       error: nil,
       updatedAtMs: currentTimeMs()
     )
     entry.state = state
-    entry.response = response
+    entry.responseOk = responseOk
+    entry.responseJson = responseJson
     entry.error = error
     entry.updatedAtMs = currentTimeMs()
     entries[commandId] = entry
@@ -127,9 +135,9 @@ final class RunnerCommandJournal {
     Date().timeIntervalSince1970 * 1000
   }
 
-  private func encodeResponseJson(_ response: Response?) -> String? {
-    guard let response else { return nil }
+  private func encodeResponseJson(_ response: Response) -> String? {
     guard let data = try? JSONEncoder().encode(response) else { return nil }
+    guard data.count <= maxResponseJsonBytes else { return nil }
     return String(data: data, encoding: .utf8)
   }
 }

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum RunnerCommandLifecycleState: String {
+  case notAccepted
   case accepted
   case started
   case completed
@@ -66,13 +67,16 @@ final class RunnerCommandJournal {
 
   func status(commandId: String) -> DataPayload {
     guard let normalized = normalizedCommandId(commandId) else {
-      return DataPayload(lifecycleState: "notAccepted")
+      return DataPayload(lifecycleState: RunnerCommandLifecycleState.notAccepted.rawValue)
     }
     lock.lock()
     let entry = entries[normalized]
     lock.unlock()
     guard let entry else {
-      return DataPayload(commandId: normalized, lifecycleState: "notAccepted")
+      return DataPayload(
+        commandId: normalized,
+        lifecycleState: RunnerCommandLifecycleState.notAccepted.rawValue
+      )
     }
     return DataPayload(
       commandId: entry.commandId,

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+enum RunnerCommandLifecycleState: String {
+  case accepted
+  case started
+  case completed
+  case failed
+}
+
+struct RunnerCommandJournalEntry {
+  let commandId: String
+  let command: String
+  var state: RunnerCommandLifecycleState
+  var response: Response?
+  var error: ErrorPayload?
+  var updatedAtMs: Double
+}
+
+final class RunnerCommandJournal {
+  private let lock = NSLock()
+  private let maxEntries = 64
+  private var entries: [String: RunnerCommandJournalEntry] = [:]
+  private var order: [String] = []
+
+  func accept(command: Command) {
+    guard let commandId = normalizedCommandId(command.commandId) else { return }
+    lock.lock()
+    defer { lock.unlock() }
+    entries[commandId] = RunnerCommandJournalEntry(
+      commandId: commandId,
+      command: command.command.rawValue,
+      state: .accepted,
+      response: nil,
+      error: nil,
+      updatedAtMs: currentTimeMs()
+    )
+    order.removeAll { $0 == commandId }
+    order.append(commandId)
+    pruneIfNeeded()
+  }
+
+  func start(command: Command) {
+    update(command: command, state: .started, response: nil, error: nil)
+  }
+
+  func finish(command: Command, response: Response) {
+    update(
+      command: command,
+      state: response.ok ? .completed : .failed,
+      response: response,
+      error: response.error
+    )
+  }
+
+  func fail(command: Command, error: Error) {
+    update(
+      command: command,
+      state: .failed,
+      response: nil,
+      error: ErrorPayload(message: error.localizedDescription)
+    )
+  }
+
+  func status(commandId: String) -> DataPayload {
+    guard let normalized = normalizedCommandId(commandId) else {
+      return DataPayload(lifecycleState: "notAccepted")
+    }
+    lock.lock()
+    let entry = entries[normalized]
+    lock.unlock()
+    guard let entry else {
+      return DataPayload(commandId: normalized, lifecycleState: "notAccepted")
+    }
+    return DataPayload(
+      commandId: entry.commandId,
+      lifecycleState: entry.state.rawValue,
+      lifecycleCommand: entry.command,
+      lifecycleResponseOk: entry.response?.ok,
+      lifecycleResponseJson: encodeResponseJson(entry.response),
+      lifecycleErrorCode: entry.error?.code,
+      lifecycleErrorMessage: entry.error?.message,
+      lifecycleErrorHint: entry.error?.hint
+    )
+  }
+
+  private func update(
+    command: Command,
+    state: RunnerCommandLifecycleState,
+    response: Response?,
+    error: ErrorPayload?
+  ) {
+    guard let commandId = normalizedCommandId(command.commandId) else { return }
+    lock.lock()
+    defer { lock.unlock() }
+    var entry = entries[commandId] ?? RunnerCommandJournalEntry(
+      commandId: commandId,
+      command: command.command.rawValue,
+      state: .accepted,
+      response: nil,
+      error: nil,
+      updatedAtMs: currentTimeMs()
+    )
+    entry.state = state
+    entry.response = response
+    entry.error = error
+    entry.updatedAtMs = currentTimeMs()
+    entries[commandId] = entry
+    order.removeAll { $0 == commandId }
+    order.append(commandId)
+    pruneIfNeeded()
+  }
+
+  private func pruneIfNeeded() {
+    while order.count > maxEntries {
+      let removed = order.removeFirst()
+      entries.removeValue(forKey: removed)
+    }
+  }
+
+  private func normalizedCommandId(_ value: String?) -> String? {
+    guard let value else { return nil }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private func currentTimeMs() -> Double {
+    Date().timeIntervalSince1970 * 1000
+  }
+
+  private func encodeResponseJson(_ response: Response?) -> String? {
+    guard let response else { return nil }
+    guard let data = try? JSONEncoder().encode(response) else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+}

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandJournal.swift
@@ -14,7 +14,6 @@ struct RunnerCommandJournalEntry {
   var responseOk: Bool?
   var responseJson: String?
   var error: ErrorPayload?
-  var updatedAtMs: Double
 }
 
 final class RunnerCommandJournal {
@@ -34,8 +33,7 @@ final class RunnerCommandJournal {
       state: .accepted,
       responseOk: nil,
       responseJson: nil,
-      error: nil,
-      updatedAtMs: currentTimeMs()
+      error: nil
     )
     order.removeAll { $0 == commandId }
     order.append(commandId)
@@ -104,14 +102,12 @@ final class RunnerCommandJournal {
       state: .accepted,
       responseOk: nil,
       responseJson: nil,
-      error: nil,
-      updatedAtMs: currentTimeMs()
+      error: nil
     )
     entry.state = state
     entry.responseOk = responseOk
     entry.responseJson = responseJson
     entry.error = error
-    entry.updatedAtMs = currentTimeMs()
     entries[commandId] = entry
     order.removeAll { $0 == commandId }
     order.append(commandId)
@@ -131,11 +127,8 @@ final class RunnerCommandJournal {
     return trimmed.isEmpty ? nil : trimmed
   }
 
-  private func currentTimeMs() -> Double {
-    Date().timeIntervalSince1970 * 1000
-  }
-
   private func encodeResponseJson(_ response: Response) -> String? {
+    guard response.data?.nodes == nil else { return nil }
     guard let data = try? JSONEncoder().encode(response) else { return nil }
     guard data.count <= maxResponseJsonBytes else { return nil }
     return String(data: data, encoding: .utf8)

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift
@@ -30,6 +30,7 @@ enum CommandType: String, Codable {
   case transformGesture
   case recordStart
   case recordStop
+  case status
   case uptime
   case shutdown
 }
@@ -91,6 +92,9 @@ extension CommandType {
     case .recordStop, .uptime, .shutdown:
       return CommandTraits(isInteraction: false, readOnly: .never, isLifecycle: true)
 
+    case .status:
+      return CommandTraits(isInteraction: false, readOnly: .always, isLifecycle: true)
+
     // Normal preflight, not retried.
     // NOTE: mouseClick stays non-interaction for now — it is macOS-only and the foreground
     // guard interacts with bespoke macOS activation, so classifying it needs a macOS smoke
@@ -104,6 +108,8 @@ extension CommandType {
 
 struct Command: Codable {
   let command: CommandType
+  let commandId: String?
+  let statusCommandId: String?
   let appBundleId: String?
   let text: String?
   let selectorKey: String?
@@ -171,6 +177,14 @@ struct DataPayload: Codable {
   let referenceWidth: Double?
   let referenceHeight: Double?
   let currentUptimeMs: Double?
+  let commandId: String?
+  let lifecycleState: String?
+  let lifecycleCommand: String?
+  let lifecycleResponseOk: Bool?
+  let lifecycleResponseJson: String?
+  let lifecycleErrorCode: String?
+  let lifecycleErrorMessage: String?
+  let lifecycleErrorHint: String?
   let visible: Bool?
   let wasVisible: Bool?
   let dismissed: Bool?
@@ -192,6 +206,14 @@ struct DataPayload: Codable {
     referenceWidth: Double? = nil,
     referenceHeight: Double? = nil,
     currentUptimeMs: Double? = nil,
+    commandId: String? = nil,
+    lifecycleState: String? = nil,
+    lifecycleCommand: String? = nil,
+    lifecycleResponseOk: Bool? = nil,
+    lifecycleResponseJson: String? = nil,
+    lifecycleErrorCode: String? = nil,
+    lifecycleErrorMessage: String? = nil,
+    lifecycleErrorHint: String? = nil,
     visible: Bool? = nil,
     wasVisible: Bool? = nil,
     dismissed: Bool? = nil,
@@ -212,6 +234,14 @@ struct DataPayload: Codable {
     self.referenceWidth = referenceWidth
     self.referenceHeight = referenceHeight
     self.currentUptimeMs = currentUptimeMs
+    self.commandId = commandId
+    self.lifecycleState = lifecycleState
+    self.lifecycleCommand = lifecycleCommand
+    self.lifecycleResponseOk = lifecycleResponseOk
+    self.lifecycleResponseJson = lifecycleResponseJson
+    self.lifecycleErrorCode = lifecycleErrorCode
+    self.lifecycleErrorMessage = lifecycleErrorMessage
+    self.lifecycleErrorHint = lifecycleErrorHint
     self.visible = visible
     self.wasVisible = wasVisible
     self.dismissed = dismissed

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -53,6 +53,7 @@ final class RunnerTests: XCTestCase {
   var needsPostSnapshotInteractionDelay = false
   var needsFirstInteractionDelay = false
   var activeRecording: ScreenRecorder?
+  let commandJournal = RunnerCommandJournal()
   let interactiveTypes: Set<XCUIElement.ElementType> = [
     .button,
     .cell,

--- a/src/platforms/ios/__tests__/runner-client.test.ts
+++ b/src/platforms/ios/__tests__/runner-client.test.ts
@@ -389,6 +389,12 @@ test('withRunnerCommandId replaces blank command ids', () => {
   assert.match(command.commandId ?? '', /^runner-/);
 });
 
+test('withRunnerCommandId preserves existing command ids', () => {
+  const command = withRunnerCommandId({ command: 'uptime', commandId: 'runner-existing' });
+
+  assert.deepEqual(command, { command: 'uptime', commandId: 'runner-existing' });
+});
+
 test('withRunnerCommandId does not add command ids to status probes', () => {
   const command = withRunnerCommandId({
     command: 'status',

--- a/src/platforms/ios/__tests__/runner-client.test.ts
+++ b/src/platforms/ios/__tests__/runner-client.test.ts
@@ -32,6 +32,7 @@ vi.mock('../runner-macos-products.ts', async () => {
 import type { DeviceInfo } from '../../../utils/device.ts';
 import { AppError } from '../../../utils/errors.ts';
 import type { RunnerCommand } from '../runner-contract.ts';
+import { withRunnerCommandId } from '../runner-contract.ts';
 import {
   assertSafeDerivedCleanup,
   isRetryableRunnerError,
@@ -380,6 +381,12 @@ test('runner protocol fixtures cover every runner command with JSON-safe samples
   assert.equal(roundTrip.rotate!.orientation, 'landscape-left');
   assert.equal(roundTrip.recordStart!.fps, 30);
   assert.equal(roundTrip.recordStart!.quality, 7);
+});
+
+test('withRunnerCommandId replaces blank command ids', () => {
+  const command = withRunnerCommandId({ command: 'uptime', commandId: '   ' });
+
+  assert.match(command.commandId ?? '', /^runner-/);
 });
 
 test('resolveRunnerDestination uses device destination for physical devices', () => {

--- a/src/platforms/ios/__tests__/runner-client.test.ts
+++ b/src/platforms/ios/__tests__/runner-client.test.ts
@@ -389,6 +389,15 @@ test('withRunnerCommandId replaces blank command ids', () => {
   assert.match(command.commandId ?? '', /^runner-/);
 });
 
+test('withRunnerCommandId does not add command ids to status probes', () => {
+  const command = withRunnerCommandId({
+    command: 'status',
+    statusCommandId: 'runner-command-1',
+  });
+
+  assert.deepEqual(command, { command: 'status', statusCommandId: 'runner-command-1' });
+});
+
 test('resolveRunnerDestination uses device destination for physical devices', () => {
   assert.equal(resolveRunnerDestination(iosDevice), 'platform=iOS,id=00008110-000E12341234002E');
 });

--- a/src/platforms/ios/__tests__/runner-client.test.ts
+++ b/src/platforms/ios/__tests__/runner-client.test.ts
@@ -159,6 +159,7 @@ const runnerProtocolCommandFixtures: Record<RunnerCommand['command'], RunnerComm
     quality: 7,
   },
   recordStop: { command: 'recordStop' },
+  status: { command: 'status', statusCommandId: 'runner-command-1' },
   uptime: { command: 'uptime' },
   shutdown: { command: 'shutdown' },
 };
@@ -359,6 +360,7 @@ test('runner protocol fixtures cover every runner command with JSON-safe samples
     'screenshot',
     'shutdown',
     'snapshot',
+    'status',
     'swipe',
     'tap',
     'tapSeries',

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -159,10 +159,14 @@ test('runner session executes status command as read-only lifecycle command', as
     lifecycleResponseOk: true,
   });
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
-  assertRunnerCommand(mockWaitForRunner.mock.calls[0]?.[2], {
-    command: 'status',
-    statusCommandId: 'runner-command-1',
-  });
+  assertRunnerCommand(
+    mockWaitForRunner.mock.calls[0]?.[2],
+    {
+      command: 'status',
+      statusCommandId: 'runner-command-1',
+    },
+    { commandId: false },
+  );
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 0);
 });
 
@@ -488,11 +492,17 @@ function runnerError(error: { code: string; message: string }): Response {
 function assertRunnerCommand(
   actual: unknown,
   expected: Record<string, unknown>,
+  options: { commandId?: boolean } = {},
 ): asserts actual is Record<string, unknown> {
   assert.equal(typeof actual, 'object');
   assert.notEqual(actual, null);
   const command = actual as Record<string, unknown>;
   const commandId = command.commandId;
+  if (options.commandId === false) {
+    assert.equal(commandId, undefined);
+    assert.deepEqual(command, expected);
+    return;
+  }
   if (typeof commandId !== 'string') {
     assert.fail('expected runner commandId');
   }

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -128,9 +128,40 @@ test('runner session executes read-only commands without uptime preflight', asyn
   assert.deepEqual(result, { nodes: [], truncated: false });
   assert.equal(session.ready, true);
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
-  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], {
+  assertRunnerCommand(mockWaitForRunner.mock.calls[0]?.[2], {
     command: 'snapshot',
     appBundleId: 'com.example.demo',
+  });
+  assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 0);
+});
+
+test('runner session executes status command as read-only lifecycle command', async () => {
+  const session = makeRunnerSession({ ready: true });
+  mockWaitForRunner.mockResolvedValueOnce(
+    runnerResponse({
+      commandId: 'runner-command-1',
+      lifecycleState: 'completed',
+      lifecycleResponseOk: true,
+    }),
+  );
+
+  const result = await executeRunnerCommandWithSession(
+    IOS_SIMULATOR,
+    session,
+    { command: 'status', statusCommandId: 'runner-command-1' },
+    '/tmp/runner.log',
+    30_000,
+  );
+
+  assert.deepEqual(result, {
+    commandId: 'runner-command-1',
+    lifecycleState: 'completed',
+    lifecycleResponseOk: true,
+  });
+  assert.equal(mockWaitForRunner.mock.calls.length, 1);
+  assertRunnerCommand(mockWaitForRunner.mock.calls[0]?.[2], {
+    command: 'status',
+    statusCommandId: 'runner-command-1',
   });
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 0);
 });
@@ -151,9 +182,9 @@ test('runner session probes readiness before mutating commands', async () => {
   assert.deepEqual(result, { tapped: true });
   assert.equal(session.ready, true);
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
-  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assertRunnerCommand(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
-  assert.deepEqual(mockSendRunnerCommandOnce.mock.calls[0]?.[2], {
+  assertRunnerCommand(mockSendRunnerCommandOnce.mock.calls[0]?.[2], {
     command: 'tap',
     x: 120,
     y: 240,
@@ -239,7 +270,7 @@ test('runner session keeps readiness preflight for tap commands when ready but n
 
   assert.deepEqual(result, { tapped: true });
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
-  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assertRunnerCommand(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
 });
 
@@ -261,7 +292,7 @@ test('runner session keeps readiness preflight for tap commands when marked read
 
   assert.deepEqual(result, { tapped: true });
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
-  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assertRunnerCommand(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
 });
 
@@ -280,7 +311,7 @@ test('runner session keeps readiness preflight for non-tap mutating commands whe
 
   assert.deepEqual(result, { pressed: true });
   assert.equal(mockWaitForRunner.mock.calls.length, 1);
-  assert.deepEqual(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
+  assertRunnerCommand(mockWaitForRunner.mock.calls[0]?.[2], { command: 'uptime' });
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
 });
 
@@ -371,7 +402,7 @@ test('runner session stop sends shutdown, cleans temporary runner files, and rel
   mockIsProcessAlive.mockReturnValue(false);
   await stopRunnerSession(session);
 
-  assert.deepEqual(mockWaitForRunner.mock.calls.at(-1)?.[2], { command: 'shutdown' });
+  assertRunnerCommand(mockWaitForRunner.mock.calls.at(-1)?.[2], { command: 'shutdown' });
   assert.deepEqual(mockCleanupTempFile.mock.calls, [
     ['/tmp/session-runner.xctestrun'],
     ['/tmp/session-runner.json'],
@@ -452,4 +483,19 @@ function runnerResponse(data: Record<string, unknown>): Response {
 
 function runnerError(error: { code: string; message: string }): Response {
   return new Response(JSON.stringify({ ok: false, error }));
+}
+
+function assertRunnerCommand(
+  actual: unknown,
+  expected: Record<string, unknown>,
+): asserts actual is Record<string, unknown> {
+  assert.equal(typeof actual, 'object');
+  assert.notEqual(actual, null);
+  const command = actual as Record<string, unknown>;
+  const commandId = command.commandId;
+  if (typeof commandId !== 'string') {
+    assert.fail('expected runner commandId');
+  }
+  assert.match(commandId, /^runner-/);
+  assert.deepEqual({ ...command, commandId: undefined }, { ...expected, commandId: undefined });
 }

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -18,6 +18,7 @@ import {
   isReadOnlyRunnerCommand,
   isRetryableRunnerError,
   shouldRetryRunnerConnectError,
+  withRunnerCommandId,
   type RunnerCommand,
 } from './runner-contract.ts';
 import {
@@ -43,17 +44,18 @@ export async function runIosRunnerCommand(
 ): Promise<Record<string, unknown>> {
   validateRunnerDevice(device);
   assertRunnerRequestActive(options.requestId);
+  const runnerCommand = withRunnerCommandId(command);
   const provider = resolveAppleRunnerProvider(
     device,
     createLocalAppleRunnerProvider(executeRunnerCommand),
     undefined,
     { requestId: options.requestId },
   );
-  if (isReadOnlyRunnerCommand(command.command)) {
+  if (isReadOnlyRunnerCommand(runnerCommand.command)) {
     return withRetry(
       () => {
         assertRunnerRequestActive(options.requestId);
-        return provider.runCommand(device, command, options);
+        return provider.runCommand(device, runnerCommand, options);
       },
       {
         shouldRetry: (error) => {
@@ -63,7 +65,7 @@ export async function runIosRunnerCommand(
       },
     );
   }
-  return provider.runCommand(device, command, options);
+  return provider.runCommand(device, runnerCommand, options);
 }
 
 export function prewarmIosRunnerSession(

--- a/src/platforms/ios/runner-contract.ts
+++ b/src/platforms/ios/runner-contract.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { AppError } from '../../utils/errors.ts';
 import type { ClickButton } from '../../core/click-button.ts';
 import type { DeviceRotation } from '../../core/device-rotation.ts';
@@ -39,8 +40,11 @@ export type RunnerCommand = {
     | 'pinch'
     | 'recordStart'
     | 'recordStop'
+    | 'status'
     | 'uptime'
     | 'shutdown';
+  commandId?: string;
+  statusCommandId?: string;
   appBundleId?: string;
   text?: string;
   selectorKey?: 'id' | 'label' | 'text' | 'value';
@@ -199,8 +203,18 @@ export function isReadOnlyRunnerCommand(command: RunnerCommand['command']): bool
     command === 'querySelector' ||
     command === 'readText' ||
     command === 'alert' ||
+    command === 'status' ||
     command === 'uptime'
   );
+}
+
+export function withRunnerCommandId(command: RunnerCommand): RunnerCommand {
+  if (command.commandId) return command;
+  return { ...command, commandId: createRunnerCommandId() };
+}
+
+function createRunnerCommandId(): string {
+  return `runner-${crypto.randomUUID()}`;
 }
 
 export function assertRunnerRequestActive(requestId: string | undefined): void {

--- a/src/platforms/ios/runner-contract.ts
+++ b/src/platforms/ios/runner-contract.ts
@@ -209,7 +209,7 @@ export function isReadOnlyRunnerCommand(command: RunnerCommand['command']): bool
 }
 
 export function withRunnerCommandId(command: RunnerCommand): RunnerCommand {
-  if (command.commandId) return command;
+  if (command.commandId?.trim()) return command;
   return { ...command, commandId: createRunnerCommandId() };
 }
 

--- a/src/platforms/ios/runner-contract.ts
+++ b/src/platforms/ios/runner-contract.ts
@@ -209,6 +209,7 @@ export function isReadOnlyRunnerCommand(command: RunnerCommand['command']): bool
 }
 
 export function withRunnerCommandId(command: RunnerCommand): RunnerCommand {
+  if (command.command === 'status') return command;
   if (command.commandId?.trim()) return command;
   return { ...command, commandId: createRunnerCommandId() };
 }

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -25,7 +25,11 @@ import {
   resolveRunnerMaxConcurrentDestinationsFlag,
   runnerPrepProcesses,
 } from './runner-xctestrun.ts';
-import { isReadOnlyRunnerCommand, type RunnerCommand } from './runner-contract.ts';
+import {
+  isReadOnlyRunnerCommand,
+  withRunnerCommandId,
+  type RunnerCommand,
+} from './runner-contract.ts';
 import type { RunnerSession } from './runner-session-types.ts';
 
 export type { RunnerSession } from './runner-session-types.ts';
@@ -259,9 +263,9 @@ async function stopRunnerSessionInternal(
       await waitForRunner(
         session.device,
         session.port,
-        {
+        withRunnerCommandId({
           command: 'shutdown',
-        } as RunnerCommand,
+        } as RunnerCommand),
         undefined,
         RUNNER_SHUTDOWN_TIMEOUT_MS,
       );
@@ -432,19 +436,34 @@ export async function executeRunnerCommandWithSession(
   signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
   emitRunnerStartupTimings(session, command.command);
-  const readOnlyCommand = isReadOnlyRunnerCommand(command.command);
+  const runnerCommand = withRunnerCommandId(command);
+  const readOnlyCommand = isReadOnlyRunnerCommand(runnerCommand.command);
   if (readOnlyCommand) {
     const response = await withDiagnosticTimer(
       'ios_runner_command_send',
       async () =>
-        await waitForRunner(device, session.port, command, logPath, timeoutMs, session, signal),
-      { command: command.command, readOnly: true, sessionReady: session.ready, timeoutMs },
+        await waitForRunner(
+          device,
+          session.port,
+          runnerCommand,
+          logPath,
+          timeoutMs,
+          session,
+          signal,
+        ),
+      {
+        command: runnerCommand.command,
+        commandId: runnerCommand.commandId,
+        readOnly: true,
+        sessionReady: session.ready,
+        timeoutMs,
+      },
     );
     return await parseRunnerResponse(response, session, logPath);
   }
 
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  const shouldPreflight = shouldPreflightMutatingRunnerCommand(session, command);
+  const shouldPreflight = shouldPreflightMutatingRunnerCommand(session, runnerCommand);
   if (shouldPreflight) {
     const readinessTimeoutMs = session.ready
       ? Math.min(RUNNER_READY_PREFLIGHT_TIMEOUT_MS, deadline.remainingMs())
@@ -456,13 +475,18 @@ export async function executeRunnerCommandWithSession(
           await waitForRunner(
             device,
             session.port,
-            { command: 'uptime' },
+            withRunnerCommandId({ command: 'uptime' }),
             logPath,
             readinessTimeoutMs,
             session,
             signal,
           ),
-        { command: command.command, sessionReady: session.ready, timeoutMs: readinessTimeoutMs },
+        {
+          command: runnerCommand.command,
+          commandId: runnerCommand.commandId,
+          sessionReady: session.ready,
+          timeoutMs: readinessTimeoutMs,
+        },
       );
       await parseRunnerResponse(readinessResponse, session, logPath);
     } catch (error) {
@@ -474,6 +498,7 @@ export async function executeRunnerCommandWithSession(
       phase: 'ios_runner_readiness_preflight_skipped',
       data: {
         command: command.command,
+        commandId: runnerCommand.commandId,
         lastSuccessfulRunnerResponseAgeMs:
           session.lastSuccessfulRunnerResponseAtMs === undefined
             ? undefined
@@ -488,8 +513,9 @@ export async function executeRunnerCommandWithSession(
   }
   const response = await withDiagnosticTimer(
     'ios_runner_command_send',
-    async () => await sendRunnerCommandOnce(device, session.port, command, remainingMs, signal),
-    { command: command.command },
+    async () =>
+      await sendRunnerCommandOnce(device, session.port, runnerCommand, remainingMs, signal),
+    { command: runnerCommand.command, commandId: runnerCommand.commandId },
   );
   return await parseRunnerResponse(response, session, logPath);
 }

--- a/test/integration/provider-scenarios/providers.ts
+++ b/test/integration/provider-scenarios/providers.ts
@@ -1,4 +1,5 @@
 import type { AppleRunnerProvider } from '../../../src/platforms/ios/runner-provider.ts';
+import type { RunnerCommand } from '../../../src/platforms/ios/runner-contract.ts';
 import type {
   AppleMacOsHostProvider,
   ApplePlistProvider,
@@ -24,11 +25,18 @@ export function createAppleRunnerProviderFromTranscript(
 ): AppleRunnerProvider {
   return {
     runCommand: async (device, command) =>
-      transcript.next(`${commandPrefix}.${command.command}`, command, {
+      transcript.next(`${commandPrefix}.${command.command}`, stripRunnerCommandId(command), {
         deviceId: device.id,
         platform: device.platform,
       }) as Record<string, unknown>,
   };
+}
+
+function stripRunnerCommandId(command: RunnerCommand): RunnerCommand {
+  if (command.commandId === undefined) return command;
+  const normalized = { ...command };
+  delete normalized.commandId;
+  return normalized;
 }
 
 export function createRecordingAppleToolProvider(handlers: RecordingAppleToolHandlers = {}): {


### PR DESCRIPTION
## Summary

Refactors the iOS runner command path to carry lifecycle ids through the existing protocol without changing daemon retry or preflight policy. Lifecycle-tracked runner commands now get a `commandId`, the Swift runner records accepted/started/completed/failed state in an in-memory journal, and a new read-only `status` command can query that lifecycle state by `statusCommandId`.

Closes #656

```mermaid
flowchart LR
  D["Daemon"] -->|"runner command + commandId"| R["iOS runner"]
  R -->|"accepted"| J["Lifecycle journal"]
  R -->|"started"| J
  R -->|"completed or failed"| J
  D -->|"status with statusCommandId"| R
  R -->|"state plus cached response or error"| D
```

Helpful cases versus the previous behavior:

- Completed command, response lost: daemon can ask `status` and see `completed` with cached response JSON when the response is small enough to retain, instead of treating the result as an ambiguous timeout.
- Structured runner failure, response lost: daemon can recover `failed` with error code/message/hint instead of collapsing everything into transport failure.
- Accepted/started mutation, runner disconnected: daemon can distinguish `accepted`/`started` from `unknown` once follow-up transport/retry wiring can query status before resend.

This is intentionally a pure refactor for now: eager `uptime`, existing retries, and all command behavior remain in place so performance policy can be changed separately after the protocol is merged.

Review hardening included in this PR:

- `status` probes are not journaled and do not get their own generated `commandId`, so polling cannot evict the command being queried and carries only `statusCommandId`.
- `status` reads the locked journal directly instead of dispatching through the XCTest main-thread command path.
- Journal entries retain only lifecycle metadata plus capped response JSON, not the full `Response` object; response JSON is omitted for snapshots and when encoded JSON exceeds 16 KiB.
- Blank/whitespace TypeScript `commandId` values are normalized by assigning a generated runner id; caller-supplied ids are preserved.
- Dead journal timestamp metadata was removed; pruning uses the journal order list.

Known follow-ups:

- The daemon still does not query `status` before retrying after transport failure. The later reliability/performance change should add status-before-resend ordering and keep the original `commandId` in the retry-owning scope.
- The runner currently handles connections on a serial queue, so accepted/started states are recorded but not practically observable during a long-running command until follow-up transport work lets status escape command serialization.

Touched-file scope: focused on the iOS runner protocol/client/session path and protocol fixtures/tests.

## Validation

Passed:

- `pnpm format`
- `pnpm typecheck`
- `pnpm exec vitest run src/platforms/ios/__tests__/runner-client.test.ts`
- `pnpm exec vitest run src/platforms/ios/__tests__/runner-client.test.ts src/platforms/ios/__tests__/runner-session.test.ts`
- `pnpm exec vitest run src/platforms/ios/__tests__/runner-session.test.ts src/platforms/ios/__tests__/runner-client.test.ts src/platforms/ios/__tests__/runner-command-retry.test.ts src/platforms/ios/__tests__/runner-provider.test.ts`
- `pnpm exec vitest run test/integration/provider-scenarios/ios-lifecycle.test.ts test/integration/provider-scenarios/ios-alert-settings.test.ts test/integration/provider-scenarios/ios-record-trace.test.ts test/integration/provider-scenarios/macos-recording.test.ts test/integration/provider-scenarios/tvos-remote.test.ts test/integration/provider-scenarios/transcript.test.ts`
- `pnpm build:xcuitest`

Known gap: broad `pnpm check:unit` was attempted but failed in unrelated environment/tooling suites, including local server `listen EPERM`, mocked tool timeouts, platform helper failures, and OCR/script typecheck failures.