### PR TITLE
fix: harden covered snapshot targets

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -46,7 +46,6 @@ jobs:
           build-command: sh ./scripts/build-xcuitest-apple.sh
           xcuitest-platform: ios
           xcuitest-destination: generic/platform=iOS Simulator
-          build-on-miss: 'false'
 
       - name: Boot iOS test simulator
         uses: ./.github/actions/boot-ios-test-simulator

--- a/src/__tests__/runtime-interactions.test.ts
+++ b/src/__tests__/runtime-interactions.test.ts
@@ -133,6 +133,38 @@ test('runtime click keeps distinct tab button centers when iOS reports the tab b
   assert.equal(selectorResult.node?.label, 'Settings');
 });
 
+test('runtime click rejects refs covered by floating overlays', async () => {
+  const calls: Point[] = [];
+  const device = createInteractionDevice(coveredByTabBarSnapshot(), {
+    tap: async (_context, point) => {
+      calls.push(point);
+    },
+  });
+
+  await assert.rejects(
+    () => device.interactions.click(ref('@e2'), { session: 'default' }),
+    /Ref @e2 is covered by another visible element/,
+  );
+  assert.deepEqual(calls, []);
+});
+
+test('runtime selector interactions skip covered matches when an uncovered duplicate exists', async () => {
+  const calls: Point[] = [];
+  const device = createInteractionDevice(duplicateCoveredLabelSnapshot(), {
+    tap: async (_context, point) => {
+      calls.push(point);
+    },
+  });
+
+  const result = await device.interactions.click(selector('label="Save draft"'), {
+    session: 'default',
+  });
+
+  assert.equal(result.kind, 'selector');
+  assert.equal(result.node?.ref, 'e2');
+  assert.deepEqual(calls, [{ x: 86, y: 142 }]);
+});
+
 test('runtime click keeps non-button semantic targets at their own center', async () => {
   const calls: Point[] = [];
   const device = createInteractionDevice(nonHittableCellSnapshot(), {
@@ -871,6 +903,77 @@ function iosTabBarSnapshot(): SnapshotState {
       label: 'Search',
       rect: { x: 304, y: 800, width: 92, height: 44 },
       hittable: false,
+    },
+  ]);
+}
+
+function coveredByTabBarSnapshot(): SnapshotState {
+  return makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      label: 'Example',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Save draft',
+      rect: { x: 16, y: 790, width: 140, height: 44 },
+      hittable: false,
+      interactionBlocked: 'covered',
+      presentationHints: ['covered'],
+    },
+    {
+      index: 2,
+      depth: 1,
+      parentIndex: 0,
+      type: 'TabBar',
+      rect: { x: 0, y: 760, width: 390, height: 84 },
+      hittable: true,
+    },
+  ]);
+}
+
+function duplicateCoveredLabelSnapshot(): SnapshotState {
+  return makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      label: 'Example',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Save draft',
+      rect: { x: 16, y: 120, width: 140, height: 44 },
+      hittable: true,
+    },
+    {
+      index: 2,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Button',
+      label: 'Save draft',
+      rect: { x: 16, y: 790, width: 140, height: 44 },
+      hittable: false,
+      interactionBlocked: 'covered',
+      presentationHints: ['covered'],
+    },
+    {
+      index: 3,
+      depth: 1,
+      parentIndex: 0,
+      type: 'TabBar',
+      rect: { x: 0, y: 760, width: 390, height: 84 },
+      hittable: true,
     },
   ]);
 }

--- a/src/commands/interaction-resolution.ts
+++ b/src/commands/interaction-resolution.ts
@@ -9,7 +9,8 @@ import {
   isNodeVisibleInEffectiveViewport,
   resolveEffectiveViewportRect,
 } from '../utils/mobile-snapshot-semantics.ts';
-import { resolveActionableTouchNode } from './interaction-targeting.ts';
+import { isSnapshotNodeInteractionBlocked } from '../utils/snapshot-occlusion.ts';
+import { resolveActionableTouchResolution } from './interaction-targeting.ts';
 import type { ElementTarget, ResolvedTarget } from './selector-read.ts';
 import { now, toBackendContext } from './selector-read-utils.ts';
 
