### PR TITLE
fix: stabilize Maestro replay on iOS

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           pnpm clean:daemon
           node --experimental-strip-types src/bin.ts prepare ios-runner --platform ios --timeout 300000 --json
+          pnpm clean:daemon
 
       - name: Run iOS simulator smoke replay
         run: |

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           pnpm clean:daemon
           node --experimental-strip-types src/bin.ts prepare ios-runner --platform ios --timeout 240000
+          pnpm clean:daemon
 
       - name: Run iOS command perf benchmark
         run: |

--- a/.github/workflows/replays-nightly.yml
+++ b/.github/workflows/replays-nightly.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           pnpm clean:daemon
           node --experimental-strip-types src/bin.ts prepare ios-runner --platform ios --timeout 300000 --json
+          pnpm clean:daemon
 
       - name: Run iOS simulator replay suite
         run: node --experimental-strip-types src/bin.ts test test/integration/replays/ios/simulator --retries 2 --artifacts-dir test/artifacts/replays-ios-simulator --report-junit test/artifacts/replays-ios-simulator.junit.xml

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "build": "rslib build",
-    "clean:daemon": "rm -f ~/.agent-device/daemon.json && rm -f ~/.agent-device/daemon.lock",
+    "clean:daemon": "node --experimental-strip-types scripts/clean-daemon.ts",
     "clean:xcuitest": "node scripts/clean-xcuitest-derived.mjs",
     "clean:xcuitest:ios": "node scripts/clean-xcuitest-derived.mjs ios",
     "clean:xcuitest:macos": "node scripts/clean-xcuitest-derived.mjs macos",

--- a/scripts/clean-daemon.ts
+++ b/scripts/clean-daemon.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import { resolveDaemonPaths } from '../src/daemon/config.ts';
+import { stopProcessForTakeover } from '../src/utils/process-identity.ts';
+
+const DAEMON_TERM_TIMEOUT_MS = 15_000;
+const DAEMON_KILL_TIMEOUT_MS = 2_000;
+
+type DaemonInfo = {
+  pid?: number;
+  processStartTime?: string;
+};
+
+const paths = resolveDaemonPaths(process.env.AGENT_DEVICE_STATE_DIR);
+const info = readDaemonInfo(paths.infoPath);
+
+if (info?.pid && Number.isInteger(info.pid) && info.pid > 0) {
+  await stopProcessForTakeover(info.pid, {
+    termTimeoutMs: DAEMON_TERM_TIMEOUT_MS,
+    killTimeoutMs: DAEMON_KILL_TIMEOUT_MS,
+    expectedStartTime: info.processStartTime,
+  });
+}
+
+removeIfPresent(paths.infoPath);
+removeIfPresent(paths.lockPath);
+
+function readDaemonInfo(infoPath: string): DaemonInfo | null {
+  try {
+    return JSON.parse(fs.readFileSync(infoPath, 'utf8')) as DaemonInfo;
+  } catch {
+    return null;
+  }
+}
+
+function removeIfPresent(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}

