### PR TITLE
fix: recover depth-limited iOS snapshots after AX failures

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -2,6 +2,9 @@ import XCTest
 
 extension RunnerTests {
   private static let axSnapshotErrorCode = "IOS_AX_SNAPSHOT_FAILED"
+  private static let axSnapshotFailureMessage =
+    "iOS XCTest snapshot failed while serializing the accessibility tree."
+  private static let axSnapshotUnavailableReason = "ax_snapshot_unavailable"
   private static let axSnapshotHint =
     "Snapshot state is unavailable because XCTest could not serialize this iOS accessibility tree. This can be specific to the current screen. Use plain screenshot, not screenshot --overlay-refs, as visual truth; navigate with coordinate commands if needed; then retry snapshot -i after reaching another screen. If you own the app and need full-tree inspection, simplify this screen's accessibility tree and expose stable ids on actionable controls."
   private static let collapsedTabCandidateTypes: Set<XCUIElement.ElementType> = [
@@ -93,14 +96,16 @@ extension RunnerTests {
       return blocking
     }
 
-    let context: SnapshotTraversalContext?
-    do {
-      context = try makeSnapshotTraversalContext(app: app, options: options)
-    } catch let failure as SnapshotCaptureFailure where options.interactiveOnly {
-      return snapshotAccessibilityUnavailable(failure: failure)
+    let capture = try snapshotTraversalContextOrFallback(
+      app: app,
+      options: options,
+      allowInteractiveUnavailableFallback: true
+    )
+    if let fallback = capture.fallback {
+      return fallback
     }
 
-    guard let context else {
+    guard let context = capture.context else {
       return DataPayload(nodes: [], truncated: false)
     }
 
@@ -211,7 +216,16 @@ extension RunnerTests {
       return blocking
     }
 
-    guard let context = try makeSnapshotTraversalContext(app: app, options: options) else {
+    let capture = try snapshotTraversalContextOrFallback(
+      app: app,
+      options: options,
+      allowInteractiveUnavailableFallback: false
+    )
+    if let fallback = capture.fallback {
+      return fallback
+    }
+
+    guard let context = capture.context else {
       return DataPayload(nodes: [], truncated: false)
     }
 
@@ -270,6 +284,7 @@ extension RunnerTests {
     let deadline = options.interactiveOnly
       ? Date().addingTimeInterval(Self.flatInteractiveFallbackBudget)
       : Date.distantFuture
+    let viewport = safeSnapshotViewport(app: app)
     var seen = Set<String>()
     var candidates: [SnapshotNode] = []
     for element in flatInteractiveElements(app: app, deadline: deadline) {
@@ -281,7 +296,7 @@ extension RunnerTests {
         element: element,
         index: 0,
         parentIndex: 0,
-        viewport: .infinite,
+        viewport: viewport,
         options: options
       ) else {
         continue
@@ -329,13 +344,83 @@ extension RunnerTests {
 
   private func snapshotAccessibilityUnavailable(failure: SnapshotCaptureFailure) -> DataPayload {
     NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_AX_UNAVAILABLE=%@", failure.message)
-    invalidateCachedTarget(reason: "ax_snapshot_unavailable")
+    invalidateCachedTarget(reason: Self.axSnapshotUnavailableReason)
+    return sparseTruncatedSnapshotPayload(
+      message: failure.message,
+      runnerFatal: true,
+      runnerFatalReason: Self.axSnapshotUnavailableReason
+    )
+  }
+
+  private func snapshotTraversalContextOrFallback(
+    app: XCUIApplication,
+    options: SnapshotOptions,
+    allowInteractiveUnavailableFallback: Bool
+  ) throws -> (context: SnapshotTraversalContext?, fallback: DataPayload?) {
+    do {
+      return (try makeSnapshotTraversalContext(app: app, options: options), nil)
+    } catch let failure as SnapshotCaptureFailure {
+      if let fallback = snapshotDepthLimitedAccessibilityFallback(
+        app: app,
+        options: options,
+        failure: failure
+      ) {
+        return (nil, fallback)
+      }
+      if allowInteractiveUnavailableFallback && options.interactiveOnly {
+        return (nil, snapshotAccessibilityUnavailable(failure: failure))
+      }
+      throw failure
+    }
+  }
+
+  private func snapshotDepthLimitedAccessibilityFallback(
+    app: XCUIApplication,
+    options: SnapshotOptions,
+    failure: SnapshotCaptureFailure
+  ) -> DataPayload? {
+    guard let requestedDepth = options.depth else {
+      return nil
+    }
+
+    NSLog(
+      "AGENT_DEVICE_RUNNER_SNAPSHOT_DEPTH_FALLBACK=%@",
+      failure.message
+    )
+
+    let fallbackDepth = max(0, requestedDepth)
+    if fallbackDepth == 0 {
+      return sparseTruncatedSnapshotPayload(message: failure.message)
+    }
+
+    let fallback = snapshotFlatInteractive(
+      app: app,
+      options: SnapshotOptions(
+        interactiveOnly: true,
+        compact: options.compact,
+        depth: fallbackDepth,
+        scope: options.scope,
+        raw: false
+      )
+    )
     return DataPayload(
       message: failure.message,
+      nodes: fallback.nodes,
+      truncated: true
+    )
+  }
+
+  private func sparseTruncatedSnapshotPayload(
+    message: String,
+    runnerFatal: Bool? = nil,
+    runnerFatalReason: String? = nil
+  ) -> DataPayload {
+    return DataPayload(
+      message: message,
       nodes: [compactInteractiveRootNode(rect: .zero)],
       truncated: true,
-      runnerFatal: true,
-      runnerFatalReason: "ax_snapshot_unavailable"
+      runnerFatal: runnerFatal,
+      runnerFatalReason: runnerFatalReason
     )
   }
 
@@ -345,20 +430,50 @@ extension RunnerTests {
 
     let payload = snapshotAccessibilityUnavailable(
       failure: SnapshotCaptureFailure(
-        code: "IOS_AX_SNAPSHOT_FAILED",
-        message: "iOS XCTest snapshot failed while serializing the accessibility tree.",
+        code: Self.axSnapshotErrorCode,
+        message: Self.axSnapshotFailureMessage,
         hint: Self.axSnapshotHint
       )
     )
 
-    XCTAssertEqual(payload.message, "iOS XCTest snapshot failed while serializing the accessibility tree.")
+    XCTAssertEqual(payload.message, Self.axSnapshotFailureMessage)
     XCTAssertEqual(payload.nodes?.count, 1)
     XCTAssertEqual(payload.nodes?.first?.type, "Application")
     XCTAssertEqual(payload.truncated, true)
     XCTAssertEqual(payload.runnerFatal, true)
-    XCTAssertEqual(payload.runnerFatalReason, "ax_snapshot_unavailable")
+    XCTAssertEqual(payload.runnerFatalReason, Self.axSnapshotUnavailableReason)
     XCTAssertNil(currentApp)
     XCTAssertNil(currentBundleId)
+  }
+
+  func testDepthLimitedSnapshotFailureReturnsNonFatalFallback() {
+    currentApp = app
+    currentBundleId = "com.example.app"
+
+    let payload = snapshotDepthLimitedAccessibilityFallback(
+      app: app,
+      options: SnapshotOptions(
+        interactiveOnly: false,
+        compact: false,
+        depth: 0,
+        scope: nil,
+        raw: false
+      ),
+      failure: SnapshotCaptureFailure(
+        code: Self.axSnapshotErrorCode,
+        message: "\(Self.axSnapshotFailureMessage) kAXErrorIllegalArgument.",
+        hint: Self.axSnapshotHint
+      )
+    )
+
+    XCTAssertEqual(payload?.message, "\(Self.axSnapshotFailureMessage) kAXErrorIllegalArgument.")
+    XCTAssertEqual(payload?.nodes?.count, 1)
+    XCTAssertEqual(payload?.nodes?.first?.type, "Application")
+    XCTAssertEqual(payload?.truncated, true)
+    XCTAssertNil(payload?.runnerFatal)
+    XCTAssertNil(payload?.runnerFatalReason)
+    XCTAssertNotNil(currentApp)
+    XCTAssertEqual(currentBundleId, "com.example.app")
   }
 
   private func compactInteractiveRootNode(rect: CGRect) -> SnapshotNode {
@@ -507,11 +622,12 @@ extension RunnerTests {
   }
 
   private func axSnapshotFailure(_ message: String) -> SnapshotCaptureFailure {
+    let detail = message.trimmingCharacters(in: .whitespacesAndNewlines)
     let failureMessage: String
-    if Self.hasAxIllegalArgumentCode(message) {
-      failureMessage = "iOS XCTest snapshot failed with kAXErrorIllegalArgument. \(message)"
+    if detail.isEmpty {
+      failureMessage = Self.axSnapshotFailureMessage
     } else {
-      failureMessage = "iOS XCTest snapshot failed while serializing the accessibility tree. \(message)"
+      failureMessage = "\(Self.axSnapshotFailureMessage) \(detail)"
     }
     return SnapshotCaptureFailure(
       code: Self.axSnapshotErrorCode,
@@ -632,8 +748,13 @@ extension RunnerTests {
 
   private func snapshotViewport(app: XCUIApplication) -> CGRect {
     let windows = app.windows.allElementsBoundByIndex
-    if let window = windows.first(where: { $0.exists && !$0.frame.isNull && !$0.frame.isEmpty }) {
-      return window.frame
+    let windowFrames = windows
+      .filter { $0.exists && !$0.frame.isNull && !$0.frame.isEmpty }
+      .map(\.frame)
+    if let largestWindowFrame = windowFrames.max(by: { left, right in
+      left.width * left.height < right.width * right.height
+    }) {
+      return largestWindowFrame
     }
     let appFrame = app.frame
     if !appFrame.isNull && !appFrame.isEmpty {
@@ -861,7 +982,9 @@ extension RunnerTests {
       app.textFields,
       app.secureTextFields,
       app.searchFields,
+      app.staticTexts,
       app.textViews,
+      app.images,
       app.switches,
       app.sliders,
       app.segmentedControls,
@@ -920,6 +1043,7 @@ extension RunnerTests {
       let frame = element.frame
       if frame.isNull || frame.isEmpty { return }
       let visible = isVisibleInViewport(frame, viewport)
+      if options.interactiveOnly && !visible { return }
       #if os(macOS)
         if !visible { return }
       #endif

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -356,7 +356,7 @@ extension RunnerTests {
     NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_AX_UNAVAILABLE=%@", failure.message)
     invalidateCachedTarget(reason: Self.axSnapshotUnavailableReason)
     return sparseTruncatedSnapshotPayload(
-      message: failure.message,
+      message: recoveredSnapshotMessage(failure),
       runnerFatal: true,
       runnerFatalReason: Self.axSnapshotUnavailableReason
     )
@@ -402,9 +402,11 @@ extension RunnerTests {
     )
 
     if requestedDepth <= 0 {
-      return sparseTruncatedSnapshotPayload(message: failure.message)
+      return sparseTruncatedSnapshotPayload(message: recoveredSnapshotMessage(failure))
     }
 
+    // Raw depth-limited recovery intentionally falls back to sparse interactive discovery because
+    // the raw AX tree is the failed operation.
     let fallback = snapshotFlatInteractive(
       app: app,
       options: SnapshotOptions(
@@ -416,10 +418,14 @@ extension RunnerTests {
       )
     )
     return DataPayload(
-      message: failure.message,
+      message: recoveredSnapshotMessage(failure),
       nodes: fallback.nodes,
       truncated: true
     )
+  }
+
+  private func recoveredSnapshotMessage(_ failure: SnapshotCaptureFailure) -> String {
+    return "\(failure.message) Hint: \(failure.hint)"
   }
 
   private func sparseTruncatedSnapshotPayload(
@@ -448,7 +454,7 @@ extension RunnerTests {
       )
     )
 
-    XCTAssertEqual(payload.message, Self.axSnapshotFailureMessage)
+    XCTAssertEqual(payload.message, "\(Self.axSnapshotFailureMessage) Hint: \(Self.axSnapshotHint)")
     XCTAssertEqual(payload.nodes?.count, 1)
     XCTAssertEqual(payload.nodes?.first?.type, "Application")
     XCTAssertEqual(payload.truncated, true)
@@ -456,6 +462,19 @@ extension RunnerTests {
     XCTAssertEqual(payload.runnerFatalReason, Self.axSnapshotUnavailableReason)
     XCTAssertNil(currentApp)
     XCTAssertNil(currentBundleId)
+  }
+
+  func testRecoveredSnapshotMessagePreservesHint() {
+    let message = recoveredSnapshotMessage(
+      SnapshotCaptureFailure(
+        code: Self.axSnapshotErrorCode,
+        message: Self.axSnapshotFailureMessage,
+        hint: Self.axSnapshotHint
+      )
+    )
+
+    XCTAssertTrue(message.contains(Self.axSnapshotFailureMessage))
+    XCTAssertTrue(message.contains(Self.axSnapshotHint))
   }
 
   func testDepthLimitedSnapshotFailureReturnsNonFatalFallback() {
@@ -478,7 +497,10 @@ extension RunnerTests {
       )
     )
 
-    XCTAssertEqual(payload?.message, "\(Self.axSnapshotFailureMessage) kAXErrorIllegalArgument.")
+    XCTAssertEqual(
+      payload?.message,
+      "\(Self.axSnapshotFailureMessage) kAXErrorIllegalArgument. Hint: \(Self.axSnapshotHint)"
+    )
     XCTAssertEqual(payload?.nodes?.count, 1)
     XCTAssertEqual(payload?.nodes?.first?.type, "Application")
     XCTAssertEqual(payload?.truncated, true)
@@ -990,9 +1012,7 @@ extension RunnerTests {
       app.textFields,
       app.secureTextFields,
       app.searchFields,
-      app.staticTexts,
       app.textViews,
-      app.images,
       app.switches,
       app.sliders,
       app.segmentedControls,
@@ -1003,7 +1023,9 @@ extension RunnerTests {
       app.pickers,
       app.steppers,
       app.tabBars,
-      app.menuItems
+      app.menuItems,
+      app.staticTexts,
+      app.images
     ]
 
     var elements: [XCUIElement] = []

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -40,6 +40,12 @@ extension RunnerTests {
     let visible: Bool
   }
 
+  private enum SnapshotTraversalCapture {
+    case context(SnapshotTraversalContext)
+    case fallback(DataPayload)
+    case empty
+  }
+
   struct SnapshotCaptureFailure: Error {
     let code: String
     let message: String
@@ -96,16 +102,18 @@ extension RunnerTests {
       return blocking
     }
 
-    let capture = try snapshotTraversalContextOrFallback(
+    let capture = try captureSnapshotTraversalContext(
       app: app,
       options: options,
       allowInteractiveUnavailableFallback: true
     )
-    if let fallback = capture.fallback {
+    let context: SnapshotTraversalContext
+    switch capture {
+    case .context(let traversalContext):
+      context = traversalContext
+    case .fallback(let fallback):
       return fallback
-    }
-
-    guard let context = capture.context else {
+    case .empty:
       return DataPayload(nodes: [], truncated: false)
     }
 
@@ -216,16 +224,18 @@ extension RunnerTests {
       return blocking
     }
 
-    let capture = try snapshotTraversalContextOrFallback(
+    let capture = try captureSnapshotTraversalContext(
       app: app,
       options: options,
       allowInteractiveUnavailableFallback: false
     )
-    if let fallback = capture.fallback {
+    let context: SnapshotTraversalContext
+    switch capture {
+    case .context(let traversalContext):
+      context = traversalContext
+    case .fallback(let fallback):
       return fallback
-    }
-
-    guard let context = capture.context else {
+    case .empty:
       return DataPayload(nodes: [], truncated: false)
     }
 
@@ -352,23 +362,26 @@ extension RunnerTests {
     )
   }
 
-  private func snapshotTraversalContextOrFallback(
+  private func captureSnapshotTraversalContext(
     app: XCUIApplication,
     options: SnapshotOptions,
     allowInteractiveUnavailableFallback: Bool
-  ) throws -> (context: SnapshotTraversalContext?, fallback: DataPayload?) {
+  ) throws -> SnapshotTraversalCapture {
     do {
-      return (try makeSnapshotTraversalContext(app: app, options: options), nil)
+      guard let context = try makeSnapshotTraversalContext(app: app, options: options) else {
+        return .empty
+      }
+      return .context(context)
     } catch let failure as SnapshotCaptureFailure {
       if let fallback = snapshotDepthLimitedAccessibilityFallback(
         app: app,
         options: options,
         failure: failure
       ) {
-        return (nil, fallback)
+        return .fallback(fallback)
       }
       if allowInteractiveUnavailableFallback && options.interactiveOnly {
-        return (nil, snapshotAccessibilityUnavailable(failure: failure))
+        return .fallback(snapshotAccessibilityUnavailable(failure: failure))
       }
       throw failure
     }
@@ -388,8 +401,7 @@ extension RunnerTests {
       failure.message
     )
 
-    let fallbackDepth = max(0, requestedDepth)
-    if fallbackDepth == 0 {
+    if requestedDepth <= 0 {
       return sparseTruncatedSnapshotPayload(message: failure.message)
     }
 
@@ -398,7 +410,7 @@ extension RunnerTests {
       options: SnapshotOptions(
         interactiveOnly: true,
         compact: options.compact,
-        depth: fallbackDepth,
+        depth: requestedDepth,
         scope: options.scope,
         raw: false
       )
@@ -638,12 +650,8 @@ extension RunnerTests {
 
   private static func isAxIllegalArgument(_ message: String) -> Bool {
     let normalized = message.lowercased()
-    return hasAxIllegalArgumentCode(normalized)
+    return normalized.contains("kaxerrorillegalargument")
       || (normalized.contains("illegal argument") && normalized.contains("snapshot"))
-  }
-
-  private static func hasAxIllegalArgumentCode(_ message: String) -> Bool {
-    return message.lowercased().contains("kaxerrorillegalargument")
   }
 
   private func evaluateSnapshot(
@@ -1086,13 +1094,6 @@ extension RunnerTests {
       return nil
     }
     return node
-  }
-
-  private func nonEmptyElementText(_ read: () -> String) -> String? {
-    let value = safely("SNAPSHOT_FLAT_TEXT", "") {
-      read()
-    }.trimmingCharacters(in: .whitespacesAndNewlines)
-    return value.isEmpty ? nil : value
   }
 
   private func isScrollableContainer(_ snapshot: XCUIElementSnapshot, visible: Bool) -> Bool {


### PR DESCRIPTION
## Summary

Depth-limited iOS snapshots now recover from XCTest accessibility serialization failures by returning a truncated fallback instead of failing the command outright. AX snapshot errors use the stable `IOS_AX_SNAPSHOT_FAILED` contract with the existing serialization-tree message prefix, while preserving XCTest details such as `kAXErrorIllegalArgument`.

Flat compact-interactive snapshot output is now viewport-constrained. The AX fallback uses that same visible sparse path, queries actionable controls before high-cardinality text/image content, and keeps the recovery hint in the returned payload message so agents still get remediation guidance.

Touched files: 1.

## Validation

Verified with `pnpm build:xcuitest` for both iOS simulator and macOS runner targets. Also ran `git diff --check`. Earlier manual Bluesky probing confirmed depth-limited snapshots return a truncated fallback where full root capture fails.