@@ -79,8 +80,12 @@ export async function resolveInteractionTarget(
     const capture = await resolveSnapshotForRef(runtime, options, options.target);
     const resolved = capture.resolved;
     const node = params.promoteToHittableAncestor
-      ? resolveActionableTouchNode(capture.snapshot.nodes, resolved.node)
+      ? resolveActionableNodeOrThrow(capture.snapshot.nodes, resolved.node, {
+          action: params.action,
+          label: `Ref ${options.target.ref}`,
+        })
       : resolved.node;
+    assertInteractionNotBlocked(node, `Ref ${options.target.ref}`, params.action);
     assertVisibleRefTarget(node, capture.snapshot.nodes, options.target.ref, params.action);
     const point = resolveNodeCenter(
       node,
@@ -100,7 +105,7 @@ export async function resolveInteractionTarget(
 
   const chain = parseSelectorChain(options.target.selector);
   let capture = await captureInteractionSnapshot(runtime, options, params.requireInteractive);
-  let resolved = resolveSelectorChain(capture.snapshot.nodes, chain, {
+  let resolved = resolveSelectorChain(interactableSelectorNodes(capture.snapshot.nodes), chain, {
     platform: runtime.backend.platform,
     requireRect: true,
     requireUnique: true,
@@ -108,7 +113,7 @@ export async function resolveInteractionTarget(
   });
   if ((!resolved || !resolved.node.rect) && params.requireInteractive) {
     capture = await captureInteractionSnapshot(runtime, options, false);
-    resolved = resolveSelectorChain(capture.snapshot.nodes, chain, {
+    resolved = resolveSelectorChain(interactableSelectorNodes(capture.snapshot.nodes), chain, {
       platform: runtime.backend.platform,
       requireRect: true,
       requireUnique: true,
@@ -116,14 +121,35 @@ export async function resolveInteractionTarget(
     });
   }
   if (!resolved || !resolved.node.rect) {
+    const covered = resolveSelectorChain(capture.snapshot.nodes, chain, {
+      platform: runtime.backend.platform,
+      requireRect: true,
+      requireUnique: false,
+    });
+    if (covered?.node && isSnapshotNodeInteractionBlocked(covered.node)) {
+      throw new AppError(
+        'COMMAND_FAILED',
+        `Selector ${covered.selector.raw} is covered by another visible element and cannot ${interactionVerb(params.action)} safely`,
+        {
+          hint: 'Use a different visible target, scroll it clear of the overlay, or inspect with snapshot/screenshot before retrying.',
+          selector: covered.selector.raw,
+          ref: `@${covered.node.ref}`,
+          interactionBlocked: covered.node.interactionBlocked,
+        },
+      );
+    }
     throw new AppError(
       'COMMAND_FAILED',
       formatSelectorFailure(chain, resolved?.diagnostics ?? [], { unique: true }),
     );
   }
   const node = params.promoteToHittableAncestor
-    ? resolveActionableTouchNode(capture.snapshot.nodes, resolved.node)
+    ? resolveActionableNodeOrThrow(capture.snapshot.nodes, resolved.node, {
+        action: params.action,
+        label: `Selector ${resolved.selector.raw}`,
+      })
     : resolved.node;
+  assertInteractionNotBlocked(node, `Selector ${resolved.selector.raw}`, params.action);
   const point = resolveNodeCenter(
     node,
     `Selector ${resolved.selector.raw} resolved to invalid bounds`,
@@ -138,6 +164,60 @@ export async function resolveInteractionTarget(
     }),
     refLabel: resolveRefLabel(node, capture.snapshot.nodes),
   };
+}
+
+function interactableSelectorNodes(nodes: SnapshotState['nodes']): SnapshotState['nodes'] {
+  return nodes.filter((node) => !isSnapshotNodeInteractionBlocked(node));
+}
+
+function resolveActionableNodeOrThrow(
+  nodes: SnapshotState['nodes'],
+  node: SnapshotNode,
+  options: { action: InteractionAction; label: string },
+): SnapshotNode {
+  const resolution = resolveActionableTouchResolution(nodes, node);
+  if (resolution.reason === 'covered') {
+    throw new AppError(
+      'COMMAND_FAILED',
+      `${options.label} is covered by another visible element and cannot ${interactionVerb(options.action)} safely`,
+      {
+        hint: 'Use a different visible target, scroll it clear of the overlay, or inspect with snapshot/screenshot before retrying.',
+        ref: `@${node.ref}`,
+        interactionBlocked: node.interactionBlocked,
+      },
+    );
+  }
+  return resolution.node;
+}
+
+function assertInteractionNotBlocked(
+  node: SnapshotNode,
+  label: string,
+  action: InteractionAction,
+): void {
+  if (!isSnapshotNodeInteractionBlocked(node)) return;
+  throw new AppError(
+    'COMMAND_FAILED',
+    `${label} is covered by another visible element and cannot ${interactionVerb(action)} safely`,
+    {
+      hint: 'Use a different visible target, scroll it clear of the overlay, or inspect with snapshot/screenshot before retrying.',
+      ref: `@${node.ref}`,
+      interactionBlocked: node.interactionBlocked,
+    },
+  );
+}
+
+function interactionVerb(action: InteractionAction): string {
+  switch (action) {
+    case 'fill':
+      return 'be filled';
+    case 'focus':
+      return 'be focused';
+    case 'longPress':
+      return 'be long-pressed';
+    default:
+      return 'be tapped';
+  }
 }
 
 export async function captureInteractionSnapshot(

--- a/src/commands/interaction-resolution.ts
+++ b/src/commands/interaction-resolution.ts
@@ -1,6 +1,7 @@
 import { AppError } from '../utils/errors.ts';
 import type { Point, SnapshotNode, SnapshotState } from '../utils/snapshot.ts';
-import { centerOfRect, findNodeByRef, normalizeRef } from '../utils/snapshot.ts';
+import { findNodeByRef, normalizeRef } from '../utils/snapshot.ts';
+import { resolveRectCenter } from '../utils/rect-center.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../runtime-contract.ts';
 import { formatSelectorFailure, parseSelectorChain, resolveSelectorChain } from '../selectors.ts';
 import { buildSelectorChainForNode } from '../utils/selector-build.ts';
@@ -58,52 +59,73 @@ export type CapturedSnapshot = {
   snapshot: SnapshotState;
 };
 
+type ResolveInteractionTargetParams = {
+  action: InteractionAction;
+  requireInteractive: boolean;
+  promoteToHittableAncestor: boolean;
+};
+
 export async function resolveInteractionTarget(
   runtime: AgentDeviceRuntime,
   options: CommandContext & { target: InteractionTarget },
-  params: {
-    action: InteractionAction;
-    requireInteractive: boolean;
-    promoteToHittableAncestor: boolean;
-  },
+  params: ResolveInteractionTargetParams,
 ): Promise<ResolvedInteractionTarget> {
   await assertSupportedInteractionSurface(runtime, options, params.action);
 
   if (options.target.kind === 'point') {
-    return {
-      kind: 'point',
-      point: { x: options.target.x, y: options.target.y },
-    };
+    return resolvePointInteractionTarget(options.target);
   }
 
   if (options.target.kind === 'ref') {
-    const capture = await resolveSnapshotForRef(runtime, options, options.target);
-    const resolved = capture.resolved;
-    const node = params.promoteToHittableAncestor
-      ? resolveActionableNodeOrThrow(capture.snapshot.nodes, resolved.node, {
-          action: params.action,
-          label: `Ref ${options.target.ref}`,
-        })
-      : resolved.node;
-    assertInteractionNotBlocked(node, `Ref ${options.target.ref}`, params.action);
-    assertVisibleRefTarget(node, capture.snapshot.nodes, options.target.ref, params.action);
-    const point = resolveNodeCenter(
-      node,
-      `Ref ${options.target.ref} not found or has invalid bounds`,
-    );
-    return {
-      kind: 'ref',
-      point,
-      target: { kind: 'ref', ref: `@${resolved.ref}` },
-      node,
-      selectorChain: buildSelectorChainForNode(node, runtime.backend.platform, {
-        action: params.action === 'fill' ? 'fill' : 'click',
-      }),
-      refLabel: resolveRefLabel(node, capture.snapshot.nodes),
-    };
+    return await resolveRefInteractionTarget(runtime, options, options.target, params);
   }
 
-  const chain = parseSelectorChain(options.target.selector);
+  return await resolveSelectorInteractionTarget(runtime, options, options.target, params);
+}
+
+function resolvePointInteractionTarget(target: PointTarget): ResolvedInteractionTarget {
+  return {
+    kind: 'point',
+    point: { x: target.x, y: target.y },
+  };
+}
+
+async function resolveRefInteractionTarget(
+  runtime: AgentDeviceRuntime,
+  options: CommandContext,
+  target: Extract<InteractionTarget, { kind: 'ref' }>,
+  params: ResolveInteractionTargetParams,
+): Promise<ResolvedInteractionTarget> {
+  const capture = await resolveSnapshotForRef(runtime, options, target);
+  const resolved = capture.resolved;
+  const node = params.promoteToHittableAncestor
+    ? resolveActionableNodeOrThrow(capture.snapshot.nodes, resolved.node, {
+        action: params.action,
+        label: `Ref ${target.ref}`,
+      })
+    : resolved.node;
+  assertInteractionNotBlocked(node, `Ref ${target.ref}`, params.action);
+  assertVisibleRefTarget(node, capture.snapshot.nodes, target.ref, params.action);
+  const point = resolveNodeCenter(node, `Ref ${target.ref} not found or has invalid bounds`);
+  return {
+    kind: 'ref',
+    point,
+    target: { kind: 'ref', ref: `@${resolved.ref}` },
+    node,
+    selectorChain: buildSelectorChainForNode(node, runtime.backend.platform, {
+      action: params.action === 'fill' ? 'fill' : 'click',
+    }),
+    refLabel: resolveRefLabel(node, capture.snapshot.nodes),
+  };
+}
+
+async function resolveSelectorInteractionTarget(
+  runtime: AgentDeviceRuntime,
+  options: CommandContext,
+  target: Extract<InteractionTarget, { kind: 'selector' }>,
+  params: ResolveInteractionTargetParams,
+): Promise<ResolvedInteractionTarget> {
+  const chain = parseSelectorChain(target.selector);
   let capture = await captureInteractionSnapshot(runtime, options, params.requireInteractive);
   let resolved = resolveSelectorChain(interactableSelectorNodes(capture.snapshot.nodes), chain, {
     platform: runtime.backend.platform,
@@ -127,16 +149,12 @@ export async function resolveInteractionTarget(
       requireUnique: false,
     });
     if (covered?.node && isSnapshotNodeInteractionBlocked(covered.node)) {
-      throw new AppError(
-        'COMMAND_FAILED',
-        `Selector ${covered.selector.raw} is covered by another visible element and cannot ${interactionVerb(params.action)} safely`,
-        {
-          hint: 'Use a different visible target, scroll it clear of the overlay, or inspect with snapshot/screenshot before retrying.',
-          selector: covered.selector.raw,
-          ref: `@${covered.node.ref}`,
-          interactionBlocked: covered.node.interactionBlocked,
-        },
-      );
+      throw buildCoveredInteractionError({
+        label: `Selector ${covered.selector.raw}`,
+        node: covered.node,
+        action: params.action,
+        selector: covered.selector.raw,
+      });
     }
     throw new AppError(
       'COMMAND_FAILED',
@@ -177,15 +195,11 @@ function resolveActionableNodeOrThrow(
 ): SnapshotNode {
   const resolution = resolveActionableTouchResolution(nodes, node);
   if (resolution.reason === 'covered') {
-    throw new AppError(
-      'COMMAND_FAILED',
-      `${options.label} is covered by another visible element and cannot ${interactionVerb(options.action)} safely`,
-      {
-        hint: 'Use a different visible target, scroll it clear of the overlay, or inspect with snapshot/screenshot before retrying.',
-        ref: `@${node.ref}`,
-        interactionBlocked: node.interactionBlocked,
-      },
-    );
+    throw buildCoveredInteractionError({
+      label: options.label,
+      node,
+      action: options.action,
+    });
   }
   return resolution.node;
 }
@@ -196,13 +210,23 @@ function assertInteractionNotBlocked(
   action: InteractionAction,
 ): void {
   if (!isSnapshotNodeInteractionBlocked(node)) return;
-  throw new AppError(
+  throw buildCoveredInteractionError({ label, node, action });
+}
+
+function buildCoveredInteractionError(params: {
+  label: string;
+  node: SnapshotNode;
+  action: InteractionAction;
+  selector?: string;
+}): AppError {
+  return new AppError(
     'COMMAND_FAILED',
-    `${label} is covered by another visible element and cannot ${interactionVerb(action)} safely`,
+    `${params.label} is covered by another visible element and cannot ${interactionVerb(params.action)} safely`,
     {
       hint: 'Use a different visible target, scroll it clear of the overlay, or inspect with snapshot/screenshot before retrying.',
-      ref: `@${node.ref}`,
-      interactionBlocked: node.interactionBlocked,
+      ...(params.selector ? { selector: params.selector } : {}),
+      ref: `@${params.node.ref}`,
+      interactionBlocked: params.node.interactionBlocked,
     },
   );
 }
@@ -286,7 +310,6 @@ async function resolveSnapshotForRef(
   const fallbackLabel = target.fallbackLabel ?? '';
   const stored = tryResolveRefNode(session.snapshot.nodes, target.ref, {
     fallbackLabel,
-    requireRect: true,
   });
   if (stored) {
     return { snapshot: session.snapshot, resolved: stored };
@@ -295,7 +318,6 @@ async function resolveSnapshotForRef(
   const capture = await captureInteractionSnapshot(runtime, options, true);
   const refreshed = tryResolveRefNode(capture.snapshot.nodes, target.ref, {
     fallbackLabel,
-    requireRect: true,
   });
   if (!refreshed) {
     throw new AppError('COMMAND_FAILED', `Ref ${target.ref} not found or has no bounds`);
@@ -308,50 +330,29 @@ function tryResolveRefNode(
   refInput: string,
   options: {
     fallbackLabel: string;
-    requireRect: boolean;
   },
 ): { ref: string; node: SnapshotNode } | null {
   const ref = normalizeRef(refInput);
   if (!ref) throw new AppError('INVALID_ARGS', `Invalid ref: ${refInput}`);
   const refNode = findNodeByRef(nodes, ref);
-  if (isUsableResolvedNode(refNode, options.requireRect)) return { ref, node: refNode };
+  if (isUsableResolvedNode(refNode)) return { ref, node: refNode };
   const fallbackNode =
     options.fallbackLabel.length > 0 ? findNodeByLabel(nodes, options.fallbackLabel) : null;
-  if (isUsableResolvedNode(fallbackNode, options.requireRect)) {
+  if (isUsableResolvedNode(fallbackNode)) {
     return { ref, node: fallbackNode };
   }
   return null;
 }
 
 function resolveNodeCenter(node: SnapshotNode, message: string): Point {
-  if (!node.rect) throw new AppError('COMMAND_FAILED', message);
-  const point = centerOfRect(node.rect);
-  if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) {
-    throw new AppError('COMMAND_FAILED', message);
-  }
+  const point = resolveRectCenter(node.rect);
+  if (!point) throw new AppError('COMMAND_FAILED', message);
   return point;
 }
 
-function isUsableResolvedNode(
-  node: SnapshotNode | null | undefined,
-  requireRect: boolean,
-): node is SnapshotNode {
+function isUsableResolvedNode(node: SnapshotNode | null | undefined): node is SnapshotNode {
   if (!node) return false;
-  if (!requireRect) return true;
-  if (!node.rect) return false;
-  const { x, y, width, height } = node.rect;
-  if (
-    !Number.isFinite(Number(x)) ||
-    !Number.isFinite(Number(y)) ||
-    !Number.isFinite(Number(width)) ||
-    !Number.isFinite(Number(height)) ||
-    Number(width) < 0 ||
-    Number(height) < 0
-  ) {
-    return false;
-  }
-  const point = centerOfRect(node.rect);
-  return Number.isFinite(point.x) && Number.isFinite(point.y);
+  return resolveRectCenter(node.rect) !== null;
 }
 
 function assertVisibleRefTarget(

--- a/src/commands/interaction-targeting.ts
+++ b/src/commands/interaction-targeting.ts
@@ -2,6 +2,7 @@ import type { Rect, SnapshotNode } from '../utils/snapshot.ts';
 import { centerOfRect } from '../utils/snapshot.ts';
 import { containsPoint, pickLargestRect } from '../utils/rect-visibility.ts';
 import { findNearestHittableAncestor, normalizeType } from '../utils/snapshot-processing.ts';
+import { isSnapshotNodeInteractionBlocked } from '../utils/snapshot-occlusion.ts';
 import { normalizeRect, resolveRectCenter } from '../utils/rect-center.ts';
 import { intersectArea } from '../utils/screenshot-geometry.ts';
 
@@ -24,7 +25,8 @@ type ActionableTouchResolutionReason =
   | 'semantic-target'
   | 'hittable-ancestor'
   | 'overly-broad-ancestor'
-  | 'original';
+  | 'original'
+  | 'covered';
 
 type ActionableTouchResolution = {
   node: SnapshotNode;
@@ -43,6 +45,9 @@ export function resolveActionableTouchResolution(
   nodes: SnapshotNode[],
   node: SnapshotNode,
 ): ActionableTouchResolution {
+  if (isSnapshotNodeInteractionBlocked(node)) {
+    return { node, reason: 'covered' };
+  }
   const descendant = findPreferredActionableDescendant(nodes, node);
   if (descendant?.rect && resolveRectCenter(descendant.rect)) {
     return { node: descendant, reason: 'same-rect-descendant' };
@@ -51,7 +56,11 @@ export function resolveActionableTouchResolution(
     return { node, reason: 'semantic-target' };
   }
   const ancestor = findNearestHittableAncestor(nodes, node);
-  if (ancestor?.rect && resolveRectCenter(ancestor.rect)) {
+  if (
+    ancestor?.rect &&
+    !isSnapshotNodeInteractionBlocked(ancestor) &&
+    resolveRectCenter(ancestor.rect)
+  ) {
     if (isOverlyBroadAncestor(node, ancestor, nodes)) {
       return { node, reason: 'overly-broad-ancestor' };
     }
@@ -72,7 +81,11 @@ function findPreferredActionableDescendant(
   while (!visited.has(current.ref)) {
     visited.add(current.ref);
     const sameRectChildren = nodes.filter((candidate) => {
-      if (candidate.parentIndex !== current.index || !candidate.hittable) {
+      if (
+        candidate.parentIndex !== current.index ||
+        !candidate.hittable ||
+        isSnapshotNodeInteractionBlocked(candidate)
+      ) {
         return false;
       }
       const candidateRect = normalizeRect(candidate.rect);

--- a/src/commands/interaction-targeting.ts
+++ b/src/commands/interaction-targeting.ts
@@ -3,7 +3,11 @@ import { centerOfRect } from '../utils/snapshot.ts';
 import { containsPoint, pickLargestRect } from '../utils/rect-visibility.ts';
 import { findNearestHittableAncestor, normalizeType } from '../utils/snapshot-processing.ts';
 import { isSnapshotNodeInteractionBlocked } from '../utils/snapshot-occlusion.ts';
-import { normalizeRect, resolveRectCenter } from '../utils/rect-center.ts';
+import {
+  areRectsApproximatelyEqual,
+  normalizeRect,
+  resolveRectCenter,
+} from '../utils/rect-center.ts';
 import { intersectArea } from '../utils/screenshot-geometry.ts';
 
 const SEMANTIC_TOUCH_ROLE_FRAGMENTS = [
@@ -94,9 +98,7 @@ function findPreferredActionableDescendant(
     if (sameRectChildren.length !== 1) {
       break;
     }
-    const child = sameRectChildren[0];
-    if (child === undefined) break;
-    current = child;
+    current = sameRectChildren[0]!;
   }
 
   return current === node ? null : current;
@@ -111,16 +113,6 @@ function isSemanticTouchRole(role: string): boolean {
   // Match Tab exactly so broad roles like Table/TabBar do not become touch targets.
   return (
     role === 'tab' || SEMANTIC_TOUCH_ROLE_FRAGMENTS.some((fragment) => role.includes(fragment))
-  );
-}
-
-function areRectsApproximatelyEqual(left: Rect, right: Rect): boolean {
-  const tolerance = 0.5;
-  return (
-    Math.abs(left.x - right.x) <= tolerance &&
-    Math.abs(left.y - right.y) <= tolerance &&
-    Math.abs(left.width - right.width) <= tolerance &&
-    Math.abs(left.height - right.height) <= tolerance
   );
 }
 

--- a/src/commands/snapshot-unchanged.ts
+++ b/src/commands/snapshot-unchanged.ts
@@ -100,6 +100,8 @@ function buildComparableSnapshotPresentation(
     surface: node.surface,
     hiddenContentAbove: node.hiddenContentAbove,
     hiddenContentBelow: node.hiddenContentBelow,
+    interactionBlocked: node.interactionBlocked,
+    presentationHints: node.presentationHints,
   }));
 }
 

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -215,6 +215,87 @@ test('handleFindCommands click prefers semantic controls over matching container
   expect(invokeCalls[0]!.positionals?.[0]).toBe('@e5');
 });
 
+test('handleFindCommands focus uses the promoted actionable node center', async () => {
+  const { response } = await runFindClickScenario({
+    positionals: ['Account', 'focus'],
+    nodes: [
+      {
+        index: 0,
+        ref: 'e1',
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 390, height: 844 },
+      },
+      {
+        index: 1,
+        ref: 'e2',
+        type: 'Cell',
+        label: 'Account row',
+        hittable: true,
+        rect: { x: 16, y: 100, width: 320, height: 64 },
+        parentIndex: 0,
+      },
+      {
+        index: 2,
+        ref: 'e3',
+        type: 'StaticText',
+        label: 'Account',
+        hittable: false,
+        rect: { x: 32, y: 116, width: 80, height: 24 },
+        parentIndex: 1,
+      },
+    ],
+  });
+
+  expect(response.ok).toBe(true);
+  expect(mockDispatch).toHaveBeenLastCalledWith(
+    expect.anything(),
+    'focus',
+    ['176', '132'],
+    undefined,
+    expect.anything(),
+  );
+});
+
+test('handleFindCommands focus rejects covered matches before dispatching coordinates', async () => {
+  const { response } = await runFindClickScenario({
+    positionals: ['Save draft', 'focus'],
+    nodes: [
+      {
+        index: 0,
+        ref: 'e1',
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 390, height: 844 },
+      },
+      {
+        index: 1,
+        ref: 'e2',
+        type: 'Button',
+        label: 'Save draft',
+        hittable: false,
+        interactionBlocked: 'covered',
+        presentationHints: ['covered'],
+        rect: { x: 16, y: 790, width: 140, height: 44 },
+        parentIndex: 0,
+      },
+      {
+        index: 2,
+        ref: 'e3',
+        type: 'TabBar',
+        hittable: true,
+        rect: { x: 0, y: 760, width: 390, height: 84 },
+        parentIndex: 0,
+      },
+    ],
+  });
+
+  expect(response.ok).toBe(false);
+  if (!response.ok) {
+    expect(response.error.message).toContain('is covered by another visible element');
+    expect(response.error.details?.interactionBlocked).toBe('covered');
+  }
+  expect(mockDispatch.mock.calls.filter((call) => call[1] === 'focus')).toEqual([]);
+});
+
 test('handleFindCommands forwards internal interaction outcome flags only to delegated click', async () => {
   const { response, invokeCalls, session } = await runFindClickScenario({
     positionals: ['Continue', 'click'],

--- a/src/daemon/handlers/__tests__/snapshot-capture.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-capture.test.ts
@@ -75,6 +75,91 @@ test('buildSnapshotState applies iOS interactive presentation for xctest snapsho
   ]);
 });
 
+test('buildSnapshotState marks content covered by floating overlays as visible but blocked', () => {
+  const state = buildSnapshotState(
+    {
+      nodes: [
+        {
+          index: 0,
+          depth: 0,
+          type: 'Application',
+          label: 'Example',
+          rect: { x: 0, y: 0, width: 390, height: 844 },
+        },
+        {
+          index: 1,
+          depth: 1,
+          parentIndex: 0,
+          type: 'Button',
+          label: 'Save draft',
+          rect: { x: 16, y: 790, width: 140, height: 44 },
+          hittable: true,
+        },
+        {
+          index: 2,
+          depth: 1,
+          parentIndex: 0,
+          type: 'TabBar',
+          rect: { x: 0, y: 760, width: 390, height: 84 },
+          hittable: true,
+        },
+      ],
+      backend: 'xctest',
+    },
+    undefined,
+  );
+
+  const covered = state.nodes.find((node) => node.label === 'Save draft');
+  expect(covered).toMatchObject({
+    label: 'Save draft',
+    hittable: false,
+    interactionBlocked: 'covered',
+    presentationHints: ['covered'],
+  });
+  expect(state.nodes.some((node) => node.type === 'TabBar')).toBe(true);
+});
+
+test('buildSnapshotState leaves raw snapshot hittability untouched', () => {
+  const state = buildSnapshotState(
+    {
+      nodes: [
+        {
+          index: 0,
+          depth: 0,
+          type: 'Application',
+          rect: { x: 0, y: 0, width: 390, height: 844 },
+        },
+        {
+          index: 1,
+          depth: 1,
+          parentIndex: 0,
+          type: 'Button',
+          label: 'Save draft',
+          rect: { x: 16, y: 790, width: 140, height: 44 },
+          hittable: true,
+        },
+        {
+          index: 2,
+          depth: 1,
+          parentIndex: 0,
+          type: 'TabBar',
+          rect: { x: 0, y: 760, width: 390, height: 84 },
+          hittable: true,
+        },
+      ],
+      backend: 'xctest',
+    },
+    { snapshotRaw: true },
+  );
+
+  expect(state.nodes.find((node) => node.label === 'Save draft')).toMatchObject({
+    hittable: true,
+  });
+  expect(
+    state.nodes.find((node) => node.label === 'Save draft')?.interactionBlocked,
+  ).toBeUndefined();
+});
+
 test('buildSnapshotState returns empty nodes when scoped snapshot has no label match', () => {
   const nodes = [
     { index: 0, depth: 0, type: 'Window', label: 'Root' },

--- a/src/daemon/handlers/__tests__/snapshot-capture.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-capture.test.ts
@@ -119,6 +119,112 @@ test('buildSnapshotState marks content covered by floating overlays as visible b
   expect(state.nodes.some((node) => node.type === 'TabBar')).toBe(true);
 });
 
+test('buildSnapshotState does not treat later generic hittable containers as covers', () => {
+  const state = buildSnapshotState(
+    {
+      nodes: [
+        {
+          index: 0,
+          depth: 0,
+          type: 'Application',
+          rect: { x: 0, y: 0, width: 390, height: 844 },
+        },
+        {
+          index: 1,
+          depth: 1,
+          parentIndex: 0,
+          type: 'Button',
+          label: 'Visible action',
+          rect: { x: 40, y: 100, width: 160, height: 44 },
+          hittable: true,
+        },
+        {
+          index: 2,
+          depth: 1,
+          parentIndex: 0,
+          type: 'CollectionView',
+          label: 'Content list',
+          rect: { x: 0, y: 80, width: 390, height: 600 },
+          hittable: true,
+        },
+      ],
+      backend: 'xctest',
+    },
+    undefined,
+  );
+
+  expect(state.nodes.find((node) => node.label === 'Visible action')).toMatchObject({
+    hittable: true,
+  });
+  expect(
+    state.nodes.find((node) => node.label === 'Visible action')?.interactionBlocked,
+  ).toBeUndefined();
+});
+
+test('buildSnapshotState does not let covered overlays cover earlier targets', () => {
+  const state = buildSnapshotState(
+    {
+      nodes: [
+        {
+          index: 0,
+          depth: 0,
+          type: 'Application',
+          rect: { x: 0, y: 0, width: 390, height: 844 },
+        },
+        {
+          index: 1,
+          depth: 1,
+          parentIndex: 0,
+          type: 'Button',
+          label: 'Top action',
+          rect: { x: 20, y: 30, width: 120, height: 44 },
+          hittable: true,
+        },
+        {
+          index: 2,
+          depth: 1,
+          parentIndex: 0,
+          type: 'Button',
+          label: 'Middle action',
+          rect: { x: 20, y: 170, width: 120, height: 44 },
+          hittable: true,
+        },
+        {
+          index: 3,
+          depth: 1,
+          parentIndex: 0,
+          type: 'ToolBar',
+          rect: { x: 0, y: 0, width: 390, height: 300 },
+          hittable: true,
+        },
+        {
+          index: 4,
+          depth: 1,
+          parentIndex: 0,
+          type: 'Sheet',
+          rect: { x: 0, y: 120, width: 390, height: 724 },
+          hittable: true,
+        },
+      ],
+      backend: 'xctest',
+    },
+    undefined,
+  );
+
+  expect(state.nodes.find((node) => node.label === 'Middle action')).toMatchObject({
+    interactionBlocked: 'covered',
+  });
+  expect(state.nodes.find((node) => node.type === 'ToolBar')).toMatchObject({
+    interactionBlocked: 'covered',
+  });
+  expect(state.nodes.find((node) => node.label === 'Top action')).toMatchObject({
+    hittable: true,
+  });
+  expect(
+    state.nodes.find((node) => node.label === 'Top action')?.interactionBlocked,
+  ).toBeUndefined();
+});
+
 test('buildSnapshotState leaves raw snapshot hittability untouched', () => {
   const state = buildSnapshotState(
     {

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -11,6 +11,7 @@ import {
   resolveActionableTouchNode,
   resolveActionableTouchResolution,
 } from '../../commands/interaction-targeting.ts';
+import { isSnapshotNodeInteractionBlocked } from '../../utils/snapshot-occlusion.ts';
 import { readTextForNode } from './interaction-read.ts';
 import { captureSnapshot } from './snapshot-capture.ts';
 import { setSessionSnapshot } from '../session-snapshot.ts';
@@ -467,7 +468,9 @@ async function dispatchFocusForFindMatch(
   match: ResolvedMatch,
 ): Promise<DaemonResponse> {
   const { req, device, logPath, session } = ctx;
-  const coords = match.node.rect ? centerOfRect(match.node.rect) : null;
+  const coveredResponse = rejectCoveredFindMatch(match, 'be focused');
+  if (coveredResponse) return coveredResponse;
+  const coords = match.resolvedNode.rect ? centerOfRect(match.resolvedNode.rect) : null;
   if (!coords) {
     return errorResponse('COMMAND_FAILED', 'matched element has no bounds');
   }
@@ -481,6 +484,20 @@ async function dispatchFocusForFindMatch(
     },
   );
   return { ok: true, data: response ?? { ref: match.ref } };
+}
+
+function rejectCoveredFindMatch(match: ResolvedMatch, interaction: string): DaemonResponse | null {
+  const blockedNode = [match.resolvedNode, match.node].find(isSnapshotNodeInteractionBlocked);
+  if (!blockedNode) return null;
+  return errorResponse(
+    'COMMAND_FAILED',
+    `Matched element ${match.ref} is covered by another visible element and cannot ${interaction} safely`,
+    {
+      ref: `@${blockedNode.ref}`,
+      interactionBlocked: blockedNode.interactionBlocked,
+      hint: 'Use a different visible target, scroll it clear of the overlay, or inspect with snapshot/screenshot before retrying.',
+    },
+  );
 }
 
 function recordFindAction(ctx: FindContext, match: ResolvedMatch, action: string): void {

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -258,6 +258,7 @@ function interactiveMatchScore(
   nodes: SnapshotState['nodes'],
 ): number {
   const resolution = resolveActionableTouchResolution(nodes, node);
+  if (resolution.reason === 'covered') return 0;
   if (resolution.reason === 'semantic-target' && resolution.node.rect) return 4;
   if (resolution.reason === 'same-rect-descendant' && resolution.node.rect) return 4;
   if (

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -14,6 +14,7 @@ import {
   type SnapshotBackend,
   type SnapshotState,
 } from '../../utils/snapshot.ts';
+import { annotateCoveredSnapshotNodes } from '../../utils/snapshot-occlusion.ts';
 import { normalizeSnapshotTree } from '../../utils/snapshot-tree.ts';
 export { buildSnapshotVisibility } from '../../utils/snapshot-visibility.ts';
 import type { SessionState } from '../types.ts';
@@ -37,9 +38,7 @@ import {
   getActivePendingInteractionOutcome,
   retryPendingInteractionOutcome,
 } from '../interaction-outcome-policy.ts';
-import {
-  capturePostGestureStabilizedResult,
-} from '../post-gesture-stabilization.ts';
+import { capturePostGestureStabilizedResult } from '../post-gesture-stabilization.ts';
 import { findNodeByLabel, pruneGroupNodes, resolveRefLabel } from '../snapshot-processing.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
 import { presentIosInteractiveSnapshot } from '../snapshot-presentation/ios/index.ts';
@@ -79,7 +78,9 @@ type AndroidFreshnessReason = 'empty-interactive' | 'sharp-drop' | 'stuck-route'
 type AndroidFreshnessMode = 'default' | 'ref-refresh';
 const INTERACTION_CHANGE_RECHECK_DELAY_MS = 500;
 
-export async function captureSnapshot(params: CaptureSnapshotParams): Promise<CaptureSnapshotResult> {
+export async function captureSnapshot(
+  params: CaptureSnapshotParams,
+): Promise<CaptureSnapshotResult> {
   const postActionResult = await capturePostActionAwareSnapshot(params);
   if (postActionResult) return postActionResult;
 
@@ -395,7 +396,9 @@ export function buildSnapshotState(
   const presentableNodes = shouldPresentIosInteractiveSnapshot(data?.backend, flags)
     ? presentIosInteractiveSnapshot(scopedNodes)
     : scopedNodes;
-  const nodes = attachRefs(presentableNodes);
+  const nodes = attachRefs(
+    snapshotRaw ? presentableNodes : annotateCoveredSnapshotNodes(presentableNodes),
+  );
   return {
     nodes,
     truncated: data?.truncated,

--- a/src/daemon/snapshot-presentation/tree.ts
+++ b/src/daemon/snapshot-presentation/tree.ts
@@ -1,12 +1,12 @@
 import type { RawSnapshotNode } from '../../utils/snapshot.ts';
 import { normalizeType } from '../snapshot-processing.ts';
+export { areRectsApproximatelyEqual } from '../../utils/rect-center.ts';
 
 export type SnapshotTreeRuleContext = {
   replacements: Map<number, RawSnapshotNode>;
   suppressedIndexes: Set<number>;
 };
 
-const RECT_FIELDS = ['x', 'y', 'width', 'height'] as const;
 const descendantEndPositionCache = new WeakMap<RawSnapshotNode[], number[]>();
 
 export function collectDescendants(
@@ -181,17 +181,6 @@ export function mergeReplacement(
     ...replacements.get(node.index),
     ...patch,
   });
-}
-
-export function areRectsApproximatelyEqual(
-  left: RawSnapshotNode['rect'],
-  right: RawSnapshotNode['rect'],
-): boolean {
-  if (!left || !right) {
-    return false;
-  }
-  const tolerance = 0.5;
-  return RECT_FIELDS.every((key) => Math.abs(left[key] - right[key]) <= tolerance);
 }
 
 export function findLargestViewportRect(nodes: Iterable<RawSnapshotNode>): RawSnapshotNode['rect'] {

--- a/src/utils/rect-center.ts
+++ b/src/utils/rect-center.ts
@@ -1,5 +1,8 @@
 import { centerOfRect, type Point, type Rect } from './snapshot.ts';
 
+const RECT_COMPARE_FIELDS = ['x', 'y', 'width', 'height'] as const;
+const RECT_EQUALITY_TOLERANCE = 0.5;
+
 export function resolveRectCenter(rect: Rect | undefined): { x: number; y: number } | null {
   const normalized = normalizeRect(rect);
   if (!normalized) return null;
@@ -24,6 +27,16 @@ export function normalizeRect(rect: Rect | undefined): Rect | null {
   }
   if (width < 0 || height < 0) return null;
   return { x, y, width, height };
+}
+
+export function areRectsApproximatelyEqual(
+  left: Rect | undefined,
+  right: Rect | undefined,
+): boolean {
+  if (!left || !right) return false;
+  return RECT_COMPARE_FIELDS.every(
+    (key) => Math.abs(left[key] - right[key]) <= RECT_EQUALITY_TOLERANCE,
+  );
 }
 
 export function pointInsideRect(rect: Rect): Point {

--- a/src/utils/snapshot-lines.ts
+++ b/src/utils/snapshot-lines.ts
@@ -196,14 +196,14 @@ function buildLineMetadata(
 ): string[] {
   const metadata: string[] = [];
   if (node.enabled === false) metadata.push('disabled');
+  metadata.push(...(node.presentationHints ?? []));
   if (!options.summarizeTextSurfaces) {
-    return metadata;
+    return uniqueMetadata(metadata);
   }
   if (node.selected === true) metadata.push('selected');
   if (node.focused === true) metadata.push('focused');
   if (isEditableRole(type)) metadata.push('editable');
   if (looksScrollable(node, type)) metadata.push('scrollable');
-  metadata.push(...(node.presentationHints ?? []));
   if (!textSurface.shouldSummarize) {
     return uniqueMetadata(metadata);
   }

--- a/src/utils/snapshot-occlusion.ts
+++ b/src/utils/snapshot-occlusion.ts
@@ -1,0 +1,161 @@
+import type { RawSnapshotNode, Rect } from './snapshot.ts';
+import { centerOfRect } from './snapshot.ts';
+import { containsPoint } from './rect-visibility.ts';
+import { normalizeType } from './text-surface.ts';
+
+const COVERED_PRESENTATION_HINT = 'covered';
+
+export function annotateCoveredSnapshotNodes(nodes: RawSnapshotNode[]): RawSnapshotNode[] {
+  if (nodes.length < 2) return nodes;
+
+  const byIndex = new Map(nodes.map((node) => [node.index, node]));
+  let changed = false;
+  const annotated = nodes.map((node, position) => {
+    if (!isCandidateTouchNode(node)) return node;
+    const cover = findCoveringNode(nodes, position, node, byIndex);
+    if (!cover) return node;
+    changed = true;
+    return {
+      ...node,
+      hittable: false,
+      interactionBlocked: 'covered' as const,
+      presentationHints: mergeCoveredHint(node.presentationHints),
+    };
+  });
+
+  return changed ? annotated : nodes;
+}
+
+export function isSnapshotNodeInteractionBlocked(
+  node: Pick<RawSnapshotNode, 'interactionBlocked'>,
+): boolean {
+  return node.interactionBlocked === 'covered';
+}
+
+function findCoveringNode(
+  nodes: RawSnapshotNode[],
+  targetPosition: number,
+  target: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+): RawSnapshotNode | null {
+  const targetRect = validRect(target.rect);
+  if (!targetRect) return null;
+  const center = centerOfRect(targetRect);
+
+  for (let position = targetPosition + 1; position < nodes.length; position += 1) {
+    const candidate = nodes[position];
+    if (!candidate || !isOverlayLikeNode(candidate)) continue;
+    if (areRelatedSnapshotNodes(target, candidate, byIndex)) continue;
+    const candidateRect = validRect(candidate.rect);
+    if (!candidateRect || areRectsApproximatelyEqual(targetRect, candidateRect)) continue;
+    if (containsPoint(candidateRect, center.x, center.y)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function isCandidateTouchNode(node: RawSnapshotNode): boolean {
+  if (!validRect(node.rect)) return false;
+  if (node.hittable === true) return true;
+  if (isSemanticTouchNode(node)) return true;
+  return Boolean(node.label?.trim() || node.value?.trim() || node.identifier?.trim());
+}
+
+function isOverlayLikeNode(node: RawSnapshotNode): boolean {
+  if (!validRect(node.rect)) return false;
+  if (isViewportRoot(node)) return false;
+  if (node.hittable === true) return true;
+
+  const normalized = normalizeNodeKind(node);
+  return (
+    normalized.includes('tabbar') ||
+    normalized.includes('toolbar') ||
+    normalized.includes('navigationbar') ||
+    normalized.includes('bottomnavigation') ||
+    normalized.includes('bottomnavigationview') ||
+    normalized.includes('sheet') ||
+    normalized.includes('dialog') ||
+    normalized.includes('alert') ||
+    normalized.includes('popover') ||
+    normalized.includes('menu')
+  );
+}
+
+function isSemanticTouchNode(node: RawSnapshotNode): boolean {
+  const normalized = normalizeNodeKind(node);
+  return (
+    normalized.includes('button') ||
+    normalized.includes('link') ||
+    normalized.includes('menuitem') ||
+    normalized.includes('tabitem') ||
+    normalized.includes('textfield') ||
+    normalized.includes('searchfield') ||
+    normalized.includes('edittext') ||
+    normalized.includes('checkbox') ||
+    normalized.includes('radio') ||
+    normalized.includes('switch') ||
+    normalized.includes('cell')
+  );
+}
+
+function normalizeNodeKind(node: Pick<RawSnapshotNode, 'type' | 'role' | 'subrole'>): string {
+  return [node.type, node.role, node.subrole].map((value) => normalizeType(value ?? '')).join(' ');
+}
+
+function isViewportRoot(node: RawSnapshotNode): boolean {
+  const normalized = normalizeNodeKind(node);
+  return normalized.includes('application') || normalized.includes('window');
+}
+
+function areRelatedSnapshotNodes(
+  left: RawSnapshotNode,
+  right: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+): boolean {
+  return isSnapshotAncestor(left, right, byIndex) || isSnapshotAncestor(right, left, byIndex);
+}
+
+function isSnapshotAncestor(
+  ancestor: RawSnapshotNode,
+  node: RawSnapshotNode,
+  byIndex: Map<number, RawSnapshotNode>,
+): boolean {
+  let current = typeof node.parentIndex === 'number' ? byIndex.get(node.parentIndex) : undefined;
+  const visited = new Set<number>();
+  while (current && !visited.has(current.index)) {
+    if (current.index === ancestor.index) return true;
+    visited.add(current.index);
+    current =
+      typeof current.parentIndex === 'number' ? byIndex.get(current.parentIndex) : undefined;
+  }
+  return false;
+}
+
+function validRect(rect: RawSnapshotNode['rect']): Rect | null {
+  if (!rect) return null;
+  if (
+    !Number.isFinite(rect.x) ||
+    !Number.isFinite(rect.y) ||
+    !Number.isFinite(rect.width) ||
+    !Number.isFinite(rect.height)
+  ) {
+    return null;
+  }
+  return rect.width > 0 && rect.height > 0 ? rect : null;
+}
+
+function areRectsApproximatelyEqual(left: Rect, right: Rect): boolean {
+  const tolerance = 0.5;
+  return (
+    Math.abs(left.x - right.x) <= tolerance &&
+    Math.abs(left.y - right.y) <= tolerance &&
+    Math.abs(left.width - right.width) <= tolerance &&
+    Math.abs(left.height - right.height) <= tolerance
+  );
+}
+
+function mergeCoveredHint(hints: string[] | undefined): string[] {
+  return Array.from(new Set([...(hints ?? []), COVERED_PRESENTATION_HINT]));
+}

--- a/src/utils/snapshot-occlusion.ts
+++ b/src/utils/snapshot-occlusion.ts
@@ -1,27 +1,64 @@
 import type { RawSnapshotNode, Rect } from './snapshot.ts';
 import { centerOfRect } from './snapshot.ts';
+import { areRectsApproximatelyEqual, normalizeRect } from './rect-center.ts';
 import { containsPoint } from './rect-visibility.ts';
 import { normalizeType } from './text-surface.ts';
 
 const COVERED_PRESENTATION_HINT = 'covered';
+const OVERLAY_KIND_FRAGMENTS = [
+  'tabbar',
+  'toolbar',
+  'navigationbar',
+  'bottomnavigation',
+  'bottomnavigationview',
+  'sheet',
+  'dialog',
+  'alert',
+  'popover',
+  'menu',
+];
+const SEMANTIC_TOUCH_KIND_FRAGMENTS = [
+  'button',
+  'link',
+  'menuitem',
+  'tabitem',
+  'textfield',
+  'searchfield',
+  'edittext',
+  'checkbox',
+  'radio',
+  'switch',
+  'cell',
+];
+
+type OcclusionScan = {
+  nodes: RawSnapshotNode[];
+  byIndex: Map<number, RawSnapshotNode>;
+};
 
 export function annotateCoveredSnapshotNodes(nodes: RawSnapshotNode[]): RawSnapshotNode[] {
   if (nodes.length < 2) return nodes;
 
-  const byIndex = new Map(nodes.map((node) => [node.index, node]));
+  const annotated = [...nodes];
+  const scan: OcclusionScan = {
+    nodes: annotated,
+    byIndex: new Map(annotated.map((node) => [node.index, node])),
+  };
   let changed = false;
-  const annotated = nodes.map((node, position) => {
-    if (!isCandidateTouchNode(node)) return node;
-    const cover = findCoveringNode(nodes, position, node, byIndex);
-    if (!cover) return node;
+  for (const [position, node] of annotated.entries()) {
+    if (!isCandidateTouchNode(node)) continue;
+    const cover = findCoveringNode(scan, position, node);
+    if (!cover) continue;
     changed = true;
-    return {
+    const coveredNode = {
       ...node,
       hittable: false,
       interactionBlocked: 'covered' as const,
       presentationHints: mergeCoveredHint(node.presentationHints),
     };
-  });
+    annotated[position] = coveredNode;
+    scan.byIndex.set(coveredNode.index, coveredNode);
+  }
 
   return changed ? annotated : nodes;
 }
@@ -29,75 +66,79 @@ export function annotateCoveredSnapshotNodes(nodes: RawSnapshotNode[]): RawSnaps
 export function isSnapshotNodeInteractionBlocked(
   node: Pick<RawSnapshotNode, 'interactionBlocked'>,
 ): boolean {
-  return node.interactionBlocked === 'covered';
+  return node.interactionBlocked !== undefined;
 }
 
 function findCoveringNode(
-  nodes: RawSnapshotNode[],
+  scan: OcclusionScan,
   targetPosition: number,
   target: RawSnapshotNode,
-  byIndex: Map<number, RawSnapshotNode>,
 ): RawSnapshotNode | null {
-  const targetRect = validRect(target.rect);
+  const targetRect = positiveRect(target.rect);
   if (!targetRect) return null;
   const center = centerOfRect(targetRect);
 
-  for (let position = targetPosition + 1; position < nodes.length; position += 1) {
-    const candidate = nodes[position];
-    if (!candidate || !isOverlayLikeNode(candidate)) continue;
-    if (areRelatedSnapshotNodes(target, candidate, byIndex)) continue;
-    const candidateRect = validRect(candidate.rect);
-    if (!candidateRect || areRectsApproximatelyEqual(targetRect, candidateRect)) continue;
-    if (containsPoint(candidateRect, center.x, center.y)) {
-      return candidate;
-    }
+  for (let position = targetPosition + 1; position < scan.nodes.length; position += 1) {
+    const candidate = scan.nodes[position];
+    if (candidate && canCoverPoint(scan, position, target, targetRect, center)) return candidate;
   }
 
   return null;
 }
 
+function canCoverPoint(
+  scan: OcclusionScan,
+  candidatePosition: number,
+  target: RawSnapshotNode,
+  targetRect: Rect,
+  point: { x: number; y: number },
+): boolean {
+  const candidate = scan.nodes[candidatePosition];
+  if (!candidate) return false;
+  const coverRect = visibleCoverRect(scan, candidatePosition, target, targetRect);
+  return Boolean(coverRect && containsPoint(coverRect, point.x, point.y));
+}
+
+function visibleCoverRect(
+  scan: OcclusionScan,
+  candidatePosition: number,
+  target: RawSnapshotNode,
+  targetRect: Rect,
+): Rect | null {
+  const candidate = scan.nodes[candidatePosition];
+  if (!candidate || !isOverlayLikeNode(candidate)) return null;
+  if (areRelatedSnapshotNodes(target, candidate, scan.byIndex)) return null;
+  const candidateRect = positiveRect(candidate.rect);
+  if (!candidateRect || areRectsApproximatelyEqual(targetRect, candidateRect)) return null;
+  if (findCoveringNode(scan, candidatePosition, candidate)) return null;
+  return candidateRect;
+}
+
 function isCandidateTouchNode(node: RawSnapshotNode): boolean {
-  if (!validRect(node.rect)) return false;
+  if (!positiveRect(node.rect)) return false;
   if (node.hittable === true) return true;
   if (isSemanticTouchNode(node)) return true;
   return Boolean(node.label?.trim() || node.value?.trim() || node.identifier?.trim());
 }
 
 function isOverlayLikeNode(node: RawSnapshotNode): boolean {
-  if (!validRect(node.rect)) return false;
+  if (!positiveRect(node.rect)) return false;
   if (isViewportRoot(node)) return false;
-  if (node.hittable === true) return true;
-
-  const normalized = normalizeNodeKind(node);
-  return (
-    normalized.includes('tabbar') ||
-    normalized.includes('toolbar') ||
-    normalized.includes('navigationbar') ||
-    normalized.includes('bottomnavigation') ||
-    normalized.includes('bottomnavigationview') ||
-    normalized.includes('sheet') ||
-    normalized.includes('dialog') ||
-    normalized.includes('alert') ||
-    normalized.includes('popover') ||
-    normalized.includes('menu')
-  );
+  // This is a presentation-order heuristic: only known floating UI chrome should cover
+  // later targets. Generic hittable containers can appear later without being visually on top.
+  return nodeKindIncludesAny(node, OVERLAY_KIND_FRAGMENTS);
 }
 
 function isSemanticTouchNode(node: RawSnapshotNode): boolean {
+  return nodeKindIncludesAny(node, SEMANTIC_TOUCH_KIND_FRAGMENTS);
+}
+
+function nodeKindIncludesAny(
+  node: Pick<RawSnapshotNode, 'type' | 'role' | 'subrole'>,
+  fragments: readonly string[],
+): boolean {
   const normalized = normalizeNodeKind(node);
-  return (
-    normalized.includes('button') ||
-    normalized.includes('link') ||
-    normalized.includes('menuitem') ||
-    normalized.includes('tabitem') ||
-    normalized.includes('textfield') ||
-    normalized.includes('searchfield') ||
-    normalized.includes('edittext') ||
-    normalized.includes('checkbox') ||
-    normalized.includes('radio') ||
-    normalized.includes('switch') ||
-    normalized.includes('cell')
-  );
+  return fragments.some((fragment) => normalized.includes(fragment));
 }
 
 function normalizeNodeKind(node: Pick<RawSnapshotNode, 'type' | 'role' | 'subrole'>): string {
@@ -133,27 +174,9 @@ function isSnapshotAncestor(
   return false;
 }
 
-function validRect(rect: RawSnapshotNode['rect']): Rect | null {
-  if (!rect) return null;
-  if (
-    !Number.isFinite(rect.x) ||
-    !Number.isFinite(rect.y) ||
-    !Number.isFinite(rect.width) ||
-    !Number.isFinite(rect.height)
-  ) {
-    return null;
-  }
-  return rect.width > 0 && rect.height > 0 ? rect : null;
-}
-
-function areRectsApproximatelyEqual(left: Rect, right: Rect): boolean {
-  const tolerance = 0.5;
-  return (
-    Math.abs(left.x - right.x) <= tolerance &&
-    Math.abs(left.y - right.y) <= tolerance &&
-    Math.abs(left.width - right.width) <= tolerance &&
-    Math.abs(left.height - right.height) <= tolerance
-  );
+function positiveRect(rect: RawSnapshotNode['rect']): Rect | null {
+  const normalized = normalizeRect(rect);
+  return normalized && normalized.width > 0 && normalized.height > 0 ? normalized : null;
 }
 
 function mergeCoveredHint(hints: string[] | undefined): string[] {

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -49,6 +49,7 @@ export type RawSnapshotNode = {
   surface?: string;
   hiddenContentAbove?: boolean;
   hiddenContentBelow?: boolean;
+  interactionBlocked?: 'covered';
   presentationHints?: string[];
 };
 


### PR DESCRIPTION
## Summary

- Marks covered snapshot nodes consistently while keeping actual bottom-tab controls tappable.
- Deduplicates rect comparison/normalization helpers and centralizes covered-target interaction errors.
- Fixes `find focus` / `find type` to use the promoted actionable node center.

Touched files: 7. Scope stayed within snapshot/interaction targeting and focused tests.

## Validation

- `pnpm typecheck` passed.
- `pnpm exec vitest run src/daemon/handlers/__tests__/find.test.ts src/daemon/handlers/__tests__/snapshot-capture.test.ts src/__tests__/runtime-interactions.test.ts` passed: 49 tests.
- `pnpm build` passed before live verification.
- Manual iOS verification on `iPhone 17`, React Navigation Example native bottom tabs: covered refs `@e14` / `@e38` were rejected with `interactionBlocked: "covered"`; visible `Contacts` tab tapped successfully and became selected.

Known gap: `pnpm check:unit` still fails in unrelated environment/tooling-sensitive tests: macOS trigger app event timeout, runtime hints timeout, Android bundletool tests, and iOS status bar tests.