--- a/src/cli-test-progress.ts
+++ b/src/cli-test-progress.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import type { RequestProgressEvent } from './daemon/request-progress.ts';
+import { formatDurationSeconds } from './utils/duration-format.ts';
+
+export function formatReplayTestProgressEvent(event: RequestProgressEvent): string | undefined {
+  if (event.type !== 'replay-test') return undefined;
+  if (event.status === 'pass') return undefined;
+  if (event.status === 'fail' && !event.retrying) return undefined;
+
+  const name = formatReplayTestProgressName(event);
+  const durationSuffix =
+    event.durationMs !== undefined ? ` (${formatReplayProgressDuration(event)})` : '';
+  const attemptSuffix = formatReplayProgressAttemptSuffix(event);
+  const message = event.message?.replace(/\s+/g, ' ').trim();
+
+  if (event.status === 'skip') {
+    return [`SKIP ${name}`, message ? `  ${message}` : ''].filter(Boolean).join('\n');
+  }
+
+  return [
+    `FAIL ${name}${attemptSuffix}${durationSuffix}`,
+    message ? `  ${message}` : '',
+    event.artifactsDir ? `  artifacts: ${event.artifactsDir}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function formatReplayTestProgressName(event: RequestProgressEvent): string {
+  const title = event.title?.trim();
+  if (title) return JSON.stringify(title);
+  return path.basename(event.file);
+}
+
+function formatReplayProgressAttemptSuffix(event: RequestProgressEvent): string {
+  if (event.attempt === undefined) return '';
+  if (event.status === 'fail' && event.retrying && event.maxAttempts !== undefined) {
+    return ` attempt ${event.attempt}/${event.maxAttempts} retrying`;
+  }
+  if (event.attempt > 1) return ` after ${event.attempt} attempts`;
+  return '';
+}
+
+function formatReplayProgressDuration(event: RequestProgressEvent): string {
+  const duration = formatDurationSeconds(event.durationMs ?? 0);
+  return event.attempt && event.attempt > 1 && !event.retrying ? `total ${duration}` : duration;
+}

--- a/src/compat/maestro/__tests__/replay-flow.test.ts
+++ b/src/compat/maestro/__tests__/replay-flow.test.ts
@@ -642,7 +642,11 @@ test('parseMaestroReplayFlow keeps retry commands for runtime evaluation', () =>
     control.actions.map((entry) => [entry.command, entry.positionals, entry.flags]),
     [
       ['open', ['example://details'], {}],
-      ['__maestroAssertVisible', ['label="Article" || text="Article" || id="Article"', '17000'], {}],
+      [
+        '__maestroAssertVisible',
+        ['label="Article" || text="Article" || id="Article"', '17000'],
+        {},
+      ],
     ],
   );
 });

--- a/src/compat/maestro/__tests__/runtime-assertions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-assertions.test.ts
@@ -194,7 +194,10 @@ test('invokeMaestroAssertVisible does not use raw fallback for iOS snapshot miss
 
   assert.equal(response.ok, false);
   assert.ok(snapshotFlags.length > 1);
-  assert.equal(snapshotFlags.some((flags) => flags?.snapshotRaw === true), false);
+  assert.equal(
+    snapshotFlags.some((flags) => flags?.snapshotRaw === true),
+    false,
+  );
 });
 
 test('invokeMaestroAssertVisible does not use raw fallback for Android identifiers', async () => {
@@ -242,7 +245,10 @@ test('invokeMaestroAssertVisible does not use Android raw fallback for generated
   });
 
   assert.equal(response.ok, false);
-  assert.equal(snapshotFlags.some((flags) => flags?.snapshotRaw === true), false);
+  assert.equal(
+    snapshotFlags.some((flags) => flags?.snapshotRaw === true),
+    false,
+  );
 });
 
 test('invokeMaestroAssertVisible writes terminal snapshot artifacts for failed attempts', async () => {

--- a/src/compat/maestro/__tests__/runtime-flow.test.ts
+++ b/src/compat/maestro/__tests__/runtime-flow.test.ts
@@ -112,7 +112,10 @@ test('invokeMaestroRunFlowWhenControl uses regular iOS snapshots for visible con
   });
 
   assert.equal(response.ok, true);
-  assert.deepEqual(snapshotFlags.map((flags) => flags?.snapshotRaw), [undefined]);
+  assert.deepEqual(
+    snapshotFlags.map((flags) => flags?.snapshotRaw),
+    [undefined],
+  );
   assert.deepEqual(
     invokedActions.map((action) => [action.command, action.positionals]),
     [['click', ['label="Continue"']]],

--- a/src/compat/maestro/__tests__/runtime-geometry.test.ts
+++ b/src/compat/maestro/__tests__/runtime-geometry.test.ts
@@ -2,37 +2,33 @@ import { expect, test } from 'vitest';
 import { pointForMaestroTapOnTarget, swipeCoordinatesFromTarget } from '../runtime-geometry.ts';
 
 test('pointForMaestroTapOnTarget centers resolved broad text containers', () => {
-  const point = pointForMaestroTapOnTarget(
-    {
-      node: {
-        index: 5,
-        ref: 'e5',
-        type: 'scroll-area',
-        label: 'Article',
-        rect: { x: 0, y: 117, width: 402, height: 180 },
-      },
+  const point = pointForMaestroTapOnTarget({
+    node: {
+      index: 5,
+      ref: 'e5',
+      type: 'scroll-area',
+      label: 'Article',
       rect: { x: 0, y: 117, width: 402, height: 180 },
-      frame: { referenceWidth: 402, referenceHeight: 874 },
     },
-  );
+    rect: { x: 0, y: 117, width: 402, height: 180 },
+    frame: { referenceWidth: 402, referenceHeight: 874 },
+  });
 
   expect(point).toEqual({ x: 201, y: 207 });
 });
 
 test('pointForMaestroTapOnTarget centers tall Android bottom-tab containers', () => {
-  const point = pointForMaestroTapOnTarget(
-    {
-      node: {
-        index: 40,
-        ref: 'e41',
-        type: 'android.widget.FrameLayout',
-        label: 'Albums',
-        rect: { x: 540, y: 2054, width: 270, height: 220 },
-      },
+  const point = pointForMaestroTapOnTarget({
+    node: {
+      index: 40,
+      ref: 'e41',
+      type: 'android.widget.FrameLayout',
+      label: 'Albums',
       rect: { x: 540, y: 2054, width: 270, height: 220 },
-      frame: { referenceWidth: 1080, referenceHeight: 2340 },
     },
-  );
+    rect: { x: 540, y: 2054, width: 270, height: 220 },
+    frame: { referenceWidth: 1080, referenceHeight: 2340 },
+  });
 
   expect(point).toEqual({ x: 675, y: 2164 });
 });

--- a/src/compat/maestro/__tests__/runtime-interactions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-interactions.test.ts
@@ -23,7 +23,7 @@ test('invokeMaestroTapOn resolves mutating taps from the current snapshot', asyn
   expect(clickFlags[0]?.interactionOutcome).toBeUndefined();
 });
 
-test('invokeMaestroTapOn uses regular snapshots by default', async () => {
+test('invokeMaestroTapOn uses raw snapshots for target resolution', async () => {
   const snapshotFlags: Array<DaemonRequest['flags']> = [];
   const response = await invokeMaestroTapOn({
     baseReq: {
@@ -48,11 +48,42 @@ test('invokeMaestroTapOn uses regular snapshots by default', async () => {
   expect(snapshotFlags).toHaveLength(1);
   expect(snapshotFlags[0]?.noRecord).toBe(true);
   expect(snapshotFlags[0]?.snapshotInteractiveOnly).toBeUndefined();
-  expect(snapshotFlags[0]?.snapshotRaw).toBeUndefined();
+  expect(snapshotFlags[0]?.snapshotRaw).toBe(true);
   expect(snapshotFlags[0]?.snapshotForceFull).toBeUndefined();
 });
 
-test('invokeMaestroTapOn does not use raw fallback for regular snapshot misses', async () => {
+test('invokeMaestroTapOn resolves drawer targets from raw snapshots', async () => {
+  const snapshotFlags: Array<DaemonRequest['flags']> = [];
+  const clicks: string[][] = [];
+  const response = await invokeMaestroTapOn({
+    baseReq: {
+      token: 'test',
+      session: 'drawer',
+      flags: { platform: 'ios' },
+    },
+    positionals: ['label="Feed" || text="Feed" || id="Feed"'],
+    invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
+      if (req.command === 'snapshot') {
+        snapshotFlags.push(req.flags);
+        return {
+          ok: true,
+          data: req.flags?.snapshotRaw === true ? drawerRawSnapshot() : pagesOnlySnapshot(),
+        };
+      }
+      if (req.command === 'click') {
+        clicks.push(req.positionals ?? []);
+        return { ok: true, data: {} };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  expect(response.ok).toBe(true);
+  expect(snapshotFlags.map((flags) => flags?.snapshotRaw)).toEqual([true]);
+  expect(clicks).toEqual([['201', '202']]);
+});
+
+test('invokeMaestroTapOn retries raw target snapshots without interactive fallback', async () => {
   vi.useFakeTimers();
   const snapshotFlags: Array<DaemonRequest['flags']> = [];
   const responsePromise = invokeMaestroTapOn({
@@ -78,7 +109,7 @@ test('invokeMaestroTapOn does not use raw fallback for regular snapshot misses',
     expect(response.ok).toBe(false);
     expect(snapshotFlags.length).toBeGreaterThan(1);
     expect(snapshotFlags.some((flags) => flags?.snapshotInteractiveOnly === true)).toBe(false);
-    expect(snapshotFlags.some((flags) => flags?.snapshotRaw === true)).toBe(false);
+    expect(snapshotFlags.every((flags) => flags?.snapshotRaw === true)).toBe(true);
   } finally {
     vi.useRealTimers();
   }
@@ -176,7 +207,7 @@ test('invokeMaestroTapOn resolves visible Android non-interactive text from a re
   expect(response.ok).toBe(true);
   expect(snapshotFlags).toHaveLength(1);
   expect(snapshotFlags[0]?.snapshotInteractiveOnly).toBeUndefined();
-  expect(snapshotFlags[0]?.snapshotRaw).toBeUndefined();
+  expect(snapshotFlags[0]?.snapshotRaw).toBe(true);
   expect(clicks).toEqual([['248', '231']]);
 });
 
@@ -304,7 +335,7 @@ test('invokeMaestroSwipeOn resolves visible non-interactive text from a regular 
   expect(response.ok).toBe(true);
   expect(snapshotFlags).toHaveLength(1);
   expect(snapshotFlags[0]?.snapshotInteractiveOnly).toBeUndefined();
-  expect(snapshotFlags[0]?.snapshotRaw).toBeUndefined();
+  expect(snapshotFlags[0]?.snapshotRaw).toBe(true);
   expect(swipes).toEqual([['200', '250', '8', '250', '300']]);
 });
 
@@ -412,6 +443,104 @@ function currentBreadcrumbSnapshot(): SnapshotState {
         depth: 5,
         parentIndex: 2,
         rect: { x: 8, y: 65.33333587646484, width: 155, height: 48 },
+      },
+    ],
+  };
+}
+
+function pagesOnlySnapshot(): SnapshotState {
+  return {
+    createdAt: Date.now(),
+    nodes: [
+      appNode(),
+      windowNode(),
+      {
+        index: 2,
+        ref: 'e3',
+        type: 'StaticText',
+        label: 'Pages',
+        depth: 4,
+        parentIndex: 1,
+        rect: {
+          x: 176.6666717529297,
+          y: 75.66666603088379,
+          width: 48.666656494140625,
+          height: 20.333335876464844,
+        },
+      },
+    ],
+  };
+}
+
+function drawerRawSnapshot(): SnapshotState {
+  return {
+    createdAt: Date.now(),
+    nodes: [
+      appNode(),
+      windowNode(),
+      {
+        index: 2,
+        ref: 'e3',
+        type: 'StaticText',
+        label: 'Pages',
+        depth: 4,
+        parentIndex: 1,
+        rect: {
+          x: 176.6666717529297,
+          y: 75.66666603088379,
+          width: 48.666656494140625,
+          height: 20.333335876464844,
+        },
+      },
+      {
+        index: 3,
+        ref: 'e4',
+        type: 'ScrollView',
+        label: 'Article',
+        depth: 4,
+        parentIndex: 1,
+        rect: { x: 0, y: 116.66666412353516, width: 402, height: 757.3333333333333 },
+      },
+      {
+        index: 4,
+        ref: 'e5',
+        type: 'Button',
+        label: 'Article',
+        depth: 5,
+        parentIndex: 3,
+        rect: { x: 12, y: 120.66666412353516, width: 378, height: 54.00000762939453 },
+      },
+      {
+        index: 5,
+        ref: 'e6',
+        type: 'Button',
+        label: 'Feed',
+        depth: 5,
+        parentIndex: 3,
+        rect: { x: 12, y: 174.66666412353516, width: 378, height: 54 },
+      },
+      {
+        index: 6,
+        ref: 'e7',
+        type: 'Button',
+        label: 'Albums',
+        depth: 5,
+        parentIndex: 3,
+        rect: { x: 12, y: 228.66666412353516, width: 378, height: 53.99998474121094 },
+      },
+      {
+        index: 7,
+        ref: 'e8',
+        type: 'StaticText',
+        label: 'Feed',
+        depth: 4,
+        parentIndex: 1,
+        rect: {
+          x: 181.3333282470703,
+          y: 75.66666603088379,
+          width: 39.333343505859375,
+          height: 20.333335876464844,
+        },
       },
     ],
   };

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -94,7 +94,12 @@ async function invokeNativeMaestroVisibleWaitWithSnapshotFallback(
     );
   }
 
-  return await invokeSingleSnapshotMaestroAssertVisible(params, args, nativeResponse, nativeStartedAt);
+  return await invokeSingleSnapshotMaestroAssertVisible(
+    params,
+    args,
+    nativeResponse,
+    nativeStartedAt,
+  );
 }
 
 async function runNativeVisibleWait(
@@ -221,10 +226,7 @@ function isReactNativeOverlayBlockingAssertion(response: DaemonResponse): boolea
   );
 }
 
-function readNativeVisibleWaitQuery(
-  baseReq: ReplayBaseRequest,
-  selector: string,
-): string | null {
+function readNativeVisibleWaitQuery(baseReq: ReplayBaseRequest, selector: string): string | null {
   if (baseReq.flags?.platform !== 'ios' && baseReq.flags?.platform !== 'android') return null;
   return extractMaestroVisibleTextQuery(selector);
 }

--- a/src/compat/maestro/runtime-geometry.ts
+++ b/src/compat/maestro/runtime-geometry.ts
@@ -68,9 +68,10 @@ export function swipeCoordinatesFromTarget(
   }
 }
 
-export function pointForMaestroTapOnTarget(
-  target: MaestroSnapshotTarget,
-): { x: number; y: number } {
+export function pointForMaestroTapOnTarget(target: MaestroSnapshotTarget): {
+  x: number;
+  y: number;
+} {
   return pointInsideRect(target.rect);
 }
 

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -520,7 +520,7 @@ async function resolveMaestroInteractionTarget(
 ): Promise<
   { ok: true; target: ResolvedMaestroInteractionTarget } | { ok: false; response: DaemonResponse }
 > {
-  const snapshotResponse = await captureMaestroSnapshot(params);
+  const snapshotResponse = await captureMaestroSnapshot({ ...params, raw: true });
   return resolveMaestroInteractionTargetFromResponse(
     params,
     selector,

--- a/src/daemon-client-progress.ts
+++ b/src/daemon-client-progress.ts
@@ -3,15 +3,15 @@ import { AppError } from './utils/errors.ts';
 import type { DaemonRequest } from './daemon/types.ts';
 import type { RequestProgressEvent } from './daemon/request-progress.ts';
 import { consumeTextLines } from './utils/line-stream.ts';
+import { formatReplayTestProgressEvent } from './cli-test-progress.ts';
 import {
-  formatRequestProgressEvent,
   isDaemonProgressEnvelope,
   isDaemonResponseEnvelope,
   shouldStreamRequestProgress,
 } from './daemon/request-progress-protocol.ts';
 
 export function writeRequestProgressEvent(event: RequestProgressEvent): void {
-  const line = formatRequestProgressEvent(event);
+  const line = formatReplayTestProgressEvent(event);
   if (line) process.stderr.write(`${line}\n`);
 }
 

--- a/src/daemon/__tests__/selectors.test.ts
+++ b/src/daemon/__tests__/selectors.test.ts
@@ -214,7 +214,7 @@ test('parseSelectorChain decodes escaped selector string values', () => {
       'label="Switch\\nMy Community"',
       'value="A\\tB\\rC\\bD\\fE\\/F"',
       'id="item_\\u0031\\uD83D\\uDE00"',
-      'text=\'It\\\'s OK\'',
+      "text='It\\'s OK'",
     ].join(' '),
   );
 

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1893,7 +1893,10 @@ test('runReplayScriptFile runs Maestro runFlow.when.visible commands when presen
       ['find', ['Continue', 'click']],
     ],
   );
-  assert.equal(calls.find((call) => call.command === 'click')?.flags?.interactionOutcome, undefined);
+  assert.equal(
+    calls.find((call) => call.command === 'click')?.flags?.interactionOutcome,
+    undefined,
+  );
   assert.equal(
     calls.find((call) => call.command === 'click')?.flags?.postGestureStabilization,
     true,

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -39,10 +39,7 @@ vi.mock('../../../platforms/ios/apps.ts', async (importOriginal) => {
 });
 
 import { dispatchCommand } from '../../../core/dispatch.ts';
-import {
-  runIosRunnerCommand,
-  stopIosRunnerSession,
-} from '../../../platforms/ios/runner-client.ts';
+import { runIosRunnerCommand, stopIosRunnerSession } from '../../../platforms/ios/runner-client.ts';
 import { closeIosApp } from '../../../platforms/ios/apps.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);
@@ -901,27 +898,26 @@ test('captureSnapshot lazily retries pending no-change touch before returning fr
       return { clicked: true };
     }
     return {
-      nodes:
-        !pressed
-          ? baselineNodes
-          : [
-              {
-                index: 0,
-                depth: 0,
-                type: 'Button',
-                label: 'Back',
-                identifier: 'back',
-                hittable: true,
-                rect: { x: 20, y: 60, width: 90, height: 44 },
-              },
-              {
-                index: 1,
-                depth: 0,
-                type: 'StaticText',
-                label: 'Feed',
-                rect: { x: 20, y: 140, width: 160, height: 48 },
-              },
-            ],
+      nodes: !pressed
+        ? baselineNodes
+        : [
+            {
+              index: 0,
+              depth: 0,
+              type: 'Button',
+              label: 'Back',
+              identifier: 'back',
+              hittable: true,
+              rect: { x: 20, y: 60, width: 90, height: 44 },
+            },
+            {
+              index: 1,
+              depth: 0,
+              type: 'StaticText',
+              label: 'Feed',
+              rect: { x: 20, y: 140, width: 160, height: 48 },
+            },
+          ],
       backend: 'xctest',
     };
   });
@@ -936,12 +932,10 @@ test('captureSnapshot lazily retries pending no-change touch before returning fr
   expect(result.snapshot.nodes).toEqual(
     expect.arrayContaining([expect.objectContaining({ label: 'Feed' })]),
   );
-  expect(mockDispatch.mock.calls.map((call) => call[1]).filter((command) => command === 'press'))
-    .toEqual(['press']);
-  expect(mockDispatch.mock.calls.find((call) => call[1] === 'press')?.[2]).toEqual([
-    '100',
-    '144',
-  ]);
+  expect(
+    mockDispatch.mock.calls.map((call) => call[1]).filter((command) => command === 'press'),
+  ).toEqual(['press']);
+  expect(mockDispatch.mock.calls.find((call) => call[1] === 'press')?.[2]).toEqual(['100', '144']);
   expect(session.pendingInteractionOutcome).toBeUndefined();
 });
 
@@ -1050,18 +1044,17 @@ test('captureSnapshot retries pending tap outcome before post-gesture stabilizat
       return { clicked: true };
     }
     return {
-      nodes:
-        !pressed
-          ? baselineNodes
-          : [
-              {
-                index: 0,
-                depth: 0,
-                type: 'android.widget.TextView',
-                label: 'Tab Third (3)',
-                rect: { x: 390, y: 884, width: 300, height: 55 },
-              },
-            ],
+      nodes: !pressed
+        ? baselineNodes
+        : [
+            {
+              index: 0,
+              depth: 0,
+              type: 'android.widget.TextView',
+              label: 'Tab Third (3)',
+              rect: { x: 390, y: 884, width: 300, height: 55 },
+            },
+          ],
       backend: 'android',
     };
   });
@@ -1076,12 +1069,10 @@ test('captureSnapshot retries pending tap outcome before post-gesture stabilizat
   expect(result.snapshot.nodes).toEqual(
     expect.arrayContaining([expect.objectContaining({ label: 'Tab Third (3)' })]),
   );
-  expect(mockDispatch.mock.calls.map((call) => call[1]).filter((command) => command === 'press'))
-    .toEqual(['press']);
-  expect(mockDispatch.mock.calls.find((call) => call[1] === 'press')?.[2]).toEqual([
-    '540',
-    '1356',
-  ]);
+  expect(
+    mockDispatch.mock.calls.map((call) => call[1]).filter((command) => command === 'press'),
+  ).toEqual(['press']);
+  expect(mockDispatch.mock.calls.find((call) => call[1] === 'press')?.[2]).toEqual(['540', '1356']);
   expect(session.pendingInteractionOutcome).toBeUndefined();
   expect(session.postGestureStabilization).toBeUndefined();
 });

--- a/src/daemon/request-progress-protocol.ts
+++ b/src/daemon/request-progress-protocol.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-import { formatDurationSeconds } from '../utils/duration-format.ts';
 import type { DaemonRequest, DaemonResponse } from './types.ts';
 import type { RequestProgressEvent } from './request-progress.ts';
 
@@ -47,48 +45,4 @@ export function serializeDaemonResponseEnvelope(response: DaemonResponse): strin
 
 export function serializeDaemonRpcResponseEnvelope(response: unknown): string {
   return `${JSON.stringify({ type: 'response', response } satisfies DaemonResponseEnvelope<unknown>)}\n`;
-}
-
-export function formatRequestProgressEvent(event: RequestProgressEvent): string | undefined {
-  if (event.type !== 'replay-test') return undefined;
-  const name = formatReplayTestProgressName(event);
-  const durationSuffix =
-    event.durationMs !== undefined ? ` (${formatReplayProgressDuration(event)})` : '';
-  const attemptSuffix = formatReplayProgressAttemptSuffix(event);
-  const message = event.message?.replace(/\s+/g, ' ').trim();
-
-  if (event.status === 'pass') {
-    return `PASS ${name}${attemptSuffix}${durationSuffix}`;
-  }
-  if (event.status === 'skip') {
-    return [`SKIP ${name}`, message ? `  ${message}` : ''].filter(Boolean).join('\n');
-  }
-
-  return [
-    `FAIL ${name}${attemptSuffix}${durationSuffix}`,
-    message ? `  ${message}` : '',
-    event.artifactsDir ? `  artifacts: ${event.artifactsDir}` : '',
-  ]
-    .filter(Boolean)
-    .join('\n');
-}
-
-function formatReplayTestProgressName(event: RequestProgressEvent): string {
-  const title = event.title?.trim();
-  if (title) return JSON.stringify(title);
-  return path.basename(event.file);
-}
-
-function formatReplayProgressAttemptSuffix(event: RequestProgressEvent): string {
-  if (event.attempt === undefined) return '';
-  if (event.status === 'fail' && event.retrying && event.maxAttempts !== undefined) {
-    return ` attempt ${event.attempt}/${event.maxAttempts} retrying`;
-  }
-  if (event.attempt > 1) return ` after ${event.attempt} attempts`;
-  return '';
-}
-
-function formatReplayProgressDuration(event: RequestProgressEvent): string {
-  const duration = formatDurationSeconds(event.durationMs ?? 0);
-  return event.attempt && event.attempt > 1 && !event.retrying ? `total ${duration}` : duration;
 }

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -1236,6 +1236,31 @@ test('openIosApp launches iOS simulator app before opening URL', async () => {
   ]);
 });
 
+test('openIosApp launches iOS simulator app before opening https URL with launchArgs', async () => {
+  mockEnsureBootedSimulator.mockResolvedValue();
+  mockRunCmd.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+  await openIosApp(IOS_TEST_SIMULATOR, 'MyApp', {
+    appBundleId: 'com.example.app',
+    url: 'https://example.com/item/42',
+    launchArgs: ['-FeatureFlag', 'YES'],
+  });
+
+  assert.equal(mockRunCmd.mock.calls.length, 2);
+  assert.deepEqual(mockRunCmd.mock.calls[0], [
+    'xcrun',
+    ['simctl', 'launch', 'sim-1', 'com.example.app', '-FeatureFlag', 'YES'],
+    {
+      allowFailure: true,
+    },
+  ]);
+  assert.deepEqual(mockRunCmd.mock.calls[1], [
+    'xcrun',
+    ['simctl', 'openurl', 'sim-1', 'https://example.com/item/42'],
+    undefined,
+  ]);
+});
+
 test('openIosApp rejects launchArgs combined with bare URL deep link on iOS simulator', async () => {
   mockEnsureBootedSimulator.mockResolvedValue();
   await assert.rejects(

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -1211,7 +1211,32 @@ test('openIosApp appends launchArgs alongside --payload-url for iOS device deep 
   }
 });
 
-test('openIosApp rejects launchArgs combined with URL deep link on iOS simulator', async () => {
+test('openIosApp launches iOS simulator app before opening URL', async () => {
+  mockEnsureBootedSimulator.mockResolvedValue();
+  mockRunCmd.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+  await openIosApp(IOS_TEST_SIMULATOR, 'MyApp', {
+    appBundleId: 'com.example.app',
+    url: 'myapp://item/42',
+    launchArgs: ['-FeatureFlag', 'YES'],
+  });
+
+  assert.equal(mockRunCmd.mock.calls.length, 2);
+  assert.deepEqual(mockRunCmd.mock.calls[0], [
+    'xcrun',
+    ['simctl', 'launch', 'sim-1', 'com.example.app', '-FeatureFlag', 'YES'],
+    {
+      allowFailure: true,
+    },
+  ]);
+  assert.deepEqual(mockRunCmd.mock.calls[1], [
+    'xcrun',
+    ['simctl', 'openurl', 'sim-1', 'myapp://item/42'],
+    undefined,
+  ]);
+});
+
+test('openIosApp rejects launchArgs combined with bare URL deep link on iOS simulator', async () => {
   mockEnsureBootedSimulator.mockResolvedValue();
   await assert.rejects(
     () =>
@@ -1222,19 +1247,6 @@ test('openIosApp rejects launchArgs combined with URL deep link on iOS simulator
       assert.ok(error instanceof AppError);
       assert.equal(error.code, 'INVALID_ARGS');
       assert.match(String(error.message), /simctl openurl/);
-      return true;
-    },
-  );
-  await assert.rejects(
-    () =>
-      openIosApp(IOS_TEST_SIMULATOR, 'MyApp', {
-        appBundleId: 'com.example.app',
-        url: 'https://example.com/path',
-        launchArgs: ['-FeatureFlag', 'YES'],
-      }),
-    (error: unknown) => {
-      assert.ok(error instanceof AppError);
-      assert.equal(error.code, 'INVALID_ARGS');
       return true;
     },
   );

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -98,6 +98,7 @@ vi.mock('../runner-xctestrun.ts', async () => {
 });
 
 import {
+  abortAllIosRunnerSessions,
   ensureRunnerSession,
   executeRunnerCommandWithSession,
   getRunnerSessionSnapshot,
@@ -113,7 +114,8 @@ import {
   type RunnerLease,
 } from '../runner-lease.ts';
 
-beforeEach(() => {
+beforeEach(async () => {
+  await abortAllIosRunnerSessions();
   vi.resetAllMocks();
   process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = fs.mkdtempSync(
     path.join(os.tmpdir(), 'agent-device-runner-lease-test-'),
@@ -796,6 +798,25 @@ test('runner session stop kills only owned stale xcodebuild runner processes wit
   });
 });
 
+test('runner session abort removes owned lease for in-memory sessions', async () => {
+  const device = { ...IOS_SIMULATOR, id: 'runner-session-abort-lease-sim' };
+  const session = await ensureRunnerSession(device, {});
+  const leaseDir = process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR;
+  assert.ok(leaseDir);
+  const leasePath = path.join(leaseDir, `${device.id}.json`);
+  assert.equal(fs.existsSync(leasePath), true);
+
+  await abortAllIosRunnerSessions();
+
+  assert.equal(fs.existsSync(leasePath), false);
+  assert.equal(getRunnerSessionSnapshot(session.deviceId), null);
+  assert.deepEqual(mockCleanupTempFile.mock.calls, [
+    ['/tmp/session-runner.xctestrun'],
+    ['/tmp/session-runner.json'],
+  ]);
+  assert.equal(mockRedirectRelease.mock.calls.length, 1);
+});
+
 function isXcodebuildPkillCall(call: unknown[]): boolean {
   const args = call[1];
   return call[0] === 'pkill' && Array.isArray(args) && args.includes('-f');
@@ -859,23 +880,20 @@ function makeRunnerLease(
   overrides: Partial<RunnerLease> & { deviceId: string; ownerToken?: string | undefined },
 ): RunnerLease {
   const ownerToken = overrides.ownerToken ?? `owner-${process.pid}-test`;
-  return {
+  const lease: RunnerLease = {
     schemaVersion: 1,
     deviceId: overrides.deviceId,
     ownerToken,
-    ownerPid: overrides.ownerPid ?? process.pid,
-    ownerStartTime: overrides.ownerStartTime ?? RUNNER_OWNER_START_TIME,
-    sessionId: overrides.sessionId ?? `session-${overrides.deviceId}`,
-    runnerPid: overrides.runnerPid ?? 4242,
-    port: overrides.port ?? 8123,
-    xctestrunPath:
-      overrides.xctestrunPath ??
-      `/tmp/AgentDeviceRunner.env.session-${overrides.deviceId}-${ownerToken}-8123.xctestrun`,
-    jsonPath:
-      overrides.jsonPath ??
-      `/tmp/AgentDeviceRunner.env.session-${overrides.deviceId}-${ownerToken}-8123.json`,
-    createdAtMs: overrides.createdAtMs ?? Date.now(),
+    ownerPid: process.pid,
+    ownerStartTime: RUNNER_OWNER_START_TIME,
+    sessionId: `session-${overrides.deviceId}`,
+    runnerPid: 4242,
+    port: 8123,
+    xctestrunPath: `/tmp/AgentDeviceRunner.env.session-${overrides.deviceId}-${ownerToken}-8123.xctestrun`,
+    jsonPath: `/tmp/AgentDeviceRunner.env.session-${overrides.deviceId}-${ownerToken}-8123.json`,
+    createdAtMs: Date.now(),
   };
+  return { ...lease, ...overrides, ownerToken };
 }
 
 function makeBackgroundRunner(pid: number) {

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -106,9 +106,18 @@ import {
   stopRunnerSession,
   validateRunnerDevice,
 } from '../runner-session.ts';
+import {
+  RUNNER_OWNER_START_TIME,
+  RUNNER_OWNER_TOKEN,
+  writeRunnerLease,
+  type RunnerLease,
+} from '../runner-lease.ts';
 
 beforeEach(() => {
   vi.resetAllMocks();
+  process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-runner-lease-test-'),
+  );
   mockRunXcrun.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
   mockEnsureXctestrunArtifact.mockResolvedValue({
     xctestrunPath: '/tmp/base-runner.xctestrun',
@@ -579,7 +588,7 @@ test('runner session starts xcodebuild through provider seams and reuses an aliv
   });
   assert.match(
     String(mockPrepareXctestrunWithEnv.mock.calls[0]?.[2] ?? ''),
-    /^session-runner-session-start-sim-owner-\d+-8123$/,
+    /^session-runner-session-start-sim-owner-\d+-[a-f0-9]{8}-8123$/,
   );
   assert.equal(
     mockRunXcrun.mock.calls.some((call) => call[0]?.includes('bootstatus')),
@@ -598,24 +607,71 @@ test('runner session starts xcodebuild through provider seams and reuses an aliv
   await stopRunnerSession(session);
 });
 
-test('runner session startup kills only owned stale xcodebuild before launching a new runner', async () => {
+test('runner session startup kills legacy ownerless xcodebuild before launching a new runner', async () => {
   const device = { ...IOS_SIMULATOR, id: 'runner-session-startup-stale-sim' };
 
   await ensureRunnerSession(device, {});
 
-  const pkillCalls = mockRunAppleToolCommand.mock.calls.filter((call) => call[0] === 'pkill');
+  const pkillCalls = mockRunAppleToolCommand.mock.calls.filter(isXcodebuildPkillCall);
   assert.equal(pkillCalls.length, 2);
   assert.deepEqual(pkillCalls[0]?.[1]?.slice(0, 2), ['-TERM', '-f']);
   assert.deepEqual(pkillCalls[1]?.[1]?.slice(0, 2), ['-KILL', '-f']);
   assert.match(
     String(pkillCalls[0]?.[1]?.[2] ?? ''),
-    /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-runner-session-startup-stale-sim-owner-\d+-/,
+    /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-runner-session-startup-stale-sim-\[0-9\]/,
   );
   const staleCleanupCallOrder = mockRunAppleToolCommand.mock.invocationCallOrder[0];
   const runnerLaunchCallOrder = mockRunCmdBackground.mock.invocationCallOrder[0];
   assert.ok(staleCleanupCallOrder !== undefined);
   assert.ok(runnerLaunchCallOrder !== undefined);
   assert.ok(staleCleanupCallOrder < runnerLaunchCallOrder);
+});
+
+test('runner session startup rejects live foreign runner lease', async () => {
+  const device = { ...IOS_SIMULATOR, id: 'runner-session-busy-lease-sim' };
+  writeRunnerLease(
+    makeRunnerLease({
+      deviceId: device.id,
+      ownerToken: 'owner-foreign-live',
+      ownerPid: process.pid,
+      ownerStartTime: RUNNER_OWNER_START_TIME,
+    }),
+  );
+
+  await assert.rejects(
+    () => ensureRunnerSession(device, {}),
+    /already owned by another agent-device daemon/,
+  );
+
+  assert.equal(mockRunCmdBackground.mock.calls.length, 0);
+  assert.equal(
+    mockRunAppleToolCommand.mock.calls.some((call) => call[0] === 'pkill'),
+    false,
+  );
+});
+
+test('runner session startup reclaims dead foreign runner lease before launching', async () => {
+  const device = { ...IOS_SIMULATOR, id: 'runner-session-dead-lease-sim' };
+  mockIsProcessAlive.mockImplementation((pid) => pid !== 999_999_999 && pid !== 999_999_998);
+  writeRunnerLease(
+    makeRunnerLease({
+      deviceId: device.id,
+      ownerToken: 'owner-dead-foreign',
+      ownerPid: 999_999_999,
+      runnerPid: 999_999_998,
+    }),
+  );
+
+  const session = await ensureRunnerSession(device, {});
+
+  assert.equal(session.deviceId, device.id);
+  assert.equal(mockRunCmdBackground.mock.calls.length, 1);
+  const pkillCalls = mockRunAppleToolCommand.mock.calls.filter(isXcodebuildPkillCall);
+  assert.ok(pkillCalls.length >= 2);
+  assert.match(
+    String(pkillCalls[0]?.[1]?.[2] ?? ''),
+    /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-runner-session-dead-lease-sim-owner-dead-foreign-/,
+  );
 });
 
 test('runner session restarts alive runner when expected xctestrun artifact changes', async () => {
@@ -722,10 +778,11 @@ test('runner session stop sends shutdown, cleans temporary runner files, and rel
 
 test('runner session stop kills only owned stale xcodebuild runner processes without in-memory session', async () => {
   const deviceId = '11C70358-8331-4872-A0CA-F15B6859B6FC';
+  writeRunnerLease(makeRunnerLease({ deviceId, ownerToken: RUNNER_OWNER_TOKEN }));
 
   await stopIosRunnerSession(deviceId);
 
-  const pkillCalls = mockRunAppleToolCommand.mock.calls.filter((call) => call[0] === 'pkill');
+  const pkillCalls = mockRunAppleToolCommand.mock.calls.filter(isXcodebuildPkillCall);
   assert.equal(pkillCalls.length, 2);
   assert.deepEqual(pkillCalls[0]?.[1]?.slice(0, 2), ['-TERM', '-f']);
   assert.deepEqual(pkillCalls[1]?.[1]?.slice(0, 2), ['-KILL', '-f']);
@@ -738,6 +795,11 @@ test('runner session stop kills only owned stale xcodebuild runner processes wit
     timeoutMs: 2_000,
   });
 });
+
+function isXcodebuildPkillCall(call: unknown[]): boolean {
+  const args = call[1];
+  return call[0] === 'pkill' && Array.isArray(args) && args.includes('-f');
+}
 
 test('runner session invalidation skips graceful shutdown and removes stale session', async () => {
   const device = { ...IOS_SIMULATOR, id: 'runner-session-invalidate-sim' };
@@ -791,6 +853,29 @@ function makeRunnerSession(overrides: Partial<RunnerSession> = {}): RunnerSessio
     ready: true,
     ...overrides,
   } as RunnerSession;
+}
+
+function makeRunnerLease(
+  overrides: Partial<RunnerLease> & { deviceId: string; ownerToken?: string | undefined },
+): RunnerLease {
+  const ownerToken = overrides.ownerToken ?? `owner-${process.pid}-test`;
+  return {
+    schemaVersion: 1,
+    deviceId: overrides.deviceId,
+    ownerToken,
+    ownerPid: overrides.ownerPid ?? process.pid,
+    ownerStartTime: overrides.ownerStartTime ?? RUNNER_OWNER_START_TIME,
+    sessionId: overrides.sessionId ?? `session-${overrides.deviceId}`,
+    runnerPid: overrides.runnerPid ?? 4242,
+    port: overrides.port ?? 8123,
+    xctestrunPath:
+      overrides.xctestrunPath ??
+      `/tmp/AgentDeviceRunner.env.session-${overrides.deviceId}-${ownerToken}-8123.xctestrun`,
+    jsonPath:
+      overrides.jsonPath ??
+      `/tmp/AgentDeviceRunner.env.session-${overrides.deviceId}-${ownerToken}-8123.json`,
+    createdAtMs: overrides.createdAtMs ?? Date.now(),
+  };
 }
 
 function makeBackgroundRunner(pid: number) {

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -577,6 +577,10 @@ test('runner session starts xcodebuild through provider seams and reuses an aliv
   assert.deepEqual(mockPrepareXctestrunWithEnv.mock.calls[0]?.[1], {
     AGENT_DEVICE_RUNNER_PORT: '8123',
   });
+  assert.match(
+    String(mockPrepareXctestrunWithEnv.mock.calls[0]?.[2] ?? ''),
+    /^session-runner-session-start-sim-owner-\d+-8123$/,
+  );
   assert.equal(
     mockRunXcrun.mock.calls.some((call) => call[0]?.includes('bootstatus')),
     false,
@@ -594,7 +598,7 @@ test('runner session starts xcodebuild through provider seams and reuses an aliv
   await stopRunnerSession(session);
 });
 
-test('runner session startup kills stale device-scoped xcodebuild before launching a new runner', async () => {
+test('runner session startup kills only owned stale xcodebuild before launching a new runner', async () => {
   const device = { ...IOS_SIMULATOR, id: 'runner-session-startup-stale-sim' };
 
   await ensureRunnerSession(device, {});
@@ -605,7 +609,7 @@ test('runner session startup kills stale device-scoped xcodebuild before launchi
   assert.deepEqual(pkillCalls[1]?.[1]?.slice(0, 2), ['-KILL', '-f']);
   assert.match(
     String(pkillCalls[0]?.[1]?.[2] ?? ''),
-    /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-runner-session-startup-stale-sim-/,
+    /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-runner-session-startup-stale-sim-owner-\d+-/,
   );
   const staleCleanupCallOrder = mockRunAppleToolCommand.mock.invocationCallOrder[0];
   const runnerLaunchCallOrder = mockRunCmdBackground.mock.invocationCallOrder[0];
@@ -716,7 +720,7 @@ test('runner session stop sends shutdown, cleans temporary runner files, and rel
   assert.equal(getRunnerSessionSnapshot(device.id), null);
 });
 
-test('runner session stop kills stale device-scoped xcodebuild runner processes without in-memory session', async () => {
+test('runner session stop kills only owned stale xcodebuild runner processes without in-memory session', async () => {
   const deviceId = '11C70358-8331-4872-A0CA-F15B6859B6FC';
 
   await stopIosRunnerSession(deviceId);
@@ -727,7 +731,7 @@ test('runner session stop kills stale device-scoped xcodebuild runner processes 
   assert.deepEqual(pkillCalls[1]?.[1]?.slice(0, 2), ['-KILL', '-f']);
   assert.match(
     String(pkillCalls[0]?.[1]?.[2] ?? ''),
-    /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-11C70358-8331-4872-A0CA-F15B6859B6FC-/,
+    /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-11C70358-8331-4872-A0CA-F15B6859B6FC-owner-\d+-/,
   );
   assert.deepEqual(pkillCalls[0]?.[2], {
     allowFailure: true,

--- a/src/platforms/ios/__tests__/runner-xctestrun.test.ts
+++ b/src/platforms/ios/__tests__/runner-xctestrun.test.ts
@@ -249,7 +249,7 @@ test('setup metadata script matches expected iOS simulator cache metadata', asyn
       restoreEnvVar('PATH', previousPath);
     }
   });
-});
+}, 15_000);
 
 function writeExecutable(filePath: string, contents: string): void {
   fs.writeFileSync(filePath, `${contents}\n`, { mode: 0o755 });

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -200,7 +200,11 @@ export async function openIosApp(
       throw new AppError('INVALID_ARGS', 'open <app> <url> requires a valid URL target');
     }
     if (device.kind === 'simulator') {
-      await openIosSimulatorUrl(device, explicitUrl, launchArgs);
+      const bundleId = options?.appBundleId ?? (await resolveIosApp(device, app));
+      await launchIosSimulatorApp(device, bundleId, {
+        ...(launchArgs ? { launchArgs } : {}),
+      });
+      await openIosSimulatorUrl(device, explicitUrl, undefined);
       return;
     }
     const appBundleId = options?.appBundleId ?? (await resolveIosApp(device, app));

--- a/src/platforms/ios/runner-lease.ts
+++ b/src/platforms/ios/runner-lease.ts
@@ -1,0 +1,183 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { acquireProcessLock } from '../../utils/process-lock.ts';
+import { isProcessAlive, readProcessStartTime } from '../../utils/process-identity.ts';
+
+const RUNNER_LEASE_SCHEMA_VERSION = 1;
+const RUNNER_LEASE_LOCK_TIMEOUT_MS = 30_000;
+const RUNNER_LEASE_LOCK_POLL_MS = 100;
+const RUNNER_LEASE_OWNER_GRACE_MS = 5_000;
+
+export const RUNNER_OWNER_PID = process.pid;
+export const RUNNER_OWNER_START_TIME = readProcessStartTime(process.pid);
+export const RUNNER_OWNER_TOKEN = buildRunnerOwnerToken(RUNNER_OWNER_PID, RUNNER_OWNER_START_TIME);
+
+export type RunnerLease = {
+  schemaVersion: 1;
+  deviceId: string;
+  ownerToken: string;
+  ownerPid: number;
+  ownerStartTime: string | null;
+  sessionId: string;
+  runnerPid: number | null;
+  port: number;
+  xctestrunPath: string;
+  jsonPath: string;
+  createdAtMs: number;
+};
+
+export type RunnerLeaseState =
+  | { type: 'empty' }
+  | { type: 'owned'; lease: RunnerLease }
+  | { type: 'stale'; lease: RunnerLease }
+  | { type: 'busy'; lease: RunnerLease };
+
+export function buildRunnerLease(params: {
+  deviceId: string;
+  sessionId: string;
+  runnerPid: number | undefined;
+  port: number;
+  xctestrunPath: string;
+  jsonPath: string;
+}): RunnerLease {
+  return {
+    schemaVersion: RUNNER_LEASE_SCHEMA_VERSION,
+    deviceId: params.deviceId,
+    ownerToken: RUNNER_OWNER_TOKEN,
+    ownerPid: RUNNER_OWNER_PID,
+    ownerStartTime: RUNNER_OWNER_START_TIME,
+    sessionId: params.sessionId,
+    runnerPid: params.runnerPid ?? null,
+    port: params.port,
+    xctestrunPath: params.xctestrunPath,
+    jsonPath: params.jsonPath,
+    createdAtMs: Date.now(),
+  };
+}
+
+export async function withRunnerLeaseLock<T>(deviceId: string, task: () => Promise<T>): Promise<T> {
+  const release = await acquireProcessLock({
+    lockDirPath: `${resolveRunnerLeasePath(deviceId)}.lock`,
+    owner: {
+      pid: RUNNER_OWNER_PID,
+      startTime: RUNNER_OWNER_START_TIME,
+      acquiredAtMs: Date.now(),
+    },
+    timeoutMs: RUNNER_LEASE_LOCK_TIMEOUT_MS,
+    pollMs: RUNNER_LEASE_LOCK_POLL_MS,
+    ownerGraceMs: RUNNER_LEASE_OWNER_GRACE_MS,
+    description: `iOS runner lease for ${deviceId}`,
+  });
+  try {
+    return await task();
+  } finally {
+    await release();
+  }
+}
+
+export function readRunnerLease(deviceId: string): RunnerLease | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(resolveRunnerLeasePath(deviceId), 'utf8')) as unknown;
+    return normalizeRunnerLease(parsed, deviceId);
+  } catch {
+    return null;
+  }
+}
+
+export function classifyRunnerLease(lease: RunnerLease | null): RunnerLeaseState {
+  if (!lease) return { type: 'empty' };
+  if (lease.ownerToken === RUNNER_OWNER_TOKEN) return { type: 'owned', lease };
+  return isRunnerLeaseOwnerAlive(lease) ? { type: 'busy', lease } : { type: 'stale', lease };
+}
+
+export function writeRunnerLease(lease: RunnerLease): void {
+  const leasePath = resolveRunnerLeasePath(lease.deviceId);
+  fs.mkdirSync(path.dirname(leasePath), { recursive: true });
+  const tmpPath = `${leasePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(lease, null, 2), 'utf8');
+  fs.renameSync(tmpPath, leasePath);
+}
+
+export function removeRunnerLease(params: {
+  deviceId: string;
+  ownerToken?: string;
+  sessionId?: string;
+}): void {
+  const lease = readRunnerLease(params.deviceId);
+  if (!lease) return;
+  if (params.ownerToken && lease.ownerToken !== params.ownerToken) return;
+  if (params.sessionId && lease.sessionId !== params.sessionId) return;
+  try {
+    fs.unlinkSync(resolveRunnerLeasePath(params.deviceId));
+  } catch {}
+}
+
+export function resolveRunnerLeasePath(deviceId: string): string {
+  return path.join(resolveRunnerLeaseRoot(), `${sanitizeLeaseFileName(deviceId)}.json`);
+}
+
+function resolveRunnerLeaseRoot(): string {
+  const override = process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR?.trim();
+  if (override) return path.resolve(override);
+  return path.join(os.homedir(), '.agent-device', 'ios-runner', 'leases');
+}
+
+function normalizeRunnerLease(value: unknown, deviceId: string): RunnerLease | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const raw = value as Partial<RunnerLease>;
+  if (raw.schemaVersion !== RUNNER_LEASE_SCHEMA_VERSION) return null;
+  if (raw.deviceId !== deviceId) return null;
+  const ownerToken = raw.ownerToken;
+  const ownerPid = raw.ownerPid;
+  const sessionId = raw.sessionId;
+  const port = raw.port;
+  const runnerPid = raw.runnerPid;
+  const xctestrunPath = raw.xctestrunPath;
+  const jsonPath = raw.jsonPath;
+  const createdAtMs = raw.createdAtMs;
+  if (typeof ownerToken !== 'string' || ownerToken.length === 0) return null;
+  if (typeof ownerPid !== 'number' || !Number.isInteger(ownerPid) || ownerPid <= 0) return null;
+  if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
+  if (typeof port !== 'number' || !Number.isInteger(port) || port <= 0) return null;
+  if (typeof xctestrunPath !== 'string' || xctestrunPath.length === 0) return null;
+  if (typeof jsonPath !== 'string' || jsonPath.length === 0) return null;
+  if (typeof createdAtMs !== 'number' || !Number.isFinite(createdAtMs)) return null;
+  return {
+    schemaVersion: RUNNER_LEASE_SCHEMA_VERSION,
+    deviceId: raw.deviceId,
+    ownerToken,
+    ownerPid,
+    ownerStartTime: typeof raw.ownerStartTime === 'string' ? raw.ownerStartTime : null,
+    sessionId,
+    runnerPid:
+      typeof runnerPid === 'number' && Number.isInteger(runnerPid) && runnerPid > 0
+        ? runnerPid
+        : null,
+    port,
+    xctestrunPath,
+    jsonPath,
+    createdAtMs,
+  };
+}
+
+function isRunnerLeaseOwnerAlive(lease: RunnerLease): boolean {
+  if (!isProcessAlive(lease.ownerPid)) return false;
+  if (lease.ownerStartTime) {
+    return readProcessStartTime(lease.ownerPid) === lease.ownerStartTime;
+  }
+  return true;
+}
+
+function buildRunnerOwnerToken(pid: number, startTime: string | null): string {
+  const hash = crypto.createHash('sha256');
+  hash.update(String(pid));
+  hash.update('\0');
+  hash.update(startTime ?? 'unknown-start');
+  return `owner-${pid}-${hash.digest('hex').slice(0, 8)}`;
+}
+
+function sanitizeLeaseFileName(value: string): string {
+  return value.replaceAll(/[^A-Za-z0-9._-]/g, '-') || 'unknown-device';
+}

