### PR TITLE
fix: decode escaped selector values

### DIFF
--- a/src/daemon/__tests__/selectors.test.ts
+++ b/src/daemon/__tests__/selectors.test.ts
@@ -205,6 +205,59 @@ test('parseSelectorChain rejects unknown keys and malformed quotes', () => {
 test('parseSelectorChain handles quoted values ending in escaped backslashes', () => {
   const chain = parseSelectorChain('label="path\\\\" || id=auth_continue');
   assert.equal(chain.selectors.length, 2);
+  assert.equal(chain.selectors[0]!.terms[0]!.value, 'path\\');
+});
+
+test('parseSelectorChain decodes escaped selector string values', () => {
+  const chain = parseSelectorChain(
+    [
+      'label="Switch\\nMy Community"',
+      'value="A\\tB\\rC\\bD\\fE\\/F"',
+      'id="item_\\u0031\\uD83D\\uDE00"',
+      'text=\'It\\\'s OK\'',
+    ].join(' '),
+  );
+
+  assert.equal(chain.selectors[0]!.terms[0]!.value, 'Switch\nMy Community');
+  assert.equal(chain.selectors[0]!.terms[1]!.value, 'A\tB\rC\bD\fE/F');
+  assert.equal(chain.selectors[0]!.terms[2]!.value, `item_1${String.fromCodePoint(0x1f600)}`);
+  assert.equal(chain.selectors[0]!.terms[3]!.value, "It's OK");
+});
+
+test('parseSelectorChain preserves malformed and unknown selector string escapes', () => {
+  const chain = parseSelectorChain('label="bad\\u12" value="keep\\q"');
+
+  assert.equal(chain.selectors[0]!.terms[0]!.value, 'bad\\u12');
+  assert.equal(chain.selectors[0]!.terms[1]!.value, 'keep\\q');
+});
+
+test('parseSelectorChain preserves literal escaped control sequences when double escaped', () => {
+  const chain = parseSelectorChain('label="foo\\\\nbar"');
+
+  assert.equal(chain.selectors[0]!.terms[0]!.value, 'foo\\nbar');
+});
+
+test('resolveSelectorChain matches newline labels decoded from replay selectors', () => {
+  const newlineNodes: SnapshotState['nodes'] = [
+    {
+      ref: 'n1',
+      index: 0,
+      type: 'XCUIElementTypeButton',
+      label: 'Switch\nMy Community',
+      rect: { x: 0, y: 0, width: 120, height: 44 },
+      enabled: true,
+      hittable: true,
+    },
+  ];
+  const chain = parseSelectorChain('label="Switch\\nMy Community"');
+  const resolved = resolveSelectorChain(newlineNodes, chain, {
+    platform: 'ios',
+    requireRect: true,
+    requireUnique: true,
+  });
+
+  assert.ok(resolved);
+  assert.equal(resolved.node.ref, 'n1');
 });
 
 test('text selector matches extractNodeText semantics (first non-empty field)', () => {

--- a/src/daemon/selectors-parse.ts
+++ b/src/daemon/selectors-parse.ts
@@ -48,6 +48,17 @@ const BOOLEAN_KEYS = new Set<SelectorKey>([
   'hittable',
 ]);
 const ALL_KEYS = new Set<SelectorKey>([...TEXT_KEYS, ...BOOLEAN_KEYS]);
+const SIMPLE_ESCAPE_REPLACEMENTS = new Map<string, string>([
+  ['"', '"'],
+  ["'", "'"],
+  ['\\', '\\'],
+  ['/', '/'],
+  ['b', '\b'],
+  ['f', '\f'],
+  ['n', '\n'],
+  ['r', '\r'],
+  ['t', '\t'],
+]);
 
 export function parseSelectorChain(expression: string): SelectorChain {
   const raw = expression.trim();
@@ -243,9 +254,51 @@ function unquote(value: string): string {
     (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
     (trimmed.startsWith("'") && trimmed.endsWith("'"))
   ) {
-    return trimmed.slice(1, -1).replace(/\\(["'])/g, '$1');
+    return decodeQuotedSelectorValue(trimmed.slice(1, -1));
   }
   return trimmed;
+}
+
+// Keep this manual so single-quoted selectors work and malformed hand-written escapes stay literal.
+function decodeQuotedSelectorValue(value: string): string {
+  let decoded = '';
+  let cursor = 0;
+  while (cursor < value.length) {
+    const char = value.charAt(cursor);
+    if (char !== '\\') {
+      decoded += char;
+      cursor += 1;
+      continue;
+    }
+    const escaped = value.charAt(cursor + 1);
+    if (!escaped) {
+      decoded += char;
+      cursor += 1;
+      continue;
+    }
+    const replacement = decodeSimpleEscape(escaped);
+    if (replacement !== null) {
+      decoded += replacement;
+      cursor += 2;
+      continue;
+    }
+    if (escaped === 'u') {
+      const hex = value.slice(cursor + 2, cursor + 6);
+      if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+        // JSON-style \u escapes are code units; adjacent surrogate units compose in JS strings.
+        decoded += String.fromCharCode(Number.parseInt(hex, 16));
+        cursor += 6;
+        continue;
+      }
+    }
+    decoded += char;
+    cursor += 1;
+  }
+  return decoded;
+}
+
+function decodeSimpleEscape(escaped: string): string | null {
+  return SIMPLE_ESCAPE_REPLACEMENTS.get(escaped) ?? null;
 }
 
 function parseBoolean(value: string): boolean | null {


### PR DESCRIPTION
## Summary

Fix replayed selectors whose quoted values contain escaped control characters, such as auto-recorded labels with `\n` from multi-line accessibility labels.

The selector parser now decodes quoted selector escapes with a manual scanner instead of only stripping quote escapes. This keeps replay parsing symmetric with selector recording while avoiding code execution from replay files.

Closes #710

Touched files: 2. Scope stayed within selector parsing and selector tests.

## Validation

Verified the newline replay selector regression with `pnpm exec vitest run src/daemon/__tests__/selectors.test.ts`.

Ran `pnpm check:quick`; lint and TypeScript passed.

Ran `pnpm test:smoke` outside the sandbox; all 7 smoke tests passed.

`pnpm check:unit` was attempted. The sandbox run failed on loopback listener restrictions; the escalated run reduced to two unrelated failures in `src/platforms/ios/__tests__/index.test.ts`, and that file passed when rerun alone.