### PR TITLE
perf: adapt ios runner uptime preflight

### DIFF
--- a/src/platforms/ios/__tests__/runner-command-retry.test.ts
+++ b/src/platforms/ios/__tests__/runner-command-retry.test.ts
@@ -143,6 +143,28 @@ test('mutating commands restart stale sessions when readiness preflight times ou
   assert.equal(mockExecuteRunnerCommandWithSession.mock.calls[1]?.[1], freshSession);
 });
 
+test('mutating commands emit readiness recovery diagnostics after failed preflight restart succeeds', async () => {
+  const staleSession = makeRunnerSession({ port: 8100, ready: true });
+  const freshSession = makeRunnerSession({ port: 8101, ready: false });
+
+  mockEnsureRunnerSession.mockResolvedValueOnce(staleSession).mockResolvedValueOnce(freshSession);
+  mockExecuteRunnerCommandWithSession
+    .mockRejectedValueOnce(
+      new AppError('COMMAND_FAILED', 'fetch failed', {
+        runnerReadinessPreflightFailed: true,
+      }),
+    )
+    .mockResolvedValueOnce({ message: 'tapped' });
+
+  const diagnostics = await captureDiagnostics(async () => {
+    const result = await runIosRunnerCommand(IOS_SIMULATOR, { command: 'tap', x: 120, y: 240 });
+    assert.deepEqual(result, { message: 'tapped' });
+  });
+
+  assert.match(diagnostics, /ios_runner_readiness_preflight_recovered/);
+  assert.match(diagnostics, /"recovery":"session_restarted"/);
+});
+
 test('mutating commands do not restart or replay after command send failure', async () => {
   const session = makeRunnerSession({ port: 8100, ready: true });
 
@@ -195,6 +217,35 @@ test('mutating commands recover cached responses before invalidating after comma
   const statusCommand = mockExecuteRunnerCommandWithSession.mock.calls[1]?.[2];
   assert.equal(statusCommand.command, 'status');
   assert.equal(statusCommand.statusCommandId, sentCommand.commandId);
+});
+
+test('mutating commands run status recovery after transport failure when readiness preflight was skipped', async () => {
+  const session = makeRunnerSession({ port: 8100, ready: true });
+
+  mockEnsureRunnerSession.mockResolvedValueOnce(session);
+  mockExecuteRunnerCommandWithSession
+    .mockRejectedValueOnce(
+      new AppError('COMMAND_FAILED', 'fetch failed', {
+        runnerReadinessPreflightSkipped: true,
+        runnerReadinessPreflightSkipReason: 'recent_successful_response',
+      }),
+    )
+    .mockResolvedValueOnce({
+      lifecycleState: 'completed',
+      lifecycleResponseJson: JSON.stringify({ ok: true, data: { message: 'tapped' } }),
+    });
+
+  const diagnostics = await captureDiagnostics(async () => {
+    const result = await runIosRunnerCommand(IOS_SIMULATOR, { command: 'tap', x: 120, y: 240 });
+    assert.deepEqual(result, { message: 'tapped' });
+  });
+
+  assert.equal(mockInvalidateRunnerSession.mock.calls.length, 0);
+  assert.equal(mockExecuteRunnerCommandWithSession.mock.calls.length, 2);
+  assert.equal(mockExecuteRunnerCommandWithSession.mock.calls[1]?.[2].command, 'status');
+  assert.match(diagnostics, /ios_runner_command_status_recovery/);
+  assert.match(diagnostics, /"readinessPreflightSkipped":true/);
+  assert.match(diagnostics, /"readinessPreflightSkipReason":"recent_successful_response"/);
 });
 
 test('mutating commands keep invalidating when status cannot find the command', async () => {
@@ -346,6 +397,36 @@ test('mutating commands report recovery guidance when completed status has no re
     reason: 'completed_without_retained_response',
     lifecycleState: 'completed',
   });
+});
+
+test('mutating commands include skipped readiness context in lost-response guidance', async () => {
+  const session = makeRunnerSession({ port: 8100, ready: true });
+
+  mockEnsureRunnerSession.mockResolvedValueOnce(session);
+  mockExecuteRunnerCommandWithSession
+    .mockRejectedValueOnce(
+      new AppError('COMMAND_FAILED', 'fetch failed', {
+        runnerReadinessPreflightSkipped: true,
+        runnerReadinessPreflightSkipReason: 'recent_successful_response',
+        runnerReadinessPreflightSkippedAgeMs: 4,
+      }),
+    )
+    .mockResolvedValueOnce({ lifecycleState: 'completed' });
+
+  await assert.rejects(
+    () => runIosRunnerCommand(IOS_SIMULATOR, { command: 'tap', x: 120, y: 240 }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.details?.recovery, 'completed_without_retained_response');
+      assert.equal(error.details?.readinessPreflightSkipped, true);
+      assert.equal(error.details?.readinessPreflightSkipReason, 'recent_successful_response');
+      assert.equal(error.details?.readinessPreflightSkippedAgeMs, 4);
+      assert.match(String(error.details?.hint), /skipped the uptime preflight/);
+      assert.match(String(error.details?.hint), /status recovery confirmed/);
+      assert.match(String(error.details?.hint), /snapshot -i/);
+      return true;
+    },
+  );
 });
 
 test('mutating commands preserve runner failure details from status recovery', async () => {
@@ -501,4 +582,9 @@ function makeRunnerSession(overrides: Partial<RunnerSession> = {}): RunnerSessio
     ready: true,
     ...overrides,
   } as RunnerSession;
+}
+
+async function captureDiagnostics(callback: () => Promise<void>): Promise<string> {
+  await callback();
+  return JSON.stringify(mockEmitDiagnostic.mock.calls.map(([event]) => event));
 }

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { beforeEach, test, vi } from 'vitest';
 import { IOS_SIMULATOR } from '../../../__tests__/test-utils/index.ts';
 import { AppError } from '../../../utils/errors.ts';