--- a/src/platforms/ios/runner-lease.ts
+++ b/src/platforms/ios/runner-lease.ts
@@ -2,6 +2,8 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { AppError } from '../../utils/errors.ts';
 import { acquireProcessLock } from '../../utils/process-lock.ts';
 import { isProcessAlive, readProcessStartTime } from '../../utils/process-identity.ts';
 
@@ -10,7 +12,7 @@ const RUNNER_LEASE_LOCK_TIMEOUT_MS = 30_000;
 const RUNNER_LEASE_LOCK_POLL_MS = 100;
 const RUNNER_LEASE_OWNER_GRACE_MS = 5_000;
 
-export const RUNNER_OWNER_PID = process.pid;
+const RUNNER_OWNER_PID = process.pid;
 export const RUNNER_OWNER_START_TIME = readProcessStartTime(process.pid);
 export const RUNNER_OWNER_TOKEN = buildRunnerOwnerToken(RUNNER_OWNER_PID, RUNNER_OWNER_START_TIME);
 
@@ -28,11 +30,22 @@ export type RunnerLease = {
   createdAtMs: number;
 };
 
-export type RunnerLeaseState =
+type RunnerLeaseState =
   | { type: 'empty' }
   | { type: 'owned'; lease: RunnerLease }
   | { type: 'stale'; lease: RunnerLease }
   | { type: 'busy'; lease: RunnerLease };
