### PR TITLE
fix: restore snapshot request timeout

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -117,7 +117,6 @@ type EnsuredDaemon = {
 type ResolvedDaemonTransport = 'socket' | 'http';
 
 const REQUEST_TIMEOUT_MS = 90_000;
-const SNAPSHOT_REQUEST_TIMEOUT_MS = 30_000;
 const PREPARE_REQUEST_TIMEOUT_MS = 240_000;
 const DAEMON_STARTUP_TIMEOUT_MS = 15_000;
 const DAEMON_STARTUP_ATTEMPTS = 2;
@@ -204,7 +203,6 @@ export function resolveDaemonRequestTimeoutMs(
     return req.flags.timeoutMs;
   }
   if (req.command === PUBLIC_COMMANDS.prepare) return PREPARE_REQUEST_TIMEOUT_MS;
-  if (req.command === PUBLIC_COMMANDS.snapshot) return SNAPSHOT_REQUEST_TIMEOUT_MS;
   return REQUEST_TIMEOUT_MS;
 }
 

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -182,7 +182,7 @@ test('snapshot request timeout preserves daemon metadata for follow-up evidence 
   assert.equal(shouldResetDaemonAfterRequestTimeout(undefined), true);
 });
 
-test('snapshot uses a shorter daemon request timeout with an explicit override', () => {
+test('snapshot uses the standard daemon request timeout with an explicit override', () => {
   const base = {
     session: 'default',
     positionals: [],
@@ -190,7 +190,7 @@ test('snapshot uses a shorter daemon request timeout with an explicit override',
     meta: {},
   };
 
-  assert.equal(resolveDaemonRequestTimeoutMs({ ...base, command: 'snapshot' }), 30_000);
+  assert.equal(resolveDaemonRequestTimeoutMs({ ...base, command: 'snapshot' }), 90_000);
   assert.equal(
     resolveDaemonRequestTimeoutMs({
       ...base,


### PR DESCRIPTION
## Summary

Restore `snapshot` daemon requests to the shared 90s `REQUEST_TIMEOUT_MS` instead of the shorter snapshot-specific timeout.

This gives CI jobs that have not run `prepare ios-runner` the previous first-use startup budget.

Touched files: 2. Scope stayed within daemon client timeout handling.

## Validation

Verified with formatting, the focused daemon-client test file, and the repo quick check:

- `pnpm format`
- `pnpm exec vitest run src/utils/__tests__/daemon-client.test.ts`
- `pnpm check:quick`