### PR TITLE
perf: avoid Android hierarchy probe for scroll

### DIFF
--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -316,6 +316,7 @@ test('scrollAndroid supports explicit pixel travel distance', async () => {
       const args = await fs.readFile(argsLogPath, 'utf8');
 
       assert.match(args, /shell\ninput\nswipe\n540\n1080\n540\n840\n300\n/);
+      assert.doesNotMatch(args, /uiautomator|dump/);
       assert.equal(result.pixels, 240);
       assert.equal(result.referenceWidth, 1080);
       assert.equal(result.referenceHeight, 1920);

--- a/src/platforms/android/input-actions.ts
+++ b/src/platforms/android/input-actions.ts
@@ -6,8 +6,6 @@ import { buildScrollGesturePlan, type ScrollDirection } from '../../core/scroll-
 import { runAndroidAdb, sleep } from './adb.ts';
 import { resolveAndroidTextInjector } from './adb-executor.ts';
 import { getAndroidKeyboardState, type AndroidKeyboardState } from './device-input-state.ts';
-import { captureAndroidUiHierarchyXml } from './snapshot.ts';
-import { androidUiNodes } from './ui-hierarchy.ts';
 import {
   androidFillFailureDetails,
   androidFillFailureMessage,
@@ -208,7 +206,7 @@ export async function scrollAndroid(
   direction: ScrollDirection,
   options?: { amount?: number; pixels?: number },
 ): Promise<Record<string, unknown>> {
-  const size = await getAndroidGestureViewportSize(device);
+  const size = await getAndroidScreenSize(device);
   const plan = buildScrollGesturePlan({
     direction,
     amount: options?.amount,
@@ -290,38 +288,6 @@ export async function getAndroidScreenSize(
   const match = result.stdout.match(/Physical size:\s*(\d+)x(\d+)/);
   if (!match) throw new AppError('COMMAND_FAILED', 'Unable to read screen size');
   return { width: Number(match[1]), height: Number(match[2]) };
-}
-
-async function getAndroidGestureViewportSize(
-  device: DeviceInfo,
-): Promise<{ width: number; height: number }> {
-  try {
-    const xml = await captureAndroidUiHierarchyXml(device);
-    const viewport = largestAndroidUiNodeRect(xml);
-    if (viewport) return viewport;
-  } catch (error) {
-    emitDiagnostic({
-      level: 'warn',
-      phase: 'android_gesture_viewport_probe_failed',
-      data: {
-        error: error instanceof Error ? error.message : String(error),
-      },
-    });
-  }
-  return await getAndroidScreenSize(device);
-}
-
-function largestAndroidUiNodeRect(xml: string): { width: number; height: number } | null {
-  let largest: { width: number; height: number; area: number } | null = null;
-  for (const node of androidUiNodes(xml)) {
-    const rect = node.rect;
-    if (!rect || rect.width <= 0 || rect.height <= 0) continue;
-    const area = rect.width * rect.height;
-    if (!largest || area > largest.area) {
-      largest = { width: rect.x + rect.width, height: rect.y + rect.height, area };
-    }
-  }
-  return largest ? { width: largest.width, height: largest.height } : null;
 }
 
 const ANDROID_INPUT_TEXT_CHUNK_SIZE = 8;


### PR DESCRIPTION
## Summary

Restore Android scroll to the cheap display-size path so normal scroll commands no longer capture and parse a UI hierarchy before every swipe.

This regressed in d087a62d1 (#612), where scroll started resolving viewport size through Android UI hierarchy capture. In the Android perf comparison, scroll down moved from ~734ms daemon median to ~3410ms daemon median.

Adds a regression assertion that Android scroll does not invoke uiautomator/dump for the explicit-pixels path.
<details>
<summary>Scope</summary>

Touched 2 files: Android input actions and the existing Android platform test.

</details>

## Validation

Verified with git diff --check and pnpm typecheck.

Checked for dead code around the removed Android scroll hierarchy probe: getAndroidGestureViewportSize, largestAndroidUiNodeRect, and android_gesture_viewport_probe_failed are gone; captureAndroidUiHierarchyXml and androidUiNodes remain used by Android fill verification/tests.

Ran pnpm check:fallow --base origin/main. It only flagged the unrelated untracked scripts/prototypes/* files that are not part of this PR; no Android scroll dead code was reported.

Ran the React Navigation Android Maestro suite from /Users/thymikee/.codex/worktrees/dffd/react-navigation/example using the built local agent-device binary: 37 passed, 1 failed in 340.3s. The failure was Stack - Preload Flow after returning from details and was not scroll-related; tab-view/scroll-related flows passed.

Verified the built Android snapshot path uses the new helper backend with androidSnapshot.backend="android-helper" and helperTransport="persistent-session". A patched source-mode run fell back to uiautomator because source mode lacked the packaged helper artifact, so it was not used as final backend validation.

Local pnpm vitest/format/build in this worktree are blocked by macOS native binding code-signature failures in rolldown/oxfmt/rspack optional bindings.