+import { flushDiagnosticsToSessionFile, withDiagnosticsScope } from '../../../utils/diagnostics.ts';
 import type { RunnerSession } from '../runner-session-types.ts';
 
 const {
@@ -196,6 +200,25 @@ test('runner session probes readiness before mutating commands', async () => {
   });
 });
 
+test('runner session emits reason diagnostics when readiness preflight is used', async () => {
+  const session = makeRunnerSession({ ready: false });
+  mockWaitForRunner.mockResolvedValueOnce(runnerResponse({ uptimeMs: 42 }));
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const diagnostics = await captureDiagnostics(async () => {
+    await executeRunnerCommandWithSession(
+      IOS_SIMULATOR,
+      session,
+      { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+      '/tmp/runner.log',
+      30_000,
+    );
+  });
+
+  assert.match(diagnostics, /"reason":"startup"/);
+  assert.match(diagnostics, /ios_runner_readiness_preflight/);
+});
+
 test('runner session skips readiness preflight for tap commands after a recent successful response', async () => {
   const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
   mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
@@ -211,6 +234,74 @@ test('runner session skips readiness preflight for tap commands after a recent s
   assert.deepEqual(result, { tapped: true });
   assert.equal(mockWaitForRunner.mock.calls.length, 0);
   assert.equal(mockSendRunnerCommandOnce.mock.calls.length, 1);
+});
+
+test('runner session emits explicit diagnostics when readiness preflight is skipped', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(runnerResponse({ tapped: true }));
+
+  const diagnostics = await captureDiagnostics(async () => {
+    await executeRunnerCommandWithSession(
+      IOS_SIMULATOR,
+      session,
+      { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+      '/tmp/runner.log',
+      30_000,
+    );
+  });
+
+  assert.match(diagnostics, /ios_runner_readiness_preflight_skipped/);
+  assert.match(diagnostics, /"reason":"recent_successful_response"/);
+  assert.doesNotMatch(diagnostics, /ios_runner_readiness_preflight_used/);
+});
+
+test('runner session marks transport failures after skipped readiness preflight', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockSendRunnerCommandOnce.mockRejectedValueOnce(new Error('fetch failed'));
+
+  await assert.rejects(
+    () =>
+      executeRunnerCommandWithSession(
+        IOS_SIMULATOR,
+        session,
+        { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+        '/tmp/runner.log',
+        30_000,
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.details?.runnerReadinessPreflightSkipped, true);
+      assert.equal(error.details?.runnerReadinessPreflightSkipReason, 'recent_successful_response');
+      return true;
+    },
+  );
+});
+
+test('runner session does not mark runner response failures as skipped preflight transport failures', async () => {
+  const session = makeRunnerSession({ ready: true, lastSuccessfulRunnerResponseAtMs: Date.now() });
+  mockSendRunnerCommandOnce.mockResolvedValueOnce(
+    runnerError({
+      code: 'COMMAND_FAILED',
+      message: 'Runner failed after receiving command',
+    }),
+  );
+
+  await assert.rejects(
+    () =>
+      executeRunnerCommandWithSession(
+        IOS_SIMULATOR,
+        session,
+        { command: 'tap', x: 120, y: 240, appBundleId: 'com.example.demo' },
+        '/tmp/runner.log',
+        30_000,
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.message, 'Runner failed after receiving command');
+      assert.equal(error.details?.runnerReadinessPreflightSkipped, undefined);
+      return true;
+    },
+  );
 });
 
 test('runner session skips readiness preflight for selector taps after a recent successful response', async () => {
@@ -487,6 +578,24 @@ function runnerResponse(data: Record<string, unknown>): Response {
 
 function runnerError(error: { code: string; message: string }): Response {
   return new Response(JSON.stringify({ ok: false, error }));
+}
+
+async function captureDiagnostics(callback: () => Promise<void>): Promise<string> {
+  const previousHome = process.env.HOME;
+  process.env.HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-runner-diag-'));
+  try {
+    return await withDiagnosticsScope(
+      { session: 'runner-session-test', requestId: 'request-1', command: 'tap' },
+      async () => {
+        await callback();
+        const diagnosticsPath = flushDiagnosticsToSessionFile({ force: true });
+        assert.ok(diagnosticsPath);
+        return fs.readFileSync(diagnosticsPath, 'utf8');
+      },
+    );
+  } finally {
+    process.env.HOME = previousHome;
+  }
 }
 
 function assertRunnerCommand(

--- a/src/platforms/ios/runner-client.ts
+++ b/src/platforms/ios/runner-client.ts
@@ -52,6 +52,12 @@ type RunnerTransportRecoveryContext = {
   invalidationReason: string;
 };
 
+type RunnerReadinessPreflightRecoveryDetails = {
+  readinessPreflightSkipped?: boolean;
+  readinessPreflightSkipReason?: string;
+  readinessPreflightSkippedAgeMs?: number;
+};
+
 const RUNNER_STATUS_RECOVERY_TIMEOUT_MS = 3_000;
 
 // --- Runner command execution ---
@@ -186,7 +192,7 @@ async function executeRunnerCommand(
       );
       session = await ensureRunnerSession(device, { ...options, cleanStaleBundles: true });
       try {
-        return await executeRunnerCommandWithSession(
+        const recovered = await executeRunnerCommandWithSession(
           device,
           session,
           command,
@@ -194,6 +200,17 @@ async function executeRunnerCommand(
           RUNNER_STARTUP_TIMEOUT_MS,
           signal,
         );
+        emitDiagnostic({
+          level: 'debug',
+          phase: 'ios_runner_readiness_preflight_recovered',
+          data: {
+            command: command.command,
+            commandId: command.commandId,
+            recovery: 'session_restarted',
+            sessionId: session.sessionId,
+          },
+        });
+        return recovered;
       } catch (retryErr) {
         const retryAppErr =
           retryErr instanceof AppError
@@ -328,6 +345,7 @@ async function tryRecoverRunnerCommandAfterTransportError(
   signal?: AbortSignal,
 ): Promise<RunnerTransportRecovery | undefined> {
   if (command.command === 'status' || !command.commandId?.trim()) return undefined;
+  const readinessPreflight = readReadinessPreflightRecoveryDetails(transportError);
   let status: Record<string, unknown>;
   try {
     status = await executeRunnerCommandWithSession(
@@ -346,6 +364,7 @@ async function tryRecoverRunnerCommandAfterTransportError(
         command: command.command,
         commandId: command.commandId,
         error: error instanceof Error ? error.message : String(error),
+        ...readinessPreflight,
       },
     });
     return { type: 'retainInvalidation', reason: 'status_probe_failed' };
@@ -359,6 +378,7 @@ async function tryRecoverRunnerCommandAfterTransportError(
       command: command.command,
       commandId: command.commandId,
       lifecycleState,
+      ...readinessPreflight,
     },
   });
   return handleRunnerCommandStatusRecovery(
@@ -443,6 +463,7 @@ function handleCompletedRunnerStatus(
       lifecycleState: 'completed',
     };
   }
+  const readinessPreflight = readReadinessPreflightRecoveryDetails(transportError);
   return {
     type: 'skipInvalidation',
     reason: 'completed_without_retained_response',
@@ -455,7 +476,8 @@ function handleCompletedRunnerStatus(
         commandId: command.commandId,
         lifecycleState: 'completed',
         recovery: 'completed_without_retained_response',
-        hint: completedWithoutRetainedResponseHint(command.command),
+        ...readinessPreflight,
+        hint: completedWithoutRetainedResponseHint(command.command, readinessPreflight),
         logPath: options.logPath,
         transportError: transportError.message,
       },
@@ -478,6 +500,7 @@ function runnerStatusFailureError(
       : 'Runner command failed';
   const hint =
     typeof status.lifecycleErrorHint === 'string' ? status.lifecycleErrorHint : undefined;
+  const readinessPreflight = readReadinessPreflightRecoveryDetails(transportError);
   return new AppError(
     toAppErrorCode(errorCode),
     errorMessage,
@@ -486,7 +509,8 @@ function runnerStatusFailureError(
       commandId: command.commandId,
       lifecycleState: 'failed',
       recovery: 'runner_reported_failure',
-      hint: hint ?? runnerReportedFailureHint(command.command),
+      ...readinessPreflight,
+      hint: hint ?? runnerReportedFailureHint(command.command, readinessPreflight),
       logPath: options.logPath,
       transportError: transportError.message,
     },
@@ -503,6 +527,7 @@ function runnerStatusInFlightError(
   if (isReadOnlyRunnerCommand(command.command)) {
     return transportError;
   }
+  const readinessPreflight = readReadinessPreflightRecoveryDetails(transportError);
   return new AppError(
     'COMMAND_FAILED',
     `Runner command "${command.command}" is still ${lifecycleState} after the transport response was lost.`,
@@ -511,7 +536,8 @@ function runnerStatusInFlightError(
       commandId: command.commandId,
       lifecycleState,
       recovery: 'command_still_in_flight',
-      hint: inFlightAfterLostResponseHint(command.command, lifecycleState),
+      ...readinessPreflight,
+      hint: inFlightAfterLostResponseHint(command.command, lifecycleState, readinessPreflight),
       logPath: options.logPath,
       transportError: transportError.message,
     },
@@ -537,16 +563,33 @@ function parseLifecycleResponsePayload(value: string): LifecycleResponsePayload 
   return {};
 }
 
-function completedWithoutRetainedResponseHint(command: string): string {
-  return `The runner is still reachable and reports "${command}" already completed, so agent-device kept the session open and will not replay it. Run snapshot -i to inspect the current UI, then continue from that observed state.`;
+function completedWithoutRetainedResponseHint(
+  command: string,
+  readinessPreflight: RunnerReadinessPreflightRecoveryDetails = {},
+): string {
+  return `${lostResponseReadinessContext(readinessPreflight)}The runner is still reachable and reports "${command}" already completed, so agent-device kept the session open and will not replay it. Run snapshot -i to inspect the current UI, then continue from that observed state.`;
 }
 
-function runnerReportedFailureHint(command: string): string {
-  return `The runner is still reachable and reports "${command}" failed after the transport response was lost, so agent-device kept the session open and did not replay it. Run snapshot -i to inspect the current UI and retry with a selector visible in that snapshot.`;
+function runnerReportedFailureHint(
+  command: string,
+  readinessPreflight: RunnerReadinessPreflightRecoveryDetails = {},
+): string {
+  return `${lostResponseReadinessContext(readinessPreflight)}The runner is still reachable and reports "${command}" failed after the transport response was lost, so agent-device kept the session open and did not replay it. Run snapshot -i to inspect the current UI and retry with a selector visible in that snapshot.`;
 }
 
-function inFlightAfterLostResponseHint(command: string, lifecycleState: string): string {
-  return `The runner is still reachable and reports "${command}" is ${lifecycleState}, so agent-device kept the session open and will not replay it. Wait briefly, run snapshot -i to inspect the current UI, then continue from that observed state.`;
+function inFlightAfterLostResponseHint(
+  command: string,
+  lifecycleState: string,
+  readinessPreflight: RunnerReadinessPreflightRecoveryDetails = {},
+): string {
+  return `${lostResponseReadinessContext(readinessPreflight)}The runner is still reachable and reports "${command}" is ${lifecycleState}, so agent-device kept the session open and will not replay it. Wait briefly, run snapshot -i to inspect the current UI, then continue from that observed state.`;
+}
+
+function lostResponseReadinessContext(
+  readinessPreflight: RunnerReadinessPreflightRecoveryDetails,
+): string {
+  if (readinessPreflight.readinessPreflightSkipped !== true) return '';
+  return 'This hot command skipped the uptime preflight because the runner had just responded; status recovery confirmed the runner still observed it. ';
 }
 
 function unknownLifecycleStateHint(command: string): string {
@@ -592,6 +635,34 @@ function shouldRestartAfterReadinessPreflightError(error: AppError): boolean {
 function isRunnerReadinessPreflightTimeout(error: AppError): boolean {
   const message = error.message.toLowerCase();
   return message.includes('timeout') || message.includes('timed out');
+}
+
+function readBooleanDetail(error: AppError, key: string): boolean | undefined {
+  const value = error.details?.[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function readStringDetail(error: AppError, key: string): string | undefined {
+  const value = error.details?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readNumberDetail(error: AppError, key: string): number | undefined {
+  const value = error.details?.[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function readReadinessPreflightRecoveryDetails(
+  error: AppError,
+): RunnerReadinessPreflightRecoveryDetails {
+  const details: RunnerReadinessPreflightRecoveryDetails = {};
+  const skipped = readBooleanDetail(error, 'runnerReadinessPreflightSkipped');
+  if (skipped !== undefined) details.readinessPreflightSkipped = skipped;
+  const reason = readStringDetail(error, 'runnerReadinessPreflightSkipReason');
+  if (reason !== undefined) details.readinessPreflightSkipReason = reason;
+  const ageMs = readNumberDetail(error, 'runnerReadinessPreflightSkippedAgeMs');
+  if (ageMs !== undefined) details.readinessPreflightSkippedAgeMs = ageMs;
+  return details;
 }
 
 export {

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -47,10 +47,24 @@ const runnerSessionLocks = new Map<string, Promise<unknown>>();
 const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
 const RUNNER_INVALIDATE_WAIT_TIMEOUT_MS = 1_000;
 const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 5_000;
-// Hot tap loops can skip one uptime preflight only while the runner has just responded.
-// Failed mutating taps still invalidate the session instead of being replayed.
 const RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS = 10_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
+
+type RunnerReadinessPreflightDecision =
+  | {
+      action: 'run';
+      reason:
+        | 'startup'
+        | 'conservative_command'
+        | 'no_successful_response'
+        | 'successful_response_stale';
+      lastSuccessfulRunnerResponseAgeMs?: number;
+    }
+  | {
+      action: 'skip';
+      reason: 'recent_successful_response';
+      lastSuccessfulRunnerResponseAgeMs: number;
+    };
 
 function withRunnerSessionLock<T>(deviceId: string, task: () => Promise<T>): Promise<T> {
   return withKeyedLock(runnerSessionLocks, deviceId, task);
@@ -463,8 +477,8 @@ export async function executeRunnerCommandWithSession(
   }
 
   const deadline = Deadline.fromTimeoutMs(timeoutMs);
-  const shouldPreflight = shouldPreflightMutatingRunnerCommand(session, runnerCommand);
-  if (shouldPreflight) {
+  const preflightDecision = resolveRunnerReadinessPreflightDecision(session, runnerCommand);
+  if (preflightDecision.action === 'run') {
     const readinessTimeoutMs = session.ready
       ? Math.min(RUNNER_READY_PREFLIGHT_TIMEOUT_MS, deadline.remainingMs())
       : Math.min(RUNNER_STARTUP_TIMEOUT_MS, deadline.remainingMs());
@@ -484,6 +498,8 @@ export async function executeRunnerCommandWithSession(
         {
           command: runnerCommand.command,
           commandId: runnerCommand.commandId,
+          lastSuccessfulRunnerResponseAgeMs: preflightDecision.lastSuccessfulRunnerResponseAgeMs,
+          reason: preflightDecision.reason,
           sessionReady: session.ready,
           timeoutMs: readinessTimeoutMs,
         },
@@ -499,10 +515,8 @@ export async function executeRunnerCommandWithSession(
       data: {
         command: command.command,
         commandId: runnerCommand.commandId,
-        lastSuccessfulRunnerResponseAgeMs:
-          session.lastSuccessfulRunnerResponseAtMs === undefined
-            ? undefined
-            : Date.now() - session.lastSuccessfulRunnerResponseAtMs,
+        lastSuccessfulRunnerResponseAgeMs: preflightDecision.lastSuccessfulRunnerResponseAgeMs,
+        reason: preflightDecision.reason,
         sessionReady: session.ready,
       },
     });
@@ -516,7 +530,12 @@ export async function executeRunnerCommandWithSession(
     async () =>
       await sendRunnerCommandOnce(device, session.port, runnerCommand, remainingMs, signal),
     { command: runnerCommand.command, commandId: runnerCommand.commandId },
-  );
+  ).catch((error: unknown) => {
+    if (preflightDecision.action === 'skip') {
+      throw markRunnerSkippedReadinessPreflightError(error, preflightDecision);
+    }
+    throw error;
+  });
   return await parseRunnerResponse(response, session, logPath);
 }
 
@@ -566,17 +585,42 @@ export async function parseRunnerResponse(
   return {};
 }
 
-function shouldPreflightMutatingRunnerCommand(
+function resolveRunnerReadinessPreflightDecision(
   session: RunnerSession,
   command: RunnerCommand,
-): boolean {
-  if (!session.ready) return true;
-  if (command.command !== 'tap' && command.command !== 'tapSeries') return true;
+): RunnerReadinessPreflightDecision {
+  if (!session.ready) {
+    return {
+      action: 'run',
+      reason: 'startup',
+    };
+  }
+  if (command.command !== 'tap' && command.command !== 'tapSeries') {
+    return {
+      action: 'run',
+      reason: 'conservative_command',
+    };
+  }
   const lastSuccessAt = session.lastSuccessfulRunnerResponseAtMs;
-  return (
-    lastSuccessAt === undefined ||
-    Date.now() - lastSuccessAt > RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS
-  );
+  if (lastSuccessAt === undefined) {
+    return {
+      action: 'run',
+      reason: 'no_successful_response',
+    };
+  }
+  const lastSuccessfulRunnerResponseAgeMs = Date.now() - lastSuccessAt;
+  if (lastSuccessfulRunnerResponseAgeMs > RUNNER_TAP_PREFLIGHT_SKIP_FRESHNESS_MS) {
+    return {
+      action: 'run',
+      reason: 'successful_response_stale',
+      lastSuccessfulRunnerResponseAgeMs,
+    };
+  }
+  return {
+    action: 'skip',
+    reason: 'recent_successful_response',
+    lastSuccessfulRunnerResponseAgeMs,
+  };
 }
 
 function markRunnerReadinessPreflightError(error: unknown): AppError {
@@ -595,6 +639,32 @@ function markRunnerReadinessPreflightError(error: unknown): AppError {
     {
       ...(appErr.details ?? {}),
       runnerReadinessPreflightFailed: true,
+    },
+    appErr.cause ?? error,
+  );
+}
+
+function markRunnerSkippedReadinessPreflightError(
+  error: unknown,
+  decision: Extract<RunnerReadinessPreflightDecision, { action: 'skip' }>,
+): AppError {
+  const appErr =
+    error instanceof AppError
+      ? error
+      : new AppError(
+          'COMMAND_FAILED',
+          error instanceof Error ? error.message : String(error),
+          undefined,
+          error,
+        );
+  return new AppError(
+    appErr.code,
+    appErr.message,
+    {
+      ...(appErr.details ?? {}),
+      runnerReadinessPreflightSkipped: true,
+      runnerReadinessPreflightSkipReason: decision.reason,
+      runnerReadinessPreflightSkippedAgeMs: decision.lastSuccessfulRunnerResponseAgeMs,
     },
     appErr.cause ?? error,
   );


### PR DESCRIPTION
## Summary

Implement work slice 2 from `docs/ios-runner-protocol-optimizations.md`: adaptive iOS runner `uptime` preflight policy for hot tap interactions.

- Keeps startup and no-recent-success paths conservative by running readiness preflight.
- Skips `uptime` for hot `tap`/`tapSeries` commands when the runner has a recent successful response.
- Keeps non-tap mutating commands preflighted until measured.
- Marks post-skip transport failures so status recovery diagnostics show that readiness preflight was skipped.
- Preserves the merged #666 invalidation-decision path: status recovery can still skip invalidation for observed lifecycle states, and skipped-preflight context is included in recovery guidance.
- Uses `ios_runner_readiness_preflight` as the preflight-used diagnostic and emits `ios_runner_readiness_preflight_skipped` / `ios_runner_readiness_preflight_recovered` for skipped and recovered paths.

This PR is now rebased directly on current `main`; #661, #663, #665, and #666 are merged, so the diff contains only adaptive-uptime slice changes.

## Validation

Focused unit coverage passed after the rebase:
- `pnpm exec vitest run src/platforms/ios/__tests__/runner-session.test.ts src/platforms/ios/__tests__/runner-command-retry.test.ts src/platforms/ios/__tests__/runner-client.test.ts src/platforms/ios/__tests__/runner-provider.test.ts`: 4 files, 83 tests.

Static validation passed:
- `pnpm format`
- `pnpm check:quick`

Earlier simulator validation on `iPhone 17 Pro` (`C25DBB5B-9254-4293-A8D5-2785C78DE03A`) with `--session adaptive-uptime-main --state-dir /private/tmp/agent-device-adaptive-uptime-main`:
- Opened Settings and ran the first coordinate press without a prior snapshot. Diagnostics showed `ios_runner_readiness_preflight` with `reason:"startup"`, then successful tap send.
- Ran a hot selector press with `press 'label="Silent Mode"'`. Diagnostics showed `ios_runner_readiness_preflight_skipped` with `reason:"recent_successful_response"` and no session invalidation records.
- Closed the session with matching platform/device/session/state-dir flags.

Touched files: 4. Scope stayed within the iOS runner client/session module group and focused unit tests.