### PR TITLE
docs(ios): performGesture idleTimeout guardrail + swipe/mouseClick rationale

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -36,6 +36,9 @@ extension RunnerTests {
   /// (the default) to run inside the scroll idle-timeout + quiescence-skip wrapper; synthesis
   /// gestures (pinch/rotate/transform) pass `false` because RunnerSynthesizedGesture governs its
   /// own timing. Returns the captured timing and the action's outcome.
+  ///
+  /// NOTE: a new SYNTHESIS gesture must pass `idleTimeout: false` — the default `true` would wrap
+  /// it in the scroll idle-timeout/quiescence-skip path and change its runtime behavior.
   private func performGesture(
     _ app: XCUIApplication,
     idleTimeout: Bool = true,
@@ -411,6 +414,8 @@ extension RunnerTests {
       }
       let touchFrame = resolvedTouchVisualizationFrame(app: activeApp, x: x, y: y)
       do {
+        // mouseClick throws (it has no RunnerInteractionOutcome), so it keeps raw measureGesture
+        // and only routes the success payload through gestureResponse.
         var clickError: Error?
         let timing = measureGesture {
           do {
@@ -580,6 +585,8 @@ extension RunnerTests {
       guard let direction = command.direction else {
         return Response(ok: false, error: ErrorPayload(message: "swipe requires direction"))
       }
+      // swipe returns an optional frame (tvOS-only) rather than a RunnerInteractionOutcome, so it
+      // keeps raw measureGesture and only routes the success payload through gestureResponse.
       var executedFrame: DragVisualizationFrame?
       let timing = measureGesture {
         withTemporaryScrollIdleTimeoutIfSupported(activeApp) {


### PR DESCRIPTION
Comment-only follow-up to the now-merged #659 (the doc nits from its review landed after the squash-merge, so they need their own PR).

- **`performGesture` doc**: a `NOTE` that a new *synthesis* gesture must pass `idleTimeout: false` — the default `true` would wrap it in the scroll idle-timeout and change runtime behavior.
- **`mouseClick` / `swipe`**: one-line comments on why they keep raw `measureGesture` (mouseClick throws; swipe returns an optional frame — neither is a `RunnerInteractionOutcome`), and that both still route the success payload through `gestureResponse`.

No code/behavior change (comments only).