### PR TITLE
fix: align iOS runner cache target metadata

### DIFF
--- a/scripts/write-xcuitest-cache-metadata.mjs
+++ b/scripts/write-xcuitest-cache-metadata.mjs
@@ -113,7 +113,7 @@ function resolveDeviceKind() {
 function resolveTarget() {
   if (platform === 'macos') return 'desktop';
   if (platform === 'tvos') return 'tv';
-  return 'phone';
+  return 'mobile';
 }
 
 function resolveMacRunnerArch() {

--- a/src/platforms/ios/__tests__/runner-xctestrun.test.ts
+++ b/src/platforms/ios/__tests__/runner-xctestrun.test.ts
@@ -201,7 +201,7 @@ test('setup metadata script matches expected iOS simulator cache metadata', asyn
     execFileSync(
       process.execPath,
       ['scripts/write-xcuitest-cache-metadata.mjs', 'ios', root, 'generic/platform=iOS Simulator'],
-      { cwd: process.cwd(), stdio: 'ignore' },
+      { cwd: process.cwd(), stdio: ['ignore', 'ignore', 'inherit'] },
     );
 
     const actual = JSON.parse(

--- a/src/platforms/ios/__tests__/runner-xctestrun.test.ts
+++ b/src/platforms/ios/__tests__/runner-xctestrun.test.ts
@@ -1,5 +1,6 @@
 import { test, vi } from 'vitest';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -10,6 +11,7 @@ import {
   acquireXcodebuildSimulatorSetRedirect,
   findXctestrun,
   prepareXctestrunWithEnv,
+  resolveExpectedRunnerCacheMetadata,
   resolveXcodebuildSimulatorDeviceSetPath,
   scoreXctestrunCandidate,
 } from '../runner-xctestrun.ts';
@@ -19,6 +21,7 @@ const iosSimulator: DeviceInfo = {
   id: 'sim-1',
   name: 'iPhone Simulator',
   kind: 'simulator',
+  target: 'mobile',
   booted: true,
 };
 
@@ -191,6 +194,25 @@ test('scoreXctestrunCandidate penalizes macos and env xctestrun files for simula
   );
 
   assert.ok(simulatorScore > macosEnvScore);
+});
+
+test('setup metadata script matches expected iOS simulator cache metadata', async () => {
+  await withTempDir('runner-cache-metadata-', async (root) => {
+    execFileSync(
+      process.execPath,
+      ['scripts/write-xcuitest-cache-metadata.mjs', 'ios', root, 'generic/platform=iOS Simulator'],
+      { cwd: process.cwd(), stdio: 'ignore' },
+    );
+
+    const actual = JSON.parse(
+      fs.readFileSync(path.join(root, '.agent-device-runner-cache.json'), 'utf8'),
+    );
+    const { artifacts: _actualArtifacts, ...actualComparable } = actual;
+    const { artifacts: _expectedArtifacts, ...expectedComparable } =
+      resolveExpectedRunnerCacheMetadata(iosSimulator);
+
+    assert.deepEqual(actualComparable, expectedComparable);
+  });
 });
 
 test('prepareXctestrunWithEnv avoids XCTest screen recordings for nested and legacy targets', async () => {

--- a/src/platforms/ios/runner-xctestrun.ts
+++ b/src/platforms/ios/runner-xctestrun.ts
@@ -89,7 +89,7 @@ export type RunnerXctestrunCacheMetadata = {
   runnerSourceFingerprint: string;
   platformName: string;
   deviceKind: DeviceInfo['kind'];
-  target: DeviceInfo['target'] | 'phone';
+  target: NonNullable<DeviceInfo['target']>;
   buildDestinationFamily: string;
   runnerBundleBuildSettings: string[];
   runnerSigningBuildSettings: string[];
@@ -684,7 +684,7 @@ export function resolveExpectedRunnerCacheMetadata(
     runnerSourceFingerprint: computeRunnerSourceFingerprint(projectRoot),
     platformName: resolveRunnerPlatformName(device),
     deviceKind: device.kind,
-    target: device.target ?? 'phone',
+    target: device.target ?? 'mobile',
     buildDestinationFamily: resolveRunnerBuildDestinationFamily(device),
     runnerBundleBuildSettings: resolveRunnerBundleBuildSettings(process.env),
     runnerSigningBuildSettings: resolveRunnerSigningBuildSettings(


### PR DESCRIPTION
## Summary

Align iOS runner cache metadata with the canonical mobile device target so CI prebuilt XCTest runner artifacts are reused instead of rejected as cache_metadata_mismatch.

Adds a focused regression test that compares the setup metadata script output with runtime expected metadata, and keeps script stderr visible if that subprocess fails.

Runner artifacts cached with the old target: phone metadata will rebuild once after this lands, then reuse the corrected target: mobile metadata. Local dev caches already written by runtime prepare use mobile and are unaffected.

Touched files: 3. Scope stayed within iOS runner cache metadata.

## Validation

Verified the focused iOS runner cache test passes with pnpm exec vitest run src/platforms/ios/__tests__/runner-xctestrun.test.ts. Also ran pnpm check:quick; lint and typecheck passed.