### PR TITLE
refactor: deepen replay test attempt module

### DIFF
--- a/src/cli-test-trace.ts
+++ b/src/cli-test-trace.ts
@@ -1,0 +1,183 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ReplaySuiteTestResult } from './daemon/types.ts';
+import { formatDurationSeconds } from './utils/duration-format.ts';
+
+type ReplayActionStartTrace = {
+  type: 'replay_action_start';
+  step: number;
+  line?: number;
+  command?: string;
+  positionals?: unknown[];
+};
+
+type ReplayActionStopTrace = {
+  type: 'replay_action_stop';
+  step: number;
+  line?: number;
+  command?: string;
+  ok?: boolean;
+  durationMs?: number;
+  errorCode?: string;
+  resultTiming?: Record<string, unknown>;
+};
+
+export function replayTestStepLines(result: ReplaySuiteTestResult): string[] {
+  if (result.status === 'skipped') return [];
+  const tracePath = replayTestTimingTracePath(result);
+  if (!tracePath) return [];
+  const events = readReplayTimingTrace(tracePath);
+  if (events.length === 0) return [];
+
+  const starts: ReplayActionStartTrace[] = [];
+  const stops: Array<{ stop: ReplayActionStopTrace; start: ReplayActionStartTrace | undefined }> =
+    [];
+  for (const event of events) {
+    if (isReplayActionStartTrace(event)) {
+      starts.push(event);
+      continue;
+    }
+    if (isReplayActionStopTrace(event)) {
+      stops.push({ stop: event, start: consumeReplayActionStart(starts, event) });
+    }
+  }
+  if (stops.length === 0) return [];
+
+  return [
+    result.attempts > 1 ? `steps (attempt ${result.attempts}):` : 'steps:',
+    ...stops.map(({ stop, start }) => renderReplayStepTrace(stop, start)),
+  ];
+}
+
+function consumeReplayActionStart(
+  starts: ReplayActionStartTrace[],
+  stop: ReplayActionStopTrace,
+): ReplayActionStartTrace | undefined {
+  const stopCommand = stop.command;
+  const matchingIndex = starts.findIndex(
+    (start) =>
+      start.step === stop.step &&
+      (stopCommand === undefined || start.command === undefined || start.command === stopCommand),
+  );
+  if (matchingIndex < 0) return undefined;
+  return starts.splice(matchingIndex, 1)[0];
+}
+
+function replayTestTimingTracePath(
+  result: Extract<ReplaySuiteTestResult, { status: 'passed' | 'failed' }>,
+): string | undefined {
+  return result.artifactsDir
+    ? path.join(result.artifactsDir, `attempt-${result.attempts}`, 'replay-timing.ndjson')
+    : undefined;
+}
+
+function readReplayTimingTrace(tracePath: string): Record<string, unknown>[] {
+  try {
+    return fs
+      .readFileSync(tracePath, 'utf8')
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+      .flatMap((line) => {
+        try {
+          const parsed = JSON.parse(line) as unknown;
+          return isPlainRecord(parsed) ? [parsed] : [];
+        } catch {
+          return [];
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+function isReplayActionStartTrace(event: Record<string, unknown>): event is ReplayActionStartTrace {
+  return (
+    event.type === 'replay_action_start' &&
+    hasTraceStep(event) &&
+    hasOptionalNumber(event, 'line') &&
+    hasOptionalString(event, 'command') &&
+    (event.positionals === undefined || Array.isArray(event.positionals))
+  );
+}
+
+function isReplayActionStopTrace(event: Record<string, unknown>): event is ReplayActionStopTrace {
+  return allChecksPass([
+    event.type === 'replay_action_stop' &&
+      hasTraceStep(event) &&
+      hasOptionalNumber(event, 'line') &&
+      hasOptionalString(event, 'command'),
+    hasOptionalBoolean(event, 'ok'),
+    hasOptionalNumber(event, 'durationMs'),
+    hasOptionalString(event, 'errorCode'),
+    event.resultTiming === undefined || isPlainRecord(event.resultTiming),
+  ]);
+}
+
+function hasTraceStep(event: Record<string, unknown>): boolean {
+  return typeof event.step === 'number';
+}
+
+function hasOptionalNumber(event: Record<string, unknown>, key: string): boolean {
+  return event[key] === undefined || typeof event[key] === 'number';
+}
+
+function hasOptionalString(event: Record<string, unknown>, key: string): boolean {
+  return event[key] === undefined || typeof event[key] === 'string';
+}
+
+function hasOptionalBoolean(event: Record<string, unknown>, key: string): boolean {
+  return event[key] === undefined || typeof event[key] === 'boolean';
+}
+
+function allChecksPass(checks: boolean[]): boolean {
+  return checks.every(Boolean);
+}
+
+function renderReplayStepTrace(
+  stop: ReplayActionStopTrace,
+  start: ReplayActionStartTrace | undefined,
+): string {
+  const failed = stop.ok === false;
+  const status = failed ? '[FAIL] ' : stop.ok === true ? '' : '[info] ';
+  return `  ${status}${formatReplayStepCommand(start, stop)}${formatReplayStepDetails(stop, start)}`;
+}
+
+function formatReplayStepDetails(
+  stop: ReplayActionStopTrace,
+  start: ReplayActionStartTrace | undefined,
+): string {
+  const line = start?.line ?? stop.line;
+  const details = [
+    typeof line === 'number' ? `line ${line}` : '',
+    typeof stop.durationMs === 'number' ? formatDurationSeconds(stop.durationMs) : '',
+    stop.errorCode ?? '',
+    stop.resultTiming ? `timing ${JSON.stringify(stop.resultTiming)}` : '',
+  ].filter(Boolean);
+  return details.length > 0 ? ` (${details.join(', ')})` : '';
+}
+
+function formatReplayStepCommand(
+  start: ReplayActionStartTrace | undefined,
+  stop: ReplayActionStopTrace,
+): string {
+  const command = formatReplayStepCommandName(start?.command ?? stop.command);
+  const positionals = start?.positionals ?? [];
+  return [command, ...positionals.map(formatReplayStepArg)].join(' ');
+}
+
+function formatReplayStepCommandName(command: string | undefined): string {
+  if (!command) return 'unknown';
+  if (!command.startsWith('__maestro')) return command;
+  const name = command.slice('__maestro'.length);
+  return name.length > 0 ? name[0]!.toLowerCase() + name.slice(1) : command;
+}
+
+function formatReplayStepArg(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/cli-test.ts
+++ b/src/cli-test.ts
@@ -1,9 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { ReplaySuiteResult, ReplaySuiteTestResult } from './daemon/types.ts';
+import { replayTestStepLines } from './cli-test-trace.ts';
 import { formatDurationSeconds } from './utils/duration-format.ts';
 import { AppError } from './utils/errors.ts';
 import { printJson } from './utils/output.ts';
+
+type PassedReplayTestResult = Extract<ReplaySuiteTestResult, { status: 'passed' }>;
+type FailedReplayTestResult = Extract<ReplaySuiteTestResult, { status: 'failed' }>;
+type ReplayTestError = FailedReplayTestResult['error'];
 
 export function announceReplayTestRun(options: { json?: boolean }): void {
   if (!options.json) {
@@ -89,9 +94,7 @@ function renderVerboseTestResult(result: ReplaySuiteTestResult): void {
   }
 }
 
-function renderFailedTestResult(
-  result: Extract<ReplaySuiteTestResult, { status: 'failed' }>,
-): void {
+function renderFailedTestResult(result: FailedReplayTestResult): void {
   const attemptSuffix = result.attempts > 1 ? ` after ${result.attempts} attempts` : '';
   const durationSuffix = formatReplayTestDurationSuffix(result);
   process.stdout.write(
@@ -112,197 +115,20 @@ function replayResultPrefix(result: ReplaySuiteTestResult): string {
   return 'INFO';
 }
 
-function replayFailureConsoleLines(
-  result: Extract<ReplaySuiteTestResult, { status: 'failed' }>,
-): string[] {
+function replayFailureConsoleLines(result: FailedReplayTestResult): string[] {
   return [
-    result.error?.hint ? `hint: ${result.error.hint}` : '',
-    result.artifactsDir ? `artifacts: ${result.artifactsDir}` : '',
-    result.error?.logPath ? `log: ${result.error.logPath}` : '',
-    result.error?.diagnosticId ? `diagnostic: ${result.error.diagnosticId}` : '',
-  ].filter(Boolean);
+    replayErrorHintLine(result.error),
+    replayArtifactsLine(result, 'artifacts'),
+    replayErrorLogLine(result.error, 'log'),
+    replayErrorDiagnosticLine(result.error, 'diagnostic'),
+  ].filter(isDefinedString);
 }
 
-type ReplayActionStartTrace = {
-  type: 'replay_action_start';
-  step: number;
-  line?: number;
-  command?: string;
-  positionals?: unknown[];
-};
-
-type ReplayActionStopTrace = {
-  type: 'replay_action_stop';
-  step: number;
-  line?: number;
-  command?: string;
-  ok?: boolean;
-  durationMs?: number;
-  errorCode?: string;
-  resultTiming?: Record<string, unknown>;
-};
-
-function replayTestStepLines(result: ReplaySuiteTestResult): string[] {
-  if (result.status === 'skipped') return [];
-  const tracePath = replayTestTimingTracePath(result);
-  if (!tracePath) return [];
-  const events = readReplayTimingTrace(tracePath);
-  if (events.length === 0) return [];
-
-  const starts: ReplayActionStartTrace[] = [];
-  const stops: Array<{ stop: ReplayActionStopTrace; start: ReplayActionStartTrace | undefined }> =
-    [];
-  for (const event of events) {
-    if (isReplayActionStartTrace(event)) {
-      starts.push(event);
-      continue;
-    }
-    if (isReplayActionStopTrace(event)) {
-      stops.push({ stop: event, start: consumeReplayActionStart(starts, event) });
-    }
-  }
-  if (stops.length === 0) return [];
-
-  return [
-    result.attempts > 1 ? `steps (attempt ${result.attempts}):` : 'steps:',
-    ...stops.map(({ stop, start }) => renderReplayStepTrace(stop, start)),
-  ];
-}
-
-function consumeReplayActionStart(
-  starts: ReplayActionStartTrace[],
-  stop: ReplayActionStopTrace,
-): ReplayActionStartTrace | undefined {
-  const stopCommand = stop.command;
-  const matchingIndex = starts.findIndex(
-    (start) =>
-      start.step === stop.step &&
-      (stopCommand === undefined || start.command === undefined || start.command === stopCommand),
-  );
-  if (matchingIndex < 0) return undefined;
-  return starts.splice(matchingIndex, 1)[0];
-}
-
-function replayTestTimingTracePath(
-  result: Extract<ReplaySuiteTestResult, { status: 'passed' | 'failed' }>,
-): string | undefined {
-  return result.artifactsDir
-    ? path.join(result.artifactsDir, `attempt-${result.attempts}`, 'replay-timing.ndjson')
-    : undefined;
-}
-
-function readReplayTimingTrace(tracePath: string): Record<string, unknown>[] {
-  try {
-    return fs
-      .readFileSync(tracePath, 'utf8')
-      .split(/\r?\n/)
-      .filter((line) => line.trim().length > 0)
-      .flatMap((line) => {
-        try {
-          const parsed = JSON.parse(line) as unknown;
-          return isPlainRecord(parsed) ? [parsed] : [];
-        } catch {
-          return [];
-        }
-      });
-  } catch {
-    return [];
-  }
-}
-
-function isReplayActionStartTrace(event: Record<string, unknown>): event is ReplayActionStartTrace {
-  return (
-    event.type === 'replay_action_start' &&
-    hasTraceStep(event) &&
-    hasOptionalNumber(event, 'line') &&
-    hasOptionalString(event, 'command') &&
-    (event.positionals === undefined || Array.isArray(event.positionals))
-  );
-}
-
-function isReplayActionStopTrace(event: Record<string, unknown>): event is ReplayActionStopTrace {
-  return (
-    event.type === 'replay_action_stop' &&
-    hasTraceStep(event) &&
-    hasOptionalNumber(event, 'line') &&
-    hasOptionalString(event, 'command') &&
-    (event.ok === undefined || typeof event.ok === 'boolean') &&
-    hasOptionalNumber(event, 'durationMs') &&
-    hasOptionalString(event, 'errorCode') &&
-    (event.resultTiming === undefined || isPlainRecord(event.resultTiming))
-  );
-}
-
-function hasTraceStep(event: Record<string, unknown>): boolean {
-  return typeof event.step === 'number';
-}
-
-function hasOptionalNumber(event: Record<string, unknown>, key: string): boolean {
-  return event[key] === undefined || typeof event[key] === 'number';
-}
-
-function hasOptionalString(event: Record<string, unknown>, key: string): boolean {
-  return event[key] === undefined || typeof event[key] === 'string';
-}
-
-function renderReplayStepTrace(
-  stop: ReplayActionStopTrace,
-  start: ReplayActionStartTrace | undefined,
-): string {
-  const failed = stop.ok === false;
-  const status = failed ? '[FAIL] ' : stop.ok === true ? '' : '[info] ';
-  return `  ${status}${formatReplayStepCommand(start, stop)}${formatReplayStepDetails(stop, start)}`;
-}
-
-function formatReplayStepDetails(
-  stop: ReplayActionStopTrace,
-  start: ReplayActionStartTrace | undefined,
-): string {
-  const line = start?.line ?? stop.line;
-  const details = [
-    typeof line === 'number' ? `line ${line}` : '',
-    typeof stop.durationMs === 'number' ? formatDurationSeconds(stop.durationMs) : '',
-    stop.errorCode ?? '',
-    stop.resultTiming ? `timing ${JSON.stringify(stop.resultTiming)}` : '',
-  ].filter(Boolean);
-  return details.length > 0 ? ` (${details.join(', ')})` : '';
-}
-
-function formatReplayStepCommand(
-  start: ReplayActionStartTrace | undefined,
-  stop: ReplayActionStopTrace,
-): string {
-  const command = formatReplayStepCommandName(start?.command ?? stop.command);
-  const positionals = start?.positionals ?? [];
-  return [command, ...positionals.map(formatReplayStepArg)].join(' ');
-}
-
-function formatReplayStepCommandName(command: string | undefined): string {
-  if (!command) return 'unknown';
-  if (!command.startsWith('__maestro')) return command;
-  const name = command.slice('__maestro'.length);
-  return name.length > 0 ? name[0]!.toLowerCase() + name.slice(1) : command;
-}
-
-function formatReplayStepArg(value: unknown): string {
-  if (typeof value === 'string') return JSON.stringify(value);
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-  return JSON.stringify(value);
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function isFlakyReplayTestResult(
-  result: ReplaySuiteTestResult,
-): result is Extract<ReplaySuiteTestResult, { status: 'passed' }> {
+function isFlakyReplayTestResult(result: ReplaySuiteTestResult): result is PassedReplayTestResult {
   return result.status === 'passed' && result.attempts > 1;
 }
 
-function renderFlakyTestSummary(
-  results: Array<Extract<ReplaySuiteTestResult, { status: 'passed' }>>,
-): void {
+function renderFlakyTestSummary(results: PassedReplayTestResult[]): void {
   if (results.length === 0) return;
   process.stdout.write('Flaky tests:\n');
   for (const result of results) {
@@ -327,9 +153,7 @@ function replayTestDisplayName(result: ReplaySuiteTestResult): string {
   return `${base}${formatReplayTestShardSuffix(result)}`;
 }
 
-function replayFailedTestDisplayName(
-  result: Extract<ReplaySuiteTestResult, { status: 'failed' }>,
-): string {
+function replayFailedTestDisplayName(result: FailedReplayTestResult): string {
   const title = replayTestTitle(result);
   const filename = path.basename(result.file);
   const base = title && title.length > 0 ? `${JSON.stringify(title)} in ${filename}` : filename;
@@ -360,9 +184,7 @@ function formatReplayTestDurationSuffix(result: ReplaySuiteTestResult): string {
   return durationMs > 0 ? ` (${formatDurationSeconds(durationMs)})` : '';
 }
 
-function formatFlakyReplayDurationSuffix(
-  result: Extract<ReplaySuiteTestResult, { status: 'passed' }>,
-): string {
+function formatFlakyReplayDurationSuffix(result: PassedReplayTestResult): string {
   const timings = [
     typeof result.finalAttemptDurationMs === 'number'
       ? `passed attempt ${formatDurationSeconds(result.finalAttemptDurationMs)}`
@@ -434,10 +256,10 @@ function renderJUnitTestCase(test: ReplaySuiteTestResult): string[] {
   return lines;
 }
 
-function buildFailureDetails(test: Extract<ReplaySuiteTestResult, { status: 'failed' }>): string {
+function buildFailureDetails(test: FailedReplayTestResult): string {
   const lines = [test.error.message];
   appendReplayErrorMetadata(lines, test.error, { includeDetails: false });
-  if (test.artifactsDir) lines.push(`artifactsDir: ${test.artifactsDir}`);
+  appendOptionalLine(lines, replayArtifactsLine(test, 'artifactsDir'));
   appendReplayErrorDetails(lines, test.error, 2);
   return lines.join('\n');
 }
@@ -456,10 +278,7 @@ function appendReplaySystemOutMetadata(lines: string[], test: ReplaySuiteTestRes
   for (const warning of replayTestWarningLines(test)) {
     lines.push(warning);
   }
-  appendOptionalLine(
-    lines,
-    'artifactsDir' in test && test.artifactsDir ? `artifactsDir: ${test.artifactsDir}` : undefined,
-  );
+  appendOptionalLine(lines, replayArtifactsLine(test, 'artifactsDir'));
   appendReplayTestShardMetadata(lines, test);
   if (test.status === 'failed') {
     appendReplayFailureSystemOut(lines, test);
@@ -487,23 +306,20 @@ function appendReplayTestShardMetadata(lines: string[], result: ReplaySuiteTestR
   );
 }
 
-function appendReplayFailureSystemOut(
-  lines: string[],
-  test: Extract<ReplaySuiteTestResult, { status: 'failed' }>,
-): void {
+function appendReplayFailureSystemOut(lines: string[], test: FailedReplayTestResult): void {
   lines.push(`errorCode: ${test.error.code}`);
   appendReplayErrorMetadata(lines, test.error, { includeMessage: true });
 }
 
 function appendReplayErrorMetadata(
   lines: string[],
-  error: Extract<ReplaySuiteTestResult, { status: 'failed' }>['error'],
+  error: ReplayTestError,
   options: { includeMessage?: boolean; includeDetails?: boolean; detailsIndent?: number } = {},
 ): void {
   if (options.includeMessage) lines.push(`errorMessage: ${error.message}`);
-  if (error.hint) lines.push(`hint: ${error.hint}`);
-  if (error.diagnosticId) lines.push(`diagnosticId: ${error.diagnosticId}`);
-  if (error.logPath) lines.push(`logPath: ${error.logPath}`);
+  appendOptionalLine(lines, replayErrorHintLine(error));
+  appendOptionalLine(lines, replayErrorDiagnosticLine(error, 'diagnosticId'));
+  appendOptionalLine(lines, replayErrorLogLine(error, 'logPath'));
   if (options.includeDetails !== false) {
     appendReplayErrorDetails(lines, error, options.detailsIndent);
   }
@@ -511,15 +327,43 @@ function appendReplayErrorMetadata(
 
 function appendReplayErrorDetails(
   lines: string[],
-  error: Extract<ReplaySuiteTestResult, { status: 'failed' }>['error'],
+  error: ReplayTestError,
   detailsIndent?: number,
 ): void {
   const details = error.details ? JSON.stringify(error.details, null, detailsIndent) : undefined;
   if (details) lines.push(`details: ${details}`);
 }
 
+function replayArtifactsLine(
+  result: ReplaySuiteTestResult,
+  label: 'artifacts' | 'artifactsDir',
+): string | undefined {
+  return 'artifactsDir' in result && result.artifactsDir
+    ? `${label}: ${result.artifactsDir}`
+    : undefined;
+}
+
+function replayErrorHintLine(error: ReplayTestError): string | undefined {
+  return error.hint ? `hint: ${error.hint}` : undefined;
+}
+
+function replayErrorDiagnosticLine(
+  error: ReplayTestError,
+  label: 'diagnostic' | 'diagnosticId',
+): string | undefined {
+  return error.diagnosticId ? `${label}: ${error.diagnosticId}` : undefined;
+}
+
+function replayErrorLogLine(error: ReplayTestError, label: 'log' | 'logPath'): string | undefined {
+  return error.logPath ? `${label}: ${error.logPath}` : undefined;
+}
+
 function appendOptionalLine(lines: string[], line: string | undefined): void {
   if (line) lines.push(line);
+}
+
+function isDefinedString(value: string | undefined): value is string {
+  return value !== undefined;
 }
 
 function replayTestWarningLines(result: ReplaySuiteTestResult): string[] {

--- a/src/daemon/handlers/session-test-attempt.ts
+++ b/src/daemon/handlers/session-test-attempt.ts
@@ -1,0 +1,306 @@
+import path from 'node:path';
+import { emitRequestProgress } from '../request-progress.ts';
+import type { DaemonResponse, ReplaySuiteTestFailed, ReplaySuiteTestResult } from '../types.ts';
+import {
+  buildReplayTestArtifactSlug,
+  materializeReplayTestAttemptArtifacts,
+  prepareReplayTestAttemptArtifacts,
+} from './session-test-artifacts.ts';
+import {
+  buildReplayTestAttemptRequestId,
+  buildReplayTestSessionName,
+  type ReplayTestRunEntry,
+} from './session-test-discovery.ts';
+import { isReplayInfrastructureFailure } from './session-test-infrastructure.ts';
+import { runReplayTestAttempt } from './session-test-runtime.ts';
+import type { ReplayTestRuntimeDependencies } from './session-test-types.ts';
+import type { ReplayTestShardContext } from './session-test-sharding.ts';
+
+type ReplayTestCaseResult = Extract<ReplaySuiteTestResult, { status: 'passed' | 'failed' }>;
+type ReplayTestAttemptFailure = NonNullable<
+  Extract<ReplaySuiteTestResult, { status: 'passed' }>['attemptFailures']
+>[number];
+
+export async function runReplayTestCase(
+  params: ReplayTestCaseParams,
+): Promise<ReplayTestCaseResult> {
+  const context = buildReplayTestCaseContext(params);
+  const outcome = await runReplayTestCaseAttempts(params, context);
+  return buildReplayTestCaseResult(params, context, outcome);
+}
+
+type ReplayTestCaseParams = {
+  entry: ReplayTestRunEntry;
+  sessionName: string;
+  suiteInvocationId: string;
+  caseIndex: number;
+  cwd?: string;
+  requestId?: string;
+  retries: number;
+  timeoutMs?: number;
+  suiteArtifactsDir: string;
+  suiteIndex: number;
+  suiteTotal: number;
+  shard?: ReplayTestShardContext;
+} & ReplayTestRuntimeDependencies;
+
+type ReplayTestCaseContext = {
+  testStartedAt: number;
+  testArtifactsDir: string;
+  maxAttempts: number;
+};
+
+type ReplayTestAttemptResult = {
+  response: DaemonResponse;
+  sessionName: string;
+  attempt: number;
+  durationMs: number;
+};
+
+type ReplayTestCaseOutcome = {
+  finalResponse?: DaemonResponse;
+  finalSessionName: string;
+  attempts: number;
+  finalAttemptDurationMs: number;
+  attemptFailures: ReplayTestAttemptFailure[];
+};
+
+function buildReplayTestCaseContext(params: ReplayTestCaseParams): ReplayTestCaseContext {
+  const { entry, cwd, retries, suiteArtifactsDir, shard } = params;
+  return {
+    testStartedAt: Date.now(),
+    testArtifactsDir: path.join(
+      suiteArtifactsDir,
+      ...(shard ? [`shard-${shard.shardIndex + 1}`] : []),
+      buildReplayTestArtifactSlug(entry.path, cwd),
+    ),
+    maxAttempts: retries + 1,
+  };
+}
+
+async function runReplayTestCaseAttempts(
+  params: ReplayTestCaseParams,
+  context: ReplayTestCaseContext,
+): Promise<ReplayTestCaseOutcome> {
+  const outcome: ReplayTestCaseOutcome = {
+    finalSessionName: '',
+    attempts: 0,
+    finalAttemptDurationMs: 0,
+    attemptFailures: [],
+  };
+
+  for (let attemptIndex = 0; attemptIndex <= params.retries; attemptIndex += 1) {
+    const attempt = await runSingleReplayTestAttempt(params, context, attemptIndex);
+    updateReplayTestCaseOutcome(outcome, attempt);
+    if (shouldStopReplayTestAttempts(attempt.response, attemptIndex, params.retries)) break;
+    emitReplayTestRetryProgress(params, context, attempt);
+  }
+
+  return outcome;
+}
+
+async function runSingleReplayTestAttempt(
+  params: ReplayTestCaseParams,
+  context: ReplayTestCaseContext,
+  attemptIndex: number,
+): Promise<ReplayTestAttemptResult> {
+  const { entry, sessionName, suiteInvocationId, caseIndex, requestId, timeoutMs, shard } = params;
+  const attempt = attemptIndex + 1;
+  const startedAt = Date.now();
+  const testSessionName = buildReplayTestSessionName(
+    sessionName,
+    suiteInvocationId,
+    entry.path,
+    caseIndex,
+    attemptIndex,
+  );
+  const attemptArtifactsDir = path.join(context.testArtifactsDir, `attempt-${attempt}`);
+  prepareReplayTestAttemptArtifacts(entry.path, attemptArtifactsDir);
+
+  const response = await runReplayTestAttempt({
+    filePath: entry.path,
+    sessionName: testSessionName,
+    requestId: buildReplayTestAttemptRequestId({
+      requestId,
+      suiteInvocationId,
+      filePath: entry.path,
+      caseIndex,
+      attemptIndex,
+      shardIndex: shard?.shardIndex,
+    }),
+    timeoutMs,
+    platform: entry.metadata.platform,
+    target: entry.metadata.target,
+    artifactsDir: attemptArtifactsDir,
+    shard,
+    runReplay: params.runReplay,
+    cleanupSession: params.cleanupSession,
+    finalizeAttempt: params.finalizeAttempt,
+  });
+  const durationMs = Date.now() - startedAt;
+  materializeReplayTestAttemptArtifacts({
+    response,
+    filePath: entry.path,
+    sessionName: testSessionName,
+    attempts: attempt,
+    maxAttempts: context.maxAttempts,
+    attemptArtifactsDir,
+  });
+  return { response, sessionName: testSessionName, attempt, durationMs };
+}
+
+function updateReplayTestCaseOutcome(
+  outcome: ReplayTestCaseOutcome,
+  attempt: ReplayTestAttemptResult,
+): void {
+  outcome.finalResponse = attempt.response;
+  outcome.finalSessionName = attempt.sessionName;
+  outcome.attempts = attempt.attempt;
+  outcome.finalAttemptDurationMs = attempt.durationMs;
+  if (attempt.response.ok) return;
+  outcome.attemptFailures.push({
+    attempt: attempt.attempt,
+    message: attempt.response.error.message,
+    durationMs: attempt.durationMs,
+  });
+}
+
+function shouldStopReplayTestAttempts(
+  response: DaemonResponse,
+  attemptIndex: number,
+  retries: number,
+): boolean {
+  return response.ok || isReplayInfrastructureFailure(response) || attemptIndex >= retries;
+}
+
+function emitReplayTestRetryProgress(
+  params: ReplayTestCaseParams,
+  context: ReplayTestCaseContext,
+  attempt: ReplayTestAttemptResult,
+): void {
+  if (attempt.response.ok) return;
+  emitRequestProgress({
+    type: 'replay-test',
+    file: params.entry.path,
+    title: params.entry.title,
+    status: 'fail',
+    index: params.suiteIndex,
+    total: params.suiteTotal,
+    attempt: attempt.attempt,
+    maxAttempts: context.maxAttempts,
+    durationMs: attempt.durationMs,
+    retrying: true,
+    message: attempt.response.error.message,
+  });
+}
+
+function buildReplayTestCaseResult(
+  params: ReplayTestCaseParams,
+  context: ReplayTestCaseContext,
+  outcome: ReplayTestCaseOutcome,
+): ReplayTestCaseResult {
+  const durationMs = Date.now() - context.testStartedAt;
+  if (outcome.finalResponse?.ok) {
+    return buildReplayTestPassedResult(params, context, outcome, durationMs);
+  }
+  return buildReplayTestFailedResult(params, context, outcome, durationMs);
+}
+
+function buildReplayTestPassedResult(
+  params: ReplayTestCaseParams,
+  context: ReplayTestCaseContext,
+  outcome: ReplayTestCaseOutcome,
+  durationMs: number,
+): Extract<ReplaySuiteTestResult, { status: 'passed' }> {
+  const { entry, suiteIndex, suiteTotal, shard } = params;
+  const response = outcome.finalResponse;
+  if (!response?.ok) throw new Error('Expected passing replay test response.');
+  emitRequestProgress({
+    type: 'replay-test',
+    file: entry.path,
+    title: entry.title,
+    status: 'pass',
+    index: suiteIndex,
+    total: suiteTotal,
+    attempt: outcome.attempts,
+    maxAttempts: context.maxAttempts,
+    durationMs,
+    artifactsDir: context.testArtifactsDir,
+  });
+  return {
+    file: entry.path,
+    title: entry.title,
+    session: outcome.finalSessionName,
+    status: 'passed',
+    durationMs,
+    finalAttemptDurationMs: outcome.finalAttemptDurationMs,
+    attempts: outcome.attempts,
+    artifactsDir: context.testArtifactsDir,
+    replayed: typeof response.data?.replayed === 'number' ? response.data.replayed : 0,
+    healed: typeof response.data?.healed === 'number' ? response.data.healed : 0,
+    ...replayTestWarningsResultMetadata(response.data?.warnings),
+    ...replayTestShardResultMetadata(shard),
+    ...(outcome.attemptFailures.length > 0 ? { attemptFailures: outcome.attemptFailures } : {}),
+  };
+}
+
+function buildReplayTestFailedResult(
+  params: ReplayTestCaseParams,
+  context: ReplayTestCaseContext,
+  outcome: ReplayTestCaseOutcome,
+  durationMs: number,
+): Extract<ReplaySuiteTestResult, { status: 'failed' }> {
+  const { entry, suiteIndex, suiteTotal, shard } = params;
+  const error = replayTestFailureError(outcome.finalResponse);
+  emitRequestProgress({
+    type: 'replay-test',
+    file: entry.path,
+    title: entry.title,
+    status: 'fail',
+    index: suiteIndex,
+    total: suiteTotal,
+    attempt: outcome.attempts,
+    maxAttempts: context.maxAttempts,
+    durationMs,
+    artifactsDir: context.testArtifactsDir,
+    message: error.message,
+  });
+  return {
+    file: entry.path,
+    title: entry.title,
+    session: outcome.finalSessionName,
+    status: 'failed',
+    durationMs,
+    attempts: outcome.attempts,
+    artifactsDir: context.testArtifactsDir,
+    error,
+    ...replayTestShardResultMetadata(shard),
+  };
+}
+
+function replayTestFailureError(
+  response: DaemonResponse | undefined,
+): Extract<ReplaySuiteTestResult, { status: 'failed' }>['error'] {
+  if (response && !response.ok) return response.error;
+  return { code: 'COMMAND_FAILED', message: 'Unknown replay test failure' };
+}
+
+function replayTestWarningsResultMetadata(
+  warnings: unknown,
+): Pick<Extract<ReplaySuiteTestResult, { status: 'passed' }>, 'warnings'> {
+  if (!Array.isArray(warnings)) return {};
+  const filtered = warnings.filter((entry): entry is string => typeof entry === 'string');
+  return filtered.length > 0 ? { warnings: filtered } : {};
+}
+
+function replayTestShardResultMetadata(
+  shard: ReplayTestShardContext | undefined,
+): Pick<ReplaySuiteTestFailed, 'shardIndex' | 'shardCount' | 'deviceId'> {
+  return shard
+    ? {
+        shardIndex: shard.shardIndex,
+        shardCount: shard.shardCount,
+        deviceId: shard.device.id,
+      }
+    : {};
+}

--- a/src/daemon/handlers/session-test-discovery.ts
+++ b/src/daemon/handlers/session-test-discovery.ts
@@ -25,6 +25,8 @@ export type ReplayTestDiscoveryEntry =
       message: string;
     };
 
+export type ReplayTestRunEntry = Extract<ReplayTestDiscoveryEntry, { kind: 'run' }>;
+
 export function discoverReplayTestEntries(params: {
   inputs: string[];
   cwd?: string;

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { asAppError, normalizeError } from '../../utils/errors.ts';
 import { errorResponse } from './response.ts';
 import type {
@@ -8,30 +7,22 @@ import type {
   ReplaySuiteTestFailed,
   ReplaySuiteTestResult,
 } from '../types.ts';
-import {
-  buildReplayTestArtifactSlug,
-  materializeReplayTestAttemptArtifacts,
-  prepareReplayTestAttemptArtifacts,
-  resolveReplayTestArtifactsDir,
-} from './session-test-artifacts.ts';
+import { resolveReplayTestArtifactsDir } from './session-test-artifacts.ts';
 import { emitRequestProgress } from '../request-progress.ts';
 import {
-  buildReplayTestAttemptRequestId,
   buildReplayTestInvocationId,
-  buildReplayTestSessionName,
   discoverReplayTestEntries,
+  type ReplayTestRunEntry,
   resolveReplayTestRetries,
   resolveReplayTestTimeout,
 } from './session-test-discovery.ts';
 import { isReplayInfrastructureFailure } from './session-test-infrastructure.ts';
-import { runReplayTestAttempt } from './session-test-runtime.ts';
+import { runReplayTestCase } from './session-test-attempt.ts';
 import type { ReplayTestRuntimeDependencies } from './session-test-types.ts';
 import { buildReplayTestShardPlan, type ReplayTestShardContext } from './session-test-sharding.ts';
 
 type ReplayTestEntry = ReturnType<typeof discoverReplayTestEntries>[number];
-type ReplayTestRunEntry = Extract<ReplayTestEntry, { kind: 'run' }>;
 
-// fallow-ignore-next-line complexity
 export async function runReplayTestSuite(
   params: {
     req: DaemonRequest;
@@ -337,205 +328,6 @@ async function runReplayTestEntries(
     if (flags?.failFast === true || isReplayInfrastructureFailure(result)) break;
   }
   return results;
-}
-
-// fallow-ignore-next-line complexity
-async function runReplayTestCase(
-  params: {
-    entry: ReplayTestRunEntry;
-    sessionName: string;
-    suiteInvocationId: string;
-    caseIndex: number;
-    cwd?: string;
-    requestId?: string;
-    retries: number;
-    timeoutMs?: number;
-    suiteArtifactsDir: string;
-    suiteIndex: number;
-    suiteTotal: number;
-    shard?: ReplayTestShardContext;
-  } & ReplayTestRuntimeDependencies,
-): Promise<Extract<ReplaySuiteTestResult, { status: 'passed' | 'failed' }>> {
-  const {
-    entry,
-    sessionName,
-    suiteInvocationId,
-    caseIndex,
-    cwd,
-    requestId,
-    retries,
-    timeoutMs,
-    suiteArtifactsDir,
-    suiteIndex,
-    suiteTotal,
-    shard,
-    runReplay,
-    cleanupSession,
-    finalizeAttempt,
-  } = params;
-  const testStartedAt = Date.now();
-  const testArtifactsDir = path.join(
-    suiteArtifactsDir,
-    ...(shard ? [`shard-${shard.shardIndex + 1}`] : []),
-    buildReplayTestArtifactSlug(entry.path, cwd),
-  );
-  let finalResponse: DaemonResponse | undefined;
-  let finalSessionName = '';
-  let attempts = 0;
-  let finalAttemptDurationMs = 0;
-  const attemptFailures: NonNullable<
-    Extract<ReplaySuiteTestResult, { status: 'passed' }>['attemptFailures']
-  > = [];
-
-  for (let attemptIndex = 0; attemptIndex <= retries; attemptIndex += 1) {
-    attempts = attemptIndex + 1;
-    const attemptStartedAt = Date.now();
-    const testSessionName = buildReplayTestSessionName(
-      sessionName,
-      suiteInvocationId,
-      entry.path,
-      caseIndex,
-      attemptIndex,
-    );
-    const attemptArtifactsDir = path.join(testArtifactsDir, `attempt-${attempts}`);
-    prepareReplayTestAttemptArtifacts(entry.path, attemptArtifactsDir);
-
-    const attemptRequestId = buildReplayTestAttemptRequestId({
-      requestId,
-      suiteInvocationId,
-      filePath: entry.path,
-      caseIndex,
-      attemptIndex,
-      shardIndex: shard?.shardIndex,
-    });
-    const response = await runReplayTestAttempt({
-      filePath: entry.path,
-      sessionName: testSessionName,
-      requestId: attemptRequestId,
-      timeoutMs,
-      platform: entry.metadata.platform,
-      target: entry.metadata.target,
-      artifactsDir: attemptArtifactsDir,
-      shard,
-      runReplay,
-      cleanupSession,
-      finalizeAttempt,
-    });
-    finalAttemptDurationMs = Date.now() - attemptStartedAt;
-    materializeReplayTestAttemptArtifacts({
-      response,
-      filePath: entry.path,
-      sessionName: testSessionName,
-      attempts,
-      maxAttempts: retries + 1,
-      attemptArtifactsDir,
-    });
-    finalResponse = response;
-    finalSessionName = testSessionName;
-    if (response.ok) break;
-    attemptFailures.push({
-      attempt: attempts,
-      message: response.error.message,
-      durationMs: finalAttemptDurationMs,
-    });
-    if (isReplayInfrastructureFailure(response)) break;
-    if (attemptIndex >= retries) break;
-    emitRequestProgress({
-      type: 'replay-test',
-      file: entry.path,
-      title: entry.title,
-      status: 'fail',
-      index: suiteIndex,
-      total: suiteTotal,
-      attempt: attempts,
-      maxAttempts: retries + 1,
-      durationMs: finalAttemptDurationMs,
-      retrying: true,
-      message: response.error.message,
-    });
-  }
-
-  const durationMs = Date.now() - testStartedAt;
-  if (finalResponse?.ok) {
-    emitRequestProgress({
-      type: 'replay-test',
-      file: entry.path,
-      title: entry.title,
-      status: 'pass',
-      index: suiteIndex,
-      total: suiteTotal,
-      attempt: attempts,
-      maxAttempts: retries + 1,
-      durationMs,
-      artifactsDir: testArtifactsDir,
-    });
-    return {
-      file: entry.path,
-      title: entry.title,
-      session: finalSessionName,
-      status: 'passed',
-      durationMs,
-      finalAttemptDurationMs,
-      attempts,
-      artifactsDir: testArtifactsDir,
-      replayed: typeof finalResponse.data?.replayed === 'number' ? finalResponse.data.replayed : 0,
-      healed: typeof finalResponse.data?.healed === 'number' ? finalResponse.data.healed : 0,
-      ...replayTestWarningsResultMetadata(finalResponse.data?.warnings),
-      ...replayTestShardResultMetadata(shard),
-      ...(attemptFailures.length > 0 ? { attemptFailures } : {}),
-    };
-  }
-
-  const error = finalResponse?.ok
-    ? { code: 'COMMAND_FAILED', message: 'Unknown replay test failure' }
-    : (finalResponse?.error ?? {
-        code: 'COMMAND_FAILED',
-        message: 'Unknown replay test failure',
-      });
-  emitRequestProgress({
-    type: 'replay-test',
-    file: entry.path,
-    title: entry.title,
-    status: 'fail',
-    index: suiteIndex,
-    total: suiteTotal,
-    attempt: attempts,
-    maxAttempts: retries + 1,
-    durationMs,
-    artifactsDir: testArtifactsDir,
-    message: error.message,
-  });
-  return {
-    file: entry.path,
-    title: entry.title,
-    session: finalSessionName,
-    status: 'failed',
-    durationMs,
-    attempts,
-    artifactsDir: testArtifactsDir,
-    error,
-    ...replayTestShardResultMetadata(shard),
-  };
-}
-
-function replayTestWarningsResultMetadata(
-  warnings: unknown,
-): Pick<Extract<ReplaySuiteTestResult, { status: 'passed' }>, 'warnings'> {
-  if (!Array.isArray(warnings)) return {};
-  const filtered = warnings.filter((entry): entry is string => typeof entry === 'string');
-  return filtered.length > 0 ? { warnings: filtered } : {};
-}
-
-function replayTestShardResultMetadata(
-  shard: ReplayTestShardContext | undefined,
-): Pick<ReplaySuiteTestFailed, 'shardIndex' | 'shardCount' | 'deviceId'> {
-  return shard
-    ? {
-        shardIndex: shard.shardIndex,
-        shardCount: shard.shardCount,
-        deviceId: shard.device.id,
-      }
-    : {};
 }
 
 function summarizeReplayTestResults(


### PR DESCRIPTION
## Summary

Extract replay test attempt orchestration into `session-test-attempt.ts`, keeping suite/shard orchestration in `session-test.ts`.
Extract replay timing trace parsing and step rendering into `cli-test-trace.ts`, keeping `cli-test.ts` focused on summary and JUnit output rendering.

Benefits:
- Replay attempt behavior now has better locality: generated test session names, attempt artifacts, request IDs, retries, progress events, result shaping, and cleanup/finalization wiring are easier to reason about together.
- CLI replay output is easier to maintain because trace parsing/step formatting no longer sits inside the summary/JUnit renderer.
- The refactor removes local `fallow-ignore` suppressions from the touched replay test files and keeps the changed files passing Fallow.

Tradeoff:
- This adds two small focused modules, so there are slightly more files, but the interfaces are narrower and the owning files are smaller.

## Validation

Passed `pnpm format`, `pnpm check:quick`, and `pnpm check:fallow --base origin/main`.
Passed focused unit coverage for replay test suite/runtime/artifacts/discovery/infrastructure/session replay and CLI network output: 40 tests across 7 files.
Full `pnpm check:unit` was attempted; sandboxed run failed with `listen EPERM`, and the escalated run still had 9 unrelated Android/iOS host-tool and daemon-client timing failures outside the touched replay/CLI files.
