### PR TITLE
refactor: deepen runner disposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,9 +295,9 @@ Command-only flags (like `find --first`) that do not flow to the platform layer 
 - Open a ready-for-review PR by default. Use a draft PR only when the user explicitly asks for one or the work is intentionally incomplete.
 - Run required checks for touched scope from **Testing Matrix**.
 - PR body must be short and include:
-  - `## Summary`: describe the user-visible or reviewer-relevant change as before/after when useful, and include the issue closed by the PR using `Closes #123` when applicable.
+  - `## Summary`: lead with benefits and reviewer-relevant outcomes. Prefer a compact before/after when it makes the improvement clearer. Include the issue closed by the PR using `Closes #123` when applicable.
   - `## Validation`: answer this prompt in concise prose: "How did you verify the change, and what passed or changed on screen?" Prefer evidence over command dumps; mention the relevant check category or scenario, and include screenshots when visual/UI behavior is relevant.
-- Call out known gaps/follow-ups explicitly.
+- Call out real tradeoffs, known gaps, or follow-ups explicitly; omit boilerplate when there are none.
 - Include touched-file count and note if scope expanded beyond initial command family.
 
 ## Priority Order

--- a/src/daemon/__tests__/daemon-command-registry.test.ts
+++ b/src/daemon/__tests__/daemon-command-registry.test.ts
@@ -13,6 +13,7 @@ import {
   shouldLockSessionExecution,
   shouldPreferExplicitDeviceOverExistingSession,
   shouldValidateSessionSelector,
+  resolveProviderDeviceResolutionIntent,
   usesSessionlessDefaultProviderDevice,
 } from '../daemon-command-registry.ts';
 import type { DaemonRequest } from '../types.ts';
@@ -154,6 +155,40 @@ test('daemon command registry preserves provider device resolution traits', () =
   assert.equal(
     usesSessionlessDefaultProviderDevice(makeRequest(PUBLIC_COMMANDS.record, ['stop'])),
     false,
+  );
+  assert.equal(
+    resolveProviderDeviceResolutionIntent(makeRequest(PUBLIC_COMMANDS.test), {
+      hasExistingSession: false,
+      hasExplicitDeviceSelector: false,
+    }),
+    'skip',
+  );
+  assert.equal(
+    resolveProviderDeviceResolutionIntent(
+      {
+        ...makeRequest(PUBLIC_COMMANDS.test),
+        flags: { shardAll: 2 },
+      },
+      {
+        hasExistingSession: false,
+        hasExplicitDeviceSelector: true,
+      },
+    ),
+    'skip',
+  );
+  assert.equal(
+    resolveProviderDeviceResolutionIntent(makeRequest(PUBLIC_COMMANDS.open), {
+      hasExistingSession: false,
+      hasExplicitDeviceSelector: false,
+    }),
+    'sessionless-default-device',
+  );
+  assert.equal(
+    resolveProviderDeviceResolutionIntent(makeRequest(PUBLIC_COMMANDS.apps), {
+      hasExistingSession: true,
+      hasExplicitDeviceSelector: true,
+    }),
+    'explicit-device',
   );
 });
 

--- a/src/daemon/__tests__/request-platform-providers.test.ts
+++ b/src/daemon/__tests__/request-platform-providers.test.ts
@@ -92,6 +92,39 @@ test('request platform provider scope follows explicit apps selector for existin
   assert.deepEqual(seenDevices, [`default:${OTHER_IOS_SIMULATOR.id}`]);
 });
 
