### PR TITLE
fix: keep iOS runner hot across app closes

### DIFF
--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -1,0 +1,79 @@
+# ADR 0004: iOS Snapshot Backend Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Agent Device exposes iOS UI state through snapshots produced by the long-lived XCTest runner. The
+runner has two different snapshot needs:
+
+- rich diagnostics and selector disambiguation, where a recursive XCTest snapshot is useful because
+  it preserves hierarchy, static text, wrappers, scroll containers, and ancestry;
+- agent-facing compact interactive context, where the important contract is fast, bounded discovery
+  of visible controls and stable refs for the next action.
+
+These needs should not share one capture strategy blindly. Recursive `XCUIElement.snapshot()` is
+rich, but some real simulator app trees can make XCTest fail with `kAXErrorIllegalArgument` while
+the same app remains visually usable and can be inspected by lower-level simulator accessibility
+services. Bluesky is the current known example: Argent's `ax-service` can describe the screen, but
+XCTest recursive snapshots and typed `XCUIElementQuery` enumeration can degrade to no useful child
+nodes.
+
+This is different from presentation filtering. The daemon's snapshot presentation can hide noisy
+or inaccessible nodes, but it cannot recover nodes that XCTest never returns. More filters,
+Maestro-specific heuristics, or retries in the daemon would only make this failure slower and less
+predictable.
+
+## Decision
+
+Keep XCTest as the default iOS automation runner and split iOS snapshot capture into explicit
+strategies:
+
+- **Full tree strategy**: use recursive XCTest snapshots for normal/full snapshots, raw snapshots,
+  diagnostics, and cases that need hierarchy. If XCTest reports a real AX serialization failure,
+  preserve that error instead of pretending the UI is empty.
+- **Compact interactive strategy**: for `snapshot -i -c`, use a bounded flat XCTest query strategy
+  that avoids recursive root snapshots and app/window property reads. It should prefer fast,
+  one-screen actionability over hierarchy fidelity and should return a sparse root quickly when
+  XCTest cannot enumerate controls.
+- **Future simulator AX-service strategy**: treat Bluesky-class failures as evidence that XCTest is
+  not a complete semantic snapshot backend. A robust semantic fix should add a host-side simulator
+  accessibility backend, similar in role to `idb` accessibility commands or Argent's `ax-service`,
+  and normalize its output into the same `SnapshotNode` model. That backend can be simulator-only;
+  physical devices can continue using XCTest unless a supported lower-level API exists.
+
+The daemon should make degraded compact output observable. If an iOS compact interactive snapshot
+contains only the synthetic application root, surface a warning so agents know the snapshot is
+bounded fallback output rather than proof that the screen has no controls.
+
+## Regression Notes
+
+PR #639 made XCTest AX serialization failures explicit instead of swallowing them as empty
+snapshots. That was the correct diagnostic change, but it exposed apps whose accessibility trees
+XCTest cannot serialize.
+
+The first compact fallback then still paid several XCTest reads (`app.label`, `app.identifier`,
+`app.frame`, window frame lookup) before enumerating flat controls. On broken trees those reads can
+hit the same AX failure path, which made `snapshot -i -c` much slower than the plain snapshot in
+some apps. PR #700 changed compact interactive snapshots to enter the flat strategy immediately and
+avoid those app/window reads.
+
+## Consequences
+
+Compact interactive snapshots are allowed to be less complete than full snapshots, but they must be
+bounded and honest. They should never block for the full daemon snapshot timeout because one app has
+a pathological AX tree.
+
+Full snapshots remain the right tool when hierarchy matters. They may still fail loudly on
+XCTest-broken trees; that failure is useful because retrying the same recursive capture is unlikely
+to reveal a different tree.
+
+A future AX-service backend is the correct place to regain Bluesky-class semantic coverage. It
+should be added as a platform backend with its own lifecycle, protocol, normalization, timing
+metrics, and fallback rules, not as another special case inside the XCTest runner.
+
+When adding new iOS snapshot behavior, maintainers should first decide which strategy owns it. If a
+change tries to make compact snapshots rich by reintroducing recursive snapshots, or tries to make
+full snapshots fast by hiding XCTest failures, it is probably crossing strategy boundaries.

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Alert.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Alert.swift
@@ -8,20 +8,18 @@ extension RunnerTests {
   }
 
   func resolveAlert(app activeApp: XCUIApplication) -> RunnerAlert? {
+#if !os(macOS)
+    if let systemModal = firstBlockingSystemModal(in: springboard) {
+      return runnerAlert(root: systemModal, ownerApp: springboard)
+    }
+#endif
     if let alert = firstExistingElement(in: activeApp.alerts.allElementsBoundByIndex) {
       return runnerAlert(root: alert, ownerApp: activeApp)
     }
     if let popup = firstDismissPopupWindow(in: activeApp) {
       return runnerAlert(root: popup, ownerApp: activeApp)
     }
-#if os(macOS)
     return nil
-#else
-    if let systemModal = firstBlockingSystemModal(in: springboard) {
-      return runnerAlert(root: systemModal, ownerApp: springboard)
-    }
-    return nil
-#endif
   }
 
   func handleAlert(_ alert: RunnerAlert, action: String) -> Response {
@@ -32,6 +30,27 @@ extension RunnerTests {
       let outcome = activateElement(app: alert.ownerApp, element: button, action: "alert \(action)")
       if let response = unsupportedResponse(for: outcome) {
         return response
+      }
+      sleepFor(0.2)
+      if alertStillVisible(alert, actionButtonLabel: button.label) {
+        let frame = button.frame
+        if !frame.isNull && !frame.isEmpty {
+          let coordinateOutcome = tapAt(app: alert.ownerApp, x: frame.midX, y: frame.midY)
+          if let response = unsupportedResponse(for: coordinateOutcome) {
+            return response
+          }
+          sleepFor(0.2)
+        }
+      }
+      if alertStillVisible(alert, actionButtonLabel: button.label) {
+        return Response(
+          ok: false,
+          error: ErrorPayload(
+            code: "INTERACTION_FAILED",
+            message: "alert \(action) did not dismiss the visible alert",
+            hint: "The alert button was found but the system still reports the alert after tapping it."
+          )
+        )
       }
       return Response(ok: true, data: DataPayload(message: action == "accept" ? "accepted" : "dismissed"))
     }
@@ -51,6 +70,21 @@ extension RunnerTests {
       return nil
     }
     return RunnerAlert(root: root, ownerApp: ownerApp, buttons: buttons)
+  }
+
+  private func alertStillVisible(_ alert: RunnerAlert, actionButtonLabel: String) -> Bool {
+    guard let current = resolveAlert(app: alert.ownerApp) else {
+      return false
+    }
+    let previousTitle = preferredAlertTitle(alert.root, buttons: alert.buttons)
+    let currentTitle = preferredAlertTitle(current.root, buttons: current.buttons)
+    if previousTitle == currentTitle {
+      return true
+    }
+    let normalizedActionLabel = actionButtonLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+    return current.buttons.contains { button in
+      button.label.trimmingCharacters(in: .whitespacesAndNewlines) == normalizedActionLabel
+    }
   }
 
   private func firstExistingElement(in elements: [XCUIElement]) -> XCUIElement? {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -16,6 +16,7 @@ extension RunnerTests {
     .scrollView,
     .table
   ]
+  private static let flatInteractiveFallbackBudget: TimeInterval = 1.0
 
   private struct SnapshotTraversalContext {
     let queryRoot: XCUIElement
@@ -85,6 +86,9 @@ extension RunnerTests {
   }
 
   func snapshotFast(app: XCUIApplication, options: SnapshotOptions) throws -> DataPayload {
+    if options.interactiveOnly && options.compact {
+      return snapshotFlatInteractive(app: app, options: options)
+    }
     if let blocking = blockingSystemAlertSnapshot() {
       return blocking
     }
@@ -257,58 +261,50 @@ extension RunnerTests {
   }
 
   private func snapshotFlatInteractive(app: XCUIApplication, options: SnapshotOptions) -> DataPayload {
-    let viewport = safeSnapshotViewport(app: app)
     var nodes: [SnapshotNode] = [
-      SnapshotNode(
-        index: 0,
-        type: "Application",
-        label: nonEmptyElementText { app.label },
-        identifier: nonEmptyElementText { app.identifier },
-        value: nil,
-        rect: snapshotRect(from: safely("SNAPSHOT_FLAT_APP_FRAME", CGRect.zero) { app.frame }),
-        enabled: true,
-        focused: nil,
-        selected: nil,
-        hittable: false,
-        depth: 0,
-        parentIndex: nil,
-        hiddenContentAbove: nil,
-        hiddenContentBelow: nil
-      )
+      compactInteractiveRootNode(rect: .zero)
     ]
     if options.depth == 0 {
       return DataPayload(nodes: nodes, truncated: false)
     }
 
+    let deadline = options.interactiveOnly
+      ? Date().addingTimeInterval(Self.flatInteractiveFallbackBudget)
+      : Date.distantFuture
     var seen = Set<String>()
-    let candidates = flatFallbackElements(app: app)
-      .compactMap { element in
-        flatSnapshotNode(
-          element: element,
-          index: 0,
-          parentIndex: 0,
-          viewport: viewport,
-          options: options
-        )
+    var candidates: [SnapshotNode] = []
+    for element in flatFallbackElements(app: app, options: options) {
+      if Date() >= deadline {
+        NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_FLAT_FALLBACK_DEADLINE")
+        break
       }
-      .filter { node in
-        let key = "\(node.type)-\(node.label ?? "")-\(node.identifier ?? "")-\(node.value ?? "")-\(node.rect.x)-\(node.rect.y)-\(node.rect.width)-\(node.rect.height)"
-        if seen.contains(key) { return false }
-        seen.insert(key)
-        return true
+      guard let node = flatSnapshotNode(
+        element: element,
+        index: 0,
+        parentIndex: 0,
+        viewport: .infinite,
+        options: options
+      ) else {
+        continue
       }
-      .sorted { left, right in
-        if left.rect.y != right.rect.y {
-          return left.rect.y < right.rect.y
-        }
-        if left.rect.x != right.rect.x {
-          return left.rect.x < right.rect.x
-        }
-        return left.type < right.type
+      let key = "\(node.type)-\(node.label ?? "")-\(node.identifier ?? "")-\(node.value ?? "")-\(node.rect.x)-\(node.rect.y)-\(node.rect.width)-\(node.rect.height)"
+      if seen.contains(key) { continue }
+      seen.insert(key)
+      candidates.append(node)
+    }
+    candidates.sort { left, right in
+      if left.rect.y != right.rect.y {
+        return left.rect.y < right.rect.y
       }
+      if left.rect.x != right.rect.x {
+        return left.rect.x < right.rect.x
+      }
+      return left.type < right.type
+    }
 
     let remaining = max(0, fastSnapshotLimit - nodes.count)
     let truncated = candidates.count > remaining
+    nodes[0] = compactInteractiveRootNode(rect: compactInteractiveRootFrame(for: candidates))
     for candidate in candidates.prefix(remaining) {
       nodes.append(
         SnapshotNode(
@@ -330,6 +326,34 @@ extension RunnerTests {
       )
     }
     return DataPayload(nodes: nodes, truncated: truncated)
+  }
+
+  private func compactInteractiveRootNode(rect: CGRect) -> SnapshotNode {
+    SnapshotNode(
+      index: 0,
+      type: "Application",
+      label: nil,
+      identifier: nil,
+      value: nil,
+      rect: snapshotRect(from: rect),
+      enabled: true,
+      focused: nil,
+      selected: nil,
+      hittable: false,
+      depth: 0,
+      parentIndex: nil,
+      hiddenContentAbove: nil,
+      hiddenContentBelow: nil
+    )
+  }
+
+  private func compactInteractiveRootFrame(for candidates: [SnapshotNode]) -> CGRect {
+    guard !candidates.isEmpty else {
+      return .zero
+    }
+    let maxX = candidates.map { CGFloat($0.rect.x + $0.rect.width) }.max() ?? 0
+    let maxY = candidates.map { CGFloat($0.rect.y + $0.rect.height) }.max() ?? 0
+    return CGRect(x: 0, y: 0, width: max(1, maxX), height: max(1, maxY))
   }
 
   func snapshotRect(from frame: CGRect) -> SnapshotRect {
@@ -798,8 +822,26 @@ extension RunnerTests {
     safely("SNAPSHOT_QUERY", [], fetch)
   }
 
-  private func flatFallbackElements(app: XCUIApplication) -> [XCUIElement] {
-    let queries: [XCUIElementQuery] = [
+  private func flatFallbackElements(app: XCUIApplication, options: SnapshotOptions) -> [XCUIElement] {
+    let queries: [XCUIElementQuery] = options.interactiveOnly ? [
+      app.buttons,
+      app.links,
+      app.textFields,
+      app.secureTextFields,
+      app.searchFields,
+      app.textViews,
+      app.switches,
+      app.sliders,
+      app.segmentedControls,
+      app.cells,
+      app.collectionViews,
+      app.tables,
+      app.scrollViews,
+      app.pickers,
+      app.steppers,
+      app.tabBars,
+      app.menuItems
+    ] : [
       app.buttons,
       app.cells,
       app.collectionViews,
@@ -816,11 +858,26 @@ extension RunnerTests {
       app.textFields,
       app.textViews
     ]
-    return queries.flatMap { query in
-      safeSnapshotElementsQuery {
-        query.allElementsBoundByIndex
+    guard options.interactiveOnly else {
+      return queries.flatMap { query in
+        safeSnapshotElementsQuery {
+          query.allElementsBoundByIndex
+        }
       }
     }
+
+    let deadline = Date().addingTimeInterval(Self.flatInteractiveFallbackBudget)
+    var elements: [XCUIElement] = []
+    for query in queries {
+      if Date() >= deadline {
+        NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_FLAT_FALLBACK_DEADLINE")
+        break
+      }
+      elements.append(contentsOf: safeSnapshotElementsQuery {
+        query.allElementsBoundByIndex
+      })
+    }
+    return elements
   }
 
   private func flatSnapshotNode(

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -273,7 +273,7 @@ extension RunnerTests {
       : Date.distantFuture
     var seen = Set<String>()
     var candidates: [SnapshotNode] = []
-    for element in flatFallbackElements(app: app, options: options) {
+    for element in flatFallbackElements(app: app, options: options, deadline: deadline) {
       if Date() >= deadline {
         NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_FLAT_FALLBACK_DEADLINE")
         break
@@ -822,7 +822,11 @@ extension RunnerTests {
     safely("SNAPSHOT_QUERY", [], fetch)
   }
 
-  private func flatFallbackElements(app: XCUIApplication, options: SnapshotOptions) -> [XCUIElement] {
+  private func flatFallbackElements(
+    app: XCUIApplication,
+    options: SnapshotOptions,
+    deadline: Date
+  ) -> [XCUIElement] {
     let queries: [XCUIElementQuery] = options.interactiveOnly ? [
       app.buttons,
       app.links,
@@ -866,7 +870,6 @@ extension RunnerTests {
       }
     }
 
-    let deadline = Date().addingTimeInterval(Self.flatInteractiveFallbackBudget)
     var elements: [XCUIElement] = []
     for query in queries {
       if Date() >= deadline {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -89,7 +89,15 @@ extension RunnerTests {
       return blocking
     }
 
-    guard let context = try makeSnapshotTraversalContext(app: app, options: options) else {
+    let context: SnapshotTraversalContext?
+    do {
+      context = try makeSnapshotTraversalContext(app: app, options: options)
+    } catch let failure as SnapshotCaptureFailure where options.interactiveOnly {
+      NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_FLAT_FALLBACK=%@", failure.message)
+      return snapshotFlatInteractive(app: app, options: options)
+    }
+
+    guard let context else {
       return DataPayload(nodes: [], truncated: false)
     }
 
@@ -245,6 +253,82 @@ extension RunnerTests {
     }
 
     walk(context.rootSnapshot, depth: 0, parentIndex: nil)
+    return DataPayload(nodes: nodes, truncated: truncated)
+  }
+
+  private func snapshotFlatInteractive(app: XCUIApplication, options: SnapshotOptions) -> DataPayload {
+    let viewport = safeSnapshotViewport(app: app)
+    var nodes: [SnapshotNode] = [
+      SnapshotNode(
+        index: 0,
+        type: "Application",
+        label: nonEmptyElementText { app.label },
+        identifier: nonEmptyElementText { app.identifier },
+        value: nil,
+        rect: snapshotRect(from: safely("SNAPSHOT_FLAT_APP_FRAME", CGRect.zero) { app.frame }),
+        enabled: true,
+        focused: nil,
+        selected: nil,
+        hittable: false,
+        depth: 0,
+        parentIndex: nil,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      )
+    ]
+    if options.depth == 0 {
+      return DataPayload(nodes: nodes, truncated: false)
+    }
+
+    var seen = Set<String>()
+    let candidates = flatFallbackElements(app: app)
+      .compactMap { element in
+        flatSnapshotNode(
+          element: element,
+          index: 0,
+          parentIndex: 0,
+          viewport: viewport,
+          options: options
+        )
+      }
+      .filter { node in
+        let key = "\(node.type)-\(node.label ?? "")-\(node.identifier ?? "")-\(node.value ?? "")-\(node.rect.x)-\(node.rect.y)-\(node.rect.width)-\(node.rect.height)"
+        if seen.contains(key) { return false }
+        seen.insert(key)
+        return true
+      }
+      .sorted { left, right in
+        if left.rect.y != right.rect.y {
+          return left.rect.y < right.rect.y
+        }
+        if left.rect.x != right.rect.x {
+          return left.rect.x < right.rect.x
+        }
+        return left.type < right.type
+      }
+
+    let remaining = max(0, fastSnapshotLimit - nodes.count)
+    let truncated = candidates.count > remaining
+    for candidate in candidates.prefix(remaining) {
+      nodes.append(
+        SnapshotNode(
+          index: nodes.count,
+          type: candidate.type,
+          label: candidate.label,
+          identifier: candidate.identifier,
+          value: candidate.value,
+          rect: candidate.rect,
+          enabled: candidate.enabled,
+          focused: candidate.focused,
+          selected: candidate.selected,
+          hittable: candidate.hittable,
+          depth: 1,
+          parentIndex: 0,
+          hiddenContentAbove: nil,
+          hiddenContentBelow: nil
+        )
+      )
+    }
     return DataPayload(nodes: nodes, truncated: truncated)
   }
 
@@ -712,6 +796,95 @@ extension RunnerTests {
 
   private func safeSnapshotElementsQuery(_ fetch: () -> [XCUIElement]) -> [XCUIElement] {
     safely("SNAPSHOT_QUERY", [], fetch)
+  }
+
+  private func flatFallbackElements(app: XCUIApplication) -> [XCUIElement] {
+    let queries: [XCUIElementQuery] = [
+      app.buttons,
+      app.cells,
+      app.collectionViews,
+      app.images,
+      app.links,
+      app.scrollViews,
+      app.searchFields,
+      app.secureTextFields,
+      app.segmentedControls,
+      app.sliders,
+      app.staticTexts,
+      app.switches,
+      app.tables,
+      app.textFields,
+      app.textViews
+    ]
+    return queries.flatMap { query in
+      safeSnapshotElementsQuery {
+        query.allElementsBoundByIndex
+      }
+    }
+  }
+
+  private func flatSnapshotNode(
+    element: XCUIElement,
+    index: Int,
+    parentIndex: Int?,
+    viewport: CGRect,
+    options: SnapshotOptions
+  ) -> SnapshotNode? {
+    var node: SnapshotNode?
+    let exceptionMessage = RunnerObjCExceptionCatcher.catchException({
+      if !element.exists { return }
+      let frame = element.frame
+      if frame.isNull || frame.isEmpty { return }
+      let visible = isVisibleInViewport(frame, viewport)
+      #if os(macOS)
+        if !visible { return }
+      #endif
+      let label = element.label.trimmingCharacters(in: .whitespacesAndNewlines)
+      let identifier = element.identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+      let valueText = snapshotValueText(element)
+      let hasContent = !label.isEmpty || !identifier.isEmpty || valueText != nil
+      let elementType = element.elementType
+      let enabled = element.isEnabled
+      let hittable = visible && enabled && element.isHittable
+      if options.compact && !hasContent && !hittable && !interactiveTypes.contains(elementType) {
+        return
+      }
+      if let scope = options.scope?.trimmingCharacters(in: .whitespacesAndNewlines), !scope.isEmpty {
+        let haystack = [label, identifier, valueText ?? ""].joined(separator: "\n")
+        if !haystack.localizedCaseInsensitiveContains(scope) {
+          return
+        }
+      }
+
+      node = SnapshotNode(
+        index: index,
+        type: elementTypeName(elementType),
+        label: label.isEmpty ? nil : label,
+        identifier: identifier.isEmpty ? nil : identifier,
+        value: valueText,
+        rect: snapshotRect(from: frame),
+        enabled: enabled,
+        focused: elementHasFocus(element) ? true : nil,
+        selected: element.isSelected ? true : nil,
+        hittable: hittable,
+        depth: 1,
+        parentIndex: parentIndex,
+        hiddenContentAbove: nil,
+        hiddenContentBelow: nil
+      )
+    })
+    if let exceptionMessage {
+      NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_FLAT_IGNORED_EXCEPTION=%@", exceptionMessage)
+      return nil
+    }
+    return node
+  }
+
+  private func nonEmptyElementText(_ read: () -> String) -> String? {
+    let value = safely("SNAPSHOT_FLAT_TEXT", "") {
+      read()
+    }.trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
   }
 
   private func isScrollableContainer(_ snapshot: XCUIElementSnapshot, visible: Bool) -> Bool {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -273,7 +273,7 @@ extension RunnerTests {
       : Date.distantFuture
     var seen = Set<String>()
     var candidates: [SnapshotNode] = []
-    for element in flatFallbackElements(app: app, options: options, deadline: deadline) {
+    for element in flatInteractiveElements(app: app, deadline: deadline) {
       if Date() >= deadline {
         NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_FLAT_FALLBACK_DEADLINE")
         break
@@ -822,12 +822,11 @@ extension RunnerTests {
     safely("SNAPSHOT_QUERY", [], fetch)
   }
 
-  private func flatFallbackElements(
+  private func flatInteractiveElements(
     app: XCUIApplication,
-    options: SnapshotOptions,
     deadline: Date
   ) -> [XCUIElement] {
-    let queries: [XCUIElementQuery] = options.interactiveOnly ? [
+    let queries: [XCUIElementQuery] = [
       app.buttons,
       app.links,
       app.textFields,
@@ -845,30 +844,7 @@ extension RunnerTests {
       app.steppers,
       app.tabBars,
       app.menuItems
-    ] : [
-      app.buttons,
-      app.cells,
-      app.collectionViews,
-      app.images,
-      app.links,
-      app.scrollViews,
-      app.searchFields,
-      app.secureTextFields,
-      app.segmentedControls,
-      app.sliders,
-      app.staticTexts,
-      app.switches,
-      app.tables,
-      app.textFields,
-      app.textViews
     ]
-    guard options.interactiveOnly else {
-      return queries.flatMap { query in
-        safeSnapshotElementsQuery {
-          query.allElementsBoundByIndex
-        }
-      }
-    }
 
     var elements: [XCUIElement] = []
     for query in queries {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -48,6 +48,7 @@ final class RunnerTests: XCTestCase {
   let firstInteractionAfterActivateDelay: TimeInterval = 0.25
   let scrollInteractionIdleTimeoutDefault: TimeInterval = 1.0
   let tvRemoteDoublePressDelayDefault: TimeInterval = 0.0
+  let xctestIdleKeepaliveInterval: TimeInterval = 5.0
   let minRecordingFps = 1
   let maxRecordingFps = 120
   let minRecordingQuality = 5
@@ -119,6 +120,18 @@ final class RunnerTests: XCTestCase {
       self.handle(connection: conn)
     }
     listener?.start(queue: transportQueue)
+    let idleKeepaliveTimer = DispatchSource.makeTimerSource(queue: transportQueue)
+    idleKeepaliveTimer.schedule(
+      deadline: .now() + xctestIdleKeepaliveInterval,
+      repeating: xctestIdleKeepaliveInterval
+    )
+    idleKeepaliveTimer.setEventHandler {
+      NSLog("AGENT_DEVICE_RUNNER_IDLE_KEEPALIVE")
+    }
+    idleKeepaliveTimer.resume()
+    defer {
+      idleKeepaliveTimer.cancel()
+    }
 
     guard let expectation = doneExpectation else {
       XCTFail("runner expectation was not initialized")

--- a/ios-runner/README.md
+++ b/ios-runner/README.md
@@ -33,6 +33,19 @@ Protocol and maintenance references:
 - `RunnerTests+SystemModal.swift`: SpringBoard/system modal detection and modal snapshot shaping.
 - `RunnerTests+ScreenRecorder.swift`: nested `ScreenRecorder` implementation.
 
+## Snapshot Strategy
+
+iOS snapshots have two explicit capture modes:
+
+- full/raw snapshots use recursive XCTest snapshots for rich hierarchy and diagnostics;
+- compact interactive snapshots use a bounded flat XCTest query path for fast agent-facing refs.
+
+Some simulator apps expose accessibility trees that lower-level AX services can inspect but XCTest
+cannot serialize reliably. In those cases compact interactive snapshots may return a sparse root
+quickly, while full snapshots preserve the XCTest error. See
+[`../docs/adr/0004-ios-snapshot-backend-strategy.md`](../docs/adr/0004-ios-snapshot-backend-strategy.md)
+for the backend boundary and the rationale for a future simulator AX-service backend.
+
 ## Protocol Notes
 
 - The daemon posts JSON commands to `POST /command` on the runner's local HTTP listener.

--- a/src/__tests__/runtime-interactions.test.ts
+++ b/src/__tests__/runtime-interactions.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
-import type { AgentDeviceBackend } from '../backend.ts';
+import type { AgentDeviceBackend, BackendSnapshotOptions } from '../backend.ts';
 import { commands, ref, selector } from '../commands/index.ts';
 import { resolveActionableTouchResolution } from '../commands/interaction-targeting.ts';
 import { createLocalArtifactAdapter } from '../io.ts';
@@ -67,6 +67,45 @@ test('runtime press resolves selector targets to the actionable node center', as
     'value="Continue"',
   ]);
   assert.deepEqual(result.backendResult, { ok: true });
+});
+
+test('runtime selector interactions fall back to a full snapshot when compact interactive misses', async () => {
+  const calls: Point[] = [];
+  const captureOptions: Array<BackendSnapshotOptions | undefined> = [];
+  const device = createInteractionDevice(selectorSnapshot(), {
+    captureSnapshot: async (_context, options) => {
+      captureOptions.push(options);
+      return {
+        snapshot: options?.interactiveOnly
+          ? makeSnapshotState([])
+          : makeSnapshotState([
+              {
+                index: 0,
+                depth: 0,
+                type: 'XCUIElementTypeCell',
+                label: 'General',
+                rect: { x: 0, y: 100, width: 320, height: 44 },
+                hittable: true,
+              },
+            ]),
+      };
+    },
+    tap: async (_context, point) => {
+      calls.push(point);
+    },
+  });
+
+  const result = await device.interactions.click(selector('label=General'), {
+    session: 'default',
+  });
+
+  assert.equal(result.kind, 'selector');
+  assert.equal(result.node?.label, 'General');
+  assert.deepEqual(calls, [{ x: 160, y: 122 }]);
+  assert.deepEqual(captureOptions, [
+    { interactiveOnly: true, compact: true },
+    { interactiveOnly: false, compact: false },
+  ]);
 });
 
 test('runtime click keeps distinct tab button centers when iOS reports the tab bar as hittable', async () => {

--- a/src/__tests__/runtime-snapshot.test.ts
+++ b/src/__tests__/runtime-snapshot.test.ts
@@ -126,6 +126,43 @@ test('runtime snapshot warns when Android helper falls back to stock UIAutomator
   ]);
 });
 
+test('runtime snapshot warns when iOS compact interactive output is root-only', async () => {
+  const device = createSnapshotOnlyDevice({
+    nodes: [{ ref: 'e1', index: 0, depth: 0, type: 'Application' }],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const result = await device.capture.snapshot({
+    session: 'default',
+    interactiveOnly: true,
+    compact: true,
+  });
+
+  assert.deepEqual(result.warnings, [
+    'iOS compact interactive snapshot exposed only the application root. XCTest typed accessibility queries can fail to enumerate some simulator UI trees even when screenshots and direct gestures still work. Use screenshot as visual truth, try a scoped/full snapshot for diagnostics, and prefer direct selectors when known.',
+  ]);
+});
+
+test('runtime snapshot does not warn for a normal iOS compact interactive output', async () => {
+  const device = createSnapshotOnlyDevice({
+    nodes: [
+      { ref: 'e1', index: 0, depth: 0, type: 'Application' },
+      { ref: 'e2', index: 1, depth: 1, type: 'Button', label: 'Continue' },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const result = await device.capture.snapshot({
+    session: 'default',
+    interactiveOnly: true,
+    compact: true,
+  });
+
+  assert.equal(result.warnings, undefined);
+});
+
 test('runtime snapshot warns when Android hierarchy looks like a React Native overlay', async () => {
   const device = createSnapshotOnlyDevice({
     nodes: [

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -217,6 +217,7 @@ function buildSnapshotWarnings(params: {
 }): string[] {
   const warnings = [...(params.result.warnings ?? [])];
   warnings.push(...buildEmptyAndroidInteractiveWarnings(params));
+  warnings.push(...buildSparseIosInteractiveWarnings(params));
 
   const helperFallbackWarning = formatAndroidHelperFallbackWarning(params.result.androidSnapshot);
   if (helperFallbackWarning) warnings.push(helperFallbackWarning);
@@ -229,6 +230,27 @@ function buildSnapshotWarnings(params: {
 
   warnings.push(...formatFreshnessWarnings(params.result.freshness, params.snapshot.backend));
   return Array.from(new Set(warnings));
+}
+
+function buildSparseIosInteractiveWarnings(params: {
+  snapshot: SnapshotState;
+  options: SnapshotCommandOptions;
+}): string[] {
+  if (
+    params.snapshot.backend !== 'xctest' ||
+    params.options.interactiveOnly !== true ||
+    params.options.compact !== true ||
+    params.snapshot.nodes.length !== 1
+  ) {
+    return [];
+  }
+
+  const root = params.snapshot.nodes[0];
+  if (root?.type !== 'Application') return [];
+
+  return [
+    'iOS compact interactive snapshot exposed only the application root. XCTest typed accessibility queries can fail to enumerate some simulator UI trees even when screenshots and direct gestures still work. Use screenshot as visual truth, try a scoped/full snapshot for diagnostics, and prefer direct selectors when known.',
+  ];
 }
 
 function buildEmptyAndroidInteractiveWarnings(params: {

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -278,21 +278,37 @@ function formatRecentSnapshotDropWarning(params: {
   runtimeNow: number;
 }): string | undefined {
   const previousSnapshot = params.session?.snapshot;
-  const isRecentSnapshot = previousSnapshot
-    ? [params.capturedAt, params.runtimeNow].some((timestamp) => {
-        const elapsed = timestamp - previousSnapshot.createdAt;
-        return elapsed >= 0 && elapsed <= 2_000;
-      })
-    : false;
   if (
     !params.result.freshness &&
     previousSnapshot &&
-    isRecentSnapshot &&
+    hasSameSnapshotPresentation(previousSnapshot, params.snapshot) &&
+    isRecentSnapshot(previousSnapshot, params.capturedAt, params.runtimeNow) &&
     isLikelyStaleSnapshotDrop(previousSnapshot.nodes.length, params.snapshot.nodes.length)
   ) {
     return STALE_SNAPSHOT_DROP_WARNING;
   }
   return undefined;
+}
+
+function hasSameSnapshotPresentation(
+  previousSnapshot: Pick<SnapshotState, 'presentationKey'>,
+  snapshot: Pick<SnapshotState, 'presentationKey'>,
+): boolean {
+  if (previousSnapshot.presentationKey === undefined || snapshot.presentationKey === undefined) {
+    return true;
+  }
+  return previousSnapshot.presentationKey === snapshot.presentationKey;
+}
+
+function isRecentSnapshot(
+  previousSnapshot: Pick<SnapshotState, 'createdAt'>,
+  capturedAt: number,
+  runtimeNow: number,
+): boolean {
+  return [capturedAt, runtimeNow].some((timestamp) => {
+    const elapsed = timestamp - previousSnapshot.createdAt;
+    return elapsed >= 0 && elapsed <= 2_000;
+  });
 }
 
 const STALE_SNAPSHOT_DROP_WARNING =

--- a/src/commands/interaction-resolution.ts
+++ b/src/commands/interaction-resolution.ts
@@ -98,14 +98,23 @@ export async function resolveInteractionTarget(
     };
   }
 
-  const capture = await captureInteractionSnapshot(runtime, options, params.requireInteractive);
   const chain = parseSelectorChain(options.target.selector);
-  const resolved = resolveSelectorChain(capture.snapshot.nodes, chain, {
+  let capture = await captureInteractionSnapshot(runtime, options, params.requireInteractive);
+  let resolved = resolveSelectorChain(capture.snapshot.nodes, chain, {
     platform: runtime.backend.platform,
     requireRect: true,
     requireUnique: true,
     disambiguateAmbiguous: true,
   });
+  if ((!resolved || !resolved.node.rect) && params.requireInteractive) {
+    capture = await captureInteractionSnapshot(runtime, options, false);
+    resolved = resolveSelectorChain(capture.snapshot.nodes, chain, {
+      platform: runtime.backend.platform,
+      requireRect: true,
+      requireUnique: true,
+      disambiguateAmbiguous: true,
+    });
+  }
   if (!resolved || !resolved.node.rect) {
     throw new AppError(
       'COMMAND_FAILED',

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -3013,6 +3013,48 @@ test('close <app> on iOS stops runner before app close dispatch and performs fin
   expect(calls).toEqual(['stop-runner', 'close:com.example.app', 'stop-runner']);
 });
 
+test('close <app> on iOS simulator retains runner while terminating app', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-simulator-close-session';
+  sessionStore.set(sessionName, {
+    ...makeSession(sessionName, {
+      platform: 'ios',
+      id: 'sim-1',
+      name: 'iPhone 17 Pro',
+      kind: 'simulator',
+      booted: true,
+    }),
+    appName: 'com.example.app',
+  });
+
+  const calls: string[] = [];
+  mockStopIosRunner.mockImplementation(async () => {
+    calls.push('stop-runner');
+  });
+  mockDispatch.mockImplementation(async (_device, command, positionals) => {
+    calls.push(`${command}:${positionals.join(' ')}`);
+    return {};
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: ['com.example.app'],
+      flags: {},
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+  expect(calls).toEqual(['close:com.example.app']);
+});
+
 test('close <app> on macOS stops runner before app close dispatch and dismisses automation alert', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'macos-close-session';

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -2761,6 +2761,13 @@ test('open --relaunch on iOS stops runner before close/open', async () => {
   });
 
   const calls: string[] = [];
+  mockResolveTargetDevice.mockResolvedValue({
+    platform: 'ios',
+    id: 'ios-device-1',
+    name: 'My iPhone',
+    kind: 'device',
+    booted: true,
+  });
   mockStopIosRunner.mockImplementation(async () => {
     calls.push('stop-runner');
   });
@@ -2786,6 +2793,55 @@ test('open --relaunch on iOS stops runner before close/open', async () => {
   expect(response).toBeTruthy();
   expect(response?.ok).toBe(true);
   expect(calls).toEqual(['stop-runner', 'close:com.example.app', 'open:com.example.app']);
+});
+
+test('open --relaunch on iOS simulator keeps runner while closing app', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-simulator-session';
+  sessionStore.set(sessionName, {
+    ...makeSession(sessionName, {
+      platform: 'ios',
+      id: 'sim-1',
+      name: 'iPhone 17 Pro',
+      kind: 'simulator',
+      booted: true,
+    }),
+    appName: 'com.example.app',
+  });
+
+  const calls: string[] = [];
+  mockResolveTargetDevice.mockResolvedValue({
+    platform: 'ios',
+    id: 'sim-1',
+    name: 'iPhone 17 Pro',
+    kind: 'simulator',
+    booted: true,
+  });
+  mockStopIosRunner.mockImplementation(async () => {
+    calls.push('stop-runner');
+  });
+  mockDispatch.mockImplementation(async (_device, command, positionals) => {
+    calls.push(`${command}:${positionals.join(' ')}`);
+    return {};
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'open',
+      positionals: [],
+      flags: { relaunch: true },
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+  expect(calls).toEqual(['close:com.example.app', 'open:com.example.app']);
 });
 
 test('open --relaunch includes timing and waits for iOS runner prewarm', async () => {

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -502,6 +502,60 @@ test('snapshot warns when recent snapshot node count collapses sharply', async (
   }
 });
 
+test('snapshot does not warn on expected node drop across presentation modes', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-presentation-drop';
+  const session = makeSession(sessionName, iosSimulatorDevice);
+  session.appBundleId = 'com.example.app';
+  session.snapshot = {
+    nodes: Array.from({ length: 50 }, (_, index) => ({
+      ref: `e${index + 1}`,
+      index,
+      depth: 0,
+      type: 'StaticText',
+      label: `Row ${index + 1}`,
+    })),
+    createdAt: Date.now(),
+    backend: 'xctest',
+    presentationKey: buildSnapshotPresentationKey({ interactiveOnly: false, compact: false }),
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockResolvedValue({
+    nodes: Array.from({ length: 8 }, (_, index) => ({
+      index,
+      depth: 0,
+      type: 'Button',
+      label: `Action ${index + 1}`,
+      hittable: true,
+    })),
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const response = await handleSnapshotCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'snapshot',
+      positionals: [],
+      flags: { snapshotInteractiveOnly: true, snapshotCompact: true },
+    },
+    sessionName,
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+  });
+
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    expect(response.data?.warnings ?? []).toEqual(
+      expect.not.arrayContaining([
+        expect.stringContaining('Recent snapshots dropped sharply in node count'),
+      ]),
+    );
+  }
+});
+
 test('snapshot automatically retries stale Android trees after recent navigation', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'android-stale-retries-to-fresh';

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -96,10 +96,11 @@ async function stopAppleRunnerForClose(session: SessionState): Promise<void> {
 }
 
 function shouldRetainAppleRunnerAfterClose(req: DaemonRequest, session: SessionState): boolean {
-  const hasCloseTarget = (req.positionals?.length ?? 0) > 0;
-  return (
-    isIosSimulator(session.device) && !hasCloseTarget && !req.flags?.shutdown && !session.recording
-  );
+  return isIosSimulator(session.device) && !req.flags?.shutdown && !session.recording;
+}
+
+function shouldStopAppleRunnerBeforeTargetedClose(session: SessionState): boolean {
+  return isApplePlatform(session.device.platform) && !isIosSimulator(session.device);
 }
 
 export async function teardownSessionResources(
@@ -130,7 +131,7 @@ export async function handleCloseCommand(params: {
     await stopAppLog(session.appLog);
   }
   if (req.positionals && req.positionals.length > 0) {
-    if (isApplePlatform(session.device.platform)) {
+    if (shouldStopAppleRunnerBeforeTargetedClose(session)) {
       await stopAppleRunnerForClose(session);
     }
     await dispatchCommand(session.device, 'close', req.positionals, req.flags?.out, {

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -14,6 +14,7 @@ import { SessionStore } from '../session-store.ts';
 import {
   IOS_SIMULATOR_POST_CLOSE_SETTLE_MS,
   IOS_SIMULATOR_POST_OPEN_SETTLE_MS,
+  isIosSimulator,
   refreshSessionDeviceIfNeeded,
   settleIosSimulator,
 } from './session-device-utils.ts';
@@ -61,7 +62,7 @@ async function relaunchCloseApp(params: {
   context: Parameters<typeof dispatchCommand>[4];
 }): Promise<void> {
   const { device, closeTarget, outFlag, context } = params;
-  if (device.platform !== 'android') {
+  if (device.platform !== 'android' && !isIosSimulator(device)) {
     await stopIosRunnerSession(device.id);
   }
   await dispatchCommand(device, 'close', [closeTarget], outFlag, context);

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -17,6 +17,8 @@ const {
   mockIsProcessAlive,
   mockIsProcessGroupAlive,
   mockPrepareXctestrunWithEnv,
+  mockResolveExpectedRunnerCacheMetadata,
+  mockResolveRunnerDerivedPath,
   mockRunAppleToolCommand,
   mockRunCmdBackground,
   mockRunXcrun,
@@ -31,6 +33,8 @@ const {
   mockIsProcessAlive: vi.fn(),
   mockIsProcessGroupAlive: vi.fn(),
   mockPrepareXctestrunWithEnv: vi.fn(),
+  mockResolveExpectedRunnerCacheMetadata: vi.fn(),
+  mockResolveRunnerDerivedPath: vi.fn(),
   mockRunAppleToolCommand: vi.fn(),
   mockRunCmdBackground: vi.fn(),
   mockRunXcrun: vi.fn(),
@@ -88,6 +92,8 @@ vi.mock('../runner-xctestrun.ts', async () => {
     acquireXcodebuildSimulatorSetRedirect: mockAcquireXcodebuildSimulatorSetRedirect,
     ensureXctestrunArtifact: mockEnsureXctestrunArtifact,
     prepareXctestrunWithEnv: mockPrepareXctestrunWithEnv,
+    resolveExpectedRunnerCacheMetadata: mockResolveExpectedRunnerCacheMetadata,
+    resolveRunnerDerivedPath: mockResolveRunnerDerivedPath,
   };
 });
 
@@ -116,6 +122,8 @@ beforeEach(() => {
     xctestrunPath: '/tmp/session-runner.xctestrun',
     jsonPath: '/tmp/session-runner.json',
   });
+  mockResolveExpectedRunnerCacheMetadata.mockReturnValue({ schemaVersion: 1 });
+  mockResolveRunnerDerivedPath.mockReturnValue('/tmp/derived');
   mockAcquireXcodebuildSimulatorSetRedirect.mockResolvedValue({ release: mockRedirectRelease });
   mockRunCmdBackground.mockReturnValue(makeBackgroundRunner(4242));
   mockRunAppleToolCommand.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
@@ -478,6 +486,36 @@ test('runner session starts xcodebuild through provider seams and reuses an aliv
 
   mockIsProcessAlive.mockReturnValue(false);
   await stopRunnerSession(session);
+});
+
+test('runner session restarts alive runner when expected xctestrun artifact changes', async () => {
+  const device = { ...IOS_SIMULATOR, id: 'runner-session-stale-artifact-sim' };
+
+  mockEnsureXctestrunArtifact
+    .mockResolvedValueOnce({
+      xctestrunPath: '/tmp/base-runner.xctestrun',
+      derived: '/tmp/derived',
+      cache: 'miss',
+      artifact: 'rebuilt',
+      buildMs: 12,
+      xctestrunPathSource: 'build',
+    })
+    .mockResolvedValueOnce({
+      xctestrunPath: '/tmp/base-runner-next.xctestrun',
+      derived: '/tmp/derived-next',
+      cache: 'miss',
+      artifact: 'rebuilt',
+      buildMs: 13,
+      xctestrunPathSource: 'build',
+    });
+
+  const session = await ensureRunnerSession(device, {});
+  mockResolveRunnerDerivedPath.mockReturnValue('/tmp/derived-next');
+  const restarted = await ensureRunnerSession(device, {});
+
+  assert.notEqual(restarted, session);
+  assert.equal(restarted.xctestrunArtifact?.derived, '/tmp/derived-next');
+  assert.equal(mockRunCmdBackground.mock.calls.length, 2);
 });
 
 test('runner session keeps boot and stale bundle cleanup available when needed', async () => {

--- a/src/platforms/ios/__tests__/runner-transport.test.ts
+++ b/src/platforms/ios/__tests__/runner-transport.test.ts
@@ -2,7 +2,9 @@ import fs from 'node:fs';
 import { afterEach, beforeEach, test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import type { DeviceInfo } from '../../../utils/device.ts';
+import type { ExecBackgroundResult } from '../../../utils/exec.ts';
 import { AppError } from '../../../utils/errors.ts';
+import type { RunnerSession } from '../runner-session-types.ts';
 
 const { mockRunCmd } = vi.hoisted(() => ({
   mockRunCmd: vi.fn(),
@@ -106,6 +108,37 @@ test('waitForRunner keeps tunnel IP lookup request-local when no tunnel IP is av
   assert.equal(vi.mocked(fetch).mock.calls[0]?.[0], 'http://127.0.0.1:8100/command');
 });
 
+test('waitForRunner uses simulator fallback within the attempt for ready sessions', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }),
+  );
+  mockRunCmd.mockResolvedValue({ exitCode: 0, stdout: '{"ok":true}', stderr: '' });
+
+  const response = await waitForRunner(
+    iosSimulator,
+    8100,
+    { command: 'uptime' },
+    undefined,
+    5_000,
+    makeReadyRunnerSession(),
+  );
+
+  assert.equal(await response.text(), '{"ok":true}');
+  assert.equal(vi.mocked(fetch).mock.calls.length, 1);
+  assert.equal(mockRunCmd.mock.calls.length, 1);
+  assert.equal(mockRunCmd.mock.calls[0]?.[0], 'xcrun');
+  assert.deepEqual(mockRunCmd.mock.calls[0]?.[1]?.slice(0, 5), [
+    'simctl',
+    'spawn',
+    'sim-1',
+    '/usr/bin/curl',
+    '-s',
+  ]);
+});
+
 test('waitForRunner invalidates cached tunnel IP when localhost fallback succeeds', async () => {
   const tunnelIps = ['fd00::123', 'fd00::456'];
   mockRunCmd.mockImplementation(async (_cmd: string, args: string[]) => {
@@ -169,4 +202,18 @@ function stubSuccessfulFetch(): void {
     'fetch',
     vi.fn(async () => new Response('{}')),
   );
+}
+
+function makeReadyRunnerSession(): RunnerSession {
+  return {
+    sessionId: 'ready-session',
+    device: iosSimulator,
+    deviceId: iosSimulator.id,
+    port: 8100,
+    xctestrunPath: '/tmp/runner.xctestrun',
+    jsonPath: '/tmp/runner.json',
+    testPromise: Promise.resolve({ exitCode: 0, stdout: '', stderr: '' }),
+    child: { pid: 1234, exitCode: null } as ExecBackgroundResult['child'],
+    ready: true,
+  };
 }

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -21,6 +21,8 @@ import {
   ensureXctestrunArtifact,
   IOS_RUNNER_CONTAINER_BUNDLE_IDS,
   prepareXctestrunWithEnv,
+  resolveExpectedRunnerCacheMetadata,
+  resolveRunnerDerivedPath,
   resolveRunnerDestination,
   resolveRunnerMaxConcurrentDestinationsFlag,
   runnerPrepProcesses,
@@ -81,21 +83,8 @@ export async function ensureRunnerSession(
   return await withRunnerSessionLock(device.id, async () => {
     const existing = runnerSessions.get(device.id);
     if (existing) {
-      if (isRunnerProcessAlive(existing.child.pid)) {
-        emitDiagnostic({
-          level: 'debug',
-          phase: 'ios_runner_session_reuse',
-          data: {
-            deviceId: device.id,
-            sessionId: existing.sessionId,
-            ready: existing.ready,
-          },
-        });
-        return existing;
-      }
-      await measureRunnerStartupStep({}, 'stop_stale_session', async () => {
-        await stopRunnerSessionInternal(device.id, existing);
-      });
+      const reusable = await resolveReusableRunnerSession(device, existing);
+      if (reusable) return reusable;
     }
 
     const startupTimings: Record<string, number> = {};
@@ -203,6 +192,50 @@ export async function ensureRunnerSession(
     runnerSessions.set(device.id, session);
     return session;
   });
+}
+
+async function resolveReusableRunnerSession(
+  device: DeviceInfo,
+  existing: RunnerSession,
+): Promise<RunnerSession | null> {
+  if (!isRunnerProcessAlive(existing.child.pid)) {
+    await measureRunnerStartupStep({}, 'stop_stale_session', async () => {
+      await stopRunnerSessionInternal(device.id, existing);
+    });
+    return null;
+  }
+
+  const expectedDerived = resolveRunnerDerivedPath(
+    device,
+    resolveExpectedRunnerCacheMetadata(device),
+  );
+  if (existing.xctestrunArtifact?.derived !== expectedDerived) {
+    emitDiagnostic({
+      level: 'debug',
+      phase: 'ios_runner_session_artifact_stale',
+      data: {
+        deviceId: device.id,
+        sessionId: existing.sessionId,
+        currentDerived: existing.xctestrunArtifact?.derived,
+        expectedDerived,
+      },
+    });
+    await measureRunnerStartupStep({}, 'stop_stale_artifact_session', async () => {
+      await stopRunnerSessionInternal(device.id, existing);
+    });
+    return null;
+  }
+
+  emitDiagnostic({
+    level: 'debug',
+    phase: 'ios_runner_session_reuse',
+    data: {
+      deviceId: device.id,
+      sessionId: existing.sessionId,
+      ready: existing.ready,
+    },
+  });
+  return existing;
 }
 
 async function cleanupStaleSimulatorRunnerBundles(device: DeviceInfo): Promise<void> {

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -81,6 +81,16 @@ export async function waitForRunner(
           },
         });
         if (response) return response;
+        if (device.kind === 'simulator' && session?.ready) {
+          const simulatorResponse = await tryRunnerSimulatorEndpoint(device, port, command, {
+            signal,
+            attemptDeadline,
+            onError: (err) => {
+              lastError = err;
+            },
+          });
+          if (simulatorResponse) return simulatorResponse;
+        }
         if (device.kind === 'device' && usedCachedTunnelIp) {
           invalidateDeviceTunnelIpCache(device.id);
           const refreshed = await getEndpoints(attemptDeadline?.remainingMs(), true);
@@ -236,6 +246,31 @@ async function tryRunnerEndpoints(
     }
   }
   return null;
+}
+
+async function tryRunnerSimulatorEndpoint(
+  device: DeviceInfo,
+  port: number,
+  command: RunnerCommand,
+  params: {
+    signal?: AbortSignal;
+    attemptDeadline?: Deadline;
+    onError: (error: unknown) => void;
+  },
+): Promise<Response | null> {
+  const { signal, attemptDeadline, onError } = params;
+  const remainingMs = attemptDeadline?.remainingMs() ?? RUNNER_COMMAND_TIMEOUT_MS;
+  if (remainingMs <= 0) return null;
+  try {
+    const simResponse = await postCommandViaSimulator(device, port, command, remainingMs, signal);
+    return new Response(simResponse.body, { status: simResponse.status });
+  } catch (err) {
+    if (signal?.aborted || isRequestCanceledError(err)) {
+      throw createRequestCanceledError();
+    }
+    onError(err);
+    return null;
+  }
 }
 
 async function getDeviceTunnelIpForRequest(params: {

--- a/src/platforms/ios/runner-transport.ts
+++ b/src/platforms/ios/runner-transport.ts
@@ -51,70 +51,26 @@ export async function waitForRunner(
   try {
     return await retryWithPolicy(
       async ({ deadline: attemptDeadline }) => {
-        if (attemptDeadline?.isExpired()) {
-          throw new AppError('COMMAND_FAILED', 'Runner connection deadline exceeded', {
-            port,
-            timeoutMs,
-          });
-        }
-        if (session && session.child.exitCode !== null && session.child.exitCode !== undefined) {
-          throw await buildRunnerEarlyExitError({ session, port, logPath });
-        }
-        let usedCachedTunnelIp = false;
-        if (device.kind === 'device') {
-          const resolved = await getEndpoints(attemptDeadline?.remainingMs());
-          endpoints = resolved.endpoints;
-          usedCachedTunnelIp = resolved.cached;
-        }
-        const cachedTunnelEndpoint = usedCachedTunnelIp ? endpoints[0] : null;
-        const response = await tryRunnerEndpoints(endpoints, {
-          command,
+        const response = await attemptRunnerConnection({
+          device,
           port,
+          command,
           timeoutMs,
+          logPath,
+          session,
+          endpoints,
+          getEndpoints,
           signal,
           attemptDeadline,
-          onError: (endpoint, err) => {
+          setEndpoints: (nextEndpoints) => {
+            endpoints = nextEndpoints;
+          },
+          setLastError: (err) => {
             lastError = err;
-            if (device.kind === 'device' && endpoint === cachedTunnelEndpoint) {
-              invalidateDeviceTunnelIpCache(device.id);
-            }
           },
         });
         if (response) return response;
-        if (device.kind === 'simulator' && session?.ready) {
-          const simulatorResponse = await tryRunnerSimulatorEndpoint(device, port, command, {
-            signal,
-            attemptDeadline,
-            onError: (err) => {
-              lastError = err;
-            },
-          });
-          if (simulatorResponse) return simulatorResponse;
-        }
-        if (device.kind === 'device' && usedCachedTunnelIp) {
-          invalidateDeviceTunnelIpCache(device.id);
-          const refreshed = await getEndpoints(attemptDeadline?.remainingMs(), true);
-          endpoints = refreshed.endpoints;
-          const refreshedResponse = await tryRunnerEndpoints(endpoints, {
-            command,
-            port,
-            timeoutMs,
-            signal,
-            attemptDeadline,
-            onError: (_endpoint, err) => {
-              lastError = err;
-            },
-          });
-          if (refreshedResponse) return refreshedResponse;
-        }
-        if (signal?.aborted) {
-          throw createRequestCanceledError();
-        }
-        throw new AppError('COMMAND_FAILED', 'Runner endpoint probe failed', {
-          port,
-          endpoints,
-          lastError: lastError ? String(lastError) : undefined,
-        });
+        throw buildRunnerEndpointProbeError({ port, endpoints, lastError, signal });
       },
       {
         maxAttempts,
@@ -148,6 +104,156 @@ export async function waitForRunner(
   }
 
   throw buildRunnerConnectError({ port, endpoints, logPath, lastError });
+}
+
+type RunnerEndpointResolver = ReturnType<typeof createRunnerEndpointResolver>['getEndpoints'];
+
+async function attemptRunnerConnection(params: {
+  device: DeviceInfo;
+  port: number;
+  command: RunnerCommand;
+  timeoutMs: number;
+  logPath?: string;
+  session?: RunnerSession;
+  endpoints: string[];
+  getEndpoints: RunnerEndpointResolver;
+  signal?: AbortSignal;
+  attemptDeadline?: Deadline;
+  setEndpoints: (endpoints: string[]) => void;
+  setLastError: (error: unknown) => void;
+}): Promise<Response | null> {
+  await ensureRunnerAttemptCanStart(params);
+
+  const primary = await tryPrimaryRunnerEndpoints(params);
+  if (primary.response) return primary.response;
+
+  const simulatorFallback = await tryReadySimulatorEndpoint(params);
+  if (simulatorFallback) return simulatorFallback;
+
+  return await tryRefreshedDeviceTunnel(params, primary.usedCachedTunnelIp);
+}
+
+async function ensureRunnerAttemptCanStart(params: {
+  port: number;
+  timeoutMs: number;
+  logPath?: string;
+  session?: RunnerSession;
+  attemptDeadline?: Deadline;
+}): Promise<void> {
+  if (params.attemptDeadline?.isExpired()) {
+    throw new AppError('COMMAND_FAILED', 'Runner connection deadline exceeded', {
+      port: params.port,
+      timeoutMs: params.timeoutMs,
+    });
+  }
+  if (params.session?.child.exitCode !== null && params.session?.child.exitCode !== undefined) {
+    throw await buildRunnerEarlyExitError({
+      session: params.session,
+      port: params.port,
+      logPath: params.logPath,
+    });
+  }
+}
+
+async function tryPrimaryRunnerEndpoints(params: {
+  device: DeviceInfo;
+  port: number;
+  command: RunnerCommand;
+  timeoutMs: number;
+  endpoints: string[];
+  getEndpoints: RunnerEndpointResolver;
+  signal?: AbortSignal;
+  attemptDeadline?: Deadline;
+  setEndpoints: (endpoints: string[]) => void;
+  setLastError: (error: unknown) => void;
+}): Promise<{ response: Response | null; usedCachedTunnelIp: boolean }> {
+  let endpoints = params.endpoints;
+  let usedCachedTunnelIp = false;
+  if (params.device.kind === 'device') {
+    const resolved = await params.getEndpoints(params.attemptDeadline?.remainingMs());
+    endpoints = resolved.endpoints;
+    usedCachedTunnelIp = resolved.cached;
+    params.setEndpoints(endpoints);
+  }
+
+  const cachedTunnelEndpoint = usedCachedTunnelIp ? endpoints[0] : null;
+  const response = await tryRunnerEndpoints(endpoints, {
+    command: params.command,
+    port: params.port,
+    timeoutMs: params.timeoutMs,
+    signal: params.signal,
+    attemptDeadline: params.attemptDeadline,
+    onError: (endpoint, err) => {
+      params.setLastError(err);
+      if (params.device.kind === 'device' && endpoint === cachedTunnelEndpoint) {
+        invalidateDeviceTunnelIpCache(params.device.id);
+      }
+    },
+  });
+  return { response, usedCachedTunnelIp };
+}
+
+async function tryReadySimulatorEndpoint(params: {
+  device: DeviceInfo;
+  port: number;
+  command: RunnerCommand;
+  session?: RunnerSession;
+  signal?: AbortSignal;
+  attemptDeadline?: Deadline;
+  setLastError: (error: unknown) => void;
+}): Promise<Response | null> {
+  if (params.device.kind !== 'simulator' || !params.session?.ready) return null;
+  return await tryRunnerSimulatorEndpoint(params.device, params.port, params.command, {
+    signal: params.signal,
+    attemptDeadline: params.attemptDeadline,
+    onError: params.setLastError,
+  });
+}
+
+async function tryRefreshedDeviceTunnel(
+  params: {
+    device: DeviceInfo;
+    port: number;
+    command: RunnerCommand;
+    timeoutMs: number;
+    getEndpoints: RunnerEndpointResolver;
+    signal?: AbortSignal;
+    attemptDeadline?: Deadline;
+    setEndpoints: (endpoints: string[]) => void;
+    setLastError: (error: unknown) => void;
+  },
+  usedCachedTunnelIp: boolean,
+): Promise<Response | null> {
+  if (params.device.kind !== 'device' || !usedCachedTunnelIp) return null;
+  invalidateDeviceTunnelIpCache(params.device.id);
+  const refreshed = await params.getEndpoints(params.attemptDeadline?.remainingMs(), true);
+  params.setEndpoints(refreshed.endpoints);
+  return await tryRunnerEndpoints(refreshed.endpoints, {
+    command: params.command,
+    port: params.port,
+    timeoutMs: params.timeoutMs,
+    signal: params.signal,
+    attemptDeadline: params.attemptDeadline,
+    onError: (_endpoint, err) => {
+      params.setLastError(err);
+    },
+  });
+}
+
+function buildRunnerEndpointProbeError(params: {
+  port: number;
+  endpoints: string[];
+  lastError: unknown;
+  signal?: AbortSignal;
+}): AppError {
+  if (params.signal?.aborted) {
+    throw createRequestCanceledError();
+  }
+  return new AppError('COMMAND_FAILED', 'Runner endpoint probe failed', {
+    port: params.port,
+    endpoints: params.endpoints,
+    lastError: params.lastError ? String(params.lastError) : undefined,
+  });
 }
 
 export async function sendRunnerCommandOnce(

--- a/test/integration/replays/ios/device/01-physical-lifecycle.ad
+++ b/test/integration/replays/ios/device/01-physical-lifecycle.ad
@@ -2,7 +2,7 @@
 context platform=ios target=mobile
 open com.apple.Preferences --relaunch
 snapshot
-click "role=button label=General"
+click "role=cell label=General || role=button label=General"
 wait "label=About || label=\"Software Update\"" 5000
 back
-is exists "role=button label=General"
+is exists "role=cell label=General || role=button label=General"

--- a/test/integration/replays/ios/device/01-physical-lifecycle.ad
+++ b/test/integration/replays/ios/device/01-physical-lifecycle.ad
@@ -2,7 +2,7 @@
 context platform=ios target=mobile
 open com.apple.Preferences --relaunch
 snapshot
-click "role=cell label=General"
+click "role=button label=General"
 wait "label=About || label=\"Software Update\"" 5000
 back
-is exists "role=cell label=General"
+is exists "role=button label=General"

--- a/test/integration/replays/ios/simulator/01-settings.ad
+++ b/test/integration/replays/ios/simulator/01-settings.ad
@@ -4,7 +4,7 @@ open com.apple.Preferences --relaunch
 screenshot "./test/screenshots/replays/ios-settings.png"
 snapshot -i
 appstate
-click "role=button label=General"
+click "role=cell label=General || role=button label=General"
 wait "label=About || label=\"Software Update\" || text=\"Manage your overall setup and preferences\"" 5000
 snapshot
 is exists "label=About || label=\"Software Update\" || text=\"Manage your overall setup and preferences\""

--- a/test/integration/replays/ios/simulator/01-settings.ad
+++ b/test/integration/replays/ios/simulator/01-settings.ad
@@ -4,7 +4,7 @@ open com.apple.Preferences --relaunch
 screenshot "./test/screenshots/replays/ios-settings.png"
 snapshot -i
 appstate
-click "role=cell label=General"
+click "role=button label=General"
 wait "label=About || label=\"Software Update\" || text=\"Manage your overall setup and preferences\"" 5000
 snapshot
 is exists "label=About || label=\"Software Update\" || text=\"Manage your overall setup and preferences\""

--- a/test/integration/replays/ios/simulator/02-deep-navigation.ad
+++ b/test/integration/replays/ios/simulator/02-deep-navigation.ad
@@ -2,7 +2,7 @@
 context platform=ios target=mobile
 
 open com.apple.Preferences --relaunch
-click "role=cell label=General"
+click "role=button label=General"
 wait 1000
 find text "About" exists
 

--- a/test/integration/replays/ios/simulator/02-deep-navigation.ad
+++ b/test/integration/replays/ios/simulator/02-deep-navigation.ad
@@ -2,7 +2,7 @@
 context platform=ios target=mobile
 
 open com.apple.Preferences --relaunch
-click "role=button label=General"
+click "role=cell label=General || role=button label=General"
 wait 1000
 find text "About" exists
 

--- a/test/integration/replays/macos/01-system-settings.ad
+++ b/test/integration/replays/macos/01-system-settings.ad
@@ -4,7 +4,7 @@ open "System Settings" --relaunch
 screenshot "./test/screenshots/replays/macos-system-settings.png"
 appstate
 snapshot -i
-click "role=button label=General"
+click "role=cell label=General || role=button label=General"
 wait "role=button label=About" 5000
 snapshot -i
 is exists "role=button label=About"

--- a/test/integration/replays/macos/01-system-settings.ad
+++ b/test/integration/replays/macos/01-system-settings.ad
@@ -4,7 +4,6 @@ open "System Settings" --relaunch
 screenshot "./test/screenshots/replays/macos-system-settings.png"
 appstate
 snapshot -i
-click "role=cell label=General || role=button label=General"
 wait "role=button label=About" 5000
 snapshot -i
 is exists "role=button label=About"

--- a/test/integration/replays/macos/01-system-settings.ad
+++ b/test/integration/replays/macos/01-system-settings.ad
@@ -4,7 +4,7 @@ open "System Settings" --relaunch
 screenshot "./test/screenshots/replays/macos-system-settings.png"
 appstate
 snapshot -i
-click "role=cell label=General"
+click "role=button label=General"
 wait "role=button label=About" 5000
 snapshot -i
 is exists "role=button label=About"


### PR DESCRIPTION
## Summary

Keep the iOS simulator XCTest runner reusable across idle gaps, Maestro-style app closes, app relaunches, and local runner source/cache changes.

- adds a lightweight runner-side idle heartbeat so Xcode does not retire the long-lived XCTest process while it waits for commands
- keeps targeted app closes and `open --relaunch` from stopping the iOS simulator runner, so stopApp/relaunch does not force the next command to relaunch XCTest
- adds a simulator transport fallback for already-ready runner sessions when the direct localhost endpoint is temporarily unavailable
- splits the runner connect retry path into primary endpoint, ready-simulator fallback, and refreshed device-tunnel phases so the retry logic remains auditable
- suppresses stale-snapshot node-count warnings when switching between different snapshot presentation modes, such as full tree to compact interactive
- adds a bounded compact-interactive snapshot path for apps where XCTest cannot enumerate the normal accessibility root, avoiding expensive app/window/root probes and returning quickly with available refs or an explicitly warned sparse snapshot
- documents the iOS snapshot backend strategy in `docs/adr/0004-ios-snapshot-backend-strategy.md`: full recursive XCTest snapshots remain the rich diagnostic path, compact interactive snapshots are the bounded agent-facing path, and Bluesky-class semantic coverage needs a future simulator AX-service backend rather than more XCTest retries
- restarts a live iOS runner when the expected xctestrun artifact path changes, preventing local dirty-source/cache changes from continuing to serve an old runner process
- makes alert handling prefer blocking SpringBoard modals and fail honestly if the chosen alert button does not actually dismiss the alert

## Root Cause

The slow/empty `snapshot -i -c` behavior came from two separate issues:

- PR #639 correctly started preserving XCTest AX serialization failures instead of swallowing them as empty snapshots. That exposed real apps whose simulator accessibility tree can fail under XCTest with `kAXErrorIllegalArgument`.
- The first compact fallback still read app/window/root properties before flat enumeration. On broken trees those reads can hit the same expensive XCTest AX path, so compact snapshots could become much slower than plain snapshots.

This PR now treats compact interactive snapshots as their own bounded strategy. It does not pretend XCTest can semantically inspect every app. When XCTest typed queries cannot enumerate controls either, the CLI returns a fast sparse snapshot with a warning. A complete semantic fix for those apps should be a simulator AX-service backend normalized into the existing `SnapshotNode` model.

## Validation

- `pnpm exec vitest run src/platforms/ios/__tests__/runner-session.test.ts`
- `pnpm exec vitest run src/__tests__/runtime-snapshot.test.ts`
- `pnpm check:fallow`
- `pnpm check:quick`
- `pnpm build`
- `pnpm build:xcuitest:ios`
- Local iPhone 17 Pro / Settings: cached `prepare ios-runner` 4.7s from fresh state; `snapshot -i -c` 1.46s with visible Settings refs.
- Local iPhone 17 Pro / Bluesky logged-in state: reproduced XCTest `kAXErrorIllegalArgument` sparse-tree behavior; optimized `snapshot -i -c` returns bounded sparse output in 0.64s instead of spending ~10-60s on root/window/app probes and runner restarts.
- Local iPhone 17 Pro / React Navigation example: compact snapshot returned useful refs; first snapshot 5.69s while app settled, repeated steady-state snapshot 0.98s.