+
+type RunnerLeaseRequiredFields = Pick<
+  RunnerLease,
+  'createdAtMs' | 'jsonPath' | 'ownerPid' | 'ownerToken' | 'port' | 'sessionId' | 'xctestrunPath'
+>;
+
+export type RunnerLeaseCleanupAdapter = {
+  cleanupRunnerProcessTree(pid: number | undefined, signal: 'SIGTERM' | 'SIGKILL'): Promise<void>;
+  cleanupRunnerXcodebuildProcesses(deviceId: string, ownerToken: string | undefined): Promise<void>;
+  cleanupTempFile(filePath: string): void;
+};
 
 export function buildRunnerLease(params: {
   deviceId: string;
@@ -77,7 +90,7 @@ export async function withRunnerLeaseLock<T>(deviceId: string, task: () => Promi
   }
 }
 
-export function readRunnerLease(deviceId: string): RunnerLease | null {
+function readRunnerLease(deviceId: string): RunnerLease | null {
   try {
     const parsed = JSON.parse(fs.readFileSync(resolveRunnerLeasePath(deviceId), 'utf8')) as unknown;
     return normalizeRunnerLease(parsed, deviceId);
@@ -86,10 +99,55 @@ export function readRunnerLease(deviceId: string): RunnerLease | null {
   }
 }
 
-export function classifyRunnerLease(lease: RunnerLease | null): RunnerLeaseState {
+function classifyRunnerLease(lease: RunnerLease | null): RunnerLeaseState {
   if (!lease) return { type: 'empty' };
   if (lease.ownerToken === RUNNER_OWNER_TOKEN) return { type: 'owned', lease };
   return isRunnerLeaseOwnerAlive(lease) ? { type: 'busy', lease } : { type: 'stale', lease };
+}
+
+export async function prepareRunnerLeaseForStartup(
+  deviceId: string,
+  cleanup: RunnerLeaseCleanupAdapter,
+): Promise<void> {
+  const state = classifyRunnerLease(readRunnerLease(deviceId));
+  if (state.type === 'empty') {
+    await cleanup.cleanupRunnerXcodebuildProcesses(deviceId, undefined);
+    return;
+  }
+  if (state.type === 'busy') {
+    throw new AppError(
+      'COMMAND_FAILED',
+      `iOS runner for ${deviceId} is already owned by another agent-device daemon`,
+      {
+        deviceId,
+        ownerPid: state.lease.ownerPid,
+        ownerStartTime: state.lease.ownerStartTime,
+        ownerToken: state.lease.ownerToken,
+        sessionId: state.lease.sessionId,
+        hint: 'Use a different simulator/session, wait for the other run to finish, or stop the owning daemon before retrying.',
+      },
+    );
+  }
+  await cleanupLeasedRunnerProcesses(state.lease, state.type, cleanup);
+}
+
+export async function cleanupOwnedRunnerLease(
+  deviceId: string,
+  cleanup: RunnerLeaseCleanupAdapter,
+): Promise<void> {
+  const state = classifyRunnerLease(readRunnerLease(deviceId));
+  if (state.type === 'owned') {
+    await cleanupLeasedRunnerProcesses(state.lease, 'owned', cleanup);
+  }
+}
+
+export function releaseRunnerLease(lease: RunnerLease | undefined): void {
+  if (!lease) return;
+  removeRunnerLease({
+    deviceId: lease.deviceId,
+    ownerToken: lease.ownerToken,
+    sessionId: lease.sessionId,
+  });
 }
 
 export function writeRunnerLease(lease: RunnerLease): void {
@@ -100,7 +158,7 @@ export function writeRunnerLease(lease: RunnerLease): void {
   fs.renameSync(tmpPath, leasePath);
 }
 
-export function removeRunnerLease(params: {
+function removeRunnerLease(params: {
   deviceId: string;
   ownerToken?: string;
   sessionId?: string;
@@ -114,7 +172,7 @@ export function removeRunnerLease(params: {
   } catch {}
 }
 
-export function resolveRunnerLeasePath(deviceId: string): string {
+function resolveRunnerLeasePath(deviceId: string): string {
   return path.join(resolveRunnerLeaseRoot(), `${sanitizeLeaseFileName(deviceId)}.json`);
 }
 
@@ -129,37 +187,47 @@ function normalizeRunnerLease(value: unknown, deviceId: string): RunnerLease | n
   const raw = value as Partial<RunnerLease>;
   if (raw.schemaVersion !== RUNNER_LEASE_SCHEMA_VERSION) return null;
   if (raw.deviceId !== deviceId) return null;
-  const ownerToken = raw.ownerToken;
-  const ownerPid = raw.ownerPid;
-  const sessionId = raw.sessionId;
-  const port = raw.port;
-  const runnerPid = raw.runnerPid;
-  const xctestrunPath = raw.xctestrunPath;
-  const jsonPath = raw.jsonPath;
-  const createdAtMs = raw.createdAtMs;
-  if (typeof ownerToken !== 'string' || ownerToken.length === 0) return null;
-  if (typeof ownerPid !== 'number' || !Number.isInteger(ownerPid) || ownerPid <= 0) return null;
-  if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
-  if (typeof port !== 'number' || !Number.isInteger(port) || port <= 0) return null;
-  if (typeof xctestrunPath !== 'string' || xctestrunPath.length === 0) return null;
-  if (typeof jsonPath !== 'string' || jsonPath.length === 0) return null;
-  if (typeof createdAtMs !== 'number' || !Number.isFinite(createdAtMs)) return null;
+  const fields = readRunnerLeaseRequiredFields(raw);
+  if (!fields) return null;
   return {
     schemaVersion: RUNNER_LEASE_SCHEMA_VERSION,
-    deviceId: raw.deviceId,
-    ownerToken,
-    ownerPid,
-    ownerStartTime: typeof raw.ownerStartTime === 'string' ? raw.ownerStartTime : null,
-    sessionId,
-    runnerPid:
-      typeof runnerPid === 'number' && Number.isInteger(runnerPid) && runnerPid > 0
-        ? runnerPid
-        : null,
-    port,
-    xctestrunPath,
-    jsonPath,
-    createdAtMs,
+    deviceId,
+    ...fields,
+    ownerStartTime: readOptionalString(raw.ownerStartTime),
+    runnerPid: readPositiveInteger(raw.runnerPid),
   };
+}
+
+function readRunnerLeaseRequiredFields(
+  raw: Partial<RunnerLease>,
+): RunnerLeaseRequiredFields | null {
+  const fields = {
+    ownerToken: readNonEmptyString(raw.ownerToken),
+    ownerPid: readPositiveInteger(raw.ownerPid),
+    sessionId: readNonEmptyString(raw.sessionId),
+    port: readPositiveInteger(raw.port),
+    xctestrunPath: readNonEmptyString(raw.xctestrunPath),
+    jsonPath: readNonEmptyString(raw.jsonPath),
+    createdAtMs: readFiniteNumber(raw.createdAtMs),
+  };
+  if (Object.values(fields).some((field) => field === null)) return null;
+  return fields as RunnerLeaseRequiredFields;
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
 function isRunnerLeaseOwnerAlive(lease: RunnerLease): boolean {
@@ -168,6 +236,31 @@ function isRunnerLeaseOwnerAlive(lease: RunnerLease): boolean {
     return readProcessStartTime(lease.ownerPid) === lease.ownerStartTime;
   }
   return true;
+}
+
+async function cleanupLeasedRunnerProcesses(
+  lease: RunnerLease,
+  reason: 'owned' | 'stale',
+  cleanup: RunnerLeaseCleanupAdapter,
+): Promise<void> {
+  emitDiagnostic({
+    level: reason === 'stale' ? 'warn' : 'debug',
+    phase: 'ios_runner_lease_cleanup',
+    data: {
+      deviceId: lease.deviceId,
+      ownerPid: lease.ownerPid,
+      ownerToken: lease.ownerToken,
+      runnerPid: lease.runnerPid,
+      sessionId: lease.sessionId,
+      reason,
+    },
+  });
+  await cleanup.cleanupRunnerProcessTree(lease.runnerPid ?? undefined, 'SIGTERM');
+  await cleanup.cleanupRunnerXcodebuildProcesses(lease.deviceId, lease.ownerToken);
+  await cleanup.cleanupRunnerProcessTree(lease.runnerPid ?? undefined, 'SIGKILL');
+  cleanup.cleanupTempFile(lease.xctestrunPath);
+  cleanup.cleanupTempFile(lease.jsonPath);
+  releaseRunnerLease(lease);
 }
 
 function buildRunnerOwnerToken(pid: number, startTime: string | null): string {

--- a/src/platforms/ios/runner-lifecycle.ts
+++ b/src/platforms/ios/runner-lifecycle.ts
@@ -75,9 +75,17 @@ async function runPrepareAttempt(params: {
   });
   const connectMs = Date.now() - connectStartedAt;
   try {
-    const result = await runPrepareHealthCheck(device, session, command, options, signal, connectMs, {
-      recoveryReason,
-    });
+    const result = await runPrepareHealthCheck(
+      device,
+      session,
+      command,
+      options,
+      signal,
+      connectMs,
+      {
+        recoveryReason,
+      },
+    );
     return { kind: 'prepared', result: recordPrepareResult(device, result) };
   } catch (error) {
     return await handlePrepareHealthFailure({
@@ -186,10 +194,7 @@ async function recoverBadCachedRunnerArtifact(params: {
     });
     return recordPrepareResult(device, recovered);
   } catch (retryErr) {
-    await invalidateRunnerSessionBestEffort(
-      rebuiltSession,
-      'prepare_rebuilt_runner_health_failed',
-    );
+    await invalidateRunnerSessionBestEffort(rebuiltSession, 'prepare_rebuilt_runner_health_failed');
     const wrapped = wrapPrepareHealthFailure(retryErr, rebuiltSession, reason);
     emitPrepareDiagnostic(device, {
       cache: rebuiltSession.xctestrunArtifact?.cache,

--- a/src/platforms/ios/runner-session-types.ts
+++ b/src/platforms/ios/runner-session-types.ts
@@ -1,6 +1,7 @@
 import type { ExecResult, ExecBackgroundResult } from '../../utils/exec.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import type { RunnerXctestrunArtifact } from './runner-xctestrun.ts';
+import type { RunnerLease } from './runner-lease.ts';
 
 export type RunnerSession = {
   sessionId: string;
@@ -17,4 +18,5 @@ export type RunnerSession = {
   startupTimings?: Record<string, number>;
   startupTimingsReported?: boolean;
   simulatorSetRedirect?: { release: () => Promise<void> };
+  lease?: RunnerLease;
 };

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -34,13 +34,13 @@ import {
 } from './runner-contract.ts';
 import {
   buildRunnerLease,
-  classifyRunnerLease,
-  readRunnerLease,
-  removeRunnerLease,
+  cleanupOwnedRunnerLease,
+  prepareRunnerLeaseForStartup,
+  releaseRunnerLease,
   RUNNER_OWNER_TOKEN,
   withRunnerLeaseLock,
   writeRunnerLease,
-  type RunnerLease,
+  type RunnerLeaseCleanupAdapter,
 } from './runner-lease.ts';
 import type { RunnerSession } from './runner-session-types.ts';
 
@@ -65,6 +65,11 @@ const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 1_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 const RUNNER_STALE_BUNDLE_UNINSTALL_TIMEOUT_MS = 10_000;
 const RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS = 2_000;
+const runnerLeaseCleanupAdapter: RunnerLeaseCleanupAdapter = {
+  cleanupRunnerProcessTree: killRunnerProcessTree,
+  cleanupRunnerXcodebuildProcesses: killRunnerXcodebuildProcesses,
+  cleanupTempFile,
+};
 
 type RunnerReadinessPreflightDecision =
   | {
@@ -104,7 +109,7 @@ async function startRunnerSessionWithLease(
 ): Promise<RunnerSession> {
   const startupTimings: Record<string, number> = {};
   await measureRunnerStartupStep(startupTimings, 'cleanup_stale_xcodebuild', async () => {
-    await prepareRunnerLeaseForStartup(device.id);
+    await prepareRunnerLeaseForStartup(device.id, runnerLeaseCleanupAdapter);
   });
   await measureRunnerStartupStep(startupTimings, 'ensure_booted', async () => {
     await ensureBootedIfNeeded(device);
@@ -277,29 +282,6 @@ async function resolveReusableRunnerSession(
   return existing;
 }
 
-async function prepareRunnerLeaseForStartup(deviceId: string): Promise<void> {
-  const state = classifyRunnerLease(readRunnerLease(deviceId));
-  if (state.type === 'empty') {
-    await killLegacyRunnerXcodebuildProcesses(deviceId);
-    return;
-  }
-  if (state.type === 'busy') {
-    throw new AppError(
-      'COMMAND_FAILED',
-      `iOS runner for ${deviceId} is already owned by another agent-device daemon`,
-      {
-        deviceId,
-        ownerPid: state.lease.ownerPid,
-        ownerStartTime: state.lease.ownerStartTime,
-        ownerToken: state.lease.ownerToken,
-        sessionId: state.lease.sessionId,
-        hint: 'Use a different simulator/session, wait for the other run to finish, or stop the owning daemon before retrying.',
-      },
-    );
-  }
-  await cleanupLeasedRunnerProcesses(state.lease, state.type);
-}
-
 async function cleanupStaleSimulatorRunnerBundles(device: DeviceInfo): Promise<void> {
   if (device.kind !== 'simulator') {
     return;
@@ -437,10 +419,7 @@ export async function stopIosRunnerSession(deviceId: string): Promise<void> {
   await withRunnerSessionLock(deviceId, async () => {
     await withRunnerLeaseLock(deviceId, async () => {
       await stopRunnerSessionInternal(deviceId);
-      const state = classifyRunnerLease(readRunnerLease(deviceId));
-      if (state.type === 'owned') {
-        await cleanupLeasedRunnerProcesses(state.lease, 'owned');
-      }
+      await cleanupOwnedRunnerLease(deviceId, runnerLeaseCleanupAdapter);
     });
   });
 }
@@ -484,6 +463,14 @@ export async function abortAllIosRunnerSessions(): Promise<void> {
       await session.simulatorSetRedirect?.release();
     }),
   );
+  for (const session of activeSessions) {
+    cleanupTempFile(session.xctestrunPath);
+    cleanupTempFile(session.jsonPath);
+    releaseRunnerLease(session.lease);
+    if (runnerSessions.get(session.deviceId) === session) {
+      runnerSessions.delete(session.deviceId);
+    }
+  }
 }
 
 export async function stopAllIosRunnerSessions(): Promise<void> {
@@ -536,38 +523,6 @@ async function killRunnerProcessTree(
   } catch {}
 }
 
-async function cleanupLeasedRunnerProcesses(
-  lease: RunnerLease,
-  reason: 'owned' | 'stale',
-): Promise<void> {
-  emitDiagnostic({
-    level: reason === 'stale' ? 'warn' : 'debug',
-    phase: 'ios_runner_lease_cleanup',
-    data: {
-      deviceId: lease.deviceId,
-      ownerPid: lease.ownerPid,
-      ownerToken: lease.ownerToken,
-      runnerPid: lease.runnerPid,
-      sessionId: lease.sessionId,
-      reason,
-    },
-  });
-  await killRunnerProcessTree(lease.runnerPid ?? undefined, 'SIGTERM');
-  await killRunnerXcodebuildProcesses(lease.deviceId, lease.ownerToken);
-  await killRunnerProcessTree(lease.runnerPid ?? undefined, 'SIGKILL');
-  cleanupTempFile(lease.xctestrunPath);
-  cleanupTempFile(lease.jsonPath);
-  removeRunnerLease({
-    deviceId: lease.deviceId,
-    ownerToken: lease.ownerToken,
-    sessionId: lease.sessionId,
-  });
-}
-
-async function killLegacyRunnerXcodebuildProcesses(deviceId: string): Promise<void> {
-  await killRunnerXcodebuildProcesses(deviceId, undefined);
-}
-
 async function killRunnerXcodebuildProcesses(
   deviceId: string,
   ownerToken: string | undefined,
@@ -596,12 +551,7 @@ async function killRunnerXcodebuildProcesses(
 }
 
 function removeRunnerSessionLease(session: RunnerSession): void {
-  if (!session.lease) return;
-  removeRunnerLease({
-    deviceId: session.deviceId,
-    ownerToken: session.lease.ownerToken,
-    sessionId: session.lease.sessionId,
-  });
+  releaseRunnerLease(session.lease);
 }
 
 function escapeRegex(value: string): string {

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -409,7 +409,7 @@ async function stopRunnerSessionInternal(
   cleanupTempFile(session.xctestrunPath);
   cleanupTempFile(session.jsonPath);
   await session.simulatorSetRedirect?.release();
-  removeRunnerSessionLease(session);
+  releaseRunnerLease(session.lease);
   if (runnerSessions.get(deviceId) === session) {
     runnerSessions.delete(deviceId);
   }
@@ -548,10 +548,6 @@ async function killRunnerXcodebuildProcesses(
       });
     }
   }
-}
-
-function removeRunnerSessionLease(session: RunnerSession): void {
-  releaseRunnerLease(session.lease);
 }
 
 function escapeRegex(value: string): string {

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -32,6 +32,16 @@ import {
   withRunnerCommandId,
   type RunnerCommand,
 } from './runner-contract.ts';
+import {
+  buildRunnerLease,
+  classifyRunnerLease,
+  readRunnerLease,
+  removeRunnerLease,
+  RUNNER_OWNER_TOKEN,
+  withRunnerLeaseLock,
+  writeRunnerLease,
+  type RunnerLease,
+} from './runner-lease.ts';
 import type { RunnerSession } from './runner-session-types.ts';
 
 export type { RunnerSession } from './runner-session-types.ts';
@@ -55,7 +65,6 @@ const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 1_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 const RUNNER_STALE_BUNDLE_UNINSTALL_TIMEOUT_MS = 10_000;
 const RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS = 2_000;
-const RUNNER_OWNER_TOKEN = `owner-${process.pid}`;
 
 type RunnerReadinessPreflightDecision =
   | {
@@ -82,114 +91,143 @@ export async function ensureRunnerSession(
       if (reusable) return reusable;
     }
 
-    const startupTimings: Record<string, number> = {};
-    await measureRunnerStartupStep(startupTimings, 'cleanup_stale_xcodebuild', async () => {
-      await killStaleRunnerXcodebuildProcesses(device.id);
-    });
-    await measureRunnerStartupStep(startupTimings, 'ensure_booted', async () => {
-      await ensureBootedIfNeeded(device);
-    });
-    if (options.cleanStaleBundles) {
-      await measureRunnerStartupStep(startupTimings, 'cleanup_stale_bundles', async () => {
-        await cleanupStaleSimulatorRunnerBundles(device);
-      });
-    } else {
-      startupTimings.cleanup_stale_bundles = 0;
-      emitDiagnostic({
-        level: 'debug',
-        phase: 'ios_runner_startup_cleanup_stale_bundles_skipped',
-      });
-    }
-    const xctestrunArtifact = await measureRunnerStartupStep(
-      startupTimings,
-      'ensure_xctestrun',
-      async () => await ensureXctestrunArtifact(device, options),
+    return await withRunnerLeaseLock(
+      device.id,
+      async () => await startRunnerSessionWithLease(device, options),
     );
-    startupTimings.build_xctestrun = xctestrunArtifact.buildMs;
-    const port = await measureRunnerStartupStep(
-      startupTimings,
-      'allocate_port',
-      async () => await getFreePort(),
-    );
-    const { xctestrunPath, jsonPath } = await measureRunnerStartupStep(
-      startupTimings,
-      'prepare_xctestrun_env',
-      async () =>
-        await prepareXctestrunWithEnv(
-          xctestrunArtifact.xctestrunPath,
-          { AGENT_DEVICE_RUNNER_PORT: String(port) },
-          `session-${device.id}-${RUNNER_OWNER_TOKEN}-${port}`,
-        ),
-    );
-    const simulatorSetRedirect = await measureRunnerStartupStep(
-      startupTimings,
-      'simulator_set_redirect',
-      async () => await acquireXcodebuildSimulatorSetRedirect(device),
-    );
-    let child: ExecBackgroundResult['child'];
-    let testPromise: Promise<ExecResult>;
-    try {
-      ({ child, wait: testPromise } = await measureRunnerStartupStep(
-        startupTimings,
-        'launch_xcodebuild',
-        () =>
-          runCmdBackground(
-            'xcodebuild',
-            [
-              'test-without-building',
-              '-only-testing',
-              'AgentDeviceRunnerUITests/RunnerTests/testCommand',
-              '-parallel-testing-enabled',
-              'NO',
-              '-test-timeouts-enabled',
-              'NO',
-              '-collect-test-diagnostics',
-              'never',
-              resolveRunnerMaxConcurrentDestinationsFlag(device),
-              '1',
-              '-destination-timeout',
-              String(RUNNER_DESTINATION_TIMEOUT_SECONDS),
-              '-xctestrun',
-              xctestrunPath,
-              '-destination',
-              resolveRunnerDestination(device),
-            ],
-            {
-              allowFailure: true,
-              env: { ...process.env, AGENT_DEVICE_RUNNER_PORT: String(port) },
-              detached: true,
-            },
-          ),
-      ));
-    } catch (error) {
-      await simulatorSetRedirect?.release();
-      throw error;
-    }
-    child.stdout?.on('data', (chunk: string) => {
-      logChunk(chunk, options.logPath, options.traceLogPath, options.verbose);
-    });
-    child.stderr?.on('data', (chunk: string) => {
-      logChunk(chunk, options.logPath, options.traceLogPath, options.verbose);
-    });
-
-    const session: RunnerSession = {
-      sessionId: `${device.id}:${port}:${Date.now()}`,
-      device,
-      deviceId: device.id,
-      port,
-      xctestrunPath,
-      xctestrunArtifact,
-      jsonPath,
-      testPromise,
-      child,
-      ready: false,
-      startupTimeoutMs: normalizeRunnerStartupTimeoutMs(options.startupTimeoutMs),
-      startupTimings,
-      simulatorSetRedirect: simulatorSetRedirect ?? undefined,
-    };
-    runnerSessions.set(device.id, session);
-    return session;
   });
+}
+
+async function startRunnerSessionWithLease(
+  device: DeviceInfo,
+  options: RunnerSessionOptions,
+): Promise<RunnerSession> {
+  const startupTimings: Record<string, number> = {};
+  await measureRunnerStartupStep(startupTimings, 'cleanup_stale_xcodebuild', async () => {
+    await prepareRunnerLeaseForStartup(device.id);
+  });
+  await measureRunnerStartupStep(startupTimings, 'ensure_booted', async () => {
+    await ensureBootedIfNeeded(device);
+  });
+  if (options.cleanStaleBundles) {
+    await measureRunnerStartupStep(startupTimings, 'cleanup_stale_bundles', async () => {
+      await cleanupStaleSimulatorRunnerBundles(device);
+    });
+  } else {
+    startupTimings.cleanup_stale_bundles = 0;
+    emitDiagnostic({
+      level: 'debug',
+      phase: 'ios_runner_startup_cleanup_stale_bundles_skipped',
+    });
+  }
+  const xctestrunArtifact = await measureRunnerStartupStep(
+    startupTimings,
+    'ensure_xctestrun',
+    async () => await ensureXctestrunArtifact(device, options),
+  );
+  startupTimings.build_xctestrun = xctestrunArtifact.buildMs;
+  const port = await measureRunnerStartupStep(
+    startupTimings,
+    'allocate_port',
+    async () => await getFreePort(),
+  );
+  const { xctestrunPath, jsonPath } = await measureRunnerStartupStep(
+    startupTimings,
+    'prepare_xctestrun_env',
+    async () =>
+      await prepareXctestrunWithEnv(
+        xctestrunArtifact.xctestrunPath,
+        { AGENT_DEVICE_RUNNER_PORT: String(port) },
+        `session-${device.id}-${RUNNER_OWNER_TOKEN}-${port}`,
+      ),
+  );
+  const simulatorSetRedirect = await measureRunnerStartupStep(
+    startupTimings,
+    'simulator_set_redirect',
+    async () => await acquireXcodebuildSimulatorSetRedirect(device),
+  );
+  let child: ExecBackgroundResult['child'] | undefined;
+  let testPromise: Promise<ExecResult>;
+  try {
+    ({ child, wait: testPromise } = await measureRunnerStartupStep(
+      startupTimings,
+      'launch_xcodebuild',
+      () =>
+        runCmdBackground(
+          'xcodebuild',
+          [
+            'test-without-building',
+            '-only-testing',
+            'AgentDeviceRunnerUITests/RunnerTests/testCommand',
+            '-parallel-testing-enabled',
+            'NO',
+            '-test-timeouts-enabled',
+            'NO',
+            '-collect-test-diagnostics',
+            'never',
+            resolveRunnerMaxConcurrentDestinationsFlag(device),
+            '1',
+            '-destination-timeout',
+            String(RUNNER_DESTINATION_TIMEOUT_SECONDS),
+            '-xctestrun',
+            xctestrunPath,
+            '-destination',
+            resolveRunnerDestination(device),
+          ],
+          {
+            allowFailure: true,
+            env: { ...process.env, AGENT_DEVICE_RUNNER_PORT: String(port) },
+            detached: true,
+          },
+        ),
+    ));
+  } catch (error) {
+    await simulatorSetRedirect?.release();
+    throw error;
+  }
+  child.stdout?.on('data', (chunk: string) => {
+    logChunk(chunk, options.logPath, options.traceLogPath, options.verbose);
+  });
+  child.stderr?.on('data', (chunk: string) => {
+    logChunk(chunk, options.logPath, options.traceLogPath, options.verbose);
+  });
+
+  const sessionId = `${device.id}:${port}:${Date.now()}`;
+  const lease = buildRunnerLease({
+    deviceId: device.id,
+    sessionId,
+    runnerPid: child.pid,
+    port,
+    xctestrunPath,
+    jsonPath,
+  });
+  const session: RunnerSession = {
+    sessionId,
+    device,
+    deviceId: device.id,
+    port,
+    xctestrunPath,
+    xctestrunArtifact,
+    jsonPath,
+    testPromise,
+    child,
+    ready: false,
+    startupTimeoutMs: normalizeRunnerStartupTimeoutMs(options.startupTimeoutMs),
+    startupTimings,
+    simulatorSetRedirect: simulatorSetRedirect ?? undefined,
+    lease,
+  };
+  try {
+    writeRunnerLease(lease);
+  } catch (error) {
+    await stopRunnerSessionInternal(device.id, session, {
+      graceful: false,
+      waitTimeoutMs: RUNNER_INVALIDATE_WAIT_TIMEOUT_MS,
+    });
+    throw error;
+  }
+  runnerSessions.set(device.id, session);
+  return session;
 }
 
 async function resolveReusableRunnerSession(
@@ -237,6 +275,29 @@ async function resolveReusableRunnerSession(
     },
   });
   return existing;
+}
+
+async function prepareRunnerLeaseForStartup(deviceId: string): Promise<void> {
+  const state = classifyRunnerLease(readRunnerLease(deviceId));
+  if (state.type === 'empty') {
+    await killLegacyRunnerXcodebuildProcesses(deviceId);
+    return;
+  }
+  if (state.type === 'busy') {
+    throw new AppError(
+      'COMMAND_FAILED',
+      `iOS runner for ${deviceId} is already owned by another agent-device daemon`,
+      {
+        deviceId,
+        ownerPid: state.lease.ownerPid,
+        ownerStartTime: state.lease.ownerStartTime,
+        ownerToken: state.lease.ownerToken,
+        sessionId: state.lease.sessionId,
+        hint: 'Use a different simulator/session, wait for the other run to finish, or stop the owning daemon before retrying.',
+      },
+    );
+  }
+  await cleanupLeasedRunnerProcesses(state.lease, state.type);
 }
 
 async function cleanupStaleSimulatorRunnerBundles(device: DeviceInfo): Promise<void> {
@@ -366,6 +427,7 @@ async function stopRunnerSessionInternal(
   cleanupTempFile(session.xctestrunPath);
   cleanupTempFile(session.jsonPath);
   await session.simulatorSetRedirect?.release();
+  removeRunnerSessionLease(session);
   if (runnerSessions.get(deviceId) === session) {
     runnerSessions.delete(deviceId);
   }
@@ -373,8 +435,13 @@ async function stopRunnerSessionInternal(
 
 export async function stopIosRunnerSession(deviceId: string): Promise<void> {
   await withRunnerSessionLock(deviceId, async () => {
-    await stopRunnerSessionInternal(deviceId);
-    await killStaleRunnerXcodebuildProcesses(deviceId);
+    await withRunnerLeaseLock(deviceId, async () => {
+      await stopRunnerSessionInternal(deviceId);
+      const state = classifyRunnerLease(readRunnerLease(deviceId));
+      if (state.type === 'owned') {
+        await cleanupLeasedRunnerProcesses(state.lease, 'owned');
+      }
+    });
   });
 }
 
@@ -469,8 +536,45 @@ async function killRunnerProcessTree(
   } catch {}
 }
 
-async function killStaleRunnerXcodebuildProcesses(deviceId: string): Promise<void> {
-  const pattern = `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-${escapeRegex(RUNNER_OWNER_TOKEN)}-`;
+async function cleanupLeasedRunnerProcesses(
+  lease: RunnerLease,
+  reason: 'owned' | 'stale',
+): Promise<void> {
+  emitDiagnostic({
+    level: reason === 'stale' ? 'warn' : 'debug',
+    phase: 'ios_runner_lease_cleanup',
+    data: {
+      deviceId: lease.deviceId,
+      ownerPid: lease.ownerPid,
+      ownerToken: lease.ownerToken,
+      runnerPid: lease.runnerPid,
+      sessionId: lease.sessionId,
+      reason,
+    },
+  });
+  await killRunnerProcessTree(lease.runnerPid ?? undefined, 'SIGTERM');
+  await killRunnerXcodebuildProcesses(lease.deviceId, lease.ownerToken);
+  await killRunnerProcessTree(lease.runnerPid ?? undefined, 'SIGKILL');
+  cleanupTempFile(lease.xctestrunPath);
+  cleanupTempFile(lease.jsonPath);
+  removeRunnerLease({
+    deviceId: lease.deviceId,
+    ownerToken: lease.ownerToken,
+    sessionId: lease.sessionId,
+  });
+}
+
+async function killLegacyRunnerXcodebuildProcesses(deviceId: string): Promise<void> {
+  await killRunnerXcodebuildProcesses(deviceId, undefined);
+}
+
+async function killRunnerXcodebuildProcesses(
+  deviceId: string,
+  ownerToken: string | undefined,
+): Promise<void> {
+  const pattern = ownerToken
+    ? `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-${escapeRegex(ownerToken)}-`
+    : `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-[0-9]`;
   for (const signal of ['TERM', 'KILL'] as const) {
     try {
       await runAppleToolCommand('pkill', [`-${signal}`, '-f', pattern], {
@@ -489,6 +593,15 @@ async function killStaleRunnerXcodebuildProcesses(deviceId: string): Promise<voi
       });
     }
   }
+}
+
+function removeRunnerSessionLease(session: RunnerSession): void {
+  if (!session.lease) return;
+  removeRunnerLease({
+    deviceId: session.deviceId,
+    ownerToken: session.lease.ownerToken,
+    sessionId: session.lease.sessionId,
+  });
 }
 
 function escapeRegex(value: string): string {

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -55,6 +55,7 @@ const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 1_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 const RUNNER_STALE_BUNDLE_UNINSTALL_TIMEOUT_MS = 10_000;
 const RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS = 2_000;
+const RUNNER_OWNER_TOKEN = `owner-${process.pid}`;
 
 type RunnerReadinessPreflightDecision =
   | {
@@ -117,7 +118,7 @@ export async function ensureRunnerSession(
         await prepareXctestrunWithEnv(
           xctestrunArtifact.xctestrunPath,
           { AGENT_DEVICE_RUNNER_PORT: String(port) },
-          `session-${device.id}-${port}`,
+          `session-${device.id}-${RUNNER_OWNER_TOKEN}-${port}`,
         ),
     );
     const simulatorSetRedirect = await measureRunnerStartupStep(
@@ -469,7 +470,7 @@ async function killRunnerProcessTree(
 }
 
 async function killStaleRunnerXcodebuildProcesses(deviceId: string): Promise<void> {
-  const pattern = `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-`;
+  const pattern = `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-${escapeRegex(RUNNER_OWNER_TOKEN)}-`;
   for (const signal of ['TERM', 'KILL'] as const) {
     try {
       await runAppleToolCommand('pkill', [`-${signal}`, '-f', pattern], {

--- a/src/platforms/ios/runner-xctestrun.ts
+++ b/src/platforms/ios/runner-xctestrun.ts
@@ -3,10 +3,10 @@ import crypto from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '../../utils/errors.ts';
-import { sleep } from '../../utils/timeouts.ts';
 import { runCmdStreaming, runCmdSync, type ExecBackgroundResult } from '../../utils/exec.ts';
 import { resolveIosSimulatorDeviceSetPath } from '../../utils/device-isolation.ts';
-import { isProcessAlive, readProcessStartTime } from '../../utils/process-identity.ts';
+import { readProcessStartTime } from '../../utils/process-identity.ts';
+import { acquireProcessLock, type ProcessLockOwner } from '../../utils/process-lock.ts';
 import { isEnvTruthy } from '../../utils/retry.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
@@ -89,12 +89,6 @@ type XcodebuildSimulatorSetRedirectOptions = {
   ownerPid?: number;
   ownerStartTime?: string | null;
   nowMs?: number;
-};
-
-type XcodebuildSimulatorSetLockOwner = {
-  pid: number;
-  startTime: string | null;
-  acquiredAtMs: number;
 };
 
 export type RunnerXctestrunCacheMetadata = {
@@ -388,46 +382,18 @@ function sameResolvedPath(left: string, right: string): boolean {
 
 async function acquireXcodebuildSimulatorSetLock(params: {
   lockDirPath: string;
-  owner: XcodebuildSimulatorSetLockOwner;
+  owner: ProcessLockOwner;
   timeoutMs?: number;
   pollMs?: number;
   description?: string;
 }): Promise<() => Promise<void>> {
-  const { lockDirPath, owner } = params;
-  const ownerFilePath = path.join(lockDirPath, 'owner.json');
-  const deadline = Date.now() + (params.timeoutMs ?? XCTEST_DEVICE_SET_LOCK_TIMEOUT_MS);
-  const pollMs = params.pollMs ?? XCTEST_DEVICE_SET_LOCK_POLL_MS;
-  const description = params.description ?? 'XCTest device set lock';
-
-  fs.mkdirSync(path.dirname(lockDirPath), { recursive: true });
-
-  while (Date.now() < deadline) {
-    try {
-      fs.mkdirSync(lockDirPath);
-      writeXcodebuildSimulatorSetLockOwner(ownerFilePath, owner);
-      let released = false;
-      return async () => {
-        if (released) {
-          return;
-        }
-        released = true;
-        fs.rmSync(lockDirPath, { recursive: true, force: true });
-      };
-    } catch (error) {
-      const err = error as NodeJS.ErrnoException;
-      if (err.code !== 'EEXIST') {
-        throw err;
-      }
-      if (clearStaleXcodebuildSimulatorSetLock(lockDirPath, ownerFilePath)) {
-        continue;
-      }
-      await sleep(pollMs);
-    }
-  }
-
-  throw new AppError('COMMAND_FAILED', `Timed out waiting for ${description}`, {
-    lockDirPath,
-    ...readXcodebuildSimulatorSetLockDiagnostics(lockDirPath, ownerFilePath),
+  return await acquireProcessLock({
+    lockDirPath: params.lockDirPath,
+    owner: params.owner,
+    timeoutMs: params.timeoutMs ?? XCTEST_DEVICE_SET_LOCK_TIMEOUT_MS,
+    pollMs: params.pollMs ?? XCTEST_DEVICE_SET_LOCK_POLL_MS,
+    ownerGraceMs: XCTEST_DEVICE_SET_LOCK_OWNER_GRACE_MS,
+    description: params.description ?? 'XCTest device set lock',
   });
 }
 
@@ -448,83 +414,6 @@ export async function acquireRunnerXctestrunCacheLock(
 
 function resolveRunnerXctestrunCacheLockPath(derived: string): string {
   return path.join(path.dirname(derived), `${path.basename(derived)}.lock`);
-}
-
-function writeXcodebuildSimulatorSetLockOwner(
-  ownerFilePath: string,
-  owner: XcodebuildSimulatorSetLockOwner,
-): void {
-  const tmpOwnerFilePath = `${ownerFilePath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpOwnerFilePath, JSON.stringify(owner), 'utf8');
-  fs.renameSync(tmpOwnerFilePath, ownerFilePath);
-}
-
-function clearStaleXcodebuildSimulatorSetLock(lockDirPath: string, ownerFilePath: string): boolean {
-  let ownerStats: fs.Stats | null = null;
-  try {
-    ownerStats = fs.statSync(lockDirPath);
-  } catch {
-    return true;
-  }
-
-  const owner = readXcodebuildSimulatorSetLockOwner(ownerFilePath);
-  if (owner) {
-    if (isLiveXcodebuildSimulatorSetLockOwner(owner)) {
-      return false;
-    }
-    fs.rmSync(lockDirPath, { recursive: true, force: true });
-    return true;
-  }
-  if (Date.now() - ownerStats.mtimeMs < XCTEST_DEVICE_SET_LOCK_OWNER_GRACE_MS) {
-    return false;
-  }
-  fs.rmSync(lockDirPath, { recursive: true, force: true });
-  return true;
-}
-
-function readXcodebuildSimulatorSetLockOwner(
-  ownerFilePath: string,
-): XcodebuildSimulatorSetLockOwner | null {
-  try {
-    return JSON.parse(fs.readFileSync(ownerFilePath, 'utf8')) as XcodebuildSimulatorSetLockOwner;
-  } catch {
-    return null;
-  }
-}
-
-function readXcodebuildSimulatorSetLockDiagnostics(
-  lockDirPath: string,
-  ownerFilePath: string,
-): Record<string, unknown> {
-  const nowMs = Date.now();
-  const owner = readXcodebuildSimulatorSetLockOwner(ownerFilePath);
-  let lockAgeMs: number | undefined;
-  try {
-    lockAgeMs = Math.max(0, Math.round(nowMs - fs.statSync(lockDirPath).mtimeMs));
-  } catch {}
-  return {
-    ...(lockAgeMs !== undefined ? { lockAgeMs } : {}),
-    ...(owner
-      ? {
-          ownerPid: owner.pid,
-          ownerStartTime: owner.startTime,
-          ownerAgeMs: Math.max(0, Math.round(nowMs - owner.acquiredAtMs)),
-        }
-      : {}),
-  };
-}
-
-function isLiveXcodebuildSimulatorSetLockOwner(owner: XcodebuildSimulatorSetLockOwner): boolean {
-  if (!Number.isInteger(owner.pid) || owner.pid <= 0) {
-    return false;
-  }
-  if (!isProcessAlive(owner.pid)) {
-    return false;
-  }
-  if (owner.startTime) {
-    return readProcessStartTime(owner.pid) === owner.startTime;
-  }
-  return true;
 }
 
 export async function ensureXctestrun(

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1046,6 +1046,8 @@ test('usageForCommand documents prepare ios-runner', () => {
   assert.match(help, /Prepare platform helper infrastructure/);
   assert.match(help, /--timeout <ms>/);
   assert.match(help, /XCTest runner/);
+  assert.match(help, /separate daemon/);
+  assert.match(help, /clean:daemon after prepare/);
   assert.match(help, /Runner build\/start output is written to the session runner\.log/);
 });
 
@@ -1116,6 +1118,7 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /metro prepare --kind expo/);
   assert.match(help, /agent-device prepare ios-runner --platform ios --timeout 240000/);
   assert.match(help, /prepare ios-runner builds\/reuses the XCTest runner/);
+  assert.match(help, /prepared runner does not keep a live lease/);
   assert.match(help, /help react-devtools/);
   assert.match(help, /help react-native/);
   assert.doesNotMatch(help, /agent-device react-devtools profile/);

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -506,7 +506,7 @@ test('sendToDaemon prints replay test progress before the socket response', asyn
   }
 });
 
-test('sendToDaemon prints replay test progress before the HTTP NDJSON response', async () => {
+test('sendToDaemon ignores terminal replay test progress before the HTTP NDJSON response', async () => {
   let stderr = '';
   const seenPaths: string[] = [];
   const originalStderrWrite = process.stderr.write.bind(process.stderr);
@@ -598,7 +598,7 @@ test('sendToDaemon prints replay test progress before the HTTP NDJSON response',
       assert.deepEqual(response, { ok: true, data: { via: 'http-progress' } });
     });
     assert.deepEqual(seenPaths, ['GET /agent-device/health', 'POST /agent-device/rpc']);
-    assert.match(stderr, /PASS "Payments flow" \(2\.50s\)/);
+    assert.doesNotMatch(stderr, /PASS "Payments flow" \(2\.50s\)/);
   } finally {
     (http as unknown as { request: typeof http.request }).request = originalHttpRequest;
     process.stderr.write = originalStderrWrite;

--- a/src/utils/__tests__/mobile-snapshot-semantics.test.ts
+++ b/src/utils/__tests__/mobile-snapshot-semantics.test.ts
@@ -179,11 +179,11 @@ test('mobile presentation keeps fixed bottom controls after long visible scroll 
   const presentation = buildMobileSnapshotPresentation(nodes);
   const identifiers = new Set(presentation.nodes.map((node) => node.identifier).filter(Boolean));
   assert.deepEqual([...identifiers].sort(), ['albums', 'article', 'contacts']);
-  assert.equal(presentation.nodes.some((node) => node.label === 'Contact 19'), false);
   assert.equal(
-    presentation.nodes.find((node) => node.index === 2)?.hiddenContentBelow,
-    true,
+    presentation.nodes.some((node) => node.label === 'Contact 19'),
+    false,
   );
+  assert.equal(presentation.nodes.find((node) => node.index === 2)?.hiddenContentBelow, true);
 });
 
 test('mobile presentation handles zero-width viewport gracefully', () => {

--- a/src/utils/__tests__/process-lock.test.ts
+++ b/src/utils/__tests__/process-lock.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, test } from 'vitest';
+import { AppError } from '../errors.ts';
+import { acquireProcessLock, type ProcessLockOwner } from '../process-lock.ts';
+import { readProcessStartTime } from '../process-identity.ts';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-process-lock-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('acquireProcessLock creates and releases a lock directory', async () => {
+  const lockDirPath = path.join(tmpDir, 'runner.lock');
+
+  const release = await acquireProcessLock({
+    lockDirPath,
+    owner: currentProcessOwner(),
+  });
+
+  assert.equal(fs.existsSync(lockDirPath), true);
+  await release();
+  assert.equal(fs.existsSync(lockDirPath), false);
+});
+
+test('acquireProcessLock reclaims locks owned by dead processes', async () => {
+  const lockDirPath = path.join(tmpDir, 'stale.lock');
+  fs.mkdirSync(lockDirPath);
+  fs.writeFileSync(
+    path.join(lockDirPath, 'owner.json'),
+    JSON.stringify({
+      pid: 999_999_999,
+      startTime: null,
+      acquiredAtMs: Date.now() - 10_000,
+    }),
+  );
+
+  const release = await acquireProcessLock({
+    lockDirPath,
+    owner: currentProcessOwner(),
+    timeoutMs: 50,
+    pollMs: 1,
+  });
+
+  assert.equal(fs.existsSync(path.join(lockDirPath, 'owner.json')), true);
+  await release();
+  assert.equal(fs.existsSync(lockDirPath), false);
+});
+
+test('acquireProcessLock reports live lock owner details on timeout', async () => {
+  const lockDirPath = path.join(tmpDir, 'busy.lock');
+  fs.mkdirSync(lockDirPath);
+  const owner = currentProcessOwner();
+  fs.writeFileSync(path.join(lockDirPath, 'owner.json'), JSON.stringify(owner));
+
+  await assert.rejects(
+    () =>
+      acquireProcessLock({
+        lockDirPath,
+        owner: currentProcessOwner(),
+        timeoutMs: 5,
+        pollMs: 1,
+        description: 'busy test lock',
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError);
+      assert.equal(error.code, 'COMMAND_FAILED');
+      assert.equal(error.message, 'Timed out waiting for busy test lock');
+      assert.equal(error.details?.lockDirPath, lockDirPath);
+      assert.equal(error.details?.ownerPid, process.pid);
+      return true;
+    },
+  );
+});
+
+function currentProcessOwner(): ProcessLockOwner {
+  return {
+    pid: process.pid,
+    startTime: readProcessStartTime(process.pid),
+    acquiredAtMs: Date.now(),
+  };
+}

--- a/src/utils/cli-command-overrides.ts
+++ b/src/utils/cli-command-overrides.ts
@@ -69,7 +69,7 @@ const CLI_COMMAND_OVERRIDES = {
     usageOverride: 'prepare ios-runner --platform ios|macos [--timeout <ms>]',
     listUsageOverride: 'prepare ios-runner --platform ios|macos',
     helpDescription:
-      'Prepare platform helper infrastructure. ios-runner builds/reuses, starts, and health-checks the XCTest runner so later Apple snapshots and interactions do not pay first-use startup cost. In CI, run it after boot/install and before replay/test. Runner build/start output is written to the session runner.log; daemon.log is for daemon lifecycle/startup issues.',
+      'Prepare platform helper infrastructure. ios-runner builds/reuses, starts, and health-checks the XCTest runner so later Apple snapshots and interactions do not pay first-use startup cost. In CI, run it after boot/install and before replay/test; if replay/test starts a separate daemon, run clean:daemon after prepare to release the prepared runner lease. Runner build/start output is written to the session runner.log; daemon.log is for daemon lifecycle/startup issues.',
     summary: 'Prepare platform helpers',
     positionalArgs: ['ios-runner'],
     allowedFlags: ['timeoutMs'],

--- a/src/utils/cli-help.ts
+++ b/src/utils/cli-help.ts
@@ -122,7 +122,7 @@ Bootstrap:
   agent-device prepare ios-runner --platform ios --timeout 240000
   If app id is unknown, plan devices, apps, then open <discovered-app-id>. Discovery is not enough when the task asks to open/start the app.
   Install arguments are app/package id then artifact path. If the task says install, use install; use reinstall only when explicitly requested. Fresh runtime state is open --relaunch after install.
-  In Apple CI, run prepare ios-runner after boot/install and before replay/test. prepare ios-runner builds/reuses the XCTest runner, health-checks it with a lightweight command, and retries one stuck/non-connecting runner launch before the first snapshot pays that setup cost.
+  In Apple CI, run prepare ios-runner after boot/install and before replay/test. prepare ios-runner builds/reuses the XCTest runner, health-checks it with a lightweight command, and retries one stuck/non-connecting runner launch before the first snapshot pays that setup cost. If the replay/test step starts a separate daemon, run clean:daemon after prepare so the prepared runner does not keep a live lease owned by the prepare daemon.
   CI may cache ~/.agent-device/ios-runner/derived with an exact key that includes the agent-device package and Xcode version. Avoid broad restore-key fallbacks; prepare ios-runner already recovers bad restored runner artifacts and one retryable non-connecting runner launch. Runner build/start output is written to the session's runner.log; daemon.log is for daemon lifecycle/startup issues.
   Do not open artifact paths or invent package ids. If apps lookup misses the target and no URL/artifact is provided, ask or stop.
 

--- a/src/utils/process-lock.ts
+++ b/src/utils/process-lock.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppError } from './errors.ts';
+import { isProcessAlive, readProcessStartTime } from './process-identity.ts';
+import { sleep } from './timeouts.ts';
+
+const DEFAULT_LOCK_TIMEOUT_MS = 30_000;
+const DEFAULT_LOCK_POLL_MS = 100;
+const DEFAULT_LOCK_OWNER_GRACE_MS = 5_000;
+
+export type ProcessLockOwner = {
+  pid: number;
+  startTime: string | null;
+  acquiredAtMs: number;
+};
+
+export async function acquireProcessLock(params: {
+  lockDirPath: string;
+  owner: ProcessLockOwner;
+  timeoutMs?: number;
+  pollMs?: number;
+  ownerGraceMs?: number;
+  description?: string;
+}): Promise<() => Promise<void>> {
+  const { lockDirPath, owner } = params;
+  const ownerFilePath = path.join(lockDirPath, 'owner.json');
+  const deadline = Date.now() + (params.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS);
+  const pollMs = params.pollMs ?? DEFAULT_LOCK_POLL_MS;
+  const ownerGraceMs = params.ownerGraceMs ?? DEFAULT_LOCK_OWNER_GRACE_MS;
+  const description = params.description ?? 'process lock';
+
+  fs.mkdirSync(path.dirname(lockDirPath), { recursive: true });
+
+  while (Date.now() < deadline) {
+    try {
+      fs.mkdirSync(lockDirPath);
+      writeProcessLockOwner(ownerFilePath, owner);
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        fs.rmSync(lockDirPath, { recursive: true, force: true });
+      };
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException;
+      if (err.code !== 'EEXIST') {
+        throw err;
+      }
+      if (clearStaleProcessLock(lockDirPath, ownerFilePath, ownerGraceMs)) {
+        continue;
+      }
+      await sleep(pollMs);
+    }
+  }
+
+  throw new AppError('COMMAND_FAILED', `Timed out waiting for ${description}`, {
+    lockDirPath,
+    ...readProcessLockDiagnostics(lockDirPath, ownerFilePath),
+  });
+}
+
+function writeProcessLockOwner(ownerFilePath: string, owner: ProcessLockOwner): void {
+  const tmpOwnerFilePath = `${ownerFilePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpOwnerFilePath, JSON.stringify(owner), 'utf8');
+  fs.renameSync(tmpOwnerFilePath, ownerFilePath);
+}
+
+function clearStaleProcessLock(
+  lockDirPath: string,
+  ownerFilePath: string,
+  ownerGraceMs: number,
+): boolean {
+  let ownerStats: fs.Stats | null = null;
+  try {
+    ownerStats = fs.statSync(lockDirPath);
+  } catch {
+    return true;
+  }
+
+  const owner = readProcessLockOwner(ownerFilePath);
+  if (owner) {
+    if (isLiveProcessLockOwner(owner)) {
+      return false;
+    }
+    fs.rmSync(lockDirPath, { recursive: true, force: true });
+    return true;
+  }
+  if (Date.now() - ownerStats.mtimeMs < ownerGraceMs) {
+    return false;
+  }
+  fs.rmSync(lockDirPath, { recursive: true, force: true });
+  return true;
+}
+
+function readProcessLockOwner(ownerFilePath: string): ProcessLockOwner | null {
+  try {
+    return JSON.parse(fs.readFileSync(ownerFilePath, 'utf8')) as ProcessLockOwner;
+  } catch {
+    return null;
+  }
+}
+
+function readProcessLockDiagnostics(
+  lockDirPath: string,
+  ownerFilePath: string,
+): Record<string, unknown> {
+  const nowMs = Date.now();
+  const owner = readProcessLockOwner(ownerFilePath);
+  let lockAgeMs: number | undefined;
+  try {
+    lockAgeMs = Math.max(0, Math.round(nowMs - fs.statSync(lockDirPath).mtimeMs));
+  } catch {}
+  return {
+    ...(lockAgeMs !== undefined ? { lockAgeMs } : {}),
+    ...(owner
+      ? {
+          ownerPid: owner.pid,
+          ownerStartTime: owner.startTime,
+          ownerAgeMs: Math.max(0, Math.round(nowMs - owner.acquiredAtMs)),
+        }
+      : {}),
+  };
+}
+
+function isLiveProcessLockOwner(owner: ProcessLockOwner): boolean {
+  if (!Number.isInteger(owner.pid) || owner.pid <= 0) {
+    return false;
+  }
+  if (!isProcessAlive(owner.pid)) {
+    return false;
+  }
+  if (owner.startTime) {
+    return readProcessStartTime(owner.pid) === owner.startTime;
+  }
+  return true;
+}

--- a/src/utils/swift-cache.ts
+++ b/src/utils/swift-cache.ts
@@ -2,9 +2,10 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { setTimeout as delay } from 'node:timers/promises';
 import { AppError } from './errors.ts';
 import { runCmd } from './exec.ts';
+import { acquireProcessLock } from './process-lock.ts';
+import { readProcessStartTime } from './process-identity.ts';
 
 const SWIFT_CACHE_VERSION = '2';
 const LOCK_RETRY_DELAY_MS = 25;
@@ -89,7 +90,12 @@ async function ensureSwiftExecutable(params: {
   const executableDir = path.dirname(params.executablePath);
   fs.mkdirSync(executableDir, { recursive: true });
   const lockDir = `${params.executablePath}.lock`;
-  if (!(await acquireSwiftCacheLock(lockDir, params.executablePath, params.timeoutMs ?? 120_000))) {
+  const releaseLock = await acquireSwiftCacheLock(
+    lockDir,
+    params.executablePath,
+    params.timeoutMs ?? 120_000,
+  );
+  if (!releaseLock) {
     return;
   }
 
@@ -112,7 +118,7 @@ async function ensureSwiftExecutable(params: {
     fs.renameSync(tempExecutablePath, params.executablePath);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
-    fs.rmSync(lockDir, { recursive: true, force: true });
+    await releaseLock();
   }
 }
 
@@ -120,45 +126,36 @@ async function acquireSwiftCacheLock(
   lockDir: string,
   executablePath: string,
   timeoutMs: number,
-): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (true) {
-    if (isExecutableFile(executablePath)) {
-      return false;
-    }
-    try {
-      fs.mkdirSync(lockDir);
-      return true;
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'EEXIST') {
-        throw error;
-      }
-      if (isStaleSwiftCacheLock(lockDir, timeoutMs)) {
-        fs.rmSync(lockDir, { recursive: true, force: true });
-        continue;
-      }
-      if (Date.now() >= deadline) {
-        throw new AppError(
-          'COMMAND_FAILED',
-          `Timed out waiting for Swift cache lock: ${lockDir} (${timeoutMs}ms)`,
-          {
-            lockDir,
-            timeoutMs,
-            hint: `Another agent-device process may still be compiling this Swift helper. Retry shortly; if no agent-device process is active, remove "${lockDir}" and retry.`,
-          },
-        );
-      }
-      await delay(LOCK_RETRY_DELAY_MS);
-    }
+): Promise<(() => Promise<void>) | null> {
+  if (isExecutableFile(executablePath)) {
+    return null;
   }
-}
-
-function isStaleSwiftCacheLock(lockDir: string, timeoutMs: number): boolean {
   try {
-    return Date.now() - fs.statSync(lockDir).mtimeMs >= timeoutMs;
-  } catch {
-    return false;
+    return await acquireProcessLock({
+      lockDirPath: lockDir,
+      owner: {
+        pid: process.pid,
+        startTime: readProcessStartTime(process.pid),
+        acquiredAtMs: Date.now(),
+      },
+      timeoutMs,
+      pollMs: LOCK_RETRY_DELAY_MS,
+      ownerGraceMs: timeoutMs,
+      description: `Swift cache lock: ${lockDir} (${timeoutMs}ms)`,
+    });
+  } catch (error) {
+    if (
+      error instanceof AppError &&
+      error.message.startsWith('Timed out waiting for Swift cache lock:')
+    ) {
+      throw new AppError('COMMAND_FAILED', error.message, {
+        ...error.details,
+        lockDir,
+        timeoutMs,
+        hint: `Another agent-device process may still be compiling this Swift helper. Retry shortly; if no agent-device process is active, remove "${lockDir}" and retry.`,
+      });
+    }
+    throw error;
   }
 }
 

--- a/test/integration/provider-scenarios/android-lifecycle.test.ts
+++ b/test/integration/provider-scenarios/android-lifecycle.test.ts
@@ -24,7 +24,7 @@ test('Provider-backed integration Android Settings flow uses scripted ADB provid
     await runAndroidCaptureInteractionAndReplayWorkflow(world, client);
     assertAndroidProviderContract(world);
   });
-});
+}, 15_000);
 
 test('Provider-backed integration Android text provider handles Unicode without shell input text', async () => {
   await withProviderScenarioResource(

--- a/test/integration/provider-scenarios/ios-lifecycle.test.ts
+++ b/test/integration/provider-scenarios/ios-lifecycle.test.ts
@@ -271,11 +271,10 @@ test('Provider-backed integration iOS regular snapshot preserves fixed bottom ta
   await withProviderScenarioResource(
     createIosBottomTabsSnapshotWorld,
     async ({ daemon, runnerTranscript }) => {
-      await daemon.callCommand(
-        'open',
-        ['org.reactnavigation.playground'],
-        { platform: 'ios', udid: PROVIDER_SCENARIO_IOS_SIMULATOR.id },
-      );
+      await daemon.callCommand('open', ['org.reactnavigation.playground'], {
+        platform: 'ios',
+        udid: PROVIDER_SCENARIO_IOS_SIMULATOR.id,
+      });
 
       const snapshot = await daemon.callCommand('snapshot');
       const data = snapshot.json?.result?.data;

--- a/test/integration/smoke-daemon-clean.test.ts
+++ b/test/integration/smoke-daemon-clean.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { skipWhenLoopbackUnavailable } from '../../src/__tests__/test-utils/loopback.ts';
+import { runCmdSync } from '../../src/utils/exec.ts';
+import { isProcessAlive, stopProcessForTakeover } from '../../src/utils/process-identity.ts';
+import { runCliJson } from './test-helpers.ts';
+
+type DaemonInfo = {
+  pid: number;
+  processStartTime?: string;
+};
+
+test('clean daemon script stops a live daemon before removing metadata', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) {
+    return;
+  }
+
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-clean-daemon-'));
+  let info: DaemonInfo | null = null;
+  try {
+    const cli = runCliJson(['session', 'list', '--json', '--state-dir', stateDir]);
+    assert.equal(cli.status, 0, `${cli.stderr}\n${cli.stdout}`);
+    assert.equal(cli.json?.success, true, JSON.stringify(cli.json));
+
+    info = readDaemonInfo(stateDir);
+    assert.equal(isProcessAlive(info.pid), true);
+
+    const cleanup = runCmdSync(
+      process.execPath,
+      ['--experimental-strip-types', 'scripts/clean-daemon.ts'],
+      {
+        env: { ...process.env, AGENT_DEVICE_STATE_DIR: stateDir },
+        timeoutMs: 30_000,
+      },
+    );
+    assert.equal(cleanup.exitCode, 0, cleanup.stderr);
+    assert.equal(isProcessAlive(info.pid), false);
+    assert.equal(fs.existsSync(path.join(stateDir, 'daemon.json')), false);
+    assert.equal(fs.existsSync(path.join(stateDir, 'daemon.lock')), false);
+  } finally {
+    if (info) {
+      await stopProcessForTakeover(info.pid, {
+        termTimeoutMs: 1_500,
+        killTimeoutMs: 1_500,
+        expectedStartTime: info.processStartTime,
+      });
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+function readDaemonInfo(stateDir: string): DaemonInfo {
+  return JSON.parse(fs.readFileSync(path.join(stateDir, 'daemon.json'), 'utf8')) as DaemonInfo;
+}


### PR DESCRIPTION
## Summary

Fixes Maestro replay instability in React Navigation flows by resolving Maestro tap/swipe targets from raw snapshots, so non-interactive drawer/tab items remain addressable.

Updates iOS simulator deep-link launch behavior to launch the app with launch args before opening the URL.

Moves replay progress presentation into CLI-owned code so terminal pass/fail events are rendered once from the final suite result while retry failures still stream live.

## Validation

Ran focused Maestro/runtime and iOS unit coverage, pnpm check:quick, and pnpm build.

Manually verified the Drawer - Master Detail Maestro replay on iOS prints a single PASS line and passes end to end.