+test('request platform provider scope skips sharded test orchestration requests', async () => {
+  let providerCalls = 0;
+
+  const result = await withTargetDeviceResolutionScope(
+    async () => {
+      throw new Error('Sharded test orchestration should not resolve a provider device');
+    },
+    async () =>
+      await withRequestPlatformProviderScope(
+        {
+          req: {
+            ...request('test'),
+            flags: {
+              platform: 'ios',
+              shardAll: 2,
+            },
+          },
+          existingSession: undefined,
+          providers: {
+            appleToolProvider: () => {
+              providerCalls += 1;
+              return createLocalAppleToolProvider();
+            },
+          },
+        },
+        async () => 'unscoped',
+      ),
+  );
+
+  assert.equal(result, 'unscoped');
+  assert.equal(providerCalls, 0);
+});
+
 test('request platform provider scopes stay isolated across concurrent requests', async () => {
   const androidCalls: string[] = [];
   const appleCalls: string[] = [];

--- a/src/daemon/daemon-command-registry.ts
+++ b/src/daemon/daemon-command-registry.ts
@@ -27,7 +27,14 @@ type DaemonCommandDescriptor = {
   androidBlockingDialogGuard?: boolean;
   preferExplicitDeviceOverExistingSession?: boolean;
   allowSessionlessDefaultDevice?: (req: DaemonRequest) => boolean;
+  skipSessionlessProviderDevice?: (req: DaemonRequest) => boolean;
 };
+
+export type DaemonProviderDeviceResolutionIntent =
+  | 'existing-session'
+  | 'explicit-device'
+  | 'sessionless-default-device'
+  | 'skip';
 
 const REQUEST_EXECUTION_EXEMPT = {
   leaseAdmissionExempt: true,
@@ -78,7 +85,7 @@ const DAEMON_COMMAND_DESCRIPTORS = [
   ),
   ...descriptors(
     'session',
-    { sessionKind: 'replay' },
+    { sessionKind: 'replay', skipSessionlessProviderDevice: isShardedTestRequest },
     PUBLIC_COMMANDS.replay,
     PUBLIC_COMMANDS.test,
   ),
@@ -212,6 +219,20 @@ export function usesSessionlessDefaultProviderDevice(req: DaemonRequest): boolea
   return typeof allow === 'function' ? allow(req) : false;
 }
 
+export function resolveProviderDeviceResolutionIntent(
+  req: DaemonRequest,
+  params: { hasExistingSession: boolean; hasExplicitDeviceSelector: boolean },
+): DaemonProviderDeviceResolutionIntent {
+  if (params.hasExistingSession) {
+    return shouldPreferExplicitDeviceOverExistingSession(req) && params.hasExplicitDeviceSelector
+      ? 'explicit-device'
+      : 'existing-session';
+  }
+  if (shouldSkipSessionlessProviderDevice(req)) return 'skip';
+  if (params.hasExplicitDeviceSelector) return 'explicit-device';
+  return usesSessionlessDefaultProviderDevice(req) ? 'sessionless-default-device' : 'skip';
+}
+
 function descriptor(
   command: string,
   route: DaemonCommandRoute,
@@ -251,4 +272,16 @@ function buildDaemonCommandRegistry(descriptors: readonly DaemonCommandDescripto
 
 function isRecordStartRequest(req: DaemonRequest): boolean {
   return (req.positionals?.[0] ?? '').toLowerCase() === 'start';
+}
+
+function shouldSkipSessionlessProviderDevice(req: DaemonRequest): boolean {
+  const skip = getDaemonCommandDescriptor(req.command)?.skipSessionlessProviderDevice;
+  return typeof skip === 'function' ? skip(req) : false;
+}
+
+function isShardedTestRequest(req: DaemonRequest): boolean {
+  return (
+    req.command === PUBLIC_COMMANDS.test &&
+    (typeof req.flags?.shardAll === 'number' || typeof req.flags?.shardSplit === 'number')
+  );
 }

--- a/src/daemon/request-platform-providers.ts
+++ b/src/daemon/request-platform-providers.ts
@@ -14,10 +14,7 @@ import type { AppLogProvider } from './app-log.ts';
 import { hasExplicitDeviceSelector } from './device-selector-intent.ts';
 import type { RecordingProvider } from './recording-provider.ts';
 import type { DaemonRequest, SessionState } from './types.ts';
-import {
-  shouldPreferExplicitDeviceOverExistingSession,
-  usesSessionlessDefaultProviderDevice,
-} from './daemon-command-registry.ts';
+import { resolveProviderDeviceResolutionIntent } from './daemon-command-registry.ts';
 
 export type PlatformProviderRequestSession = Pick<
   SessionState,
@@ -279,35 +276,19 @@ async function resolveScopedProviderDevice(
   req: DaemonRequest,
   existingSession: SessionState | undefined,
 ): Promise<DeviceInfo | undefined> {
-  if (existingSession) {
-    return await resolveExistingSessionProviderDevice(req, existingSession);
+  const intent = resolveProviderDeviceResolutionIntent(req, {
+    hasExistingSession: Boolean(existingSession),
+    hasExplicitDeviceSelector: hasExplicitDeviceSelector(req.flags),
+  });
+  switch (intent) {
+    case 'existing-session':
+      return existingSession?.device;
+    case 'explicit-device':
+    case 'sessionless-default-device':
+      return await resolveTargetDevice(req.flags ?? {});
+    case 'skip':
+      return undefined;
   }
-  if (shouldSkipSessionlessProviderDevice(req)) return undefined;
-  return await resolveTargetDevice(req.flags ?? {});
-}
-
-async function resolveExistingSessionProviderDevice(
-  req: DaemonRequest,
-  existingSession: SessionState,
-): Promise<DeviceInfo> {
-  if (!shouldResolveExplicitProviderDevice(req)) return existingSession.device;
-  return await resolveTargetDevice(req.flags ?? {});
-}
-
-function shouldResolveExplicitProviderDevice(req: DaemonRequest): boolean {
-  return shouldPreferExplicitDeviceOverExistingSession(req) && hasExplicitDeviceSelector(req.flags);
-}
-
-function shouldSkipSessionlessProviderDevice(req: DaemonRequest): boolean {
-  if (isShardedReplayTestRequest(req)) return true;
-  return !hasExplicitDeviceSelector(req.flags) && !usesSessionlessDefaultProviderDevice(req);
-}
-
-function isShardedReplayTestRequest(req: DaemonRequest): boolean {
-  return (
-    req.command === 'test' &&
-    (typeof req.flags?.shardAll === 'number' || typeof req.flags?.shardSplit === 'number')
-  );
 }
 
 async function requestPlatformProviderScopeWrappers(

--- a/src/platforms/ios/runner-disposal.ts
+++ b/src/platforms/ios/runner-disposal.ts
@@ -1,0 +1,199 @@
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { isProcessAlive, isProcessGroupAlive } from '../../utils/process-identity.ts';
+import { cleanupTempFile, waitForRunner } from './runner-transport.ts';
+import { withRunnerCommandId, type RunnerCommand } from './runner-contract.ts';
+import {
+  cleanupOwnedRunnerLease,
+  releaseRunnerLease,
+  type RunnerLeaseCleanupAdapter,
+} from './runner-lease.ts';
+import { runnerPrepProcesses } from './runner-xctestrun.ts';
+import { runAppleToolCommand } from './tool-provider.ts';
+import type { RunnerSession } from './runner-session-types.ts';
+
+export const RUNNER_INVALIDATE_WAIT_TIMEOUT_MS = 1_000;
+
+const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
+const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
+const RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS = 2_000;
+
+export const runnerLeaseCleanupAdapter: RunnerLeaseCleanupAdapter = {
+  cleanupRunnerProcessTree: killRunnerProcessTree,
+  cleanupRunnerXcodebuildProcesses: killRunnerXcodebuildProcesses,
+  cleanupTempFile,
+};
+
+export async function disposeRunnerSession(
+  session: RunnerSession,
+  options: { graceful?: boolean; waitTimeoutMs?: number } = {},
+): Promise<void> {
+  if (options.graceful !== false) {
+    await shutdownRunnerSessionGracefully(session);
+  } else {
+    await killRunnerProcessTree(session.child.pid, 'SIGTERM');
+  }
+
+  await waitForRunnerProcessExit(session, options.waitTimeoutMs ?? RUNNER_STOP_WAIT_TIMEOUT_MS);
+  if (isRunnerProcessTreeAlive(session.child.pid)) {
+    await killRunnerProcessTree(session.child.pid, 'SIGKILL');
+  }
+  await cleanupRunnerSessionResources(session);
+}
+
+export async function cleanupOwnedIosRunnerLease(deviceId: string): Promise<void> {
+  await cleanupOwnedRunnerLease(deviceId, runnerLeaseCleanupAdapter);
+}
+
+export async function abortRunnerSessionsAndPrepProcesses(
+  activeSessions: readonly RunnerSession[],
+): Promise<void> {
+  const prepProcesses = Array.from(runnerPrepProcesses);
+  await signalRunnerSessions(activeSessions, 'SIGINT');
+  await signalRunnerPrepProcesses(prepProcesses, 'SIGINT');
+  await signalRunnerSessions(activeSessions, 'SIGTERM');
+  await signalRunnerPrepProcesses(prepProcesses, 'SIGTERM');
+  await signalRunnerSessions(activeSessions, 'SIGKILL');
+  await signalRunnerPrepProcesses(prepProcesses, 'SIGKILL');
+  await Promise.allSettled(
+    activeSessions.map(async (session) => {
+      await cleanupRunnerSessionResources(session);
+    }),
+  );
+}
+
+export async function stopRunnerPrepProcesses(): Promise<void> {
+  const prepProcesses = Array.from(runnerPrepProcesses);
+  await Promise.allSettled(
+    prepProcesses.map(async (child) => {
+      try {
+        await killRunnerProcessTree(child.pid, 'SIGTERM');
+        await killRunnerProcessTree(child.pid, 'SIGKILL');
+      } finally {
+        runnerPrepProcesses.delete(child);
+      }
+    }),
+  );
+}
+
+async function shutdownRunnerSessionGracefully(session: RunnerSession): Promise<void> {
+  try {
+    await waitForRunner(
+      session.device,
+      session.port,
+      withRunnerCommandId({
+        command: 'shutdown',
+      } as RunnerCommand),
+      undefined,
+      RUNNER_SHUTDOWN_TIMEOUT_MS,
+    );
+  } catch {
+    await killRunnerProcessTree(session.child.pid, 'SIGTERM');
+  }
+}
+
+async function waitForRunnerProcessExit(
+  session: RunnerSession,
+  waitTimeoutMs: number,
+): Promise<void> {
+  try {
+    await Promise.race([
+      session.testPromise,
+      new Promise<void>((resolve) => setTimeout(resolve, waitTimeoutMs)),
+    ]);
+  } catch {}
+}
+
+async function cleanupRunnerSessionResources(session: RunnerSession): Promise<void> {
+  cleanupTempFile(session.xctestrunPath);
+  cleanupTempFile(session.jsonPath);
+  try {
+    await session.simulatorSetRedirect?.release();
+  } finally {
+    releaseRunnerLease(session.lease);
+  }
+}
+
+function isRunnerProcessTreeAlive(pid: number | undefined): boolean {
+  if (!pid) return false;
+  return isRunnerProcessAlive(pid) || isProcessGroupAlive(pid);
+}
+
+export function isRunnerProcessAlive(pid: number | undefined): boolean {
+  if (!pid) return false;
+  return isProcessAlive(pid);
+}
+
+async function signalRunnerSessions(
+  activeSessions: readonly RunnerSession[],
+  signal: 'SIGINT' | 'SIGTERM' | 'SIGKILL',
+): Promise<void> {
+  await Promise.allSettled(
+    activeSessions.map(async (session) => {
+      await killRunnerProcessTree(session.child.pid, signal);
+    }),
+  );
+}
+
+async function signalRunnerPrepProcesses(
+  prepProcesses: readonly RunnerSession['child'][],
+  signal: 'SIGINT' | 'SIGTERM' | 'SIGKILL',
+): Promise<void> {
+  await Promise.allSettled(
+    prepProcesses.map(async (child) => {
+      await killRunnerProcessTree(child.pid, signal);
+      if (signal === 'SIGKILL') {
+        runnerPrepProcesses.delete(child);
+      }
+    }),
+  );
+}
+
+async function killRunnerProcessTree(
+  pid: number | undefined,
+  signal: 'SIGINT' | 'SIGTERM' | 'SIGKILL',
+): Promise<void> {
+  if (!pid || pid <= 0) return;
+  try {
+    process.kill(-pid, signal);
+  } catch {}
+  try {
+    process.kill(pid, signal);
+  } catch {}
+  const pkillSignal = signal === 'SIGINT' ? 'INT' : signal === 'SIGTERM' ? 'TERM' : 'KILL';
+  try {
+    await runAppleToolCommand('pkill', [`-${pkillSignal}`, '-P', String(pid)], {
+      allowFailure: true,
+    });
+  } catch {}
+}
+
+async function killRunnerXcodebuildProcesses(
+  deviceId: string,
+  ownerToken: string | undefined,
+): Promise<void> {
+  const pattern = ownerToken
+    ? `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-${escapeRegex(ownerToken)}-`
+    : `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-[0-9]`;
+  for (const signal of ['TERM', 'KILL'] as const) {
+    try {
+      await runAppleToolCommand('pkill', [`-${signal}`, '-f', pattern], {
+        allowFailure: true,
+        timeoutMs: RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS,
+      });
+    } catch (error) {
+      emitDiagnostic({
+        level: 'warn',
+        phase: 'ios_runner_stale_xcodebuild_kill_failed',
+        data: {
+          deviceId,
+          signal,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  }
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -2,17 +2,15 @@ import { AppError, toAppErrorCode } from '../../utils/errors.ts';
 import { runCmdBackground, type ExecResult, type ExecBackgroundResult } from '../../utils/exec.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
 import { Deadline } from '../../utils/retry.ts';
-import { isProcessAlive, isProcessGroupAlive } from '../../utils/process-identity.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
-import { runAppleToolCommand, runXcrun } from './tool-provider.ts';
+import { runXcrun } from './tool-provider.ts';
 import {
   waitForRunner,
   sendRunnerCommandOnce,
   getFreePort,
   logChunk,
-  cleanupTempFile,
   RUNNER_STARTUP_TIMEOUT_MS,
   RUNNER_DESTINATION_TIMEOUT_SECONDS,
 } from './runner-transport.ts';
@@ -25,7 +23,6 @@ import {
   resolveRunnerDerivedPath,
   resolveRunnerDestination,
   resolveRunnerMaxConcurrentDestinationsFlag,
-  runnerPrepProcesses,
 } from './runner-xctestrun.ts';
 import {
   isReadOnlyRunnerCommand,
@@ -34,14 +31,20 @@ import {
 } from './runner-contract.ts';
 import {
   buildRunnerLease,
-  cleanupOwnedRunnerLease,
   prepareRunnerLeaseForStartup,
-  releaseRunnerLease,
   RUNNER_OWNER_TOKEN,
   withRunnerLeaseLock,
   writeRunnerLease,
-  type RunnerLeaseCleanupAdapter,
 } from './runner-lease.ts';
+import {
+  abortRunnerSessionsAndPrepProcesses,
+  cleanupOwnedIosRunnerLease,
+  disposeRunnerSession,
+  isRunnerProcessAlive,
+  runnerLeaseCleanupAdapter,
+  RUNNER_INVALIDATE_WAIT_TIMEOUT_MS,
+  stopRunnerPrepProcesses,
+} from './runner-disposal.ts';
 import type { RunnerSession } from './runner-session-types.ts';
 
 export type { RunnerSession } from './runner-session-types.ts';
@@ -59,17 +62,8 @@ export type RunnerSessionOptions = {
 
 const runnerSessions = new Map<string, RunnerSession>();
 const runnerSessionLocks = new Map<string, Promise<unknown>>();
-const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
-const RUNNER_INVALIDATE_WAIT_TIMEOUT_MS = 1_000;
 const RUNNER_READY_PREFLIGHT_TIMEOUT_MS = 1_000;
-const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
 const RUNNER_STALE_BUNDLE_UNINSTALL_TIMEOUT_MS = 10_000;
-const RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS = 2_000;
-const runnerLeaseCleanupAdapter: RunnerLeaseCleanupAdapter = {
-  cleanupRunnerProcessTree: killRunnerProcessTree,
-  cleanupRunnerXcodebuildProcesses: killRunnerXcodebuildProcesses,
-  cleanupTempFile,
-};
 
 type RunnerReadinessPreflightDecision =
   | {
@@ -378,38 +372,7 @@ async function stopRunnerSessionInternal(
 ): Promise<void> {
   const session = sessionOverride ?? runnerSessions.get(deviceId);
   if (!session) return;
-  if (options.graceful !== false) {
-    try {
-      await waitForRunner(
-        session.device,
-        session.port,
-        withRunnerCommandId({
-          command: 'shutdown',
-        } as RunnerCommand),
-        undefined,
-        RUNNER_SHUTDOWN_TIMEOUT_MS,
-      );
-    } catch {
-      await killRunnerProcessTree(session.child.pid, 'SIGTERM');
-    }
-  } else {
-    await killRunnerProcessTree(session.child.pid, 'SIGTERM');
-  }
-  try {
-    await Promise.race([
-      session.testPromise,
-      new Promise<void>((resolve) =>
-        setTimeout(resolve, options.waitTimeoutMs ?? RUNNER_STOP_WAIT_TIMEOUT_MS),
-      ),
-    ]);
-  } catch {}
-  if (isRunnerProcessTreeAlive(session.child.pid)) {
-    await killRunnerProcessTree(session.child.pid, 'SIGKILL');
-  }
-  cleanupTempFile(session.xctestrunPath);
-  cleanupTempFile(session.jsonPath);
-  await session.simulatorSetRedirect?.release();
-  releaseRunnerLease(session.lease);
+  await disposeRunnerSession(session, options);
   if (runnerSessions.get(deviceId) === session) {
     runnerSessions.delete(deviceId);
   }
@@ -419,54 +382,15 @@ export async function stopIosRunnerSession(deviceId: string): Promise<void> {
   await withRunnerSessionLock(deviceId, async () => {
     await withRunnerLeaseLock(deviceId, async () => {
       await stopRunnerSessionInternal(deviceId);
-      await cleanupOwnedRunnerLease(deviceId, runnerLeaseCleanupAdapter);
+      await cleanupOwnedIosRunnerLease(deviceId);
     });
   });
 }
 
 export async function abortAllIosRunnerSessions(): Promise<void> {
   const activeSessions = Array.from(runnerSessions.values());
-  const prepProcesses = Array.from(runnerPrepProcesses);
-  await Promise.allSettled(
-    activeSessions.map(async (session) => {
-      await killRunnerProcessTree(session.child.pid, 'SIGINT');
-    }),
-  );
-  await Promise.allSettled(
-    prepProcesses.map(async (child) => {
-      await killRunnerProcessTree(child.pid, 'SIGINT');
-    }),
-  );
-  await Promise.allSettled(
-    activeSessions.map(async (session) => {
-      await killRunnerProcessTree(session.child.pid, 'SIGTERM');
-    }),
-  );
-  await Promise.allSettled(
-    prepProcesses.map(async (child) => {
-      await killRunnerProcessTree(child.pid, 'SIGTERM');
-    }),
-  );
-  await Promise.allSettled(
-    activeSessions.map(async (session) => {
-      await killRunnerProcessTree(session.child.pid, 'SIGKILL');
-    }),
-  );
-  await Promise.allSettled(
-    prepProcesses.map(async (child) => {
-      await killRunnerProcessTree(child.pid, 'SIGKILL');
-      runnerPrepProcesses.delete(child);
-    }),
-  );
-  await Promise.allSettled(
-    activeSessions.map(async (session) => {
-      await session.simulatorSetRedirect?.release();
-    }),
-  );
+  await abortRunnerSessionsAndPrepProcesses(activeSessions);
   for (const session of activeSessions) {
-    cleanupTempFile(session.xctestrunPath);
-    cleanupTempFile(session.jsonPath);
-    releaseRunnerLease(session.lease);
     if (runnerSessions.get(session.deviceId) === session) {
       runnerSessions.delete(session.deviceId);
     }
@@ -481,77 +405,7 @@ export async function stopAllIosRunnerSessions(): Promise<void> {
       await stopIosRunnerSession(deviceId);
     }),
   );
-  const prepProcesses = Array.from(runnerPrepProcesses);
-  await Promise.allSettled(
-    prepProcesses.map(async (child) => {
-      try {
-        await killRunnerProcessTree(child.pid, 'SIGTERM');
-        await killRunnerProcessTree(child.pid, 'SIGKILL');
-      } finally {
-        runnerPrepProcesses.delete(child);
-      }
-    }),
-  );
-}
-
-function isRunnerProcessAlive(pid: number | undefined): boolean {
-  if (!pid) return false;
-  return isProcessAlive(pid);
-}
-
-function isRunnerProcessTreeAlive(pid: number | undefined): boolean {
-  if (!pid) return false;
-  return isRunnerProcessAlive(pid) || isProcessGroupAlive(pid);
-}
-
-async function killRunnerProcessTree(
-  pid: number | undefined,
-  signal: 'SIGINT' | 'SIGTERM' | 'SIGKILL',
-): Promise<void> {
-  if (!pid || pid <= 0) return;
-  try {
-    process.kill(-pid, signal);
-  } catch {}
-  try {
-    process.kill(pid, signal);
-  } catch {}
-  const pkillSignal = signal === 'SIGINT' ? 'INT' : signal === 'SIGTERM' ? 'TERM' : 'KILL';
-  try {
-    await runAppleToolCommand('pkill', [`-${pkillSignal}`, '-P', String(pid)], {
-      allowFailure: true,
-    });
-  } catch {}
-}
-
-async function killRunnerXcodebuildProcesses(
-  deviceId: string,
-  ownerToken: string | undefined,
-): Promise<void> {
-  const pattern = ownerToken
-    ? `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-${escapeRegex(ownerToken)}-`
-    : `xcodebuild.*test-without-building.*AgentDeviceRunner\\.env\\.session-${escapeRegex(deviceId)}-[0-9]`;
-  for (const signal of ['TERM', 'KILL'] as const) {
-    try {
-      await runAppleToolCommand('pkill', [`-${signal}`, '-f', pattern], {
-        allowFailure: true,
-        timeoutMs: RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS,
-      });
-    } catch (error) {
-      emitDiagnostic({
-        level: 'warn',
-        phase: 'ios_runner_stale_xcodebuild_kill_failed',
-        data: {
-          deviceId,
-          signal,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      });
-    }
-  }
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  await stopRunnerPrepProcesses();
 }
 
 function ensureBootedIfNeeded(device: DeviceInfo): Promise<void> {


### PR DESCRIPTION
## Summary

This PR makes runner lifecycle cleanup easier to reason about and harder to get wrong.

Before:
- Runner disposal policy was split across session invalidation, graceful stop, daemon shutdown, forced abort, lease cleanup, and prep-process cleanup.
- Request provider scoping still carried a command-specific sharded-test exception even though daemon command policy belongs in the registry.

After:
- iOS runner disposal has one focused module for shutdown intent, process cleanup, temporary file cleanup, simulator redirect release, lease release, and prep-process cleanup.
- runner-session.ts keeps session map and locking ownership instead of carrying disposal mechanics.
- Provider device resolution intent lives in the daemon command registry, so request-platform-providers.ts only applies provider adapters.
- Future lifecycle fixes should have fewer paths to audit when runner leases, daemon shutdown, and clean:daemon behavior interact.

Tradeoffs:
- This adds one iOS runner module, but removes duplicated lifecycle policy from the session module and makes the ownership boundary clearer.

Touched files: 7. Scope stayed within iOS runner lifecycle, daemon provider policy, and PR guidance.

## Validation

Focused runner/provider tests passed: runner-session, daemon-command-registry, and request-platform-providers suites. pnpm check:quick passed. Smoke checks passed with listener-dependent cases skipped by the environment. Full pnpm check:unit was attempted in sandbox and escalated; remaining failures were unrelated mocked Android/iOS tool tests and timeouts outside the touched modules. CI later passed all required checks on the PR.
