### PR TITLE
feat: record replay test videos

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -444,6 +444,20 @@ test('replay.test keeps backend alias for suite discovery', async () => {
   assert.equal(setup.calls[0]?.flags?.replayBackend, 'maestro');
 });
 
+test('replay.test forwards recordVideo for per-attempt video recording', async () => {
+  const setup = createTransport(async () => ({ ok: true, data: {} }));
+  const client = createAgentDeviceClient(setup.config, { transport: setup.transport });
+
+  await client.replay.test({
+    paths: ['./flows/login.ad'],
+    recordVideo: true,
+  });
+
+  assert.equal(setup.calls.length, 1);
+  assert.equal(setup.calls[0]?.command, 'test');
+  assert.equal(setup.calls[0]?.flags?.recordVideo, true);
+});
+
 test('structured replay.test command forwards Maestro backend for suite discovery', async () => {
   const setup = createTransport(async () => ({ ok: true, data: {} }));
   const client = createAgentDeviceClient(setup.config, { transport: setup.transport });

--- a/src/cli-test.ts
+++ b/src/cli-test.ts
@@ -63,6 +63,9 @@ function renderDefaultTestResult(result: ReplaySuiteTestResult): void {
   process.stdout.write(
     `PASS ${replayTestDisplayName(result)}${formatReplayTestDurationSuffix(result)}\n`,
   );
+  for (const line of replayTestWarningLines(result)) {
+    process.stdout.write(`  ${line}\n`);
+  }
 }
 
 function renderVerboseTestResult(result: ReplaySuiteTestResult): void {
@@ -77,6 +80,9 @@ function renderVerboseTestResult(result: ReplaySuiteTestResult): void {
   );
   if (result.status === 'skipped') {
     process.stdout.write(`  ${result.message ?? 'skipped'}\n`);
+  }
+  for (const line of replayTestWarningLines(result)) {
+    process.stdout.write(`  ${line}\n`);
   }
   for (const line of replayTestStepLines(result)) {
     process.stdout.write(`  ${line}\n`);
@@ -447,6 +453,9 @@ function appendReplaySystemOutMetadata(lines: string[], test: ReplaySuiteTestRes
   appendOptionalLine(lines, 'session' in test ? `session: ${test.session}` : undefined);
   appendOptionalLine(lines, 'replayed' in test ? `replayed: ${test.replayed}` : undefined);
   appendOptionalLine(lines, 'healed' in test ? `healed: ${test.healed}` : undefined);
+  for (const warning of replayTestWarningLines(test)) {
+    lines.push(warning);
+  }
   appendOptionalLine(
     lines,
     'artifactsDir' in test && test.artifactsDir ? `artifactsDir: ${test.artifactsDir}` : undefined,
@@ -511,6 +520,11 @@ function appendReplayErrorDetails(
 
 function appendOptionalLine(lines: string[], line: string | undefined): void {
   if (line) lines.push(line);
+}
+
+function replayTestWarningLines(result: ReplaySuiteTestResult): string[] {
+  if (result.status !== 'passed') return [];
+  return (result.warnings ?? []).map((warning) => `warning: ${warning}`);
 }
 
 function formatJUnitSeconds(durationMs: number): string {

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -319,6 +319,7 @@ export function buildFlags(options: InternalRequestOptions): CommandFlags {
     failFast: options.failFast,
     timeoutMs: options.timeoutMs,
     retries: options.retries,
+    recordVideo: options.recordVideo,
     artifactsDir: options.artifactsDir,
     reportJunit: options.reportJunit,
     shardAll: options.shardAll,

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -716,6 +716,7 @@ export type ReplayTestOptions = AgentDeviceRequestOverrides &
     failFast?: boolean;
     timeoutMs?: number;
     retries?: number;
+    recordVideo?: boolean;
     artifactsDir?: string;
     reportJunit?: string;
     shardAll?: number;
@@ -855,6 +856,7 @@ type CommandExecutionOptions = Partial<ScreenshotRequestFlags> & {
   failFast?: boolean;
   timeoutMs?: number;
   retries?: number;
+  recordVideo?: boolean;
   artifactsDir?: string;
   reportJunit?: string;
   shardAll?: number;

--- a/src/commands/cli-grammar/replay.ts
+++ b/src/commands/cli-grammar/replay.ts
@@ -19,6 +19,7 @@ export const replayCliReaders = {
     failFast: flags.failFast,
     timeoutMs: flags.timeoutMs,
     retries: flags.retries,
+    recordVideo: flags.recordVideo,
     artifactsDir: flags.artifactsDir,
     reportJunit: flags.reportJunit,
     shardAll: flags.shardAll,

--- a/src/commands/client-command-metadata.ts
+++ b/src/commands/client-command-metadata.ts
@@ -175,6 +175,7 @@ export const clientCommandMetadata = [
     failFast: booleanField(),
     timeoutMs: integerField(),
     retries: integerField(),
+    recordVideo: booleanField(),
     artifactsDir: stringField(),
     reportJunit: stringField(),
     shardAll: integerField(),

--- a/src/daemon/__tests__/request-router-android-modal.test.ts
+++ b/src/daemon/__tests__/request-router-android-modal.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 let snapshotCalls = 0;
 const dispatchCalls: string[][] = [];
+let snapshotMode: 'blocking-dialog' | 'throws' = 'blocking-dialog';
 
 vi.mock('../../core/dispatch.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../core/dispatch.ts')>();
@@ -27,6 +28,9 @@ vi.mock('../../platforms/android/snapshot.ts', async (importOriginal) => {
     ...actual,
     snapshotAndroid: vi.fn(async () => {
       snapshotCalls += 1;
+      if (snapshotMode === 'throws') {
+        throw new Error('uiautomator dump did not return XML');
+      }
       if (snapshotCalls === 1) {
         return {
           nodes: [
@@ -101,6 +105,7 @@ function makeAndroidSession(name: string): SessionState {
 
 test('generic Android gesture commands dismiss blocking system dialogs during recording', async () => {
   snapshotCalls = 0;
+  snapshotMode = 'blocking-dialog';
   execCalls.length = 0;
   dispatchCalls.length = 0;
 
@@ -133,4 +138,39 @@ test('generic Android gesture commands dismiss blocking system dialogs during re
     'com.android.settings',
   );
   expect(snapshotCalls).toBe(2);
+});
+
+test('generic Android gesture commands continue when recording dialog inspection fails', async () => {
+  snapshotCalls = 0;
+  snapshotMode = 'throws';
+  execCalls.length = 0;
+  dispatchCalls.length = 0;
+
+  const sessionStore = makeSessionStore('agent-device-router-android-modal-');
+  sessionStore.set('default', makeAndroidSession('default'));
+
+  const { openAndroidApp } = await import('../../platforms/android/app-lifecycle.ts');
+  vi.mocked(openAndroidApp).mockClear();
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'default',
+    command: 'scroll',
+    positionals: ['down', '0.55'],
+    meta: { requestId: 'req-android-modal-inspection-failed' },
+  });
+
+  expect(response.ok).toBe(true);
+  expect(dispatchCalls).toEqual([['scroll', 'down', '0.55']]);
+  expect(execCalls).toEqual([]);
+  expect(openAndroidApp).not.toHaveBeenCalled();
+  expect(snapshotCalls).toBe(1);
 });

--- a/src/daemon/android-system-dialog.ts
+++ b/src/daemon/android-system-dialog.ts
@@ -21,10 +21,10 @@ const ANDROID_BLOCKING_DIALOG_HINT =
   'Wait for Android to recover, close the dialog, restart the app, or reboot the emulator, then retry.';
 
 export type AndroidBlockingDialogRecoveryResult =
-  | 'absent'
-  | 'recovered'
-  | 'failed'
-  | 'inspection-failed';
+  | { status: 'absent' }
+  | { status: 'recovered' }
+  | { status: 'failed'; reason: 'tap-failed' | 'dismiss-failed' | 'relaunch-failed' | 'error' }
+  | { status: 'unknown'; reason: 'inspection-failed' };
 export type AndroidBlockingDialogReadinessResult =
   | { status: 'clear' }
   | { status: 'recovered'; warning: string };
@@ -43,7 +43,7 @@ export async function recoverAndroidBlockingSystemDialog(params: {
   const { session } = params;
 
   if (session.device.platform !== 'android' || !session.recording) {
-    return 'absent';
+    return { status: 'absent' };
   }
 
   let nodes: SnapshotNode[];
@@ -59,12 +59,12 @@ export async function recoverAndroidBlockingSystemDialog(params: {
         error: error instanceof Error ? error.message : String(error),
       },
     });
-    return 'inspection-failed';
+    return { status: 'unknown', reason: 'inspection-failed' };
   }
 
   const closeAppButton = findCloseAppButton(nodes);
   if (!closeAppButton?.rect) {
-    return 'absent';
+    return { status: 'absent' };
   }
 
   try {
@@ -81,7 +81,7 @@ export async function recoverAndroidBlockingSystemDialog(params: {
           stderr: tapResult.stderr.trim(),
         },
       });
-      return 'failed';
+      return { status: 'failed', reason: 'tap-failed' };
     }
 
     const dismissed = await waitForBlockingDialogToDismiss(session);
@@ -94,7 +94,7 @@ export async function recoverAndroidBlockingSystemDialog(params: {
           deviceId: session.device.id,
         },
       });
-      return 'failed';
+      return { status: 'failed', reason: 'dismiss-failed' };
     }
 
     if (session.appBundleId) {
@@ -110,7 +110,7 @@ export async function recoverAndroidBlockingSystemDialog(params: {
             appBundleId: session.appBundleId,
           },
         });
-        return 'failed';
+        return { status: 'failed', reason: 'relaunch-failed' };
       }
     }
 
@@ -125,7 +125,7 @@ export async function recoverAndroidBlockingSystemDialog(params: {
         y: tapResult.y,
       },
     });
-    return 'recovered';
+    return { status: 'recovered' };
   } catch (error) {
     emitDiagnostic({
       level: 'warn',
@@ -136,7 +136,7 @@ export async function recoverAndroidBlockingSystemDialog(params: {
         error: error instanceof Error ? error.message : String(error),
       },
     });
-    return 'failed';
+    return { status: 'failed', reason: 'error' };
   }
 }
 

--- a/src/daemon/android-system-dialog.ts
+++ b/src/daemon/android-system-dialog.ts
@@ -20,7 +20,11 @@ const ANDROID_MODAL_POLL_ATTEMPTS = 12;
 const ANDROID_BLOCKING_DIALOG_HINT =
   'Wait for Android to recover, close the dialog, restart the app, or reboot the emulator, then retry.';
 
-export type AndroidBlockingDialogRecoveryResult = 'absent' | 'recovered' | 'failed';
+export type AndroidBlockingDialogRecoveryResult =
+  | 'absent'
+  | 'recovered'
+  | 'failed'
+  | 'inspection-failed';
 export type AndroidBlockingDialogReadinessResult =
   | { status: 'clear' }
   | { status: 'recovered'; warning: string };
@@ -42,13 +46,28 @@ export async function recoverAndroidBlockingSystemDialog(params: {
     return 'absent';
   }
 
+  let nodes: SnapshotNode[];
   try {
-    const nodes = await readAndroidSnapshotNodes(session);
-    const closeAppButton = findCloseAppButton(nodes);
-    if (!closeAppButton?.rect) {
-      return 'absent';
-    }
+    nodes = await readAndroidSnapshotNodes(session);
+  } catch (error) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'android_blocking_dialog_inspection_failed',
+      data: {
+        session: session.name,
+        deviceId: session.device.id,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
+    return 'inspection-failed';
+  }
 
+  const closeAppButton = findCloseAppButton(nodes);
+  if (!closeAppButton?.rect) {
+    return 'absent';
+  }
+
+  try {
     const tapResult = await tapAndroidDialogButton(session, closeAppButton);
     if (!tapResult.ok) {
       emitDiagnostic({

--- a/src/daemon/handlers/__tests__/session-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay.test.ts
@@ -247,7 +247,8 @@ test('test --record-video records each replay attempt on the generated test sess
       if (nestedReq.command === 'open') {
         const provisionalSession = makeIosSession(nestedReq.session);
         sessionStore.set(nestedReq.session, provisionalSession);
-        const hookResponse = await nestedReq.meta?.beforeOpenDispatch?.(provisionalSession);
+        const hookResponse =
+          await nestedReq.internal?.openLifecycle?.beforeDispatch?.(provisionalSession);
         if (hookResponse && !hookResponse.ok) return hookResponse;
         events.push('open:dispatch');
       }
@@ -265,6 +266,16 @@ test('test --record-video records each replay attempt on the generated test sess
   if (typeof generatedSession !== 'string') throw new Error('Expected generated test session');
   expectRecordVideoCalls({ generatedSession, artifactsDir: testResult.artifactsDir });
   assert.deepEqual(events, ['record:start', 'open:dispatch', 'record:stop']);
+  const timingPath = path.join(testResult.artifactsDir ?? '', 'attempt-1', 'replay-timing.ndjson');
+  const timingEvents = fs
+    .readFileSync(timingPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as { type?: string });
+  assert.deepEqual(
+    timingEvents.map((event) => event.type).filter((type) => type?.startsWith('video_')),
+    ['video_recording_start', 'video_preroll_done', 'video_tail_start', 'video_recording_stop'],
+  );
   assert.equal(
     nestedRequests.some((nestedReq) => nestedReq.flags?.recordVideo === true),
     false,

--- a/src/daemon/handlers/__tests__/session-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay.test.ts
@@ -2,9 +2,144 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { test } from 'vitest';
-import { buildNestedReplayFlags } from '../session-replay.ts';
+import { beforeEach, test, vi } from 'vitest';
+import { SessionStore } from '../../session-store.ts';
+import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/index.ts';
+import { buildNestedReplayFlags, handleSessionReplayCommands } from '../session-replay.ts';
 import { collectReplayActionArtifactPaths } from '../session-replay-runtime.ts';
+
+const recordTraceMocks = vi.hoisted(() => ({
+  handleRecordCommand: vi.fn(),
+}));
+
+vi.mock('../record-trace-recording.ts', () => ({
+  handleRecordCommand: recordTraceMocks.handleRecordCommand,
+}));
+
+beforeEach(() => {
+  recordTraceMocks.handleRecordCommand.mockReset();
+});
+
+type RecordCommandCall = [{ req: DaemonRequest; sessionName: string }];
+
+type RecordVideoFixture = {
+  root: string;
+  replayPath: string;
+  sessionStore: SessionStore;
+  nestedRequests: DaemonRequest[];
+};
+
+type MockRecordingState = {
+  recordingPath: string;
+};
+
+function createRecordVideoFixture(): RecordVideoFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-record-video-'));
+  const replayPath = path.join(root, 'flow.ad');
+  fs.writeFileSync(replayPath, 'open "Demo"\nclick "Continue"\n');
+  return {
+    root,
+    replayPath,
+    sessionStore: new SessionStore(path.join(root, 'sessions')),
+    nestedRequests: [],
+  };
+}
+
+function installMockRecordingHandler(sessionStore: SessionStore, state: MockRecordingState): void {
+  recordTraceMocks.handleRecordCommand.mockImplementation(
+    async (params: { req: DaemonRequest }): Promise<DaemonResponse> =>
+      await handleMockRecordCommand({
+        req: params.req,
+        sessionStore,
+        state,
+      }),
+  );
+}
+
+async function handleMockRecordCommand(params: {
+  req: DaemonRequest;
+  sessionStore: SessionStore;
+  state: MockRecordingState;
+}): Promise<DaemonResponse> {
+  const { req, sessionStore, state } = params;
+  const action = req.positionals?.[0];
+  if (action === 'start') return startMockRecording({ req, sessionStore, state });
+  if (action === 'stop') return stopMockRecording({ req, sessionStore, state });
+  return { ok: false, error: { code: 'INVALID_ARGS', message: 'unexpected record action' } };
+}
+
+function startMockRecording(params: {
+  req: DaemonRequest;
+  sessionStore: SessionStore;
+  state: MockRecordingState;
+}): DaemonResponse {
+  const { req, sessionStore, state } = params;
+  state.recordingPath = req.positionals?.[1] ?? '';
+  const session = sessionStore.get(req.session);
+  if (session) {
+    session.recording = {
+      platform: 'ios',
+      outPath: state.recordingPath,
+      startedAt: Date.now(),
+      showTouches: true,
+      gestureEvents: [],
+      child: { kill: () => true, pid: 123 },
+      wait: Promise.resolve({ stdout: '', stderr: '', exitCode: 0 }),
+    } as NonNullable<typeof session.recording>;
+    sessionStore.set(req.session, session);
+  }
+  return { ok: true, data: { recording: 'started', outPath: state.recordingPath } };
+}
+
+function stopMockRecording(params: {
+  req: DaemonRequest;
+  sessionStore: SessionStore;
+  state: MockRecordingState;
+}): DaemonResponse {
+  const { req, sessionStore, state } = params;
+  const session = sessionStore.get(req.session);
+  if (session) {
+    session.recording = undefined;
+    sessionStore.set(req.session, session);
+  }
+  fs.writeFileSync(state.recordingPath, 'video');
+  return {
+    ok: true,
+    data: {
+      recording: 'stopped',
+      outPath: state.recordingPath,
+      artifacts: [
+        {
+          field: 'outPath',
+          path: state.recordingPath,
+          fileName: path.basename(state.recordingPath),
+        },
+      ],
+    },
+  };
+}
+
+function expectRecordVideoCalls(params: {
+  generatedSession: string;
+  artifactsDir: string | undefined;
+}): void {
+  const { generatedSession, artifactsDir } = params;
+  const recordCalls = recordTraceMocks.handleRecordCommand.mock.calls as RecordCommandCall[];
+  assert.equal(recordCalls.length, 2);
+
+  const startCall = recordCalls[0]?.[0];
+  const stopCall = recordCalls[1]?.[0];
+  assert.equal(startCall?.sessionName, generatedSession);
+  assert.equal(startCall?.req.session, generatedSession);
+  assert.deepEqual(startCall?.req.positionals, [
+    'start',
+    path.join(artifactsDir ?? '', 'attempt-1', 'recording.mp4'),
+  ]);
+  assert.equal(stopCall?.sessionName, generatedSession);
+  assert.equal(stopCall?.req.session, generatedSession);
+  assert.deepEqual(stopCall?.req.positionals, ['stop']);
+}
 
 test('buildNestedReplayFlags returns parent flags untouched when neither override is set', () => {
   const parent = { platform: 'android' as const, timeoutMs: 5000 };
@@ -56,6 +191,17 @@ test('buildNestedReplayFlags overrides a parent artifactsDir with the attempt-le
   assert.equal(result?.artifactsDir, '/suite-root/flow/attempt-2');
 });
 
+test('buildNestedReplayFlags strips test-only recordVideo before replay actions inherit flags', () => {
+  const result = buildNestedReplayFlags({
+    parentFlags: { platform: 'ios', recordVideo: true },
+    platform: undefined,
+    target: undefined,
+    artifactsDir: undefined,
+  });
+
+  assert.deepEqual(result, { platform: 'ios' });
+});
+
 test('collectReplayActionArtifactPaths includes failed action artifact details', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-artifacts-'));
   const snapshotPath = path.join(root, 'failure-snapshot.txt');
@@ -73,4 +219,44 @@ test('collectReplayActionArtifactPaths includes failed action artifact details',
   });
 
   assert.deepEqual(paths, [snapshotPath]);
+});
+
+test('test --record-video records each replay attempt on the generated test session', async () => {
+  const { root, replayPath, sessionStore, nestedRequests } = createRecordVideoFixture();
+  installMockRecordingHandler(sessionStore, { recordingPath: '' });
+
+  const response = await handleSessionReplayCommands({
+    req: {
+      token: 'token',
+      session: 'default',
+      command: 'test',
+      positionals: [replayPath],
+      flags: { recordVideo: true, artifactsDir: path.join(root, 'artifacts') },
+      meta: { cwd: root, requestId: 'record-video-suite' },
+    },
+    sessionName: 'default',
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (nestedReq) => {
+      nestedRequests.push(nestedReq);
+      if (nestedReq.command === 'open') {
+        sessionStore.set(nestedReq.session, makeIosSession(nestedReq.session));
+      }
+      return { ok: true, data: { session: nestedReq.session } };
+    },
+  });
+
+  if (!response) throw new Error('Expected response');
+  if (!response.ok) throw new Error(response.error.message);
+  const suite = response.data as {
+    tests?: Array<{ session?: string; artifactsDir?: string }>;
+  };
+  const testResult = suite.tests?.[0] ?? {};
+  const generatedSession = testResult.session;
+  if (typeof generatedSession !== 'string') throw new Error('Expected generated test session');
+  expectRecordVideoCalls({ generatedSession, artifactsDir: testResult.artifactsDir });
+  assert.equal(
+    nestedRequests.some((nestedReq) => nestedReq.flags?.recordVideo === true),
+    false,
+  );
 });

--- a/src/daemon/handlers/__tests__/session-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay.test.ts
@@ -28,10 +28,12 @@ type RecordVideoFixture = {
   replayPath: string;
   sessionStore: SessionStore;
   nestedRequests: DaemonRequest[];
+  events: string[];
 };
 
 type MockRecordingState = {
   recordingPath: string;
+  events: string[];
 };
 
 function createRecordVideoFixture(): RecordVideoFixture {
@@ -43,6 +45,7 @@ function createRecordVideoFixture(): RecordVideoFixture {
     replayPath,
     sessionStore: new SessionStore(path.join(root, 'sessions')),
     nestedRequests: [],
+    events: [],
   };
 }
 
@@ -75,6 +78,7 @@ function startMockRecording(params: {
   state: MockRecordingState;
 }): DaemonResponse {
   const { req, sessionStore, state } = params;
+  state.events.push('record:start');
   state.recordingPath = req.positionals?.[1] ?? '';
   const session = sessionStore.get(req.session);
   if (session) {
@@ -98,6 +102,7 @@ function stopMockRecording(params: {
   state: MockRecordingState;
 }): DaemonResponse {
   const { req, sessionStore, state } = params;
+  state.events.push('record:stop');
   const session = sessionStore.get(req.session);
   if (session) {
     session.recording = undefined;
@@ -222,8 +227,8 @@ test('collectReplayActionArtifactPaths includes failed action artifact details',
 });
 
 test('test --record-video records each replay attempt on the generated test session', async () => {
-  const { root, replayPath, sessionStore, nestedRequests } = createRecordVideoFixture();
-  installMockRecordingHandler(sessionStore, { recordingPath: '' });
+  const { root, replayPath, sessionStore, nestedRequests, events } = createRecordVideoFixture();
+  installMockRecordingHandler(sessionStore, { recordingPath: '', events });
 
   const response = await handleSessionReplayCommands({
     req: {
@@ -240,7 +245,11 @@ test('test --record-video records each replay attempt on the generated test sess
     invoke: async (nestedReq) => {
       nestedRequests.push(nestedReq);
       if (nestedReq.command === 'open') {
-        sessionStore.set(nestedReq.session, makeIosSession(nestedReq.session));
+        const provisionalSession = makeIosSession(nestedReq.session);
+        sessionStore.set(nestedReq.session, provisionalSession);
+        const hookResponse = await nestedReq.meta?.beforeOpenDispatch?.(provisionalSession);
+        if (hookResponse && !hookResponse.ok) return hookResponse;
+        events.push('open:dispatch');
       }
       return { ok: true, data: { session: nestedReq.session } };
     },
@@ -255,6 +264,7 @@ test('test --record-video records each replay attempt on the generated test sess
   const generatedSession = testResult.session;
   if (typeof generatedSession !== 'string') throw new Error('Expected generated test session');
   expectRecordVideoCalls({ generatedSession, artifactsDir: testResult.artifactsDir });
+  assert.deepEqual(events, ['record:start', 'open:dispatch', 'record:stop']);
   assert.equal(
     nestedRequests.some((nestedReq) => nestedReq.flags?.recordVideo === true),
     false,

--- a/src/daemon/handlers/__tests__/session-replay.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay.test.ts
@@ -18,6 +18,7 @@ vi.mock('../record-trace-recording.ts', () => ({
 }));
 
 beforeEach(() => {
+  vi.useRealTimers();
   recordTraceMocks.handleRecordCommand.mockReset();
 });
 
@@ -227,10 +228,11 @@ test('collectReplayActionArtifactPaths includes failed action artifact details',
 });
 
 test('test --record-video records each replay attempt on the generated test session', async () => {
+  vi.useFakeTimers({ now: 1_000 });
   const { root, replayPath, sessionStore, nestedRequests, events } = createRecordVideoFixture();
   installMockRecordingHandler(sessionStore, { recordingPath: '', events });
 
-  const response = await handleSessionReplayCommands({
+  const responsePromise = handleSessionReplayCommands({
     req: {
       token: 'token',
       session: 'default',
@@ -255,6 +257,9 @@ test('test --record-video records each replay attempt on the generated test sess
       return { ok: true, data: { session: nestedReq.session } };
     },
   });
+  await vi.advanceTimersByTimeAsync(4_000);
+  const response = await responsePromise;
+  vi.useRealTimers();
 
   if (!response) throw new Error('Expected response');
   if (!response.ok) throw new Error(response.error.message);

--- a/src/daemon/handlers/__tests__/session-test-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-runtime.test.ts
@@ -15,7 +15,14 @@ test('runReplayTestAttempt keeps cancellation active until a timed-out replay se
     resolveReplay = resolve;
   });
   const replaySettled = replayPromise.then(() => undefined);
-  const cleanupSession = vi.fn(async () => {});
+  const lifecycleEvents: string[] = [];
+  const cleanupSession = vi.fn(async () => {
+    lifecycleEvents.push('cleanup');
+  });
+  const finalizeAttempt = vi.fn(async () => {
+    lifecycleEvents.push('finalize');
+    return undefined;
+  });
 
   const attemptPromise = runReplayTestAttempt({
     filePath: '01-timeout.ad',
@@ -23,6 +30,7 @@ test('runReplayTestAttempt keeps cancellation active until a timed-out replay se
     requestId: 'req-timeout-open',
     timeoutMs: 10,
     runReplay: async () => await replayPromise,
+    finalizeAttempt,
     cleanupSession,
   });
 
@@ -37,6 +45,13 @@ test('runReplayTestAttempt keeps cancellation active until a timed-out replay se
     expect(result.error.details?.timeoutCleanupPending).toBe(true);
   }
   expect(cleanupSession).toHaveBeenCalledWith('default:test:timeout');
+  expect(finalizeAttempt).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sessionName: 'default:test:timeout',
+      artifactPaths: expect.any(Set),
+    }),
+  );
+  expect(lifecycleEvents).toEqual(['finalize', 'cleanup']);
   expect(isRequestCanceled('req-timeout-open')).toBe(true);
 
   resolveReplay?.({
@@ -50,4 +65,26 @@ test('runReplayTestAttempt keeps cancellation active until a timed-out replay se
   await vi.waitFor(() => {
     expect(cleanupSession).toHaveBeenCalledTimes(2);
   });
+});
+
+test('runReplayTestAttempt reports finalization failure after a passing replay', async () => {
+  const cleanupSession = vi.fn(async () => {});
+
+  const result = await runReplayTestAttempt({
+    filePath: '01-pass.ad',
+    sessionName: 'default:test:pass',
+    requestId: 'req-pass',
+    runReplay: async () => ({ ok: true, data: { replayed: 1, healed: 0 } }),
+    finalizeAttempt: async () => ({
+      ok: false,
+      error: { code: 'COMMAND_FAILED', message: 'failed to stop recording' },
+    }),
+    cleanupSession,
+  });
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.error.message).toBe('failed to stop recording');
+  }
+  expect(cleanupSession).toHaveBeenCalledWith('default:test:pass');
 });

--- a/src/daemon/handlers/__tests__/session-test-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-runtime.test.ts
@@ -67,7 +67,7 @@ test('runReplayTestAttempt keeps cancellation active until a timed-out replay se
   });
 });
 
-test('runReplayTestAttempt reports finalization failure after a passing replay', async () => {
+test('runReplayTestAttempt keeps a passing replay passed when finalization fails', async () => {
   const cleanupSession = vi.fn(async () => {});
 
   const result = await runReplayTestAttempt({
@@ -82,9 +82,10 @@ test('runReplayTestAttempt reports finalization failure after a passing replay',
     cleanupSession,
   });
 
-  expect(result.ok).toBe(false);
-  if (!result.ok) {
-    expect(result.error.message).toBe('failed to stop recording');
-  }
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error(result.error.message);
+  expect(result.data?.warnings).toEqual([
+    'Replay test finalization failed: failed to stop recording',
+  ]);
   expect(cleanupSession).toHaveBeenCalledWith('default:test:pass');
 });

--- a/src/daemon/handlers/interaction.ts
+++ b/src/daemon/handlers/interaction.ts
@@ -65,7 +65,7 @@ async function recoverAndroidRecordingDialogForType(
 ): Promise<DaemonResponse | null> {
   if (session.device.platform === 'android' && session.recording) {
     const androidRecoveryResult = await recoverAndroidBlockingSystemDialog({ session });
-    if (androidRecoveryResult === 'failed') {
+    if (androidRecoveryResult.status === 'failed') {
       return errorResponse('COMMAND_FAILED', 'Android system dialog blocked the recording session');
     }
   }

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -329,8 +329,8 @@ async function prepareOpenDispatchSession(params: {
     appName,
     existingSession,
   } = params;
-  const beforeOpenDispatch = req.meta?.beforeOpenDispatch;
-  if (!beforeOpenDispatch) return { type: 'session', session: existingSession };
+  const beforeDispatch = req.internal?.openLifecycle?.beforeDispatch;
+  if (!beforeDispatch) return { type: 'session', session: existingSession };
   const provisionalSession = buildNextOpenSession({
     existingSession,
     sessionName: existingSession?.name ?? resolvePublicSessionName(req),
@@ -342,9 +342,9 @@ async function prepareOpenDispatchSession(params: {
     saveScript: Boolean(req.flags?.saveScript),
   });
   sessionStore.set(sessionName, provisionalSession);
-  const hookResponse = await beforeOpenDispatch(provisionalSession);
-  if (hookResponse && !hookResponse.ok) {
-    return { type: 'response', response: hookResponse };
+  const lifecycleResponse = await beforeDispatch(provisionalSession);
+  if (lifecycleResponse && !lifecycleResponse.ok) {
+    return { type: 'response', response: lifecycleResponse };
   }
   return { type: 'session', session: sessionStore.get(sessionName) ?? provisionalSession };
 }

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -203,6 +203,20 @@ async function completeOpenCommand(params: {
     }
   }
   const openStartedAtMs = Date.now();
+  const provisionalSession = await prepareOpenDispatchSession({
+    req,
+    sessionName,
+    sessionStore,
+    device,
+    surface,
+    sessionAppBundleId,
+    appName,
+    existingSession,
+  });
+  if (provisionalSession.type === 'response') {
+    return provisionalSession.response;
+  }
+  const openDispatchSession = provisionalSession.session ?? existingSession;
   await dispatchCommand(device, 'open', openPositionals, req.flags?.out, {
     ...contextFromFlags(logPath, req.flags, sessionAppBundleId),
   });
@@ -250,7 +264,7 @@ async function completeOpenCommand(params: {
     markAndroidSnapshotFreshness(existingSession, 'open', existingSession.snapshot);
   }
   const nextSession = buildNextOpenSession({
-    existingSession,
+    existingSession: openDispatchSession,
     sessionName: existingSession?.name ?? resolvePublicSessionName(req),
     sessionScope: existingSession?.sessionScope ?? resolveImplicitSessionScope(req),
     device,
@@ -291,6 +305,48 @@ async function completeOpenCommand(params: {
   });
   sessionStore.set(sessionName, nextSession);
   return { ok: true, data: openResult };
+}
+
+async function prepareOpenDispatchSession(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  sessionStore: SessionStore;
+  device: DeviceInfo;
+  surface: SessionSurface;
+  sessionAppBundleId: string | undefined;
+  appName: string | undefined;
+  existingSession: SessionState | undefined;
+}): Promise<
+  { type: 'session'; session?: SessionState } | { type: 'response'; response: DaemonResponse }
+> {
+  const {
+    req,
+    sessionName,
+    sessionStore,
+    device,
+    surface,
+    sessionAppBundleId,
+    appName,
+    existingSession,
+  } = params;
+  const beforeOpenDispatch = req.meta?.beforeOpenDispatch;
+  if (!beforeOpenDispatch) return { type: 'session', session: existingSession };
+  const provisionalSession = buildNextOpenSession({
+    existingSession,
+    sessionName: existingSession?.name ?? resolvePublicSessionName(req),
+    sessionScope: existingSession?.sessionScope ?? resolveImplicitSessionScope(req),
+    device,
+    surface,
+    appBundleId: sessionAppBundleId,
+    appName,
+    saveScript: Boolean(req.flags?.saveScript),
+  });
+  sessionStore.set(sessionName, provisionalSession);
+  const hookResponse = await beforeOpenDispatch(provisionalSession);
+  if (hookResponse && !hookResponse.ok) {
+    return { type: 'response', response: hookResponse };
+  }
+  return { type: 'session', session: sessionStore.get(sessionName) ?? provisionalSession };
 }
 
 export async function handleOpenCommand(params: {

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -100,6 +100,7 @@ async function invokeResolvedReplayAction(params: {
     flags,
     runtime: resolved.runtime,
     meta: req.meta,
+    internal: req.internal,
   };
   const response =
     (await invokeReplayControl({

--- a/src/daemon/handlers/session-replay-video-recording.ts
+++ b/src/daemon/handlers/session-replay-video-recording.ts
@@ -1,0 +1,152 @@
+import path from 'node:path';
+import type { DaemonOpenLifecycle, DaemonRequest, DaemonResponse } from '../types.ts';
+import { SessionStore } from '../session-store.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { sleep } from '../../utils/timeouts.ts';
+import { handleRecordCommand } from './record-trace-recording.ts';
+import { appendReplayTestTimingEvent } from './session-test-runtime.ts';
+import { collectReplayActionArtifactPaths } from './session-replay-runtime.ts';
+
+const REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS = 1_000;
+const REPLAY_TEST_VIDEO_RECORDING_TAIL_MS = 3_000;
+
+export type ReplayTestVideoRecording = {
+  openLifecycle: DaemonOpenLifecycle | undefined;
+  startIfReady: () => Promise<DaemonResponse | undefined>;
+  finalize: (artifactPaths: Set<string>) => Promise<DaemonResponse | undefined>;
+};
+
+export function createReplayTestVideoRecording(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  artifactsDir: string | undefined;
+  tracePath: string | undefined;
+}): ReplayTestVideoRecording {
+  const { req, sessionName, logPath, sessionStore, artifactsDir, tracePath } = params;
+  const enabled = req.flags?.recordVideo === true;
+  const openLifecycle = enabled
+    ? {
+        beforeDispatch: async () => await startIfReady(),
+      }
+    : undefined;
+
+  async function startIfReady(): Promise<DaemonResponse | undefined> {
+    if (!enabled) return undefined;
+    const activeSession = sessionStore.get(sessionName);
+    if (!activeSession || activeSession.recording) return undefined;
+
+    const videoPath = artifactsDir
+      ? path.join(artifactsDir, 'recording.mp4')
+      : `./recording-${Date.now()}.mp4`;
+    appendVideoTimingEvent(tracePath, {
+      type: 'video_recording_start',
+      session: sessionName,
+      videoPath,
+    });
+    emitDiagnostic({
+      phase: 'replay_test_video_recording_start',
+      data: { session: sessionName, videoPath },
+    });
+    const startResponse = await handleRecordCommand({
+      req: {
+        token: req.token,
+        session: sessionName,
+        command: 'record',
+        positionals: ['start', videoPath],
+        flags: {},
+        meta: req.meta,
+      },
+      sessionName,
+      sessionStore,
+      logPath,
+    });
+    if (!startResponse.ok) {
+      appendVideoTimingEvent(tracePath, {
+        type: 'video_recording_start_failed',
+        session: sessionName,
+        videoPath,
+        errorCode: startResponse.error.code,
+      });
+      return startResponse;
+    }
+
+    const prerollStartedAt = Date.now();
+    await sleep(REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS);
+    appendVideoTimingEvent(tracePath, {
+      type: 'video_preroll_done',
+      session: sessionName,
+      durationMs: Date.now() - prerollStartedAt,
+      requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS,
+    });
+    emitDiagnostic({
+      phase: 'replay_test_video_recording_preroll_done',
+      durationMs: Date.now() - prerollStartedAt,
+      data: { session: sessionName, requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS },
+    });
+    return startResponse;
+  }
+
+  async function finalize(artifactPaths: Set<string>): Promise<DaemonResponse | undefined> {
+    if (!enabled) return undefined;
+    if (!sessionStore.get(sessionName)?.recording) return undefined;
+
+    appendVideoTimingEvent(tracePath, {
+      type: 'video_tail_start',
+      session: sessionName,
+      requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_TAIL_MS,
+    });
+    const tailStartedAt = Date.now();
+    await sleep(REPLAY_TEST_VIDEO_RECORDING_TAIL_MS);
+    const stopStartedAt = Date.now();
+    const stopResponse = await handleRecordCommand({
+      req: {
+        token: req.token,
+        session: sessionName,
+        command: 'record',
+        positionals: ['stop'],
+        flags: {},
+        meta: req.meta,
+      },
+      sessionName,
+      sessionStore,
+      logPath,
+    });
+    collectReplayActionArtifactPaths(stopResponse).forEach((entry) => artifactPaths.add(entry));
+    appendVideoTimingEvent(tracePath, {
+      type: 'video_recording_stop',
+      session: sessionName,
+      ok: stopResponse.ok,
+      durationMs: Date.now() - stopStartedAt,
+      tailDurationMs: stopStartedAt - tailStartedAt,
+      errorCode: stopResponse.ok ? undefined : stopResponse.error.code,
+    });
+    emitDiagnostic({
+      phase: 'replay_test_video_recording_stop',
+      durationMs: Date.now() - stopStartedAt,
+      data: {
+        session: sessionName,
+        ok: stopResponse.ok,
+        tailDurationMs: stopStartedAt - tailStartedAt,
+      },
+    });
+    return stopResponse;
+  }
+
+  return {
+    openLifecycle,
+    startIfReady,
+    finalize,
+  };
+}
+
+function appendVideoTimingEvent(
+  tracePath: string | undefined,
+  event: Record<string, unknown>,
+): void {
+  appendReplayTestTimingEvent(tracePath, {
+    ...event,
+    ts: new Date().toISOString(),
+  });
+}

--- a/src/daemon/handlers/session-replay-video-recording.ts
+++ b/src/daemon/handlers/session-replay-video-recording.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import type { DaemonOpenLifecycle, DaemonRequest, DaemonResponse } from '../types.ts';
-import { SessionStore } from '../session-store.ts';
+import type { SessionStore } from '../session-store.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import { handleRecordCommand } from './record-trace-recording.ts';
@@ -10,135 +10,132 @@ import { collectReplayActionArtifactPaths } from './session-replay-runtime.ts';
 const REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS = 1_000;
 const REPLAY_TEST_VIDEO_RECORDING_TAIL_MS = 3_000;
 
-export type ReplayTestVideoRecording = {
-  openLifecycle: DaemonOpenLifecycle | undefined;
-  startIfReady: () => Promise<DaemonResponse | undefined>;
-  finalize: (artifactPaths: Set<string>) => Promise<DaemonResponse | undefined>;
-};
+export function buildReplayTestVideoOpenLifecycle(
+  params: ReplayTestVideoRecordingParams,
+): DaemonOpenLifecycle | undefined {
+  if (params.req.flags?.recordVideo !== true) return undefined;
+  return {
+    beforeDispatch: async () => await startReplayTestVideoRecordingIfReady(params),
+  };
+}
 
-export function createReplayTestVideoRecording(params: {
+type ReplayTestVideoRecordingParams = {
   req: DaemonRequest;
   sessionName: string;
   logPath: string;
   sessionStore: SessionStore;
   artifactsDir: string | undefined;
   tracePath: string | undefined;
-}): ReplayTestVideoRecording {
+};
+
+export async function startReplayTestVideoRecordingIfReady(
+  params: ReplayTestVideoRecordingParams,
+): Promise<DaemonResponse | undefined> {
   const { req, sessionName, logPath, sessionStore, artifactsDir, tracePath } = params;
-  const enabled = req.flags?.recordVideo === true;
-  const openLifecycle = enabled
-    ? {
-        beforeDispatch: async () => await startIfReady(),
-      }
-    : undefined;
+  if (req.flags?.recordVideo !== true) return undefined;
+  const activeSession = sessionStore.get(sessionName);
+  if (!activeSession || activeSession.recording) return undefined;
 
-  async function startIfReady(): Promise<DaemonResponse | undefined> {
-    if (!enabled) return undefined;
-    const activeSession = sessionStore.get(sessionName);
-    if (!activeSession || activeSession.recording) return undefined;
-
-    const videoPath = artifactsDir
-      ? path.join(artifactsDir, 'recording.mp4')
-      : `./recording-${Date.now()}.mp4`;
+  const videoPath = artifactsDir
+    ? path.join(artifactsDir, 'recording.mp4')
+    : `./recording-${Date.now()}.mp4`;
+  appendVideoTimingEvent(tracePath, {
+    type: 'video_recording_start',
+    session: sessionName,
+    videoPath,
+  });
+  emitDiagnostic({
+    phase: 'replay_test_video_recording_start',
+    data: { session: sessionName, videoPath },
+  });
+  const startResponse = await handleRecordCommand({
+    req: {
+      token: req.token,
+      session: sessionName,
+      command: 'record',
+      positionals: ['start', videoPath],
+      flags: {},
+      meta: req.meta,
+    },
+    sessionName,
+    sessionStore,
+    logPath,
+  });
+  if (!startResponse.ok) {
     appendVideoTimingEvent(tracePath, {
-      type: 'video_recording_start',
+      type: 'video_recording_start_failed',
       session: sessionName,
       videoPath,
-    });
-    emitDiagnostic({
-      phase: 'replay_test_video_recording_start',
-      data: { session: sessionName, videoPath },
-    });
-    const startResponse = await handleRecordCommand({
-      req: {
-        token: req.token,
-        session: sessionName,
-        command: 'record',
-        positionals: ['start', videoPath],
-        flags: {},
-        meta: req.meta,
-      },
-      sessionName,
-      sessionStore,
-      logPath,
-    });
-    if (!startResponse.ok) {
-      appendVideoTimingEvent(tracePath, {
-        type: 'video_recording_start_failed',
-        session: sessionName,
-        videoPath,
-        errorCode: startResponse.error.code,
-      });
-      return startResponse;
-    }
-
-    const prerollStartedAt = Date.now();
-    await sleep(REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS);
-    appendVideoTimingEvent(tracePath, {
-      type: 'video_preroll_done',
-      session: sessionName,
-      durationMs: Date.now() - prerollStartedAt,
-      requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS,
-    });
-    emitDiagnostic({
-      phase: 'replay_test_video_recording_preroll_done',
-      durationMs: Date.now() - prerollStartedAt,
-      data: { session: sessionName, requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS },
+      errorCode: startResponse.error.code,
     });
     return startResponse;
   }
 
-  async function finalize(artifactPaths: Set<string>): Promise<DaemonResponse | undefined> {
-    if (!enabled) return undefined;
-    if (!sessionStore.get(sessionName)?.recording) return undefined;
+  const prerollStartedAt = Date.now();
+  await sleep(REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS);
+  appendVideoTimingEvent(tracePath, {
+    type: 'video_preroll_done',
+    session: sessionName,
+    durationMs: Date.now() - prerollStartedAt,
+    requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS,
+  });
+  emitDiagnostic({
+    phase: 'replay_test_video_recording_preroll_done',
+    durationMs: Date.now() - prerollStartedAt,
+    data: { session: sessionName, requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_PREROLL_MS },
+  });
+  return startResponse;
+}
 
-    appendVideoTimingEvent(tracePath, {
-      type: 'video_tail_start',
+export async function finalizeReplayTestVideoRecording(
+  params: ReplayTestVideoRecordingParams & {
+    artifactPaths: Set<string>;
+  },
+): Promise<DaemonResponse | undefined> {
+  const { req, sessionName, logPath, sessionStore, tracePath, artifactPaths } = params;
+  if (req.flags?.recordVideo !== true) return undefined;
+  if (!sessionStore.get(sessionName)?.recording) return undefined;
+
+  appendVideoTimingEvent(tracePath, {
+    type: 'video_tail_start',
+    session: sessionName,
+    requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_TAIL_MS,
+  });
+  const tailStartedAt = Date.now();
+  await sleep(REPLAY_TEST_VIDEO_RECORDING_TAIL_MS);
+  const stopStartedAt = Date.now();
+  const stopResponse = await handleRecordCommand({
+    req: {
+      token: req.token,
       session: sessionName,
-      requestedDurationMs: REPLAY_TEST_VIDEO_RECORDING_TAIL_MS,
-    });
-    const tailStartedAt = Date.now();
-    await sleep(REPLAY_TEST_VIDEO_RECORDING_TAIL_MS);
-    const stopStartedAt = Date.now();
-    const stopResponse = await handleRecordCommand({
-      req: {
-        token: req.token,
-        session: sessionName,
-        command: 'record',
-        positionals: ['stop'],
-        flags: {},
-        meta: req.meta,
-      },
-      sessionName,
-      sessionStore,
-      logPath,
-    });
-    collectReplayActionArtifactPaths(stopResponse).forEach((entry) => artifactPaths.add(entry));
-    appendVideoTimingEvent(tracePath, {
-      type: 'video_recording_stop',
+      command: 'record',
+      positionals: ['stop'],
+      flags: {},
+      meta: req.meta,
+    },
+    sessionName,
+    sessionStore,
+    logPath,
+  });
+  collectReplayActionArtifactPaths(stopResponse).forEach((entry) => artifactPaths.add(entry));
+  appendVideoTimingEvent(tracePath, {
+    type: 'video_recording_stop',
+    session: sessionName,
+    ok: stopResponse.ok,
+    durationMs: Date.now() - stopStartedAt,
+    tailDurationMs: stopStartedAt - tailStartedAt,
+    errorCode: stopResponse.ok ? undefined : stopResponse.error.code,
+  });
+  emitDiagnostic({
+    phase: 'replay_test_video_recording_stop',
+    durationMs: Date.now() - stopStartedAt,
+    data: {
       session: sessionName,
       ok: stopResponse.ok,
-      durationMs: Date.now() - stopStartedAt,
       tailDurationMs: stopStartedAt - tailStartedAt,
-      errorCode: stopResponse.ok ? undefined : stopResponse.error.code,
-    });
-    emitDiagnostic({
-      phase: 'replay_test_video_recording_stop',
-      durationMs: Date.now() - stopStartedAt,
-      data: {
-        session: sessionName,
-        ok: stopResponse.ok,
-        tailDurationMs: stopStartedAt - tailStartedAt,
-      },
-    });
-    return stopResponse;
-  }
-
-  return {
-    openLifecycle,
-    startIfReady,
-    finalize,
-  };
+    },
+  });
+  return stopResponse;
 }
 
 function appendVideoTimingEvent(

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { CommandFlags } from '../../core/dispatch.ts';
+import { sleep } from '../../utils/timeouts.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { runReplayTestSuite } from './session-test.ts';
@@ -8,6 +9,9 @@ import { handleRecordCommand } from './record-trace-recording.ts';
 import { collectReplayActionArtifactPaths, runReplayScriptFile } from './session-replay-runtime.ts';
 import type { ReplayScriptMetadata } from '../../replay/script.ts';
 import { buildReplayTestShardFlags, type ReplayTestShardContext } from './session-test-sharding.ts';
+
+const REPLAY_TEST_RECORDING_PREROLL_MS = 1_000;
+const REPLAY_TEST_RECORDING_TAIL_MS = 1_000;
 
 export function buildNestedReplayFlags(params: {
   parentFlags: CommandFlags | undefined;
@@ -70,6 +74,30 @@ async function startReplayTestRecording(params: {
   });
 }
 
+async function startReplayTestRecordingIfNeeded(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  artifactsDir: string | undefined;
+}): Promise<DaemonResponse | undefined> {
+  const { req, sessionName, logPath, sessionStore, artifactsDir } = params;
+  if (req.flags?.recordVideo !== true) return undefined;
+  const activeSession = sessionStore.get(sessionName);
+  if (!activeSession || activeSession.recording) return undefined;
+  const response = await startReplayTestRecording({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+    artifactsDir,
+  });
+  if (response.ok) {
+    await sleep(REPLAY_TEST_RECORDING_PREROLL_MS);
+  }
+  return response;
+}
+
 async function stopReplayTestRecording(params: {
   req: DaemonRequest;
   sessionName: string;
@@ -102,6 +130,7 @@ async function finalizeReplayTestRecording(params: {
   const { req, sessionName, logPath, sessionStore, artifactPaths } = params;
   if (req.flags?.recordVideo !== true) return undefined;
   if (!sessionStore.get(sessionName)?.recording) return undefined;
+  await sleep(REPLAY_TEST_RECORDING_TAIL_MS);
   const response = await stopReplayTestRecording({
     req,
     sessionName,
@@ -160,6 +189,14 @@ export async function handleSessionReplayCommands(params: {
           shard,
         });
 
+        const startRecording = async (): Promise<DaemonResponse | undefined> =>
+          await startReplayTestRecordingIfNeeded({
+            req,
+            sessionName: testSessionName,
+            logPath,
+            sessionStore,
+            artifactsDir,
+          });
         const replayResponse = await runReplayScriptFile({
           req: {
             ...req,
@@ -167,30 +204,20 @@ export async function handleSessionReplayCommands(params: {
             session: testSessionName,
             positionals: [filePath],
             flags: nestedFlags,
-            meta: requestId ? { ...(req.meta ?? {}), requestId } : req.meta,
+            meta: {
+              ...(req.meta ?? {}),
+              ...(requestId ? { requestId } : {}),
+              beforeOpenDispatch: async () => await startRecording(),
+            },
           },
           sessionName: testSessionName,
           logPath,
           sessionStore,
           tracePath,
           invoke: async (nestedReq) => {
+            const startResponse = await startRecording();
+            if (startResponse && !startResponse.ok) return startResponse;
             const response = captureArtifacts(await invoke(nestedReq));
-            const activeSession = sessionStore.get(testSessionName);
-            if (
-              response.ok &&
-              req.flags?.recordVideo === true &&
-              activeSession &&
-              !activeSession.recording
-            ) {
-              const startResponse = await startReplayTestRecording({
-                req,
-                sessionName: testSessionName,
-                logPath,
-                sessionStore,
-                artifactsDir,
-              });
-              if (!startResponse.ok) return startResponse;
-            }
             return response;
           },
         });

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -11,7 +11,7 @@ import type { ReplayScriptMetadata } from '../../replay/script.ts';
 import { buildReplayTestShardFlags, type ReplayTestShardContext } from './session-test-sharding.ts';
 
 const REPLAY_TEST_RECORDING_PREROLL_MS = 1_000;
-const REPLAY_TEST_RECORDING_TAIL_MS = 1_000;
+const REPLAY_TEST_RECORDING_TAIL_MS = 3_000;
 
 export function buildNestedReplayFlags(params: {
   parentFlags: CommandFlags | undefined;

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -1,8 +1,10 @@
+import path from 'node:path';
 import type { CommandFlags } from '../../core/dispatch.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { runReplayTestSuite } from './session-test.ts';
 import { handleCloseCommand } from './session-close.ts';
+import { handleRecordCommand } from './record-trace-recording.ts';
 import { collectReplayActionArtifactPaths, runReplayScriptFile } from './session-replay-runtime.ts';
 import type { ReplayScriptMetadata } from '../../replay/script.ts';
 import { buildReplayTestShardFlags, type ReplayTestShardContext } from './session-test-sharding.ts';
@@ -14,7 +16,8 @@ export function buildNestedReplayFlags(params: {
   artifactsDir: string | undefined;
   shard?: ReplayTestShardContext;
 }): CommandFlags | undefined {
-  const { parentFlags, platform, target, artifactsDir, shard } = params;
+  const { platform, target, artifactsDir, shard } = params;
+  const parentFlags = stripReplayTestHarnessFlags(params.parentFlags);
   if (
     platform === undefined &&
     target === undefined &&
@@ -32,6 +35,81 @@ export function buildNestedReplayFlags(params: {
     },
     shard,
   );
+}
+
+function stripReplayTestHarnessFlags(flags: CommandFlags | undefined): CommandFlags | undefined {
+  if (flags?.recordVideo !== true) return flags;
+  const nestedFlags = { ...flags };
+  delete nestedFlags.recordVideo;
+  return Object.keys(nestedFlags).length > 0 ? nestedFlags : undefined;
+}
+
+async function startReplayTestRecording(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  artifactsDir: string | undefined;
+}): Promise<DaemonResponse> {
+  const { req, sessionName, logPath, sessionStore, artifactsDir } = params;
+  const outPath = artifactsDir
+    ? path.join(artifactsDir, 'recording.mp4')
+    : `./recording-${Date.now()}.mp4`;
+  return await handleRecordCommand({
+    req: {
+      token: req.token,
+      session: sessionName,
+      command: 'record',
+      positionals: ['start', outPath],
+      flags: {},
+      meta: req.meta,
+    },
+    sessionName,
+    sessionStore,
+    logPath,
+  });
+}
+
+async function stopReplayTestRecording(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+}): Promise<DaemonResponse> {
+  const { req, sessionName, logPath, sessionStore } = params;
+  return await handleRecordCommand({
+    req: {
+      token: req.token,
+      session: sessionName,
+      command: 'record',
+      positionals: ['stop'],
+      flags: {},
+      meta: req.meta,
+    },
+    sessionName,
+    sessionStore,
+    logPath,
+  });
+}
+
+async function finalizeReplayTestRecording(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath: string;
+  sessionStore: SessionStore;
+  artifactPaths: Set<string>;
+}): Promise<DaemonResponse | undefined> {
+  const { req, sessionName, logPath, sessionStore, artifactPaths } = params;
+  if (req.flags?.recordVideo !== true) return undefined;
+  if (!sessionStore.get(sessionName)?.recording) return undefined;
+  const response = await stopReplayTestRecording({
+    req,
+    sessionName,
+    logPath,
+    sessionStore,
+  });
+  collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
+  return response;
 }
 
 export async function handleSessionReplayCommands(params: {
@@ -82,7 +160,7 @@ export async function handleSessionReplayCommands(params: {
           shard,
         });
 
-        return await runReplayScriptFile({
+        const replayResponse = await runReplayScriptFile({
           req: {
             ...req,
             command: 'replay',
@@ -95,9 +173,37 @@ export async function handleSessionReplayCommands(params: {
           logPath,
           sessionStore,
           tracePath,
-          invoke: async (nestedReq) => captureArtifacts(await invoke(nestedReq)),
+          invoke: async (nestedReq) => {
+            const response = captureArtifacts(await invoke(nestedReq));
+            const activeSession = sessionStore.get(testSessionName);
+            if (
+              response.ok &&
+              req.flags?.recordVideo === true &&
+              activeSession &&
+              !activeSession.recording
+            ) {
+              const startResponse = await startReplayTestRecording({
+                req,
+                sessionName: testSessionName,
+                logPath,
+                sessionStore,
+                artifactsDir,
+              });
+              if (!startResponse.ok) return startResponse;
+            }
+            return response;
+          },
         });
+        return replayResponse;
       },
+      finalizeAttempt: async ({ sessionName: testSessionName, artifactPaths }) =>
+        await finalizeReplayTestRecording({
+          req,
+          sessionName: testSessionName,
+          logPath,
+          sessionStore,
+          artifactPaths,
+        }),
       cleanupSession: async (testSessionName) => {
         if (!sessionStore.get(testSessionName)) return;
         await handleCloseCommand({

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -1,17 +1,15 @@
-import path from 'node:path';
 import type { CommandFlags } from '../../core/dispatch.ts';
-import { sleep } from '../../utils/timeouts.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { runReplayTestSuite } from './session-test.ts';
 import { handleCloseCommand } from './session-close.ts';
-import { handleRecordCommand } from './record-trace-recording.ts';
 import { collectReplayActionArtifactPaths, runReplayScriptFile } from './session-replay-runtime.ts';
 import type { ReplayScriptMetadata } from '../../replay/script.ts';
 import { buildReplayTestShardFlags, type ReplayTestShardContext } from './session-test-sharding.ts';
-
-const REPLAY_TEST_RECORDING_PREROLL_MS = 1_000;
-const REPLAY_TEST_RECORDING_TAIL_MS = 3_000;
+import {
+  createReplayTestVideoRecording,
+  type ReplayTestVideoRecording,
+} from './session-replay-video-recording.ts';
 
 export function buildNestedReplayFlags(params: {
   parentFlags: CommandFlags | undefined;
@@ -48,99 +46,6 @@ function stripReplayTestHarnessFlags(flags: CommandFlags | undefined): CommandFl
   return Object.keys(nestedFlags).length > 0 ? nestedFlags : undefined;
 }
 
-async function startReplayTestRecording(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath: string;
-  sessionStore: SessionStore;
-  artifactsDir: string | undefined;
-}): Promise<DaemonResponse> {
-  const { req, sessionName, logPath, sessionStore, artifactsDir } = params;
-  const outPath = artifactsDir
-    ? path.join(artifactsDir, 'recording.mp4')
-    : `./recording-${Date.now()}.mp4`;
-  return await handleRecordCommand({
-    req: {
-      token: req.token,
-      session: sessionName,
-      command: 'record',
-      positionals: ['start', outPath],
-      flags: {},
-      meta: req.meta,
-    },
-    sessionName,
-    sessionStore,
-    logPath,
-  });
-}
-
-async function startReplayTestRecordingIfNeeded(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath: string;
-  sessionStore: SessionStore;
-  artifactsDir: string | undefined;
-}): Promise<DaemonResponse | undefined> {
-  const { req, sessionName, logPath, sessionStore, artifactsDir } = params;
-  if (req.flags?.recordVideo !== true) return undefined;
-  const activeSession = sessionStore.get(sessionName);
-  if (!activeSession || activeSession.recording) return undefined;
-  const response = await startReplayTestRecording({
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-    artifactsDir,
-  });
-  if (response.ok) {
-    await sleep(REPLAY_TEST_RECORDING_PREROLL_MS);
-  }
-  return response;
-}
-
-async function stopReplayTestRecording(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath: string;
-  sessionStore: SessionStore;
-}): Promise<DaemonResponse> {
-  const { req, sessionName, logPath, sessionStore } = params;
-  return await handleRecordCommand({
-    req: {
-      token: req.token,
-      session: sessionName,
-      command: 'record',
-      positionals: ['stop'],
-      flags: {},
-      meta: req.meta,
-    },
-    sessionName,
-    sessionStore,
-    logPath,
-  });
-}
-
-async function finalizeReplayTestRecording(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath: string;
-  sessionStore: SessionStore;
-  artifactPaths: Set<string>;
-}): Promise<DaemonResponse | undefined> {
-  const { req, sessionName, logPath, sessionStore, artifactPaths } = params;
-  if (req.flags?.recordVideo !== true) return undefined;
-  if (!sessionStore.get(sessionName)?.recording) return undefined;
-  await sleep(REPLAY_TEST_RECORDING_TAIL_MS);
-  const response = await stopReplayTestRecording({
-    req,
-    sessionName,
-    logPath,
-    sessionStore,
-  });
-  collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
-  return response;
-}
-
 export async function handleSessionReplayCommands(params: {
   req: DaemonRequest;
   sessionName: string;
@@ -161,6 +66,7 @@ export async function handleSessionReplayCommands(params: {
   }
 
   if (req.command === 'test') {
+    const videoRecordings = new Map<string, ReplayTestVideoRecording>();
     return await runReplayTestSuite({
       req,
       sessionName,
@@ -189,14 +95,15 @@ export async function handleSessionReplayCommands(params: {
           shard,
         });
 
-        const startRecording = async (): Promise<DaemonResponse | undefined> =>
-          await startReplayTestRecordingIfNeeded({
-            req,
-            sessionName: testSessionName,
-            logPath,
-            sessionStore,
-            artifactsDir,
-          });
+        const videoRecording = createReplayTestVideoRecording({
+          req,
+          sessionName: testSessionName,
+          logPath,
+          sessionStore,
+          artifactsDir,
+          tracePath,
+        });
+        videoRecordings.set(testSessionName, videoRecording);
         const replayResponse = await runReplayScriptFile({
           req: {
             ...req,
@@ -207,7 +114,10 @@ export async function handleSessionReplayCommands(params: {
             meta: {
               ...(req.meta ?? {}),
               ...(requestId ? { requestId } : {}),
-              beforeOpenDispatch: async () => await startRecording(),
+            },
+            internal: {
+              ...(req.internal ?? {}),
+              openLifecycle: videoRecording.openLifecycle,
             },
           },
           sessionName: testSessionName,
@@ -215,7 +125,7 @@ export async function handleSessionReplayCommands(params: {
           sessionStore,
           tracePath,
           invoke: async (nestedReq) => {
-            const startResponse = await startRecording();
+            const startResponse = await videoRecording.startIfReady();
             if (startResponse && !startResponse.ok) return startResponse;
             const response = captureArtifacts(await invoke(nestedReq));
             return response;
@@ -224,14 +134,9 @@ export async function handleSessionReplayCommands(params: {
         return replayResponse;
       },
       finalizeAttempt: async ({ sessionName: testSessionName, artifactPaths }) =>
-        await finalizeReplayTestRecording({
-          req,
-          sessionName: testSessionName,
-          logPath,
-          sessionStore,
-          artifactPaths,
-        }),
+        await videoRecordings.get(testSessionName)?.finalize(artifactPaths),
       cleanupSession: async (testSessionName) => {
+        videoRecordings.delete(testSessionName);
         if (!sessionStore.get(testSessionName)) return;
         await handleCloseCommand({
           req: {

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -7,8 +7,9 @@ import { collectReplayActionArtifactPaths, runReplayScriptFile } from './session
 import type { ReplayScriptMetadata } from '../../replay/script.ts';
 import { buildReplayTestShardFlags, type ReplayTestShardContext } from './session-test-sharding.ts';
 import {
-  createReplayTestVideoRecording,
-  type ReplayTestVideoRecording,
+  buildReplayTestVideoOpenLifecycle,
+  finalizeReplayTestVideoRecording,
+  startReplayTestVideoRecordingIfReady,
 } from './session-replay-video-recording.ts';
 
 export function buildNestedReplayFlags(params: {
@@ -66,7 +67,6 @@ export async function handleSessionReplayCommands(params: {
   }
 
   if (req.command === 'test') {
-    const videoRecordings = new Map<string, ReplayTestVideoRecording>();
     return await runReplayTestSuite({
       req,
       sessionName,
@@ -95,15 +95,15 @@ export async function handleSessionReplayCommands(params: {
           shard,
         });
 
-        const videoRecording = createReplayTestVideoRecording({
+        const videoRecordingParams = {
           req,
           sessionName: testSessionName,
           logPath,
           sessionStore,
           artifactsDir,
           tracePath,
-        });
-        videoRecordings.set(testSessionName, videoRecording);
+        };
+        const openLifecycle = buildReplayTestVideoOpenLifecycle(videoRecordingParams);
         const replayResponse = await runReplayScriptFile({
           req: {
             ...req,
@@ -115,17 +115,21 @@ export async function handleSessionReplayCommands(params: {
               ...(req.meta ?? {}),
               ...(requestId ? { requestId } : {}),
             },
-            internal: {
-              ...(req.internal ?? {}),
-              openLifecycle: videoRecording.openLifecycle,
-            },
+            ...(req.internal || openLifecycle
+              ? {
+                  internal: {
+                    ...(req.internal ?? {}),
+                    ...(openLifecycle ? { openLifecycle } : {}),
+                  },
+                }
+              : {}),
           },
           sessionName: testSessionName,
           logPath,
           sessionStore,
           tracePath,
           invoke: async (nestedReq) => {
-            const startResponse = await videoRecording.startIfReady();
+            const startResponse = await startReplayTestVideoRecordingIfReady(videoRecordingParams);
             if (startResponse && !startResponse.ok) return startResponse;
             const response = captureArtifacts(await invoke(nestedReq));
             return response;
@@ -133,10 +137,22 @@ export async function handleSessionReplayCommands(params: {
         });
         return replayResponse;
       },
-      finalizeAttempt: async ({ sessionName: testSessionName, artifactPaths }) =>
-        await videoRecordings.get(testSessionName)?.finalize(artifactPaths),
+      finalizeAttempt: async ({
+        sessionName: testSessionName,
+        artifactPaths,
+        artifactsDir,
+        tracePath,
+      }) =>
+        await finalizeReplayTestVideoRecording({
+          req,
+          sessionName: testSessionName,
+          logPath,
+          sessionStore,
+          artifactsDir,
+          tracePath,
+          artifactPaths,
+        }),
       cleanupSession: async (testSessionName) => {
-        videoRecordings.delete(testSessionName);
         if (!sessionStore.get(testSessionName)) return;
         await handleCloseCommand({
           req: {

--- a/src/daemon/handlers/session-test-runtime.ts
+++ b/src/daemon/handlers/session-test-runtime.ts
@@ -315,7 +315,7 @@ function prepareReplayTestTimingTrace(params: {
   return tracePath;
 }
 
-function appendReplayTestTimingEvent(
+export function appendReplayTestTimingEvent(
   tracePath: string | undefined,
   event: Record<string, unknown>,
 ): void {

--- a/src/daemon/handlers/session-test-runtime.ts
+++ b/src/daemon/handlers/session-test-runtime.ts
@@ -137,7 +137,10 @@ export async function runReplayTestAttempt(
       tracePath,
     });
     if (response?.ok && finalizedResponse && !finalizedResponse.ok) {
-      response = finalizedResponse;
+      appendReplayTestWarning(
+        response,
+        `Replay test finalization failed: ${finalizedResponse.error.message}`,
+      );
     }
     const cleanupStartedAt = Date.now();
     try {
@@ -279,6 +282,17 @@ function markReplayTimeoutCleanupPending(response: DaemonResponse | undefined): 
     reason: REPLAY_TIMEOUT_CLEANUP_PENDING_REASON,
     timeoutCleanupPending: true,
   };
+}
+
+function appendReplayTestWarning(
+  response: Extract<DaemonResponse, { ok: true }>,
+  warning: string,
+): void {
+  const data = (response.data ??= {});
+  const warnings = Array.isArray(data.warnings)
+    ? data.warnings.filter((entry): entry is string => typeof entry === 'string')
+    : [];
+  data.warnings = [...warnings, warning];
 }
 
 function prepareReplayTestTimingTrace(params: {

--- a/src/daemon/handlers/session-test-runtime.ts
+++ b/src/daemon/handlers/session-test-runtime.ts
@@ -133,6 +133,7 @@ export async function runReplayTestAttempt(
       finalizeAttempt,
       sessionName,
       artifactPaths,
+      artifactsDir,
       tracePath,
     });
     if (response?.ok && finalizedResponse && !finalizedResponse.ok) {
@@ -222,9 +223,10 @@ async function finalizeReplayTestAttempt(params: {
   finalizeAttempt: ReplayTestRuntimeDependencies['finalizeAttempt'];
   sessionName: string;
   artifactPaths: Set<string>;
+  artifactsDir?: string;
   tracePath?: string;
 }): Promise<DaemonResponse | undefined> {
-  const { finalizeAttempt, sessionName, artifactPaths, tracePath } = params;
+  const { finalizeAttempt, sessionName, artifactPaths, artifactsDir, tracePath } = params;
   if (!finalizeAttempt) return undefined;
   const finalizeStartedAt = Date.now();
   appendReplayTestTimingEvent(tracePath, {
@@ -236,6 +238,8 @@ async function finalizeReplayTestAttempt(params: {
     const finalized = await finalizeAttempt({
       sessionName,
       artifactPaths,
+      artifactsDir,
+      tracePath,
     });
     appendReplayTestTimingEvent(tracePath, {
       type: 'replay_test_finalize_stop',

--- a/src/daemon/handlers/session-test-runtime.ts
+++ b/src/daemon/handlers/session-test-runtime.ts
@@ -43,6 +43,7 @@ export async function runReplayTestAttempt(
     shard,
     runReplay,
     cleanupSession,
+    finalizeAttempt,
   } = params;
   registerRequestAbort(requestId);
   const artifactPaths = new Set<string>();
@@ -105,7 +106,6 @@ export async function runReplayTestAttempt(
       durationMs: Date.now() - attemptStartedAt,
       errorCode: response.ok ? undefined : response.error.code,
     });
-    return response;
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
     if (timedOut) {
@@ -128,6 +128,15 @@ export async function runReplayTestAttempt(
           requestId,
         });
       }
+    }
+    const finalizedResponse = await finalizeReplayTestAttempt({
+      finalizeAttempt,
+      sessionName,
+      artifactPaths,
+      tracePath,
+    });
+    if (response?.ok && finalizedResponse && !finalizedResponse.ok) {
+      response = finalizedResponse;
     }
     const cleanupStartedAt = Date.now();
     try {
@@ -164,6 +173,15 @@ export async function runReplayTestAttempt(
       });
     }
   }
+  return (
+    response ?? {
+      ok: false,
+      error: {
+        code: 'COMMAND_FAILED',
+        message: 'Unknown replay test failure',
+      },
+    }
+  );
 }
 
 async function waitForReplayAfterTimeout(replayPromise: Promise<DaemonResponse>): Promise<boolean> {
@@ -197,6 +215,56 @@ async function cleanupSessionAfterLateReplay(params: {
         },
       });
     }
+  }
+}
+
+async function finalizeReplayTestAttempt(params: {
+  finalizeAttempt: ReplayTestRuntimeDependencies['finalizeAttempt'];
+  sessionName: string;
+  artifactPaths: Set<string>;
+  tracePath?: string;
+}): Promise<DaemonResponse | undefined> {
+  const { finalizeAttempt, sessionName, artifactPaths, tracePath } = params;
+  if (!finalizeAttempt) return undefined;
+  const finalizeStartedAt = Date.now();
+  appendReplayTestTimingEvent(tracePath, {
+    type: 'replay_test_finalize_start',
+    ts: new Date().toISOString(),
+    session: sessionName,
+  });
+  try {
+    const finalized = await finalizeAttempt({
+      sessionName,
+      artifactPaths,
+    });
+    appendReplayTestTimingEvent(tracePath, {
+      type: 'replay_test_finalize_stop',
+      ts: new Date().toISOString(),
+      session: sessionName,
+      ok: finalized?.ok ?? true,
+      durationMs: Date.now() - finalizeStartedAt,
+      errorCode: finalized?.ok === false ? finalized.error.code : undefined,
+    });
+    return finalized;
+  } catch (error) {
+    const appErr = normalizeError(error);
+    appendReplayTestTimingEvent(tracePath, {
+      type: 'replay_test_finalize_stop',
+      ts: new Date().toISOString(),
+      session: sessionName,
+      ok: false,
+      durationMs: Date.now() - finalizeStartedAt,
+      errorCode: appErr.code,
+    });
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'test_finalize_failed',
+      data: {
+        session: sessionName,
+        error: appErr.message,
+      },
+    });
+    return { ok: false, error: appErr };
   }
 }
 

--- a/src/daemon/handlers/session-test-types.ts
+++ b/src/daemon/handlers/session-test-types.ts
@@ -18,7 +18,13 @@ export type ReplayTestRunReplay = (params: ReplayTestRunReplayParams) => Promise
 
 export type ReplayTestCleanupSession = (sessionName: string) => Promise<void>;
 
+export type ReplayTestFinalizeAttempt = (params: {
+  sessionName: string;
+  artifactPaths: Set<string>;
+}) => Promise<DaemonResponse | undefined>;
+
 export type ReplayTestRuntimeDependencies = {
   runReplay: ReplayTestRunReplay;
   cleanupSession: ReplayTestCleanupSession;
+  finalizeAttempt?: ReplayTestFinalizeAttempt;
 };

--- a/src/daemon/handlers/session-test-types.ts
+++ b/src/daemon/handlers/session-test-types.ts
@@ -21,6 +21,8 @@ export type ReplayTestCleanupSession = (sessionName: string) => Promise<void>;
 export type ReplayTestFinalizeAttempt = (params: {
   sessionName: string;
   artifactPaths: Set<string>;
+  artifactsDir?: string;
+  tracePath?: string;
 }) => Promise<DaemonResponse | undefined>;
 
 export type ReplayTestRuntimeDependencies = {

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -38,7 +38,7 @@ export async function runReplayTestSuite(
     sessionName: string;
   } & ReplayTestRuntimeDependencies,
 ): Promise<DaemonResponse> {
-  const { req, sessionName, runReplay, cleanupSession } = params;
+  const { req, sessionName, runReplay, cleanupSession, finalizeAttempt } = params;
   if ((req.positionals?.length ?? 0) === 0) {
     return errorResponse('INVALID_ARGS', 'test requires at least one path or glob');
   }
@@ -82,6 +82,7 @@ export async function runReplayTestSuite(
           suiteTotal: shardPlan.total,
           runReplay,
           cleanupSession,
+          finalizeAttempt,
         })),
       );
     } else {
@@ -97,6 +98,7 @@ export async function runReplayTestSuite(
           suiteTotal: entries.length,
           runReplay,
           cleanupSession,
+          finalizeAttempt,
         })),
       );
     }
@@ -239,6 +241,7 @@ async function runReplayTestEntriesInDiscoveryOrder(
     suiteTotal,
     runReplay,
     cleanupSession,
+    finalizeAttempt,
   } = params;
   const results: ReplaySuiteTestResult[] = [];
   let executed = 0;
@@ -276,6 +279,7 @@ async function runReplayTestEntriesInDiscoveryOrder(
       suiteTotal,
       runReplay,
       cleanupSession,
+      finalizeAttempt,
     });
     results.push(result);
     if (flags?.failFast === true || isReplayInfrastructureFailure(result)) break;
@@ -308,6 +312,7 @@ async function runReplayTestEntries(
     shard,
     runReplay,
     cleanupSession,
+    finalizeAttempt,
   } = params;
   const results: ReplaySuiteTestResult[] = [];
   for (const [entryIndex, entry] of entries.entries()) {
@@ -326,6 +331,7 @@ async function runReplayTestEntries(
       shard,
       runReplay,
       cleanupSession,
+      finalizeAttempt,
     });
     results.push(result);
     if (flags?.failFast === true || isReplayInfrastructureFailure(result)) break;
@@ -365,6 +371,7 @@ async function runReplayTestCase(
     shard,
     runReplay,
     cleanupSession,
+    finalizeAttempt,
   } = params;
   const testStartedAt = Date.now();
   const testArtifactsDir = path.join(
@@ -412,6 +419,7 @@ async function runReplayTestCase(
       shard,
       runReplay,
       cleanupSession,
+      finalizeAttempt,
     });
     finalAttemptDurationMs = Date.now() - attemptStartedAt;
     materializeReplayTestAttemptArtifacts({

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -480,6 +480,7 @@ async function runReplayTestCase(
       artifactsDir: testArtifactsDir,
       replayed: typeof finalResponse.data?.replayed === 'number' ? finalResponse.data.replayed : 0,
       healed: typeof finalResponse.data?.healed === 'number' ? finalResponse.data.healed : 0,
+      ...replayTestWarningsResultMetadata(finalResponse.data?.warnings),
       ...replayTestShardResultMetadata(shard),
       ...(attemptFailures.length > 0 ? { attemptFailures } : {}),
     };
@@ -515,6 +516,14 @@ async function runReplayTestCase(
     error,
     ...replayTestShardResultMetadata(shard),
   };
+}
+
+function replayTestWarningsResultMetadata(
+  warnings: unknown,
+): Pick<Extract<ReplaySuiteTestResult, { status: 'passed' }>, 'warnings'> {
+  if (!Array.isArray(warnings)) return {};
+  const filtered = warnings.filter((entry): entry is string => typeof entry === 'string');
+  return filtered.length > 0 ? { warnings: filtered } : {};
 }
 
 function replayTestShardResultMetadata(

--- a/src/daemon/request-generic-dispatch.ts
+++ b/src/daemon/request-generic-dispatch.ts
@@ -166,7 +166,7 @@ async function ensureGenericCommandReady(
     session.device.platform !== 'android' ||
     !session.recording ||
     platformCommand === 'record' ||
-    (await recoverAndroidBlockingSystemDialog({ session })) !== 'failed'
+    (await recoverAndroidBlockingSystemDialog({ session })).status !== 'failed'
   ) {
     return null;
   }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -25,8 +25,14 @@ type DaemonRequestMeta = Omit<PublicDaemonRequestMeta, 'installSource' | 'lockPl
   installSource?: DaemonInstallSource;
   lockPlatform?: PlatformSelector;
   leaseBackend?: LeaseBackend;
-  /** Internal same-process hook used by replay test orchestration before platform open dispatch. */
-  beforeOpenDispatch?: (session: SessionState) => Promise<DaemonResponse | undefined>;
+};
+
+export type DaemonOpenLifecycle = {
+  beforeDispatch?: (session: SessionState) => Promise<DaemonResponse | undefined>;
+};
+
+type DaemonRequestInternal = {
+  openLifecycle?: DaemonOpenLifecycle;
 };
 
 export type DaemonRequest = Omit<PublicDaemonRequest, 'token' | 'session' | 'flags' | 'meta'> & {
@@ -34,6 +40,7 @@ export type DaemonRequest = Omit<PublicDaemonRequest, 'token' | 'session' | 'fla
   session: string;
   flags?: CommandFlags;
   meta?: DaemonRequestMeta;
+  internal?: DaemonRequestInternal;
 };
 
 export type ReplaySuiteTestSkipReason = 'skipped-by-filter';

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -56,6 +56,7 @@ export type ReplaySuiteTestPassed = {
   artifactsDir?: string;
   replayed: number;
   healed: number;
+  warnings?: string[];
   attemptFailures?: ReplaySuiteAttemptFailure[];
   shardIndex?: number;
   shardCount?: number;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -25,6 +25,8 @@ type DaemonRequestMeta = Omit<PublicDaemonRequestMeta, 'installSource' | 'lockPl
   installSource?: DaemonInstallSource;
   lockPlatform?: PlatformSelector;
   leaseBackend?: LeaseBackend;
+  /** Internal same-process hook used by replay test orchestration before platform open dispatch. */
+  beforeOpenDispatch?: (session: SessionState) => Promise<DaemonResponse | undefined>;
 };
 
 export type DaemonRequest = Omit<PublicDaemonRequest, 'token' | 'session' | 'flags' | 'meta'> & {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1033,10 +1033,17 @@ test('usageForCommand includes Maestro test suite flag', () => {
   if (help === null) throw new Error('Expected test help text');
   assert.match(help, /Run one or more replay scripts as a serial test suite/);
   assert.match(help, /--maestro/);
+  assert.match(help, /--record-video/);
   assert.match(help, /--shard-all <n>/);
   assert.match(help, /--shard-split <n>/);
   assert.match(help, /AD_SHARD_INDEX is zero-based/);
   assert.match(help, /Replay\/Test: inject or override/);
+});
+
+test('parseArgs recognizes test --record-video flag', () => {
+  const parsed = parseArgs(['test', './suite', '--record-video'], { strictFlags: true });
+  assert.equal(parsed.command, 'test');
+  assert.equal(parsed.flags.recordVideo, true);
 });
 
 test('usageForCommand documents prepare ios-runner', () => {
@@ -1494,6 +1501,7 @@ test('command usage describes test suite flags', () => {
   assert.match(help, /each shard stops independently/);
   assert.match(help, /--timeout <ms>/);
   assert.match(help, /--retries <n>/);
+  assert.match(help, /--record-video/);
   assert.match(help, /--artifacts-dir <path>/);
   assert.match(help, /test --verbose prints per-test step timings without debug logs/);
 });

--- a/src/utils/cli-command-overrides.ts
+++ b/src/utils/cli-command-overrides.ts
@@ -231,6 +231,7 @@ const CLI_COMMAND_OVERRIDES = {
       'failFast',
       'timeoutMs',
       'retries',
+      'recordVideo',
       'artifactsDir',
       'reportJunit',
       'shardAll',

--- a/src/utils/cli-flags.ts
+++ b/src/utils/cli-flags.ts
@@ -90,6 +90,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     failFast?: boolean;
     timeoutMs?: number;
     retries?: number;
+    recordVideo?: boolean;
     artifactsDir?: string;
     reportJunit?: string;
     shardAll?: number;
@@ -814,6 +815,13 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
     max: 3,
     usageLabel: '--retries <n>',
     usageDescription: 'Test: retry each failed script up to n additional times',
+  },
+  {
+    key: 'recordVideo',
+    names: ['--record-video'],
+    type: 'boolean',
+    usageLabel: '--record-video',
+    usageDescription: 'Test: record each replay attempt to recording.mp4 in its attempt artifacts',
   },
   {
     key: 'artifactsDir',


### PR DESCRIPTION
## Summary

Adds `agent-device test --record-video` so replay test attempts can record through the generated test session instead of requiring a separate `record start`/`record stop` session.

Aligns recording timing with replay execution: recording is started before platform `open` dispatch, given a short preroll, and stopped after a short tail before cleanup. Android recording-time dialog recovery now distinguishes real recovery failure from an initial snapshot inspection failure, so gestures can continue while screen recording when there is no confirmed blocking dialog.

Touched 18 files; scope stayed within the test/replay command surface, daemon replay-test orchestration/runtime, Android recording guard behavior, and focused tests.

## Validation

Focused parser/client/replay tests passed, plus the new timing/Android recovery coverage. `pnpm check:quick`, `pnpm check:fallow --base origin/main`, and `pnpm build` passed. `pnpm check:unit` passes in CI; locally, the sandboxed full unit bundle hit environment/tooling failures, and the escalated run narrowed that to unrelated mocked `xcrun`/`bundletool` timeouts outside this change.

Built the CLI and reset daemon state before live device verification. iOS simulator e2e passed with `--record-video` and produced `/private/tmp/agent-device-record-video-timing/artifacts/ios-final-after-android-fix/4c17d6ece6e6c9b3/ios-settings-navigation.ad/attempt-1/recording.mp4`; the contact sheet shows Settings navigation from the root list into General. Android emulator e2e passed with `--record-video` and produced `/private/tmp/agent-device-record-video-timing/artifacts/android-swipe-fixed/1072664493b96d4a/android-2048-swipe.ad/attempt-1/recording.mp4`; the contact sheet shows recording starts before the app launch transition, and the previously failing recording-time swipe path now passes.

All PR checks for the latest pushed commit passed: Typecheck, Unit Tests, Integration Tests, Coverage, Fallow, no test-only DI seams, Bundle Size, platform Smoke Tests, iOS Runner Swift Compatibility, and CodeQL.
