### PR TITLE
refactor(types): consolidate duplicated types across src/ into single sources of truth

### DIFF
--- a/src/alert-contract.ts
+++ b/src/alert-contract.ts
@@ -2,7 +2,8 @@ export const ALERT_POLL_INTERVAL_MS = 300;
 export const DEFAULT_ALERT_TIMEOUT_MS = 10_000;
 export const ALERT_ACTION_RETRY_MS = 2_000;
 
-export type AlertAction = 'get' | 'accept' | 'dismiss' | 'wait';
+export const ALERT_ACTIONS = ['get', 'accept', 'dismiss', 'wait'] as const;
+export type AlertAction = (typeof ALERT_ACTIONS)[number];
 
 export type AlertPlatform = 'android' | 'ios' | 'macos';
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -8,6 +8,7 @@ import type {
   SnapshotOptions,
   SnapshotState,
 } from './utils/snapshot.ts';
+import type { NetworkIncludeMode } from './contracts.ts';
 import type { DeviceTarget, Platform, PlatformSelector } from './utils/device.ts';
 import type { BackMode } from './core/back-mode.ts';
 import type { ClickButton } from './core/click-button.ts';
@@ -342,7 +343,7 @@ export type BackendReadLogsResult = {
   notes?: readonly string[];
 };
 
-export type BackendNetworkIncludeMode = 'summary' | 'headers' | 'body' | 'all';
+export type BackendNetworkIncludeMode = NetworkIncludeMode;
 
 export type BackendNetworkEntry = {
   timestamp?: string;

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -11,6 +11,7 @@ import type {
 import type { NetworkIncludeMode } from './contracts.ts';
 import type { DeviceTarget, Platform, PlatformSelector } from './utils/device.ts';
 import type { BackMode } from './core/back-mode.ts';
+import type { RepeatedInput } from './commands/command-input.ts';
 import type { ClickButton } from './core/click-button.ts';
 import type { DeviceRotation } from './core/device-rotation.ts';
 import type { ScrollDirection } from './core/scroll-gesture.ts';
@@ -136,13 +137,8 @@ export type BackendAlertResult =
       timedOut?: boolean;
     };
 
-export type BackendTapOptions = {
+export type BackendTapOptions = RepeatedInput & {
   button?: ClickButton;
-  count?: number;
-  intervalMs?: number;
-  holdMs?: number;
-  jitterPx?: number;
-  doubleTap?: boolean;
 };
 
 export type BackendFillOptions = {

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -8,8 +8,14 @@ import type {
   SnapshotOptions,
   SnapshotState,
 } from './utils/snapshot.ts';
+import type { DeviceTarget, Platform, PlatformSelector } from './utils/device.ts';
+import type { BackMode } from './core/back-mode.ts';
+import type { ClickButton } from './core/click-button.ts';
+import type { DeviceRotation } from './core/device-rotation.ts';
+import type { ScrollDirection } from './core/scroll-gesture.ts';
+import type { SessionSurface } from './core/session-surface.ts';
 
-export type AgentDeviceBackendPlatform = 'ios' | 'android' | 'macos' | 'linux';
+export type AgentDeviceBackendPlatform = Platform;
 
 export const BACKEND_CAPABILITY_NAMES = [
   'android.shell',
@@ -71,7 +77,7 @@ export type BackendScreenshotOptions = {
   fullscreen?: boolean;
   overlayRefs?: boolean;
   stabilize?: boolean;
-  surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
+  surface?: SessionSurface;
 };
 
 export type BackendScreenshotResult = {
@@ -81,14 +87,10 @@ export type BackendScreenshotResult = {
 
 export type BackendActionResult = Record<string, unknown> | void;
 
-export type BackendDeviceOrientation =
-  | 'portrait'
-  | 'portrait-upside-down'
-  | 'landscape-left'
-  | 'landscape-right';
+export type BackendDeviceOrientation = DeviceRotation;
 
 export type BackendBackOptions = {
-  mode?: 'in-app' | 'system';
+  mode?: BackMode;
 };
 
 export type BackendKeyboardOptions = {
@@ -96,7 +98,7 @@ export type BackendKeyboardOptions = {
 };
 
 export type BackendKeyboardResult = {
-  platform?: 'android' | 'ios' | 'macos' | 'linux';
+  platform?: Platform;
   action?: BackendKeyboardOptions['action'];
   visible?: boolean;
   inputType?: string | null;
@@ -134,7 +136,7 @@ export type BackendAlertResult =
     };
 
 export type BackendTapOptions = {
-  button?: 'primary' | 'secondary' | 'middle';
+  button?: ClickButton;
   count?: number;
   intervalMs?: number;
   holdMs?: number;
@@ -164,7 +166,7 @@ export type BackendScrollTarget =
     };
 
 export type BackendScrollOptions = {
-  direction: 'up' | 'down' | 'left' | 'right';
+  direction: ScrollDirection;
   amount?: number;
   pixels?: number;
 };
@@ -234,8 +236,8 @@ export type BackendAppEvent = {
 };
 
 export type BackendDeviceFilter = {
-  platform?: AgentDeviceBackendPlatform | 'apple';
-  target?: 'mobile' | 'tv' | 'desktop';
+  platform?: PlatformSelector;
+  target?: DeviceTarget;
   kind?: 'simulator' | 'emulator' | 'device' | 'desktop';
 };
 

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -4,14 +4,19 @@ import type {
   DaemonLockPolicy,
   DaemonRequest,
   DaemonResponse,
+  DaemonServerMode,
+  DaemonTransportPreference,
   LeaseBackend,
+  NetworkIncludeMode,
+  SessionIsolationMode,
   SessionRuntimeHints,
 } from './contracts.ts';
 import type { DeviceKind, DeviceTarget, Platform, PlatformSelector } from './utils/device.ts';
 import type { BackMode } from './core/back-mode.ts';
 import type { ClickButton } from './core/click-button.ts';
 import type { DeviceRotation } from './core/device-rotation.ts';
-import type { ScrollDirection } from './core/scroll-gesture.ts';
+import type { ScrollDirection, SwipePattern, SwipePreset } from './core/scroll-gesture.ts';
+import type { ScrollInputDirection } from './commands/interaction-gestures.ts';
 import type { SessionSurface } from './core/session-surface.ts';
 import type { FindLocator } from './utils/finders.ts';
 import type { AndroidSnapshotBackendMetadata } from './platforms/android/snapshot-types.ts';
@@ -38,10 +43,6 @@ export type { CompanionTunnelScope, MetroBridgeScope } from './client-companion-
 export type { AppsFilter } from './commands/app-inventory-contract.ts';
 export type { AlertAction, AlertInfo, AlertPlatform, AlertSource } from './alert-contract.ts';
 
-type DaemonTransportMode = 'auto' | 'socket' | 'http';
-type DaemonServerMode = 'socket' | 'http' | 'dual';
-type SessionIsolationMode = 'none' | 'tenant';
-
 export type AgentDeviceDaemonTransport = (
   req: Omit<DaemonRequest, 'token'>,
 ) => Promise<DaemonResponse>;
@@ -54,7 +55,7 @@ export type AgentDeviceClientConfig = {
   stateDir?: string;
   daemonBaseUrl?: string;
   daemonAuthToken?: string;
-  daemonTransport?: DaemonTransportMode;
+  daemonTransport?: DaemonTransportPreference;
   daemonServerMode?: DaemonServerMode;
   tenant?: string;
   sessionIsolation?: SessionIsolationMode;
@@ -594,7 +595,7 @@ export type SwipeOptions = ClientCommandBaseOptions & {
   durationMs?: number;
   count?: number;
   pauseMs?: number;
-  pattern?: 'one-way' | 'ping-pong';
+  pattern?: SwipePattern;
 };
 
 export type PanOptions = ClientCommandBaseOptions & {
@@ -614,7 +615,7 @@ export type FlingOptions = ClientCommandBaseOptions & {
 };
 
 export type SwipeGestureOptions = ClientCommandBaseOptions & {
-  preset: 'left' | 'right' | 'left-edge' | 'right-edge';
+  preset: SwipePreset;
   durationMs?: number;
 };
 
@@ -636,7 +637,7 @@ export type FillOptions = ClientCommandBaseOptions &
   };
 
 export type ScrollOptions = ClientCommandBaseOptions & {
-  direction: 'up' | 'down' | 'left' | 'right' | 'top' | 'bottom';
+  direction: ScrollInputDirection;
   amount?: number;
   pixels?: number;
 };
@@ -755,7 +756,7 @@ export type LogsOptions = AgentDeviceRequestOverrides & {
 export type NetworkOptions = AgentDeviceRequestOverrides & {
   action?: 'dump' | 'log';
   limit?: number;
-  include?: 'summary' | 'headers' | 'body' | 'all';
+  include?: NetworkIncludeMode;
 };
 
 type RecordingQuality = 5 | 6 | 7 | 8 | 9 | 10;
@@ -851,7 +852,7 @@ type CommandExecutionOptions = Partial<ScreenshotRequestFlags> & {
   doubleTap?: boolean;
   clickButton?: ClickButton;
   pauseMs?: number;
-  pattern?: 'one-way' | 'ping-pong';
+  pattern?: SwipePattern;
   headless?: boolean;
   restart?: boolean;
   replayUpdate?: boolean;
@@ -868,7 +869,7 @@ type CommandExecutionOptions = Partial<ScreenshotRequestFlags> & {
   shardSplit?: number;
   findFirst?: boolean;
   findLast?: boolean;
-  networkInclude?: 'summary' | 'headers' | 'body' | 'all';
+  networkInclude?: NetworkIncludeMode;
   batchOnError?: 'stop';
   batchMaxSteps?: number;
   batchSteps?: DaemonBatchStep[];

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -17,6 +17,7 @@ import type { ClickButton } from './core/click-button.ts';
 import type { DeviceRotation } from './core/device-rotation.ts';
 import type { ScrollDirection, SwipePattern, SwipePreset } from './core/scroll-gesture.ts';
 import type { ScrollInputDirection } from './commands/interaction-gestures.ts';
+import type { LogAction } from './commands/log-command-contract.ts';
 import type { SessionSurface } from './core/session-surface.ts';
 import type { FindLocator } from './utils/finders.ts';
 import type { AndroidSnapshotBackendMetadata } from './platforms/android/snapshot-types.ts';
@@ -748,7 +749,7 @@ export type PerfOptions = ClientCommandBaseOptions & {
 };
 
 export type LogsOptions = AgentDeviceRequestOverrides & {
-  action?: 'path' | 'start' | 'stop' | 'doctor' | 'mark' | 'clear';
+  action?: LogAction;
   message?: string;
   restart?: boolean;
 };

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -8,6 +8,11 @@ import type {
   SessionRuntimeHints,
 } from './contracts.ts';
 import type { DeviceKind, DeviceTarget, Platform, PlatformSelector } from './utils/device.ts';
+import type { BackMode } from './core/back-mode.ts';
+import type { ClickButton } from './core/click-button.ts';
+import type { DeviceRotation } from './core/device-rotation.ts';
+import type { ScrollDirection } from './core/scroll-gesture.ts';
+import type { SessionSurface } from './core/session-surface.ts';
 import type { FindLocator } from './utils/finders.ts';
 import type { AndroidSnapshotBackendMetadata } from './platforms/android/snapshot-types.ts';
 import type {
@@ -26,7 +31,7 @@ import type { AppsFilter } from './commands/app-inventory-contract.ts';
 import type { ScreenshotRequestFlags } from './commands/capture-screenshot-options.ts';
 import type { PerfAction, PerfArea } from './commands/perf-command-contract.ts';
 import type { DaemonBatchStep } from './core/batch.ts';
-import type { AlertInfo } from './alert-contract.ts';
+import type { AlertAction, AlertInfo } from './alert-contract.ts';
 
 export type { FindLocator } from './utils/finders.ts';
 export type { CompanionTunnelScope, MetroBridgeScope } from './client-companion-tunnel-contract.ts';
@@ -175,7 +180,7 @@ export type AppOpenOptions = AgentDeviceRequestOverrides &
   AgentDeviceSelectionOptions & {
     app?: string;
     url?: string;
-    surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
+    surface?: SessionSurface;
     activity?: string;
     launchConsole?: string;
     launchArgs?: string[];
@@ -333,7 +338,7 @@ export type CaptureScreenshotOptions = AgentDeviceRequestOverrides & {
   fullscreen?: boolean;
   maxSize?: number;
   stabilize?: boolean;
-  surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
+  surface?: SessionSurface;
 };
 
 export type CaptureScreenshotResult = {
@@ -379,20 +384,20 @@ type WaitCommandTarget =
 export type WaitCommandOptions = DeviceCommandBaseOptions & WaitCommandTarget;
 
 export type AlertCommandOptions = DeviceCommandBaseOptions & {
-  action?: 'get' | 'accept' | 'dismiss' | 'wait';
+  action?: AlertAction;
   timeoutMs?: number;
 };
 
 export type AppStateCommandOptions = DeviceCommandBaseOptions;
 
 export type BackCommandOptions = DeviceCommandBaseOptions & {
-  mode?: 'in-app' | 'system';
+  mode?: BackMode;
 };
 
 export type HomeCommandOptions = DeviceCommandBaseOptions;
 
 export type RotateCommandOptions = DeviceCommandBaseOptions & {
-  orientation: 'portrait' | 'portrait-upside-down' | 'landscape-left' | 'landscape-right';
+  orientation: DeviceRotation;
 };
 
 export type AppSwitcherCommandOptions = DeviceCommandBaseOptions;
@@ -441,11 +446,11 @@ export type AppStateCommandResult = DaemonResponseData & {
   package?: string;
   activity?: string;
   source?: 'session';
-  surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
+  surface?: SessionSurface;
 };
 
 export type BackCommandResult = CommandActionResult<'back'> & {
-  mode?: 'in-app' | 'system';
+  mode?: BackMode;
 };
 
 export type HomeCommandResult = CommandActionResult<'home'>;
@@ -569,7 +574,7 @@ export type ClickOptions = ClientCommandBaseOptions &
   SelectorSnapshotCommandOptions &
   InteractionTarget &
   RepeatedPressOptions & {
-    button?: 'primary' | 'secondary' | 'middle';
+    button?: ClickButton;
   };
 
 export type PressOptions = ClientCommandBaseOptions &
@@ -601,7 +606,7 @@ export type PanOptions = ClientCommandBaseOptions & {
 };
 
 export type FlingOptions = ClientCommandBaseOptions & {
-  direction: 'up' | 'down' | 'left' | 'right';
+  direction: ScrollDirection;
   x: number;
   y: number;
   distance?: number;
@@ -844,7 +849,7 @@ type CommandExecutionOptions = Partial<ScreenshotRequestFlags> & {
   jitterPx?: number;
   pixels?: number;
   doubleTap?: boolean;
-  clickButton?: 'primary' | 'secondary' | 'middle';
+  clickButton?: ClickButton;
   pauseMs?: number;
   pattern?: 'one-way' | 'ping-pong';
   headless?: boolean;
@@ -874,7 +879,7 @@ export type InternalRequestOptions = AgentDeviceClientConfig &
   CommandExecutionOptions & {
     runtime?: SessionRuntimeHints;
     overlayRefs?: boolean;
-    surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
+    surface?: SessionSurface;
     activity?: string;
     launchConsole?: string;
     launchArgs?: string[];
@@ -882,7 +887,7 @@ export type InternalRequestOptions = AgentDeviceClientConfig &
     shutdown?: boolean;
     saveScript?: boolean | string;
     noRecord?: boolean;
-    backMode?: 'in-app' | 'system';
+    backMode?: BackMode;
     metroHost?: string;
     metroPort?: number;
     bundleUrl?: string;

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -15,7 +15,12 @@ import type { DeviceKind, DeviceTarget, Platform, PlatformSelector } from './uti
 import type { BackMode } from './core/back-mode.ts';
 import type { ClickButton } from './core/click-button.ts';
 import type { DeviceRotation } from './core/device-rotation.ts';
-import type { ScrollDirection, SwipePattern, SwipePreset } from './core/scroll-gesture.ts';
+import type {
+  ScrollDirection,
+  SwipePattern,
+  SwipePreset,
+  TransformGestureParams,
+} from './core/scroll-gesture.ts';
 import type { ScrollInputDirection } from './commands/interaction-gestures.ts';
 import type { LogAction } from './commands/log-command-contract.ts';
 import type { SessionSurface } from './core/session-surface.ts';
@@ -656,15 +661,7 @@ export type RotateGestureOptions = ClientCommandBaseOptions & {
   velocity?: number;
 };
 
-export type TransformGestureOptions = ClientCommandBaseOptions & {
-  x: number;
-  y: number;
-  dx: number;
-  dy: number;
-  scale: number;
-  degrees: number;
-  durationMs?: number;
-};
+export type TransformGestureOptions = ClientCommandBaseOptions & TransformGestureParams;
 
 export type GetOptions = ClientCommandBaseOptions &
   SelectorSnapshotCommandOptions &

--- a/src/command-catalog.ts
+++ b/src/command-catalog.ts
@@ -67,8 +67,9 @@ const LOCAL_CLI_COMMANDS = {
   session: 'session',
 } as const;
 
-const GESTURE_SUBCOMMANDS = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'transform'] as const;
-export const GESTURE_SUBCOMMAND_ERROR = `gesture requires one of: ${GESTURE_SUBCOMMANDS.join(', ')}`;
+export const GESTURE_KINDS = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'transform'] as const;
+export type GestureKind = (typeof GESTURE_KINDS)[number];
+export const GESTURE_SUBCOMMAND_ERROR = `gesture requires one of: ${GESTURE_KINDS.join(', ')}`;
 
 export type PublicCommandName = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
 export type LocalCliCommandName = (typeof LOCAL_CLI_COMMANDS)[keyof typeof LOCAL_CLI_COMMANDS];

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,5 +1,4 @@
 import type {
-  BackendActionResult,
   BackendCommandContext,
   BackendDeviceFilter,
   BackendDeviceInfo,
@@ -10,7 +9,7 @@ import type {
 import type { AgentDeviceRuntime, CommandContext } from '../runtime-contract.ts';
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
-import type { RuntimeCommand } from './runtime-types.ts';
+import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
 import { resolveCommandInput } from './io-policy.ts';
 import { toBackendContext } from './selector-read-utils.ts';
 import { normalizeOptionalText, requireText } from './text.ts';
@@ -282,8 +281,4 @@ function formatSource(source: BackendInstallSource): string {
   if (source.kind === 'path') return source.path;
   if (source.kind === 'uploadedArtifact') return source.id;
   return source.url;
-}
-
-function toBackendResult(result: BackendActionResult): Record<string, unknown> | undefined {
-  return result && typeof result === 'object' ? result : undefined;
 }

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -9,7 +9,11 @@ import type {
 import type { AgentDeviceRuntime, CommandContext } from '../runtime-contract.ts';
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
-import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
+import {
+  toBackendResult,
+  type BackendResultEnvelope,
+  type RuntimeCommand,
+} from './runtime-types.ts';
 import { resolveCommandInput } from './io-policy.ts';
 import { toBackendContext } from './selector-read-utils.ts';
 import { normalizeOptionalText, requireText } from './text.ts';
@@ -30,9 +34,7 @@ export type AdminBootCommandOptions = CommandContext & {
 export type AdminBootCommandResult = {
   kind: 'deviceBooted';
   target?: BackendDeviceTarget;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type AdminInstallCommandOptions = CommandContext & {
   app: string;
@@ -57,9 +59,7 @@ export type AdminInstallCommandResult = {
   launchTarget?: string;
   installablePath?: string;
   archivePath?: string;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export const devicesCommand: RuntimeCommand<
   AdminDevicesCommandOptions | undefined,

--- a/src/commands/apps.ts
+++ b/src/commands/apps.ts
@@ -12,7 +12,11 @@ import { assertResolvedAppsFilter } from './app-inventory-contract.ts';
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
 import { resolveCommandInput } from './io-policy.ts';
-import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
+import {
+  toBackendResult,
+  type BackendResultEnvelope,
+  type RuntimeCommand,
+} from './runtime-types.ts';
 import { normalizeOptionalText, requireText } from './text.ts';
 
 const APP_EVENT_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
@@ -29,9 +33,7 @@ export type OpenAppCommandResult = {
   kind: 'appOpened';
   target: BackendOpenTarget;
   relaunch: boolean;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type CloseAppCommandOptions = CommandContext & {
   app?: string;
@@ -40,9 +42,7 @@ export type CloseAppCommandOptions = CommandContext & {
 export type CloseAppCommandResult = {
   kind: 'appClosed';
   app?: string;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type ListAppsCommandOptions = CommandContext & {
   filter?: BackendAppListFilter;
@@ -79,9 +79,7 @@ export type PushAppCommandResult = {
   kind: 'appPushed';
   app: string;
   inputKind: 'json' | 'file';
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type TriggerAppEventCommandOptions = CommandContext & {
   name: string;
@@ -92,9 +90,7 @@ export type TriggerAppEventCommandResult = {
   kind: 'appEventTriggered';
   name: string;
   payload?: Record<string, unknown>;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export const openAppCommand: RuntimeCommand<OpenAppCommandOptions, OpenAppCommandResult> = async (
   runtime,

--- a/src/commands/apps.ts
+++ b/src/commands/apps.ts
@@ -1,5 +1,4 @@
 import type {
-  BackendActionResult,
   BackendAppInfo,
   BackendAppListFilter,
   BackendAppState,
@@ -13,7 +12,7 @@ import { assertResolvedAppsFilter } from './app-inventory-contract.ts';
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
 import { resolveCommandInput } from './io-policy.ts';
-import type { RuntimeCommand } from './runtime-types.ts';
+import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
 import { normalizeOptionalText, requireText } from './text.ts';
 
 const APP_EVENT_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
@@ -372,8 +371,4 @@ function toAppBackendContext(
     signal: options.signal ?? runtime.signal,
     metadata: options.metadata,
   };
-}
-
-function toBackendResult(result: BackendActionResult): Record<string, unknown> | undefined {
-  return result && typeof result === 'object' ? result : undefined;
 }

--- a/src/commands/cli-grammar/capture.ts
+++ b/src/commands/cli-grammar/capture.ts
@@ -175,9 +175,7 @@ function readAlertInput(positionals: string[]): Record<string, unknown> {
   return compactRecord({ action, timeoutMs });
 }
 
-function readAlertAction(
-  value: string | undefined,
-): AlertAction | undefined {
+function readAlertAction(value: string | undefined): AlertAction | undefined {
   const action = value?.toLowerCase();
   if (
     action === undefined ||

--- a/src/commands/cli-grammar/capture.ts
+++ b/src/commands/cli-grammar/capture.ts
@@ -6,6 +6,7 @@ import type {
   WaitCommandOptions,
 } from '../../client-types.ts';
 import { parseTimeout } from '../../daemon/handlers/parse-utils.ts';
+import type { AlertAction } from '../../alert-contract.ts';
 import { splitSelectorFromArgs, tryParseSelectorChain } from '../../daemon/selectors.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import { AppError } from '../../utils/errors.ts';
@@ -176,7 +177,7 @@ function readAlertInput(positionals: string[]): Record<string, unknown> {
 
 function readAlertAction(
   value: string | undefined,
-): 'get' | 'accept' | 'dismiss' | 'wait' | undefined {
+): AlertAction | undefined {
   const action = value?.toLowerCase();
   if (
     action === undefined ||

--- a/src/commands/cli-grammar/common.ts
+++ b/src/commands/cli-grammar/common.ts
@@ -6,7 +6,7 @@ import type {
 import { splitSelectorFromArgs } from '../../daemon/selectors.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import { AppError } from '../../utils/errors.ts';
-import { compactRecord } from '../command-input.ts';
+import { compactRecord, type SelectorSnapshotInput } from '../command-input.ts';
 import type {
   DaemonWriter,
   SelectionOptions,
@@ -77,11 +77,7 @@ export function selectorSnapshotInputFromFlags(flags: CliFlags): Record<string, 
   });
 }
 
-export function selectorSnapshotOptionsFromFlags(flags: CliFlags): {
-  depth?: number;
-  scope?: string;
-  raw?: boolean;
-} {
+export function selectorSnapshotOptionsFromFlags(flags: CliFlags): SelectorSnapshotInput {
   return {
     depth: flags.snapshotDepth,
     scope: flags.snapshotScope,

--- a/src/commands/cli-grammar/interactions.ts
+++ b/src/commands/cli-grammar/interactions.ts
@@ -191,9 +191,7 @@ function swipePositionals(input: CommandInput): string[] {
   ];
 }
 
-function readScrollDirection(
-  value: string | undefined,
-): ScrollInputDirection {
+function readScrollDirection(value: string | undefined): ScrollInputDirection {
   if (
     value === 'up' ||
     value === 'down' ||

--- a/src/commands/cli-grammar/interactions.ts
+++ b/src/commands/cli-grammar/interactions.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../client-types.ts';
 import { splitSelectorFromArgs } from '../../daemon/selectors.ts';
 import { AppError } from '../../utils/errors.ts';
+import type { ScrollInputDirection } from '../interaction-gestures.ts';
 import {
   commonInputFromFlags,
   direct,
@@ -192,7 +193,7 @@ function swipePositionals(input: CommandInput): string[] {
 
 function readScrollDirection(
   value: string | undefined,
-): 'up' | 'down' | 'left' | 'right' | 'top' | 'bottom' {
+): ScrollInputDirection {
   if (
     value === 'up' ||
     value === 'down' ||

--- a/src/commands/cli-grammar/observability.ts
+++ b/src/commands/cli-grammar/observability.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../client-types.ts';
 import { AppError } from '../../utils/errors.ts';
 import type { NetworkIncludeMode } from '../../contracts.ts';
+import type { LogAction } from '../log-command-contract.ts';
 import {
   isPerfAction,
   isPerfArea,
@@ -122,7 +123,7 @@ function readPerfAction(
 
 function readLogsAction(
   value: string | undefined,
-): 'path' | 'start' | 'stop' | 'doctor' | 'mark' | 'clear' | undefined {
+): LogAction | undefined {
   if (value === undefined) return undefined;
   if (
     value === 'path' ||

--- a/src/commands/cli-grammar/observability.ts
+++ b/src/commands/cli-grammar/observability.ts
@@ -6,6 +6,7 @@ import type {
   RecordOptions,
 } from '../../client-types.ts';
 import { AppError } from '../../utils/errors.ts';
+import type { NetworkIncludeMode } from '../../contracts.ts';
 import {
   isPerfAction,
   isPerfArea,
@@ -144,7 +145,7 @@ function readNetworkAction(value: string | undefined): 'dump' | 'log' | undefine
 
 function readNetworkInclude(
   value: string | undefined,
-): 'summary' | 'headers' | 'body' | 'all' | undefined {
+): NetworkIncludeMode | undefined {
   if (value === undefined) return undefined;
   if (value === 'summary' || value === 'headers' || value === 'body' || value === 'all')
     return value;

--- a/src/commands/cli-grammar/observability.ts
+++ b/src/commands/cli-grammar/observability.ts
@@ -121,9 +121,7 @@ function readPerfAction(
   throw new AppError('INVALID_ARGS', PERF_ACTION_ERROR_MESSAGE);
 }
 
-function readLogsAction(
-  value: string | undefined,
-): LogAction | undefined {
+function readLogsAction(value: string | undefined): LogAction | undefined {
   if (value === undefined) return undefined;
   if (
     value === 'path' ||
@@ -144,9 +142,7 @@ function readNetworkAction(value: string | undefined): 'dump' | 'log' | undefine
   throw new AppError('INVALID_ARGS', 'network requires dump or log');
 }
 
-function readNetworkInclude(
-  value: string | undefined,
-): NetworkIncludeMode | undefined {
+function readNetworkInclude(value: string | undefined): NetworkIncludeMode | undefined {
   if (value === undefined) return undefined;
   if (value === 'summary' || value === 'headers' || value === 'body' || value === 'all')
     return value;

--- a/src/commands/cli-grammar/system.ts
+++ b/src/commands/cli-grammar/system.ts
@@ -1,6 +1,7 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { ClipboardCommandOptions } from '../../client-types.ts';
 import { parseDeviceRotation } from '../../core/device-rotation.ts';
+import type { BackMode } from '../../core/back-mode.ts';
 import { AppError } from '../../utils/errors.ts';
 import { compactRecord } from '../command-input.ts';
 import {
@@ -56,7 +57,7 @@ export const systemDaemonWriters = {
   ]),
 } satisfies Record<string, DaemonWriter>;
 
-function readBackMode(value: unknown): 'in-app' | 'system' | undefined {
+function readBackMode(value: unknown): BackMode | undefined {
   return value === 'in-app' || value === 'system' ? value : undefined;
 }
 

--- a/src/commands/cli-grammar/types.ts
+++ b/src/commands/cli-grammar/types.ts
@@ -1,5 +1,6 @@
 import type { InteractionTarget, InternalRequestOptions } from '../../client-types.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { ClickButton } from '../../core/click-button.ts';
 
 export type DaemonCommandRequest = {
   command: string;
@@ -35,7 +36,7 @@ export type CommandInput = Omit<InternalRequestOptions, 'batchSteps' | 'target'>
     kind?: string;
     locator?: string;
     mode?: 'in-app' | 'system' | 'full' | 'limited';
-    button?: 'primary' | 'secondary' | 'middle';
+    button?: ClickButton;
     first?: boolean;
     last?: boolean;
     maxSteps?: number;

--- a/src/commands/client-command-metadata.ts
+++ b/src/commands/client-command-metadata.ts
@@ -4,6 +4,7 @@ import type { AlertAction } from '../alert-contract.ts';
 import type { BackMode } from '../core/back-mode.ts';
 import type { DeviceRotation } from '../core/device-rotation.ts';
 import type { SessionSurface } from '../core/session-surface.ts';
+import { LOG_ACTION_VALUES } from './log-command-contract.ts';
 import { requireCommandDescription } from './command-descriptions.ts';
 import {
   booleanField,
@@ -35,7 +36,6 @@ const ORIENTATION_VALUES = [
   'landscape-right',
 ] as const satisfies readonly DeviceRotation[];
 const CLIPBOARD_ACTION_VALUES = ['read', 'write'] as const;
-const LOG_ACTION_VALUES = ['path', 'start', 'stop', 'doctor', 'mark', 'clear'] as const;
 const NETWORK_ACTION_VALUES = ['dump', 'log'] as const;
 const NETWORK_INCLUDE_VALUES = ['summary', 'headers', 'body', 'all'] as const;
 const START_STOP_VALUES = ['start', 'stop'] as const;

--- a/src/commands/client-command-metadata.ts
+++ b/src/commands/client-command-metadata.ts
@@ -25,9 +25,19 @@ import {
 import { defineFieldCommandMetadata } from './field-command-contract.ts';
 import { PERF_ACTION_VALUES, PERF_AREA_VALUES } from './perf-command-contract.ts';
 
-const SURFACE_VALUES = ['app', 'frontmost-app', 'desktop', 'menubar'] as const satisfies readonly SessionSurface[];
+const SURFACE_VALUES = [
+  'app',
+  'frontmost-app',
+  'desktop',
+  'menubar',
+] as const satisfies readonly SessionSurface[];
 const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector'] as const;
-const ALERT_ACTION_VALUES = ['get', 'accept', 'dismiss', 'wait'] as const satisfies readonly AlertAction[];
+const ALERT_ACTION_VALUES = [
+  'get',
+  'accept',
+  'dismiss',
+  'wait',
+] as const satisfies readonly AlertAction[];
 const BACK_MODE_VALUES = ['in-app', 'system'] as const satisfies readonly BackMode[];
 const ORIENTATION_VALUES = [
   'portrait',

--- a/src/commands/client-command-metadata.ts
+++ b/src/commands/client-command-metadata.ts
@@ -1,5 +1,9 @@
 import type { MetroPrepareOptions, RecordOptions } from '../client-types.ts';
 import type { DaemonInstallSource } from '../contracts.ts';
+import type { AlertAction } from '../alert-contract.ts';
+import type { BackMode } from '../core/back-mode.ts';
+import type { DeviceRotation } from '../core/device-rotation.ts';
+import type { SessionSurface } from '../core/session-surface.ts';
 import { requireCommandDescription } from './command-descriptions.ts';
 import {
   booleanField,
@@ -20,16 +24,16 @@ import {
 import { defineFieldCommandMetadata } from './field-command-contract.ts';
 import { PERF_ACTION_VALUES, PERF_AREA_VALUES } from './perf-command-contract.ts';
 
-const SURFACE_VALUES = ['app', 'frontmost-app', 'desktop', 'menubar'] as const;
+const SURFACE_VALUES = ['app', 'frontmost-app', 'desktop', 'menubar'] as const satisfies readonly SessionSurface[];
 const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector'] as const;
-const ALERT_ACTION_VALUES = ['get', 'accept', 'dismiss', 'wait'] as const;
-const BACK_MODE_VALUES = ['in-app', 'system'] as const;
+const ALERT_ACTION_VALUES = ['get', 'accept', 'dismiss', 'wait'] as const satisfies readonly AlertAction[];
+const BACK_MODE_VALUES = ['in-app', 'system'] as const satisfies readonly BackMode[];
 const ORIENTATION_VALUES = [
   'portrait',
   'portrait-upside-down',
   'landscape-left',
   'landscape-right',
-] as const;
+] as const satisfies readonly DeviceRotation[];
 const CLIPBOARD_ACTION_VALUES = ['read', 'write'] as const;
 const LOG_ACTION_VALUES = ['path', 'start', 'stop', 'doctor', 'mark', 'clear'] as const;
 const NETWORK_ACTION_VALUES = ['dump', 'log'] as const;

--- a/src/commands/client-command-metadata.ts
+++ b/src/commands/client-command-metadata.ts
@@ -1,9 +1,9 @@
 import type { MetroPrepareOptions, RecordOptions } from '../client-types.ts';
 import type { DaemonInstallSource } from '../contracts.ts';
-import type { AlertAction } from '../alert-contract.ts';
-import type { BackMode } from '../core/back-mode.ts';
-import type { DeviceRotation } from '../core/device-rotation.ts';
-import type { SessionSurface } from '../core/session-surface.ts';
+import { ALERT_ACTIONS } from '../alert-contract.ts';
+import { BACK_MODES } from '../core/back-mode.ts';
+import { DEVICE_ROTATIONS } from '../core/device-rotation.ts';
+import { SESSION_SURFACES } from '../core/session-surface.ts';
 import { LOG_ACTION_VALUES } from './log-command-contract.ts';
 import { requireCommandDescription } from './command-descriptions.ts';
 import {
@@ -25,26 +25,7 @@ import {
 import { defineFieldCommandMetadata } from './field-command-contract.ts';
 import { PERF_ACTION_VALUES, PERF_AREA_VALUES } from './perf-command-contract.ts';
 
-const SURFACE_VALUES = [
-  'app',
-  'frontmost-app',
-  'desktop',
-  'menubar',
-] as const satisfies readonly SessionSurface[];
 const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector'] as const;
-const ALERT_ACTION_VALUES = [
-  'get',
-  'accept',
-  'dismiss',
-  'wait',
-] as const satisfies readonly AlertAction[];
-const BACK_MODE_VALUES = ['in-app', 'system'] as const satisfies readonly BackMode[];
-const ORIENTATION_VALUES = [
-  'portrait',
-  'portrait-upside-down',
-  'landscape-left',
-  'landscape-right',
-] as const satisfies readonly DeviceRotation[];
 const CLIPBOARD_ACTION_VALUES = ['read', 'write'] as const;
 const NETWORK_ACTION_VALUES = ['dump', 'log'] as const;
 const NETWORK_INCLUDE_VALUES = ['summary', 'headers', 'body', 'all'] as const;
@@ -71,7 +52,7 @@ export const clientCommandMetadata = [
   defineClientCommandMetadata('open', {
     app: stringField('App name, bundle id, package, or URL.'),
     url: stringField('Optional URL passed with an app shell.'),
-    surface: enumField(SURFACE_VALUES),
+    surface: enumField(SESSION_SURFACES),
     activity: stringField('Android activity name.'),
     launchConsole: stringField('Launch console mode.'),
     launchArgs: stringArrayField(
@@ -128,7 +109,7 @@ export const clientCommandMetadata = [
     fullscreen: booleanField(),
     maxSize: integerField(),
     stabilize: booleanField(),
-    surface: enumField(SURFACE_VALUES),
+    surface: enumField(SESSION_SURFACES),
   }),
   defineClientCommandMetadata('diff', {
     kind: requiredField(jsonSchemaField<'snapshot'>({ type: 'string', const: 'snapshot' })),
@@ -151,16 +132,16 @@ export const clientCommandMetadata = [
     raw: booleanField(),
   }),
   defineClientCommandMetadata('alert', {
-    action: enumField(ALERT_ACTION_VALUES),
+    action: enumField(ALERT_ACTIONS),
     timeoutMs: integerField(),
   }),
   defineClientCommandMetadata('appstate', {}),
   defineClientCommandMetadata('back', {
-    mode: enumField(BACK_MODE_VALUES),
+    mode: enumField(BACK_MODES),
   }),
   defineClientCommandMetadata('home', {}),
   defineClientCommandMetadata('rotate', {
-    orientation: requiredField(enumField(ORIENTATION_VALUES)),
+    orientation: requiredField(enumField(DEVICE_ROTATIONS)),
   }),
   defineClientCommandMetadata('app-switcher', {}),
   defineClientCommandMetadata('keyboard', {

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -7,7 +7,13 @@ import type {
 import type { DeviceTarget, PlatformSelector } from '../utils/device.ts';
 import type { JsonSchema } from './command-contract.ts';
 
-const PLATFORM_VALUES = ['ios', 'android', 'macos', 'linux', 'apple'] as const satisfies readonly PlatformSelector[];
+const PLATFORM_VALUES = [
+  'ios',
+  'android',
+  'macos',
+  'linux',
+  'apple',
+] as const satisfies readonly PlatformSelector[];
 const DEVICE_TARGET_VALUES = ['mobile', 'tv', 'desktop'] as const satisfies readonly DeviceTarget[];
 const INTERACTION_TARGET_KINDS = ['ref', 'selector', 'point'] as const;
 

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -7,8 +7,8 @@ import type {
 import type { DeviceTarget, PlatformSelector } from '../utils/device.ts';
 import type { JsonSchema } from './command-contract.ts';
 
-const PLATFORM_VALUES = ['ios', 'android', 'macos', 'linux', 'apple'] as const;
-const DEVICE_TARGET_VALUES = ['mobile', 'tv', 'desktop'] as const;
+const PLATFORM_VALUES = ['ios', 'android', 'macos', 'linux', 'apple'] as const satisfies readonly PlatformSelector[];
+const DEVICE_TARGET_VALUES = ['mobile', 'tv', 'desktop'] as const satisfies readonly DeviceTarget[];
 const INTERACTION_TARGET_KINDS = ['ref', 'selector', 'point'] as const;
 
 export type CommonCommandInput = Pick<

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -4,7 +4,7 @@ import type {
   ElementTarget,
   InteractionTarget,
 } from '../client-types.ts';
-import type { DeviceTarget, PlatformSelector } from '../utils/device.ts';
+import { DEVICE_TARGETS, type DeviceTarget, type PlatformSelector } from '../utils/device.ts';
 import type { JsonSchema } from './command-contract.ts';
 
 const PLATFORM_VALUES = [
@@ -14,7 +14,6 @@ const PLATFORM_VALUES = [
   'linux',
   'apple',
 ] as const satisfies readonly PlatformSelector[];
-const DEVICE_TARGET_VALUES = ['mobile', 'tv', 'desktop'] as const satisfies readonly DeviceTarget[];
 const INTERACTION_TARGET_KINDS = ['ref', 'selector', 'point'] as const;
 
 export type CommonCommandInput = Pick<
@@ -301,9 +300,9 @@ function readDeviceTarget(
   record: Record<string, unknown>,
   options: CommonInputOptions,
 ): DeviceTarget | undefined {
-  const deviceTarget = optionalEnum(record, 'deviceTarget', DEVICE_TARGET_VALUES);
+  const deviceTarget = optionalEnum(record, 'deviceTarget', DEVICE_TARGETS);
   if (options.readTargetAlias === false || record.target === undefined) return deviceTarget;
-  const targetAlias = optionalEnum(record, 'target', DEVICE_TARGET_VALUES);
+  const targetAlias = optionalEnum(record, 'target', DEVICE_TARGETS);
   if (deviceTarget !== undefined && targetAlias !== deviceTarget) {
     throw new Error('Expected target alias to match deviceTarget when both are set.');
   }
@@ -570,12 +569,12 @@ function commonProperties(): Record<string, JsonSchema> {
     },
     deviceTarget: {
       type: 'string',
-      enum: DEVICE_TARGET_VALUES,
+      enum: DEVICE_TARGETS,
       description: 'Device target form. Maps to the CLI --target flag.',
     },
     target: {
       type: 'string',
-      enum: DEVICE_TARGET_VALUES,
+      enum: DEVICE_TARGETS,
       description:
         'Alias for deviceTarget on commands without a UI target field. Interaction commands reserve target for the UI element.',
     },

--- a/src/commands/interaction-command-metadata.ts
+++ b/src/commands/interaction-command-metadata.ts
@@ -1,5 +1,6 @@
 import { requireCommandDescription } from './command-descriptions.ts';
 import { defineCommandMetadata } from './command-contract.ts';
+import { GESTURE_KINDS } from '../command-catalog.ts';
 import {
   booleanField,
   elementTargetField,
@@ -31,7 +32,6 @@ import type { ScrollDirection, SwipePattern, SwipePreset } from '../core/scroll-
 import type { ScrollInputDirection } from './interaction-gestures.ts';
 
 const CLICK_BUTTON_VALUES = ['primary', 'secondary', 'middle'] as const satisfies readonly ClickButton[];
-const GESTURE_KIND_VALUES = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'transform'] as const;
 const GESTURE_DIRECTION_VALUES = ['up', 'down', 'left', 'right'] as const satisfies readonly ScrollDirection[];
 const GESTURE_SWIPE_PRESET_VALUES = ['left', 'right', 'left-edge', 'right-edge'] as const satisfies readonly SwipePreset[];
 const FIND_ACTION_VALUES = [
@@ -130,7 +130,7 @@ const findFields = {
 };
 
 const gestureFields = {
-  kind: requiredField(enumField(GESTURE_KIND_VALUES, 'Gesture variant.')),
+  kind: requiredField(enumField(GESTURE_KINDS, 'Gesture variant.')),
   direction: enumField(GESTURE_DIRECTION_VALUES, 'Fling direction.'),
   preset: enumField(GESTURE_SWIPE_PRESET_VALUES, 'Swipe preset.'),
   origin: pointField('Gesture origin point.'),
@@ -237,7 +237,7 @@ export const interactionCommandMetadata = [
 function readGestureInput(input: unknown): GestureInput {
   const record = readInputRecord(input);
   const common = readCommonInput(record);
-  const kind = requiredEnum(record, 'kind', GESTURE_KIND_VALUES);
+  const kind = requiredEnum(record, 'kind', GESTURE_KINDS);
   if (kind === 'pan') {
     return {
       ...common,

--- a/src/commands/interaction-command-metadata.ts
+++ b/src/commands/interaction-command-metadata.ts
@@ -27,27 +27,16 @@ import {
   type PointInput,
 } from './command-input.ts';
 import { defineFieldCommandMetadata } from './field-command-contract.ts';
-import type { ClickButton } from '../core/click-button.ts';
-import type { ScrollDirection, SwipePattern, SwipePreset } from '../core/scroll-gesture.ts';
-import type { ScrollInputDirection } from './interaction-gestures.ts';
+import { CLICK_BUTTONS } from '../core/click-button.ts';
+import {
+  SCROLL_DIRECTIONS,
+  SWIPE_PATTERNS,
+  SWIPE_PRESETS,
+  type ScrollDirection,
+  type SwipePreset,
+} from '../core/scroll-gesture.ts';
+import { SCROLL_INPUT_DIRECTIONS } from './interaction-gestures.ts';
 
-const CLICK_BUTTON_VALUES = [
-  'primary',
-  'secondary',
-  'middle',
-] as const satisfies readonly ClickButton[];
-const GESTURE_DIRECTION_VALUES = [
-  'up',
-  'down',
-  'left',
-  'right',
-] as const satisfies readonly ScrollDirection[];
-const GESTURE_SWIPE_PRESET_VALUES = [
-  'left',
-  'right',
-  'left-edge',
-  'right-edge',
-] as const satisfies readonly SwipePreset[];
 const FIND_ACTION_VALUES = [
   'click',
   'focus',
@@ -59,22 +48,10 @@ const FIND_ACTION_VALUES = [
   'type',
 ] as const;
 const FIND_LOCATOR_VALUES = ['any', 'text', 'label', 'value', 'role', 'id'] as const;
-const SCROLL_DIRECTION_VALUES = [
-  'up',
-  'down',
-  'left',
-  'right',
-  'top',
-  'bottom',
-] as const satisfies readonly ScrollInputDirection[];
-const SWIPE_PATTERN_VALUES = ['one-way', 'ping-pong'] as const satisfies readonly SwipePattern[];
 
 const clickFields = {
   target: requiredField(interactionTargetField()),
-  button: enumField(
-    CLICK_BUTTON_VALUES,
-    'Pointer button for platforms that support mouse buttons.',
-  ),
+  button: enumField(CLICK_BUTTONS, 'Pointer button for platforms that support mouse buttons.'),
   ...selectorSnapshotFields(),
   ...repeatedFields(),
 };
@@ -104,7 +81,7 @@ const swipeFields = {
   durationMs: integerField('Swipe duration in milliseconds.', { min: 0 }),
   count: integerField('Number of swipe repetitions.', { min: 1 }),
   pauseMs: integerField('Pause between repeated swipes.', { min: 0 }),
-  pattern: enumField(SWIPE_PATTERN_VALUES),
+  pattern: enumField(SWIPE_PATTERNS),
 };
 
 const focusFields = {
@@ -118,7 +95,7 @@ const typeFields = {
 };
 
 const scrollFields = {
-  direction: requiredField(enumField(SCROLL_DIRECTION_VALUES)),
+  direction: requiredField(enumField(SCROLL_INPUT_DIRECTIONS)),
   amount: numberField('Platform scroll amount.'),
   pixels: integerField('Pixel scroll amount.', { min: 0 }),
 };
@@ -152,8 +129,8 @@ const findFields = {
 
 const gestureFields = {
   kind: requiredField(enumField(GESTURE_KINDS, 'Gesture variant.')),
-  direction: enumField(GESTURE_DIRECTION_VALUES, 'Fling direction.'),
-  preset: enumField(GESTURE_SWIPE_PRESET_VALUES, 'Swipe preset.'),
+  direction: enumField(SCROLL_DIRECTIONS, 'Fling direction.'),
+  preset: enumField(SWIPE_PRESETS, 'Swipe preset.'),
   origin: pointField('Gesture origin point.'),
   delta: pointField('Movement delta for pan or transform gestures.'),
   distance: integerField('Fling distance.', { min: 0 }),
@@ -272,7 +249,7 @@ function readGestureInput(input: unknown): GestureInput {
     return {
       ...common,
       kind,
-      direction: requiredEnum(record, 'direction', GESTURE_DIRECTION_VALUES),
+      direction: requiredEnum(record, 'direction', SCROLL_DIRECTIONS),
       origin: readPoint(record, 'origin'),
       distance: optionalInteger(record, 'distance', { min: 0 }),
       durationMs: optionalInteger(record, 'durationMs', { min: 0 }),
@@ -282,7 +259,7 @@ function readGestureInput(input: unknown): GestureInput {
     return {
       ...common,
       kind,
-      preset: requiredEnum(record, 'preset', GESTURE_SWIPE_PRESET_VALUES),
+      preset: requiredEnum(record, 'preset', SWIPE_PRESETS),
       durationMs: optionalInteger(record, 'durationMs', { min: 0 }),
     };
   }

--- a/src/commands/interaction-command-metadata.ts
+++ b/src/commands/interaction-command-metadata.ts
@@ -31,9 +31,23 @@ import type { ClickButton } from '../core/click-button.ts';
 import type { ScrollDirection, SwipePattern, SwipePreset } from '../core/scroll-gesture.ts';
 import type { ScrollInputDirection } from './interaction-gestures.ts';
 
-const CLICK_BUTTON_VALUES = ['primary', 'secondary', 'middle'] as const satisfies readonly ClickButton[];
-const GESTURE_DIRECTION_VALUES = ['up', 'down', 'left', 'right'] as const satisfies readonly ScrollDirection[];
-const GESTURE_SWIPE_PRESET_VALUES = ['left', 'right', 'left-edge', 'right-edge'] as const satisfies readonly SwipePreset[];
+const CLICK_BUTTON_VALUES = [
+  'primary',
+  'secondary',
+  'middle',
+] as const satisfies readonly ClickButton[];
+const GESTURE_DIRECTION_VALUES = [
+  'up',
+  'down',
+  'left',
+  'right',
+] as const satisfies readonly ScrollDirection[];
+const GESTURE_SWIPE_PRESET_VALUES = [
+  'left',
+  'right',
+  'left-edge',
+  'right-edge',
+] as const satisfies readonly SwipePreset[];
 const FIND_ACTION_VALUES = [
   'click',
   'focus',
@@ -45,7 +59,14 @@ const FIND_ACTION_VALUES = [
   'type',
 ] as const;
 const FIND_LOCATOR_VALUES = ['any', 'text', 'label', 'value', 'role', 'id'] as const;
-const SCROLL_DIRECTION_VALUES = ['up', 'down', 'left', 'right', 'top', 'bottom'] as const satisfies readonly ScrollInputDirection[];
+const SCROLL_DIRECTION_VALUES = [
+  'up',
+  'down',
+  'left',
+  'right',
+  'top',
+  'bottom',
+] as const satisfies readonly ScrollInputDirection[];
 const SWIPE_PATTERN_VALUES = ['one-way', 'ping-pong'] as const satisfies readonly SwipePattern[];
 
 const clickFields = {

--- a/src/commands/interaction-command-metadata.ts
+++ b/src/commands/interaction-command-metadata.ts
@@ -26,11 +26,13 @@ import {
   type PointInput,
 } from './command-input.ts';
 import { defineFieldCommandMetadata } from './field-command-contract.ts';
+import type { ClickButton } from '../core/click-button.ts';
+import type { ScrollDirection, SwipePreset } from '../core/scroll-gesture.ts';
 
-const CLICK_BUTTON_VALUES = ['primary', 'secondary', 'middle'] as const;
+const CLICK_BUTTON_VALUES = ['primary', 'secondary', 'middle'] as const satisfies readonly ClickButton[];
 const GESTURE_KIND_VALUES = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'transform'] as const;
-const GESTURE_DIRECTION_VALUES = ['up', 'down', 'left', 'right'] as const;
-const GESTURE_SWIPE_PRESET_VALUES = ['left', 'right', 'left-edge', 'right-edge'] as const;
+const GESTURE_DIRECTION_VALUES = ['up', 'down', 'left', 'right'] as const satisfies readonly ScrollDirection[];
+const GESTURE_SWIPE_PRESET_VALUES = ['left', 'right', 'left-edge', 'right-edge'] as const satisfies readonly SwipePreset[];
 const FIND_ACTION_VALUES = [
   'click',
   'focus',
@@ -154,7 +156,7 @@ export type PanInput = CommonCommandInput & {
 
 export type FlingInput = CommonCommandInput & {
   kind: 'fling';
-  direction: 'up' | 'down' | 'left' | 'right';
+  direction: ScrollDirection;
   origin: PointInput;
   distance?: number;
   durationMs?: number;

--- a/src/commands/interaction-command-metadata.ts
+++ b/src/commands/interaction-command-metadata.ts
@@ -27,7 +27,8 @@ import {
 } from './command-input.ts';
 import { defineFieldCommandMetadata } from './field-command-contract.ts';
 import type { ClickButton } from '../core/click-button.ts';
-import type { ScrollDirection, SwipePreset } from '../core/scroll-gesture.ts';
+import type { ScrollDirection, SwipePattern, SwipePreset } from '../core/scroll-gesture.ts';
+import type { ScrollInputDirection } from './interaction-gestures.ts';
 
 const CLICK_BUTTON_VALUES = ['primary', 'secondary', 'middle'] as const satisfies readonly ClickButton[];
 const GESTURE_KIND_VALUES = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'transform'] as const;
@@ -44,8 +45,8 @@ const FIND_ACTION_VALUES = [
   'type',
 ] as const;
 const FIND_LOCATOR_VALUES = ['any', 'text', 'label', 'value', 'role', 'id'] as const;
-const SCROLL_DIRECTION_VALUES = ['up', 'down', 'left', 'right', 'top', 'bottom'] as const;
-const SWIPE_PATTERN_VALUES = ['one-way', 'ping-pong'] as const;
+const SCROLL_DIRECTION_VALUES = ['up', 'down', 'left', 'right', 'top', 'bottom'] as const satisfies readonly ScrollInputDirection[];
+const SWIPE_PATTERN_VALUES = ['one-way', 'ping-pong'] as const satisfies readonly SwipePattern[];
 
 const clickFields = {
   target: requiredField(interactionTargetField()),
@@ -164,7 +165,7 @@ export type FlingInput = CommonCommandInput & {
 
 export type SwipeGestureInput = CommonCommandInput & {
   kind: 'swipe';
-  preset: 'left' | 'right' | 'left-edge' | 'right-edge';
+  preset: SwipePreset;
   durationMs?: number;
 };
 

--- a/src/commands/interaction-gestures.ts
+++ b/src/commands/interaction-gestures.ts
@@ -4,6 +4,7 @@ import { centerOfRect } from '../utils/snapshot.ts';
 import {
   buildSwipePresetGesturePlan,
   parseSwipePreset,
+  type ScrollDirection,
   type SwipePreset,
 } from '../core/scroll-gesture.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../runtime-contract.ts';
@@ -48,7 +49,7 @@ export type LongPressCommandResult = ResolvedInteractionTarget & {
   message?: string;
 };
 
-export type GestureDirection = 'up' | 'down' | 'left' | 'right';
+export type GestureDirection = ScrollDirection;
 export type ScrollInputDirection = GestureDirection | 'top' | 'bottom';
 
 export type ScrollTarget =

--- a/src/commands/interaction-gestures.ts
+++ b/src/commands/interaction-gestures.ts
@@ -4,6 +4,7 @@ import { centerOfRect } from '../utils/snapshot.ts';
 import {
   buildSwipePresetGesturePlan,
   parseSwipePreset,
+  type GestureReferenceFrame,
   type ScrollDirection,
   type SwipePreset,
 } from '../core/scroll-gesture.ts';
@@ -540,10 +541,7 @@ function resolveSnapshotViewport(nodes: SnapshotState['nodes']): Rect {
   };
 }
 
-function resolveSnapshotReferenceFrame(nodes: SnapshotState['nodes']): {
-  referenceWidth: number;
-  referenceHeight: number;
-} {
+function resolveSnapshotReferenceFrame(nodes: SnapshotState['nodes']): GestureReferenceFrame {
   const viewport = resolveSnapshotViewport(nodes);
   return {
     referenceWidth: viewport.width,

--- a/src/commands/interaction-gestures.ts
+++ b/src/commands/interaction-gestures.ts
@@ -20,7 +20,7 @@ import {
   type ScrollEdgeState,
   type ScrollEdgeTarget,
 } from '../utils/scroll-edge-state.ts';
-import type { RuntimeCommand } from './runtime-types.ts';
+import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
 import {
   assertSupportedInteractionSurface,
   captureInteractionSnapshot,
@@ -551,8 +551,4 @@ function resolveSnapshotReferenceFrame(nodes: SnapshotState['nodes']): GestureRe
 
 function isUsableRect(rect: SnapshotNode['rect']): rect is NonNullable<SnapshotNode['rect']> {
   return Boolean(rect && rect.width > 0 && rect.height > 0);
-}
-
-function toBackendResult(result: unknown): Record<string, unknown> | undefined {
-  return result && typeof result === 'object' ? (result as Record<string, unknown>) : undefined;
 }

--- a/src/commands/interaction-gestures.ts
+++ b/src/commands/interaction-gestures.ts
@@ -50,7 +50,8 @@ export type LongPressCommandResult = ResolvedInteractionTarget & {
 } & BackendResultEnvelope;
 
 export type GestureDirection = ScrollDirection;
-export type ScrollInputDirection = GestureDirection | 'top' | 'bottom';
+export const SCROLL_INPUT_DIRECTIONS = ['up', 'down', 'left', 'right', 'top', 'bottom'] as const;
+export type ScrollInputDirection = (typeof SCROLL_INPUT_DIRECTIONS)[number];
 
 export type ScrollTarget =
   | InteractionTarget

--- a/src/commands/interaction-gestures.ts
+++ b/src/commands/interaction-gestures.ts
@@ -20,7 +20,11 @@ import {
   type ScrollEdgeState,
   type ScrollEdgeTarget,
 } from '../utils/scroll-edge-state.ts';
-import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
+import {
+  toBackendResult,
+  type BackendResultEnvelope,
+  type RuntimeCommand,
+} from './runtime-types.ts';
 import {
   assertSupportedInteractionSurface,
   captureInteractionSnapshot,
@@ -34,10 +38,7 @@ export type FocusCommandOptions = CommandContext & {
   target: InteractionTarget;
 };
 
-export type FocusCommandResult = ResolvedInteractionTarget & {
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+export type FocusCommandResult = ResolvedInteractionTarget & BackendResultEnvelope;
 
 export type LongPressCommandOptions = CommandContext & {
   target: InteractionTarget;
@@ -46,9 +47,7 @@ export type LongPressCommandOptions = CommandContext & {
 
 export type LongPressCommandResult = ResolvedInteractionTarget & {
   durationMs?: number;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type GestureDirection = ScrollDirection;
 export type ScrollInputDirection = GestureDirection | 'top' | 'bottom';
@@ -109,9 +108,7 @@ export type SwipeCommandResult = {
   distance?: number;
   durationMs?: number;
   fromTarget?: ResolvedInteractionTarget | { kind: 'viewport' };
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type PinchCommandOptions = CommandContext & {
   scale: number;
@@ -123,9 +120,7 @@ export type PinchCommandResult = {
   scale: number;
   center?: Point;
   centerTarget?: ResolvedInteractionTarget;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export const focusCommand: RuntimeCommand<FocusCommandOptions, FocusCommandResult> = async (
   runtime,

--- a/src/commands/interactions.ts
+++ b/src/commands/interactions.ts
@@ -8,6 +8,7 @@ import { findMistargetedTypeRefToken } from '../utils/type-target-warning.ts';
 import type { ResolvedTarget } from './selector-read.ts';
 import { toBackendContext } from './selector-read-utils.ts';
 import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
+import type { RepeatedInput } from './command-input.ts';
 import {
   type InteractionTarget,
   type ResolvedInteractionTarget,
@@ -42,15 +43,11 @@ export type {
   ResolvedInteractionTarget,
 } from './interaction-resolution.ts';
 
-export type PressCommandOptions = CommandContext & {
-  target: InteractionTarget;
-  button?: ClickButton;
-  count?: number;
-  intervalMs?: number;
-  holdMs?: number;
-  jitterPx?: number;
-  doubleTap?: boolean;
-};
+export type PressCommandOptions = CommandContext &
+  RepeatedInput & {
+    target: InteractionTarget;
+    button?: ClickButton;
+  };
 
 export type ClickCommandOptions = PressCommandOptions;
 

--- a/src/commands/interactions.ts
+++ b/src/commands/interactions.ts
@@ -7,7 +7,11 @@ import { successText } from '../utils/success-text.ts';
 import { findMistargetedTypeRefToken } from '../utils/type-target-warning.ts';
 import type { ResolvedTarget } from './selector-read.ts';
 import { toBackendContext } from './selector-read-utils.ts';
-import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
+import {
+  toBackendResult,
+  type BackendResultEnvelope,
+  type RuntimeCommand,
+} from './runtime-types.ts';
 import type { RepeatedInput } from './command-input.ts';
 import {
   type InteractionTarget,
@@ -76,9 +80,7 @@ export type TypeTextCommandResult = {
   kind: 'text';
   text: string;
   delayMs: number;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export const pressCommand: RuntimeCommand<PressCommandOptions, PressCommandResult> = async (
   runtime,

--- a/src/commands/interactions.ts
+++ b/src/commands/interactions.ts
@@ -7,7 +7,7 @@ import { successText } from '../utils/success-text.ts';
 import { findMistargetedTypeRefToken } from '../utils/type-target-warning.ts';
 import type { ResolvedTarget } from './selector-read.ts';
 import { toBackendContext } from './selector-read-utils.ts';
-import type { RuntimeCommand } from './runtime-types.ts';
+import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
 import {
   type InteractionTarget,
   type ResolvedInteractionTarget,
@@ -189,10 +189,6 @@ async function tapCommand(
     ...resolved,
     ...(formattedBackendResult ? { backendResult: formattedBackendResult } : {}),
   };
-}
-
-function toBackendResult(result: unknown): Record<string, unknown> | undefined {
-  return result && typeof result === 'object' ? (result as Record<string, unknown>) : undefined;
 }
 
 function formatTargetForWarning(result: {

--- a/src/commands/log-command-contract.ts
+++ b/src/commands/log-command-contract.ts
@@ -1,0 +1,2 @@
+export const LOG_ACTION_VALUES = ['path', 'start', 'stop', 'doctor', 'mark', 'clear'] as const;
+export type LogAction = (typeof LOG_ACTION_VALUES)[number];

--- a/src/commands/recording.ts
+++ b/src/commands/recording.ts
@@ -9,7 +9,7 @@ import type { CommandContext } from '../runtime-contract.ts';
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
 import { requireIntInRange } from '../utils/validation.ts';
-import type { RuntimeCommand } from './runtime-types.ts';
+import type { BackendResultEnvelope, RuntimeCommand } from './runtime-types.ts';
 import { reserveCommandOutput } from './io-policy.ts';
 import { toBackendContext } from './selector-read-utils.ts';
 
@@ -42,9 +42,7 @@ export type RecordingTraceCommandResult = {
   action: 'start' | 'stop';
   outPath?: string;
   artifact?: ArtifactDescriptor;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export const recordCommand: RuntimeCommand<
   RecordingRecordCommandOptions,

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -13,6 +13,10 @@ export type BoundRuntimeCommand<TOptions = Record<string, unknown>, TResult = Co
   options: TOptions,
 ) => Promise<TResult>;
 
+export function toBackendResult(result: unknown): Record<string, unknown> | undefined {
+  return result && typeof result === 'object' ? (result as Record<string, unknown>) : undefined;
+}
+
 export type ScreenshotCommandOptions = CommandContext & {
   out?: FileOutputRef;
   fullscreen?: boolean;

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -17,6 +17,11 @@ export function toBackendResult(result: unknown): Record<string, unknown> | unde
   return result && typeof result === 'object' ? (result as Record<string, unknown>) : undefined;
 }
 
+export type BackendResultEnvelope = {
+  backendResult?: Record<string, unknown>;
+  message?: string;
+};
+
 export type ScreenshotCommandOptions = CommandContext & {
   out?: FileOutputRef;
   fullscreen?: boolean;

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -1,5 +1,6 @@
 import type { FileOutputRef } from '../io.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../runtime-contract.ts';
+import type { SessionSurface } from '../core/session-surface.ts';
 
 export type CommandResult = Record<string, unknown>;
 
@@ -20,7 +21,7 @@ export type ScreenshotCommandOptions = CommandContext & {
   stabilize?: boolean;
   appId?: string;
   appBundleId?: string;
-  surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
+  surface?: SessionSurface;
 };
 
 export type SnapshotCommandOptions = CommandContext & {

--- a/src/commands/selector-read-shared.ts
+++ b/src/commands/selector-read-shared.ts
@@ -8,6 +8,7 @@ import type { SnapshotNode, SnapshotState } from '../utils/snapshot.ts';
 import { findNodeByRef, normalizeRef } from '../utils/snapshot.ts';
 import { extractReadableText } from '../utils/text-surface.ts';
 import { findNodeByLabel, now, toBackendContext } from './selector-read-utils.ts';
+import type { SelectorSnapshotInput } from './command-input.ts';
 
 export type CapturedSnapshot = {
   sessionName: string;
@@ -15,11 +16,7 @@ export type CapturedSnapshot = {
   snapshot: SnapshotState;
 };
 
-export type SelectorSnapshotOptions = {
-  depth?: number;
-  scope?: string;
-  raw?: boolean;
-};
+export type SelectorSnapshotOptions = SelectorSnapshotInput;
 
 export async function requireSnapshotSession(
   runtime: AgentDeviceRuntime,

--- a/src/commands/system.ts
+++ b/src/commands/system.ts
@@ -11,7 +11,11 @@ import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
 import { requireIntInRange } from '../utils/validation.ts';
 import { isKeyboardAction } from '../utils/keyboard-actions.ts';
-import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
+import {
+  toBackendResult,
+  type BackendResultEnvelope,
+  type RuntimeCommand,
+} from './runtime-types.ts';
 import { toBackendContext } from './selector-read-utils.ts';
 import { normalizeOptionalText } from './text.ts';
 
@@ -22,17 +26,13 @@ export type SystemBackCommandOptions = CommandContext & {
 export type SystemBackCommandResult = {
   kind: 'systemBack';
   mode: BackMode;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type SystemHomeCommandOptions = CommandContext;
 
 export type SystemHomeCommandResult = {
   kind: 'systemHome';
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type SystemRotateCommandOptions = CommandContext & {
   orientation: BackendDeviceOrientation;
@@ -41,9 +41,7 @@ export type SystemRotateCommandOptions = CommandContext & {
 export type SystemRotateCommandResult = {
   kind: 'systemRotated';
   orientation: BackendDeviceOrientation;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type SystemKeyboardCommandOptions = CommandContext & {
   action?: 'status' | 'get' | 'dismiss' | 'enter' | 'return';
@@ -101,9 +99,7 @@ export type SystemSettingsCommandOptions = CommandContext & {
 export type SystemSettingsCommandResult = {
   kind: 'settingsOpened';
   target?: string;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export type SystemAlertCommandOptions = CommandContext & {
   action?: BackendAlertAction;
@@ -137,9 +133,7 @@ export type SystemAppSwitcherCommandOptions = CommandContext;
 
 export type SystemAppSwitcherCommandResult = {
   kind: 'appSwitcherOpened';
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+} & BackendResultEnvelope;
 
 export const backCommand: RuntimeCommand<
   SystemBackCommandOptions | undefined,

--- a/src/commands/system.ts
+++ b/src/commands/system.ts
@@ -11,7 +11,7 @@ import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
 import { requireIntInRange } from '../utils/validation.ts';
 import { isKeyboardAction } from '../utils/keyboard-actions.ts';
-import type { RuntimeCommand } from './runtime-types.ts';
+import { toBackendResult, type RuntimeCommand } from './runtime-types.ts';
 import { toBackendContext } from './selector-read-utils.ts';
 import { normalizeOptionalText } from './text.ts';
 
@@ -444,8 +444,4 @@ function normalizeAlertHandledResult(
 
 function isKeyboardResult(value: unknown): value is BackendKeyboardResult {
   return Boolean(value && typeof value === 'object');
-}
-
-function toBackendResult(result: unknown): Record<string, unknown> | undefined {
-  return result && typeof result === 'object' ? (result as Record<string, unknown>) : undefined;
 }

--- a/src/commands/system.ts
+++ b/src/commands/system.ts
@@ -6,6 +6,7 @@ import type {
   BackendKeyboardResult,
 } from '../backend.ts';
 import type { CommandContext } from '../runtime-contract.ts';
+import type { BackMode } from '../core/back-mode.ts';
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
 import { requireIntInRange } from '../utils/validation.ts';
@@ -15,12 +16,12 @@ import { toBackendContext } from './selector-read-utils.ts';
 import { normalizeOptionalText } from './text.ts';
 
 export type SystemBackCommandOptions = CommandContext & {
-  mode?: 'in-app' | 'system';
+  mode?: BackMode;
 };
 
 export type SystemBackCommandResult = {
   kind: 'systemBack';
-  mode: 'in-app' | 'system';
+  mode: BackMode;
   backendResult?: Record<string, unknown>;
   message?: string;
 };

--- a/src/compat/maestro/interactions.ts
+++ b/src/compat/maestro/interactions.ts
@@ -12,8 +12,7 @@ import {
 import { parseAbsolutePoint, parseMaestroPoint } from './points.ts';
 import { MAESTRO_RUNTIME_COMMAND } from './runtime-commands.ts';
 import type { MaestroParseContext } from './types.ts';
-
-type SwipeDirection = 'up' | 'down' | 'left' | 'right';
+import type { ScrollDirection } from '../../core/scroll-gesture.ts';
 
 export function convertTapOn(value: unknown, context: MaestroParseContext): SessionAction {
   if (typeof value === 'string') {
@@ -269,7 +268,7 @@ function convertCoordinateSwipePoints(
   );
 }
 
-function readMaestroDirection(direction: string, name: string): SwipeDirection {
+function readMaestroDirection(direction: string, name: string): ScrollDirection {
   const normalized = direction.toLowerCase();
   switch (normalized) {
     case 'up':
@@ -282,7 +281,7 @@ function readMaestroDirection(direction: string, name: string): SwipeDirection {
   }
 }
 
-function readSwipeDirection(direction: string): SwipeDirection {
+function readSwipeDirection(direction: string): ScrollDirection {
   return readMaestroDirection(direction, 'swipe direction');
 }
 

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getSnapshotReferenceFrame } from '../../daemon/touch-reference-frame.ts';
 import type { DaemonResponse } from '../../daemon/types.ts';
+import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
 import type { SnapshotState } from '../../utils/snapshot.ts';
 import { buildSnapshotDisplayLines } from '../../utils/snapshot-lines.ts';
@@ -51,8 +52,6 @@ type MaestroAssertionRuntimeParams = {
 type MaestroAssertionRequestParams = MaestroAssertionRuntimeParams & {
   positionals: string[];
 };
-
-type DaemonFailureResponse = Extract<DaemonResponse, { ok: false }>;
 
 export async function invokeMaestroAssertVisible(
   params: MaestroAssertionRequestParams,

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -4,6 +4,7 @@ import {
   buildSwipeGesturePlan,
   clampGesturePoint,
   pointFromPercent,
+  type GestureReferenceFrame,
   type ScrollDirection,
 } from '../../core/scroll-gesture.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
@@ -271,7 +272,7 @@ async function captureFrameForMaestroScreenSwipe(params: {
   baseReq: ReplayBaseRequest;
   invoke: MaestroRuntimeInvoke;
   scope?: ReplayVarScope;
-}): Promise<{ referenceWidth: number; referenceHeight: number } | undefined> {
+}): Promise<GestureReferenceFrame | undefined> {
   const snapshotResponse = await captureMaestroSnapshot(params);
   if (!snapshotResponse.ok) return undefined;
   const snapshot = readSnapshotState(snapshotResponse.data);
@@ -280,7 +281,7 @@ async function captureFrameForMaestroScreenSwipe(params: {
 
 function resolveDirectionalScreenSwipe(
   args: string[],
-  frame: { referenceWidth: number; referenceHeight: number },
+  frame: GestureReferenceFrame,
 ): MaestroScreenSwipeResolution {
   const [direction, durationMs] = args;
   if (!direction) {
@@ -306,7 +307,7 @@ function resolveDirectionalScreenSwipe(
 
 function buildMaestroDirectionalScreenSwipe(
   direction: ScrollDirection,
-  frame: { referenceWidth: number; referenceHeight: number },
+  frame: GestureReferenceFrame,
   durationMs: string | undefined,
 ): MaestroScreenSwipeResolution {
   const plan = buildSwipeGesturePlan({
@@ -327,7 +328,7 @@ function buildMaestroDirectionalScreenSwipe(
 
 function resolvePercentScreenSwipe(
   args: string[],
-  frame: { referenceWidth: number; referenceHeight: number },
+  frame: GestureReferenceFrame,
   platform: string,
 ): MaestroScreenSwipeResolution {
   const [startX, startY, endX, endY, durationMs] = args;

--- a/src/compat/maestro/runtime-support.ts
+++ b/src/compat/maestro/runtime-support.ts
@@ -8,6 +8,7 @@ import type {
   DaemonResponseData,
   SessionAction,
 } from '../../daemon/types.ts';
+import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
 import type { SnapshotState } from '../../utils/snapshot.ts';
 
@@ -21,7 +22,7 @@ export type MaestroReplayInvoker = (params: {
 
 export type MaestroRuntimeInvoke = (req: DaemonRequest) => Promise<DaemonResponse>;
 
-export type FailedDaemonResponse = Extract<DaemonResponse, { ok: false }>;
+export type FailedDaemonResponse = DaemonFailureResponse;
 
 const maestroReferenceFrameCache = new WeakMap<ReplayVarScope, TouchReferenceFrame>();
 const maestroVisibleContextCache = new WeakMap<ReplayVarScope, { selector: string }>();

--- a/src/compat/maestro/runtime-support.ts
+++ b/src/compat/maestro/runtime-support.ts
@@ -2,23 +2,15 @@ import {
   getSnapshotReferenceFrame,
   type TouchReferenceFrame,
 } from '../../daemon/touch-reference-frame.ts';
-import type {
-  DaemonRequest,
-  DaemonResponse,
-  DaemonResponseData,
-  SessionAction,
-} from '../../daemon/types.ts';
+import type { DaemonRequest, DaemonResponse, DaemonResponseData } from '../../daemon/types.ts';
 import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
+import type { ReplayActionBlockInvoker } from '../../replay/control-flow-runtime.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
 import type { SnapshotState } from '../../utils/snapshot.ts';
 
 export type ReplayBaseRequest = Omit<DaemonRequest, 'command' | 'positionals'>;
 
-export type MaestroReplayInvoker = (params: {
-  action: SessionAction;
-  line: number;
-  step: number;
-}) => Promise<DaemonResponse>;
+export type MaestroReplayInvoker = ReplayActionBlockInvoker;
 
 export type MaestroRuntimeInvoke = (req: DaemonRequest) => Promise<DaemonResponse>;
 

--- a/src/compat/maestro/runtime-targets.ts
+++ b/src/compat/maestro/runtime-targets.ts
@@ -1,4 +1,5 @@
 import type { Platform } from '../../utils/device.ts';
+import type { ElementSelectorKey } from '../../core/interactor-types.ts';
 import type { Rect, SnapshotNode, SnapshotState } from '../../utils/snapshot.ts';
 import { parseSelectorChain } from '../../daemon/selectors.ts';
 import { matchesSelector } from '../../daemon/selectors-match.ts';
@@ -334,13 +335,13 @@ function matchesMaestroTerm(
   return textEqualsOrRegex(value, term.value, options);
 }
 
-function isMaestroRegexTextKey(key: SelectorTerm['key']): key is 'id' | 'label' | 'text' | 'value' {
+function isMaestroRegexTextKey(key: SelectorTerm['key']): key is ElementSelectorKey {
   return key === 'id' || key === 'label' || key === 'text' || key === 'value';
 }
 
 function readMaestroTextTermValue(
   node: SnapshotNode,
-  key: 'id' | 'label' | 'text' | 'value',
+  key: ElementSelectorKey,
 ): string | undefined {
   if (key === 'id') return node.identifier;
   if (key === 'label') return node.label;

--- a/src/compat/maestro/runtime-targets.ts
+++ b/src/compat/maestro/runtime-targets.ts
@@ -339,10 +339,7 @@ function isMaestroRegexTextKey(key: SelectorTerm['key']): key is ElementSelector
   return key === 'id' || key === 'label' || key === 'text' || key === 'value';
 }
 
-function readMaestroTextTermValue(
-  node: SnapshotNode,
-  key: ElementSelectorKey,
-): string | undefined {
+function readMaestroTextTermValue(node: SnapshotNode, key: ElementSelectorKey): string | undefined {
   if (key === 'id') return node.identifier;
   if (key === 'label') return node.label;
   if (key === 'value') return node.value;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -362,7 +362,11 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
             leaseBackend: optionalEnum(
               meta,
               'leaseBackend',
-              ['ios-simulator', 'ios-instance', 'android-instance'] as const satisfies readonly LeaseBackend[],
+              [
+                'ios-simulator',
+                'ios-instance',
+                'android-instance',
+              ] as const satisfies readonly LeaseBackend[],
               `${path}.meta`,
             ),
             sessionIsolation: optionalEnum(
@@ -400,7 +404,13 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
             lockPlatform: optionalEnum(
               meta,
               'lockPlatform',
-              ['ios', 'macos', 'android', 'linux', 'apple'] as const satisfies readonly PlatformSelector[],
+              [
+                'ios',
+                'macos',
+                'android',
+                'linux',
+                'apple',
+              ] as const satisfies readonly PlatformSelector[],
               `${path}.meta`,
             ),
           },

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,5 +1,6 @@
 export type { AppErrorCode } from './utils/errors.ts';
 export { defaultHintForCode, normalizeError } from './utils/errors.ts';
+import type { PlatformSelector } from './utils/device.ts';
 
 export type SessionRuntimeHints = {
   platform?: 'ios' | 'android';
@@ -57,7 +58,7 @@ export type DaemonRequestMeta = {
   materializedPathRetentionMs?: number;
   materializationId?: string;
   lockPolicy?: DaemonLockPolicy;
-  lockPlatform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple';
+  lockPlatform?: PlatformSelector;
   requestProgress?: 'replay-test';
 };
 
@@ -357,7 +358,7 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
             leaseBackend: optionalEnum(
               meta,
               'leaseBackend',
-              ['ios-simulator', 'ios-instance', 'android-instance'] as const,
+              ['ios-simulator', 'ios-instance', 'android-instance'] as const satisfies readonly LeaseBackend[],
               `${path}.meta`,
             ),
             sessionIsolation: optionalEnum(
@@ -395,7 +396,7 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
             lockPlatform: optionalEnum(
               meta,
               'lockPlatform',
-              ['ios', 'macos', 'android', 'linux', 'apple'] as const,
+              ['ios', 'macos', 'android', 'linux', 'apple'] as const satisfies readonly PlatformSelector[],
               `${path}.meta`,
             ),
           },

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -39,6 +39,10 @@ export type DaemonInstallSource =
 
 export type DaemonLockPolicy = 'reject' | 'strip';
 export type LeaseBackend = 'ios-simulator' | 'ios-instance' | 'android-instance';
+export type DaemonServerMode = 'socket' | 'http' | 'dual';
+export type DaemonTransportPreference = 'auto' | 'socket' | 'http';
+export type SessionIsolationMode = 'none' | 'tenant';
+export type NetworkIncludeMode = 'summary' | 'headers' | 'body' | 'all';
 
 export type DaemonRequestMeta = {
   requestId?: string;
@@ -50,7 +54,7 @@ export type DaemonRequestMeta = {
   leaseId?: string;
   leaseTtlMs?: number;
   leaseBackend?: LeaseBackend;
-  sessionIsolation?: 'none' | 'tenant';
+  sessionIsolation?: SessionIsolationMode;
   uploadedArtifactId?: string;
   clientArtifactPaths?: Record<string, string>;
   installSource?: DaemonInstallSource;

--- a/src/core/back-mode.ts
+++ b/src/core/back-mode.ts
@@ -1,0 +1,1 @@
+export type BackMode = 'in-app' | 'system';

--- a/src/core/back-mode.ts
+++ b/src/core/back-mode.ts
@@ -1,1 +1,2 @@
-export type BackMode = 'in-app' | 'system';
+export const BACK_MODES = ['in-app', 'system'] as const;
+export type BackMode = (typeof BACK_MODES)[number];

--- a/src/core/click-button.ts
+++ b/src/core/click-button.ts
@@ -1,6 +1,7 @@
 import { AppError } from '../utils/errors.ts';
 
-export type ClickButton = 'primary' | 'secondary' | 'middle';
+export const CLICK_BUTTONS = ['primary', 'secondary', 'middle'] as const;
+export type ClickButton = (typeof CLICK_BUTTONS)[number];
 
 type ClickButtonFlags = {
   clickButton?: ClickButton;

--- a/src/core/device-rotation.ts
+++ b/src/core/device-rotation.ts
@@ -1,10 +1,12 @@
 import { AppError } from '../utils/errors.ts';
 
-export type DeviceRotation =
-  | 'portrait'
-  | 'portrait-upside-down'
-  | 'landscape-left'
-  | 'landscape-right';
+export const DEVICE_ROTATIONS = [
+  'portrait',
+  'portrait-upside-down',
+  'landscape-left',
+  'landscape-right',
+] as const;
+export type DeviceRotation = (typeof DEVICE_ROTATIONS)[number];
 
 export function parseDeviceRotation(input: string | undefined): DeviceRotation {
   if (input === undefined) {

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -3,6 +3,7 @@ import type { ScreenshotDispatchFlags } from '../commands/capture-screenshot-opt
 import type { DaemonBatchStep } from './batch.ts';
 import type { BackMode } from './back-mode.ts';
 import type { ClickButton } from './click-button.ts';
+import type { ElementSelectorKey } from './interactor-types.ts';
 import type { SwipePattern } from './scroll-gesture.ts';
 import type { SessionSurface } from './session-surface.ts';
 
@@ -56,7 +57,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   pattern?: SwipePattern;
   surface?: SessionSurface;
   directElementSelector?: {
-    key: 'id' | 'label' | 'text' | 'value';
+    key: ElementSelectorKey;
     value: string;
     raw: string;
     allowNonHittableCoordinateFallback?: boolean;

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -1,6 +1,7 @@
 import type { CliFlags, DaemonExcludedCliFlag } from '../utils/cli-flags.ts';
 import type { ScreenshotDispatchFlags } from '../commands/capture-screenshot-options.ts';
 import type { DaemonBatchStep } from './batch.ts';
+import type { BackMode } from './back-mode.ts';
 import type { ClickButton } from './click-button.ts';
 import type { SessionSurface } from './session-surface.ts';
 
@@ -49,7 +50,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   pixels?: number;
   doubleTap?: boolean;
   clickButton?: ClickButton;
-  backMode?: 'in-app' | 'system';
+  backMode?: BackMode;
   pauseMs?: number;
   pattern?: 'one-way' | 'ping-pong';
   surface?: SessionSurface;

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -3,6 +3,7 @@ import type { ScreenshotDispatchFlags } from '../commands/capture-screenshot-opt
 import type { DaemonBatchStep } from './batch.ts';
 import type { BackMode } from './back-mode.ts';
 import type { ClickButton } from './click-button.ts';
+import type { SwipePattern } from './scroll-gesture.ts';
 import type { SessionSurface } from './session-surface.ts';
 
 export type MaestroRuntimeFlags = {
@@ -52,7 +53,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   clickButton?: ClickButton;
   backMode?: BackMode;
   pauseMs?: number;
-  pattern?: 'one-way' | 'ping-pong';
+  pattern?: SwipePattern;
   surface?: SessionSurface;
   directElementSelector?: {
     key: 'id' | 'label' | 'text' | 'value';

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -10,6 +10,7 @@ import {
   type ScrollDirection,
   type SwipePattern,
   type SwipePreset,
+  type TransformGestureParams,
 } from './scroll-gesture.ts';
 import {
   getClickButtonValidationError,
@@ -775,16 +776,6 @@ type RotateGestureParams = {
   x?: number;
   y?: number;
   velocity: number;
-};
-
-type TransformGestureParams = {
-  x: number;
-  y: number;
-  dx: number;
-  dy: number;
-  scale: number;
-  degrees: number;
-  durationMs?: number;
 };
 
 function parseRotateGestureParams(positionals: string[]): RotateGestureParams {

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -7,6 +7,7 @@ import {
   inferGestureReferenceFrame,
   parseScrollDirection,
   parseSwipePreset,
+  type ScrollDirection,
   type SwipePreset,
 } from './scroll-gesture.ts';
 import {
@@ -768,8 +769,6 @@ export async function handleTransformGestureCommand(
   };
 }
 
-type GestureDirection = 'up' | 'down' | 'left' | 'right';
-
 type RotateGestureParams = {
   degrees: number;
   x?: number;
@@ -842,7 +841,7 @@ function parseOptionalGestureCenter(
   return { x, y };
 }
 
-function parseGestureDirection(input: string | undefined, field: string): GestureDirection {
+function parseGestureDirection(input: string | undefined, field: string): ScrollDirection {
   if (input === 'up' || input === 'down' || input === 'left' || input === 'right') {
     return input;
   }
@@ -859,7 +858,7 @@ function requireFinitePositiveNumber(value: number, field: string): number {
 function pointOffsetByDirection(
   x: number,
   y: number,
-  direction: GestureDirection,
+  direction: ScrollDirection,
   distance: number,
 ): { x2: number; y2: number } {
   switch (direction) {

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -8,6 +8,7 @@ import {
   parseScrollDirection,
   parseSwipePreset,
   type ScrollDirection,
+  type SwipePattern,
   type SwipePreset,
 } from './scroll-gesture.ts';
 import {
@@ -934,7 +935,7 @@ function formatPressMessage(params: { x: number; y: number; button?: ClickButton
   return `Tapped (${params.x}, ${params.y})`;
 }
 
-function formatSwipeMessage(count: number, pattern: 'one-way' | 'ping-pong'): string {
+function formatSwipeMessage(count: number, pattern: SwipePattern): string {
   if (count <= 1) return 'Swiped';
   return pattern === 'ping-pong' ? `Swiped ${count} times (ping-pong)` : `Swiped ${count} times`;
 }

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -1,3 +1,4 @@
+import type { BackMode } from './back-mode.ts';
 import type { DeviceRotation } from './device-rotation.ts';
 import type { ScrollDirection } from './scroll-gesture.ts';
 import type { SettingOptions } from '../platforms/permission-utils.ts';
@@ -17,7 +18,7 @@ export type RunnerContext = {
   traceLogPath?: string;
 };
 
-export type BackMode = 'in-app' | 'system';
+export type { BackMode };
 
 export type ScreenshotOptions = {
   appBundleId?: string;

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -1,6 +1,6 @@
 import type { BackMode } from './back-mode.ts';
 import type { DeviceRotation } from './device-rotation.ts';
-import type { ScrollDirection } from './scroll-gesture.ts';
+import type { ScrollDirection, TransformGestureParams } from './scroll-gesture.ts';
 import type { SettingOptions } from '../platforms/permission-utils.ts';
 import type { SessionSurface } from './session-surface.ts';
 import type { BackendSnapshotResult } from '../backend.ts';
@@ -112,15 +112,7 @@ export type Interactor = {
     y?: number,
     velocity?: number,
   ): Promise<Record<string, unknown> | void>;
-  transformGesture(options: {
-    x: number;
-    y: number;
-    dx: number;
-    dy: number;
-    scale: number;
-    degrees: number;
-    durationMs?: number;
-  }): Promise<Record<string, unknown> | void>;
+  transformGesture(options: TransformGestureParams): Promise<Record<string, unknown> | void>;
   appSwitcher(): Promise<void>;
   readClipboard(): Promise<string>;
   writeClipboard(text: string): Promise<void>;

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -27,8 +27,10 @@ export type ScreenshotOptions = {
   surface?: SessionSurface;
 };
 
+export type ElementSelectorKey = 'id' | 'label' | 'text' | 'value';
+
 export type ElementSelectorTapOptions = {
-  key: 'id' | 'label' | 'text' | 'value';
+  key: ElementSelectorKey;
   value: string;
   allowNonHittableCoordinateFallback?: boolean;
 };

--- a/src/core/scroll-gesture.ts
+++ b/src/core/scroll-gesture.ts
@@ -1,9 +1,12 @@
 import { AppError } from '../utils/errors.ts';
 import type { Rect, SnapshotNode } from '../utils/snapshot.ts';
 
-export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
-export type SwipePreset = 'left' | 'right' | 'left-edge' | 'right-edge';
-export type SwipePattern = 'one-way' | 'ping-pong';
+export const SCROLL_DIRECTIONS = ['up', 'down', 'left', 'right'] as const;
+export type ScrollDirection = (typeof SCROLL_DIRECTIONS)[number];
+export const SWIPE_PRESETS = ['left', 'right', 'left-edge', 'right-edge'] as const;
+export type SwipePreset = (typeof SWIPE_PRESETS)[number];
+export const SWIPE_PATTERNS = ['one-way', 'ping-pong'] as const;
+export type SwipePattern = (typeof SWIPE_PATTERNS)[number];
 
 export type TransformGestureParams = {
   x: number;

--- a/src/core/scroll-gesture.ts
+++ b/src/core/scroll-gesture.ts
@@ -5,6 +5,16 @@ export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 export type SwipePreset = 'left' | 'right' | 'left-edge' | 'right-edge';
 export type SwipePattern = 'one-way' | 'ping-pong';
 
+export type TransformGestureParams = {
+  x: number;
+  y: number;
+  dx: number;
+  dy: number;
+  scale: number;
+  degrees: number;
+  durationMs?: number;
+};
+
 export type GestureReferenceFrame = {
   referenceWidth: number;
   referenceHeight: number;

--- a/src/core/scroll-gesture.ts
+++ b/src/core/scroll-gesture.ts
@@ -3,6 +3,7 @@ import type { Rect, SnapshotNode } from '../utils/snapshot.ts';
 
 export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
 export type SwipePreset = 'left' | 'right' | 'left-edge' | 'right-edge';
+export type SwipePattern = 'one-way' | 'ping-pong';
 
 export type GestureReferenceFrame = {
   referenceWidth: number;

--- a/src/core/session-surface.ts
+++ b/src/core/session-surface.ts
@@ -1,13 +1,7 @@
 import { AppError } from '../utils/errors.ts';
 
-export type SessionSurface = 'app' | 'frontmost-app' | 'desktop' | 'menubar';
-
-export const SESSION_SURFACES: readonly SessionSurface[] = [
-  'app',
-  'frontmost-app',
-  'desktop',
-  'menubar',
-];
+export const SESSION_SURFACES = ['app', 'frontmost-app', 'desktop', 'menubar'] as const;
+export type SessionSurface = (typeof SESSION_SURFACES)[number];
 
 export function parseSessionSurface(value: string | undefined): SessionSurface {
   const normalized = value?.trim().toLowerCase();

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -67,7 +67,7 @@ export type OpenAppOptions = {
 type DaemonInfo = {
   port?: number;
   httpPort?: number;
-  transport?: 'socket' | 'http' | 'dual';
+  transport?: DaemonServerMode;
   token: string;
   pid: number;
   version?: string;

--- a/src/daemon/app-log-process.ts
+++ b/src/daemon/app-log-process.ts
@@ -1,13 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { readProcessCommand, readProcessStartTime } from '../utils/process-identity.ts';
+import type { NetworkLogBackend } from './network-log.ts';
 
 export const APP_LOG_PID_FILENAME = 'app-log.pid';
 
 export type AppLogState = 'active' | 'recovering' | 'failed';
 
 export type AppLogResult = {
-  backend: 'ios-simulator' | 'ios-device' | 'android' | 'macos';
+  backend: NetworkLogBackend;
   getState: () => AppLogState;
   startedAt: number;
   stop: () => Promise<void>;

--- a/src/daemon/app-log-process.ts
+++ b/src/daemon/app-log-process.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { readProcessCommand, readProcessStartTime } from '../utils/process-identity.ts';
 import type { NetworkLogBackend } from './network-log.ts';
+import type { ExecResult } from '../utils/exec.ts';
 
 export const APP_LOG_PID_FILENAME = 'app-log.pid';
 
@@ -12,7 +13,7 @@ export type AppLogResult = {
   getState: () => AppLogState;
   startedAt: number;
   stop: () => Promise<void>;
-  wait: Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  wait: Promise<ExecResult>;
 };
 
 type StoredAppLogProcessMeta = {

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -1,9 +1,12 @@
 import path from 'node:path';
 import { expandUserHomePath, resolveUserPath } from '../utils/path-resolution.ts';
 
-export type DaemonServerMode = 'socket' | 'http' | 'dual';
-export type DaemonTransportPreference = 'auto' | 'socket' | 'http';
-export type SessionIsolationMode = 'none' | 'tenant';
+import type {
+  DaemonServerMode,
+  DaemonTransportPreference,
+  SessionIsolationMode,
+} from '../contracts.ts';
+export type { DaemonServerMode, DaemonTransportPreference, SessionIsolationMode };
 
 export type DaemonPaths = {
   baseDir: string;

--- a/src/daemon/direct-ios-selector.ts
+++ b/src/daemon/direct-ios-selector.ts
@@ -1,9 +1,10 @@
 import type { SessionState } from './types.ts';
 import { tryParseSelectorChain } from './selectors.ts';
 import { asAppError } from '../utils/errors.ts';
+import type { ElementSelectorKey } from '../core/interactor-types.ts';
 
 export type DirectIosSelectorTarget = {
-  key: 'id' | 'label' | 'text' | 'value';
+  key: ElementSelectorKey;
   value: string;
   raw: string;
   allowNonHittableCoordinateFallback?: boolean;

--- a/src/daemon/handlers/interaction-common.ts
+++ b/src/daemon/handlers/interaction-common.ts
@@ -1,5 +1,6 @@
 import type { CommandFlags } from '../../core/dispatch.ts';
 import type { SnapshotState } from '../../utils/snapshot.ts';
+import type { GestureReferenceFrame } from '../../core/scroll-gesture.ts';
 import type { DaemonCommandContext } from '../context.ts';
 import { recordTouchVisualizationEvent } from '../recording-gestures.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
@@ -33,7 +34,7 @@ export function buildTouchVisualizationResult(params: {
   data: Record<string, unknown> | undefined;
   fallbackX: number;
   fallbackY: number;
-  referenceFrame?: { referenceWidth: number; referenceHeight: number };
+  referenceFrame?: GestureReferenceFrame;
   extra?: Record<string, unknown>;
 }): Record<string, unknown> {
   const { data, fallbackX, fallbackY, referenceFrame, extra } = params;

--- a/src/daemon/handlers/interaction-touch-reference-frame.ts
+++ b/src/daemon/handlers/interaction-touch-reference-frame.ts
@@ -1,4 +1,5 @@
 import type { CommandFlags } from '../../core/dispatch.ts';
+import type { GestureReferenceFrame } from '../../core/scroll-gesture.ts';
 import type { SnapshotNode } from '../../utils/snapshot.ts';
 import { getAndroidScreenSize } from '../../platforms/android/input-actions.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
@@ -14,7 +15,7 @@ async function resolveDirectTouchReferenceFrame(params: {
   sessionStore: SessionStore;
   contextFromFlags: ContextFromFlags;
   captureSnapshotForSession: CaptureSnapshotForSession;
-}): Promise<{ referenceWidth: number; referenceHeight: number } | undefined> {
+}): Promise<GestureReferenceFrame | undefined> {
   const { session, flags, sessionStore, contextFromFlags, captureSnapshotForSession } = params;
   if (!session.recording) {
     return undefined;
@@ -63,7 +64,7 @@ export async function resolveDirectTouchReferenceFrameSafely(params: {
   sessionStore: SessionStore;
   contextFromFlags: ContextFromFlags;
   captureSnapshotForSession: CaptureSnapshotForSession;
-}): Promise<{ referenceWidth: number; referenceHeight: number } | undefined> {
+}): Promise<GestureReferenceFrame | undefined> {
   try {
     return await resolveDirectTouchReferenceFrame(params);
   } catch (error) {
@@ -81,7 +82,7 @@ export async function resolveDirectTouchReferenceFrameSafely(params: {
 
 export function readSnapshotNodesReferenceFrame(
   nodes: SnapshotNode[],
-): { referenceWidth: number; referenceHeight: number } | undefined {
+): GestureReferenceFrame | undefined {
   return getSnapshotReferenceFrame({
     nodes,
     createdAt: 0,

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -1,4 +1,5 @@
 import { isCommandSupportedOnDevice } from '../../core/capabilities.ts';
+import type { GestureReferenceFrame } from '../../core/scroll-gesture.ts';
 import {
   buttonTag,
   getClickButtonValidationError,
@@ -392,7 +393,7 @@ function readPointFromDirectSelectorTapResult(data: Record<string, unknown>): {
 
 function readReferenceFrameFromDirectSelectorTapResult(
   data: Record<string, unknown>,
-): { referenceWidth: number; referenceHeight: number } | undefined {
+): GestureReferenceFrame | undefined {
   return typeof data.referenceWidth === 'number' && typeof data.referenceHeight === 'number'
     ? { referenceWidth: data.referenceWidth, referenceHeight: data.referenceHeight }
     : undefined;

--- a/src/daemon/handlers/record-trace-android.ts
+++ b/src/daemon/handlers/record-trace-android.ts
@@ -17,6 +17,8 @@ import {
 } from './record-trace-android-chunks.ts';
 import { copyAndroidRecordingChunksWithValidation } from './record-trace-android-copy.ts';
 
+type AndroidRecordingSize = { width: number; height: number };
+
 const ANDROID_REMOTE_FILE_POLL_MS = 250;
 const ANDROID_REMOTE_FILE_ATTEMPTS = 20;
 const ANDROID_REMOTE_FILE_STABLE_POLLS = 4;
@@ -150,7 +152,7 @@ function androidRemoteRecordingPaths(timestamp: number, preferredDir?: string): 
 async function resolveAndroidRecordingSize(params: {
   deviceId: string;
   quality: number | undefined;
-}): Promise<{ width: number; height: number } | undefined> {
+}): Promise<AndroidRecordingSize | undefined> {
   const { deviceId, quality } = params;
   if (quality === undefined || quality >= 10) {
     return undefined;
@@ -180,7 +182,7 @@ function scaledEvenDimension(value: number, quality: number): number {
 
 function buildAndroidScreenrecordCommand(
   remotePath: string,
-  size: { width: number; height: number } | undefined,
+  size: AndroidRecordingSize | undefined,
 ): string {
   const screenrecordArgs = ['screenrecord'];
   if (size) {
@@ -219,7 +221,7 @@ async function forceStopAndroidProcess(deviceId: string, pid: string): Promise<b
 
 async function startAndroidScreenrecordChunk(params: {
   device: AndroidDevice;
-  recordingSize: { width: number; height: number } | undefined;
+  recordingSize: AndroidRecordingSize | undefined;
   preferredRemoteDir?: string;
 }): Promise<
   { remotePath: string; remotePid: string; startedAt: number } | { error: DaemonResponse }
@@ -281,7 +283,7 @@ export async function startAndroidRecording(params: {
   recordingBase: AndroidRecordingBase;
 }): Promise<DaemonResponse | AndroidRecording> {
   const { device, recordingBase } = params;
-  let recordingSize: { width: number; height: number } | undefined;
+  let recordingSize: AndroidRecordingSize | undefined;
   try {
     recordingSize = await resolveAndroidRecordingSize({
       deviceId: device.id,

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -20,16 +20,21 @@ import {
 } from '../app-log.ts';
 import { buildPerfFramesResponseData, buildPerfResponseData } from './session-perf.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
+import type { NetworkIncludeMode } from '../../contracts.ts';
 
 const LOG_ACTIONS = ['path', 'start', 'stop', 'doctor', 'mark', 'clear'] as const;
 const LOG_ACTIONS_MESSAGE = `logs requires ${LOG_ACTIONS.slice(0, -1).join(', ')}, or ${LOG_ACTIONS.at(-1)}`;
 const NETWORK_ACTIONS = ['dump', 'log'] as const;
 const NETWORK_ACTIONS_MESSAGE = `network requires ${NETWORK_ACTIONS.join(' or ')}`;
-const NETWORK_INCLUDE_MODES = ['summary', 'headers', 'body', 'all'] as const;
+const NETWORK_INCLUDE_MODES = [
+  'summary',
+  'headers',
+  'body',
+  'all',
+] as const satisfies readonly NetworkIncludeMode[];
 const NETWORK_INCLUDE_MESSAGE = `network include mode must be one of: ${NETWORK_INCLUDE_MODES.join(', ')}`;
 
 type LogsAction = (typeof LOG_ACTIONS)[number];
-type NetworkIncludeMode = (typeof NETWORK_INCLUDE_MODES)[number];
 
 type ObservabilityParams = {
   req: DaemonRequest;

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -21,8 +21,9 @@ import {
 import { buildPerfFramesResponseData, buildPerfResponseData } from './session-perf.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
 import type { NetworkIncludeMode } from '../../contracts.ts';
+import type { NetworkLogBackend } from '../network-log.ts';
+import { LOG_ACTION_VALUES as LOG_ACTIONS, type LogAction as LogsAction } from '../../commands/log-command-contract.ts';
 
-const LOG_ACTIONS = ['path', 'start', 'stop', 'doctor', 'mark', 'clear'] as const;
 const LOG_ACTIONS_MESSAGE = `logs requires ${LOG_ACTIONS.slice(0, -1).join(', ')}, or ${LOG_ACTIONS.at(-1)}`;
 const NETWORK_ACTIONS = ['dump', 'log'] as const;
 const NETWORK_ACTIONS_MESSAGE = `network requires ${NETWORK_ACTIONS.join(' or ')}`;
@@ -34,7 +35,6 @@ const NETWORK_INCLUDE_MODES = [
 ] as const satisfies readonly NetworkIncludeMode[];
 const NETWORK_INCLUDE_MESSAGE = `network include mode must be one of: ${NETWORK_INCLUDE_MODES.join(', ')}`;
 
-type LogsAction = (typeof LOG_ACTIONS)[number];
 
 type ObservabilityParams = {
   req: DaemonRequest;
@@ -66,7 +66,7 @@ const LOG_ACTION_HANDLERS: Record<
 
 function resolveSessionLogBackendLabel(
   session: SessionState,
-): 'ios-simulator' | 'ios-device' | 'android' | 'macos' {
+): NetworkLogBackend {
   if (session.appLog) {
     return session.appLog.backend;
   }

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -22,7 +22,10 @@ import { buildPerfFramesResponseData, buildPerfResponseData } from './session-pe
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
 import type { NetworkIncludeMode } from '../../contracts.ts';
 import type { NetworkLogBackend } from '../network-log.ts';
-import { LOG_ACTION_VALUES as LOG_ACTIONS, type LogAction as LogsAction } from '../../commands/log-command-contract.ts';
+import {
+  LOG_ACTION_VALUES as LOG_ACTIONS,
+  type LogAction as LogsAction,
+} from '../../commands/log-command-contract.ts';
 
 const LOG_ACTIONS_MESSAGE = `logs requires ${LOG_ACTIONS.slice(0, -1).join(', ')}, or ${LOG_ACTIONS.at(-1)}`;
 const NETWORK_ACTIONS = ['dump', 'log'] as const;
@@ -34,7 +37,6 @@ const NETWORK_INCLUDE_MODES = [
   'all',
 ] as const satisfies readonly NetworkIncludeMode[];
 const NETWORK_INCLUDE_MESSAGE = `network include mode must be one of: ${NETWORK_INCLUDE_MODES.join(', ')}`;
-
 
 type ObservabilityParams = {
   req: DaemonRequest;
@@ -64,9 +66,7 @@ const LOG_ACTION_HANDLERS: Record<
     handleLogsStop(session, sessionName, sessionStore),
 };
 
-function resolveSessionLogBackendLabel(
-  session: SessionState,
-): NetworkLogBackend {
+function resolveSessionLogBackendLabel(session: SessionState): NetworkLogBackend {
   if (session.appLog) {
     return session.appLog.backend;
   }

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -9,15 +9,14 @@ import type { DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
 import { mergeParentFlags } from './handler-utils.ts';
 import { invokeMaestroRuntimeCommand } from '../../compat/maestro/runtime.ts';
 import { invokeMaestroRunFlowWhenControl } from '../../compat/maestro/runtime-flow.ts';
-import { invokeReplayRetryBlock } from '../../replay/control-flow-runtime.ts';
+import {
+  invokeReplayRetryBlock,
+  type ReplayActionBlockInvoker,
+} from '../../replay/control-flow-runtime.ts';
 
 type ReplayBaseRequest = Omit<DaemonRequest, 'command' | 'positionals'>;
 
-type ReplayActionInvoker = (params: {
-  action: SessionAction;
-  line: number;
-  step: number;
-}) => Promise<DaemonResponse>;
+type ReplayActionInvoker = ReplayActionBlockInvoker;
 
 export async function invokeReplayAction(params: {
   req: DaemonRequest;

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -1,7 +1,7 @@
 import http, { type IncomingHttpHeaders } from 'node:http';
 import fs from 'node:fs';
 import { AppError, normalizeError, toAppErrorCode } from '../utils/errors.ts';
-import type { JsonRpcId, JsonRpcRequestEnvelope } from '../contracts.ts';
+import type { JsonRpcId, JsonRpcRequestEnvelope, LeaseBackend } from '../contracts.ts';
 import type { DaemonInstallSource, DaemonRequest, DaemonResponse } from './types.ts';
 import { normalizeTenantId } from './config.ts';
 import {
@@ -273,11 +273,7 @@ function toLeaseDaemonRequest(
       runId: readStringParam(params, 'runId'),
       leaseId: readStringParam(params, 'leaseId'),
       leaseTtlMs: readIntParam(params, 'ttlMs'),
-      leaseBackend: readStringParam(params, 'backend') as
-        | 'ios-simulator'
-        | 'ios-instance'
-        | 'android-instance'
-        | undefined,
+      leaseBackend: readStringParam(params, 'backend') as LeaseBackend | undefined,
     },
   };
 }

--- a/src/daemon/network-log.ts
+++ b/src/daemon/network-log.ts
@@ -18,7 +18,8 @@ const ANDROID_NEARBY_LINE_RADIUS = 5;
 const ANDROID_PACKET_SCAN_RADIUS = 12;
 const NETWORK_LOG_MEMORY_PATH = '<memory>';
 
-export type NetworkIncludeMode = 'summary' | 'headers' | 'body' | 'all';
+import type { NetworkIncludeMode } from '../contracts.ts';
+export type { NetworkIncludeMode };
 export type NetworkLogBackend = 'ios-simulator' | 'ios-device' | 'android' | 'macos';
 
 export type NetworkEntry = {

--- a/src/daemon/record-trace-errors.ts
+++ b/src/daemon/record-trace-errors.ts
@@ -1,3 +1,5 @@
+import type { ExecResult } from '../utils/exec.ts';
+
 export function formatRecordTraceError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -13,10 +15,7 @@ type RecordStopFailure = {
   tooShort: boolean;
 };
 
-export function formatRecordTraceExecFailure(
-  result: { stdout: string; stderr: string; exitCode: number },
-  command: string,
-): string {
+export function formatRecordTraceExecFailure(result: ExecResult, command: string): string {
   return (
     result.stderr.trim() || result.stdout.trim() || `${command} exited with code ${result.exitCode}`
   );

--- a/src/daemon/recording-gestures.ts
+++ b/src/daemon/recording-gestures.ts
@@ -6,7 +6,7 @@ import {
   resolveTapVisualizationOffsetMs,
 } from './recording-timing.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
-import { buildScrollGesturePlan } from '../core/scroll-gesture.ts';
+import { buildScrollGesturePlan, type ScrollDirection } from '../core/scroll-gesture.ts';
 import {
   getSnapshotReferenceFrame,
   type TouchReferenceFrame as ReferenceFrame,
@@ -477,7 +477,7 @@ function resolveEventReferenceFrame(
   return getSnapshotReferenceFrame(snapshot);
 }
 
-function readDirection(value: unknown): 'up' | 'down' | 'left' | 'right' | undefined {
+function readDirection(value: unknown): ScrollDirection | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value.trim().toLowerCase();
   switch (normalized) {
@@ -485,7 +485,7 @@ function readDirection(value: unknown): 'up' | 'down' | 'left' | 'right' | undef
     case 'down':
     case 'left':
     case 'right':
-      return normalized as 'up' | 'down' | 'left' | 'right';
+      return normalized as ScrollDirection;
     default:
       return undefined;
   }

--- a/src/daemon/recording-gestures.ts
+++ b/src/daemon/recording-gestures.ts
@@ -6,7 +6,11 @@ import {
   resolveTapVisualizationOffsetMs,
 } from './recording-timing.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
-import { buildScrollGesturePlan, type ScrollDirection } from '../core/scroll-gesture.ts';
+import {
+  buildScrollGesturePlan,
+  type ScrollDirection,
+  type SwipePattern,
+} from '../core/scroll-gesture.ts';
 import {
   getSnapshotReferenceFrame,
   type TouchReferenceFrame as ReferenceFrame,
@@ -312,7 +316,7 @@ function buildSwipeEvents(
 
 function resolveSwipePathForIndex(
   index: number,
-  pattern: 'one-way' | 'ping-pong',
+  pattern: SwipePattern,
   x1: number,
   y1: number,
   x2: number,

--- a/src/daemon/request-platform-providers.ts
+++ b/src/daemon/request-platform-providers.ts
@@ -24,41 +24,27 @@ export type PlatformProviderRequestSession = Pick<
   'name' | 'device' | 'appBundleId' | 'appName' | 'surface'
 >;
 
-export type AndroidAdbProviderResolver = (params: {
-  req: DaemonRequest;
-  device: DeviceInfo;
-  session?: PlatformProviderRequestSession;
-}) => AndroidAdbProvider | AndroidAdbExecutor | undefined;
+export type PlatformProviderResolver<TResult> = (
+  params: RequestPlatformProviderResolverContext,
+) => TResult;
 
-export type AppleRunnerProviderResolver = (params: {
-  req: DaemonRequest;
-  device: DeviceInfo;
-  session?: PlatformProviderRequestSession;
-}) => AppleRunnerProvider | AppleRunnerCommandExecutor | undefined;
+export type AndroidAdbProviderResolver = PlatformProviderResolver<
+  AndroidAdbProvider | AndroidAdbExecutor | undefined
+>;
 
-export type AppleToolProviderResolver = (params: {
-  req: DaemonRequest;
-  device: DeviceInfo;
-  session?: PlatformProviderRequestSession;
-}) => AppleToolProvider | AppleToolCommandExecutor | undefined;
+export type AppleRunnerProviderResolver = PlatformProviderResolver<
+  AppleRunnerProvider | AppleRunnerCommandExecutor | undefined
+>;
 
-export type LinuxToolProviderResolver = (params: {
-  req: DaemonRequest;
-  device: DeviceInfo;
-  session?: PlatformProviderRequestSession;
-}) => LinuxToolProvider | undefined;
+export type AppleToolProviderResolver = PlatformProviderResolver<
+  AppleToolProvider | AppleToolCommandExecutor | undefined
+>;
 
-export type AppLogProviderResolver = (params: {
-  req: DaemonRequest;
-  device: DeviceInfo;
-  session?: PlatformProviderRequestSession;
-}) => AppLogProvider | undefined;
+export type LinuxToolProviderResolver = PlatformProviderResolver<LinuxToolProvider | undefined>;
 
-export type RecordingProviderResolver = (params: {
-  req: DaemonRequest;
-  device: DeviceInfo;
-  session?: PlatformProviderRequestSession;
-}) => RecordingProvider | undefined;
+export type AppLogProviderResolver = PlatformProviderResolver<AppLogProvider | undefined>;
+
+export type RecordingProviderResolver = PlatformProviderResolver<RecordingProvider | undefined>;
 
 export type PlatformProviderResolvers = {
   androidAdbProvider?: AndroidAdbProviderResolver;

--- a/src/daemon/touch-reference-frame.ts
+++ b/src/daemon/touch-reference-frame.ts
@@ -1,10 +1,7 @@
-import { inferGestureReferenceFrame } from '../core/scroll-gesture.ts';
+import { inferGestureReferenceFrame, type GestureReferenceFrame } from '../core/scroll-gesture.ts';
 import type { SnapshotState } from '../utils/snapshot.ts';
 
-export type TouchReferenceFrame = {
-  referenceWidth: number;
-  referenceHeight: number;
-};
+export type TouchReferenceFrame = GestureReferenceFrame;
 
 const snapshotReferenceFrameCache = new WeakMap<SnapshotState, TouchReferenceFrame>();
 

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -10,7 +10,7 @@ import type {
 } from '../contracts.ts';
 export type { DaemonLockPolicy } from '../contracts.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
-import type { ScrollDirection } from '../core/scroll-gesture.ts';
+import type { GestureReferenceFrame, ScrollDirection } from '../core/scroll-gesture.ts';
 import type { NetworkLogBackend } from './network-log.ts';
 import type { SessionSurface } from '../core/session-surface.ts';
 import type { DeviceInfo, Platform, PlatformSelector } from '../utils/device.ts';
@@ -197,10 +197,7 @@ type SessionRecordingBase = {
   quality?: number;
   showTouches: boolean;
   gestureEvents: RecordingGestureEvent[];
-  touchReferenceFrame?: {
-    referenceWidth: number;
-    referenceHeight: number;
-  };
+  touchReferenceFrame?: GestureReferenceFrame;
   gestureClockOriginAtMs?: number;
   gestureClockOriginUptimeMs?: number;
   runnerSessionId?: string;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -5,6 +5,7 @@ import type {
   DaemonResponse as PublicDaemonResponse,
   DaemonResponseData as PublicDaemonResponseData,
   DaemonInstallSource as PublicDaemonInstallSource,
+  DaemonError,
   LeaseBackend,
   SessionRuntimeHints as PublicSessionRuntimeHints,
 } from '../contracts.ts';
@@ -73,14 +74,7 @@ export type ReplaySuiteTestFailed = {
   durationMs: number;
   attempts: number;
   artifactsDir?: string;
-  error: {
-    code: string;
-    message: string;
-    hint?: string;
-    diagnosticId?: string;
-    logPath?: string;
-    details?: Record<string, unknown>;
-  };
+  error: DaemonError;
   shardIndex?: number;
   shardCount?: number;
   deviceId?: string;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -11,6 +11,7 @@ import type {
 export type { DaemonLockPolicy } from '../contracts.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
 import type { ScrollDirection } from '../core/scroll-gesture.ts';
+import type { NetworkLogBackend } from './network-log.ts';
 import type { SessionSurface } from '../core/session-surface.ts';
 import type { DeviceInfo, Platform, PlatformSelector } from '../utils/device.ts';
 import type { ExecBackgroundResult, ExecResult } from '../utils/exec.ts';
@@ -273,7 +274,7 @@ export type SessionState = {
   /** Session-scoped app log stream; logs written to outPath for agent to grep */
   appLog?: {
     platform: Platform;
-    backend: 'ios-simulator' | 'ios-device' | 'android' | 'macos';
+    backend: NetworkLogBackend;
     outPath: string;
     startedAt: number;
     getState: () => AppLogState;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -10,6 +10,7 @@ import type {
 } from '../contracts.ts';
 export type { DaemonLockPolicy } from '../contracts.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
+import type { ScrollDirection } from '../core/scroll-gesture.ts';
 import type { SessionSurface } from '../core/session-surface.ts';
 import type { DeviceInfo, Platform, PlatformSelector } from '../utils/device.ts';
 import type { ExecBackgroundResult, ExecResult } from '../utils/exec.ts';
@@ -142,7 +143,7 @@ export type RecordingGestureEvent =
     })
   | (RecordingTelemetryTravel & {
       kind: 'scroll';
-      contentDirection: 'up' | 'down' | 'left' | 'right';
+      contentDirection: ScrollDirection;
       amount?: number;
       pixels?: number;
     })

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -1,16 +1,11 @@
 import { listCommandTools, commandToolExecutor } from './command-tools.ts';
 import { readVersion } from '../utils/version.ts';
+import type { JsonRpcId, JsonRpcRequestEnvelope } from '../contracts.ts';
 
-type JsonRpcId = string | number | null;
 const MCP_SERVER_NAME = 'agent-device';
 const SUPPORTED_PROTOCOL_VERSION = '2025-11-25';
 
-export type JsonRpcMessage = {
-  jsonrpc?: string;
-  id?: JsonRpcId;
-  method?: string;
-  params?: unknown;
-};
+export type JsonRpcMessage = JsonRpcRequestEnvelope;
 
 type JsonRpcResponse =
   | { jsonrpc: '2.0'; id: JsonRpcId; result: unknown }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,7 +1,7 @@
 import { handleMcpMessage, type JsonRpcMessage } from './router.ts';
+import type { JsonRpcId } from '../contracts.ts';
 
 type JsonRpcResponse = Awaited<NonNullable<ReturnType<typeof handleMcpMessage>>>;
-type JsonRpcId = string | number | null;
 type MessageSink = (message: JsonRpcMessage | JsonRpcMessage[]) => void;
 type PayloadHandler = (
   messageOrBatch: JsonRpcMessage | JsonRpcMessage[],

--- a/src/metro.ts
+++ b/src/metro.ts
@@ -3,6 +3,7 @@ import {
   buildMetroRuntimeHints,
   prepareMetroRuntime,
   reloadMetro,
+  type MetroPrepareKind,
   type ReloadMetroOptions,
   type ReloadMetroResult,
 } from './client-metro.ts';
@@ -110,7 +111,7 @@ export type MetroTunnelMessage = MetroTunnelRequestMessage | MetroTunnelResponse
 
 export type PrepareRemoteMetroOptions = {
   projectRoot: string;
-  kind: 'auto' | 'react-native' | 'expo';
+  kind: MetroPrepareKind;
   publicBaseUrl?: string;
   proxyBaseUrl?: string;
   proxyBearerToken?: string;

--- a/src/platforms/android/adb-executor.ts
+++ b/src/platforms/android/adb-executor.ts
@@ -103,8 +103,10 @@ export type AndroidBundleInstaller = (
   options: { mode: string },
 ) => Promise<void>;
 
+export type AndroidTextInputAction = 'type' | 'fill';
+
 export type AndroidTextInjectionRequest = {
-  action: 'type' | 'fill';
+  action: AndroidTextInputAction;
   text: string;
   delayMs?: number;
   /**

--- a/src/platforms/android/input-actions.ts
+++ b/src/platforms/android/input-actions.ts
@@ -4,7 +4,7 @@ import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import type { DeviceRotation } from '../../core/device-rotation.ts';
 import { buildScrollGesturePlan, type ScrollDirection } from '../../core/scroll-gesture.ts';
 import { runAndroidAdb, sleep } from './adb.ts';
-import { resolveAndroidTextInjector } from './adb-executor.ts';
+import { resolveAndroidTextInjector, type AndroidTextInputAction } from './adb-executor.ts';
 import { getAndroidKeyboardState, type AndroidKeyboardState } from './device-input-state.ts';
 import {
   androidFillFailureDetails,
@@ -246,7 +246,7 @@ function resolveAndroidUserRotation(orientation: DeviceRotation): string {
 
 async function assertAndroidShellInputIsAppOwned(
   device: DeviceInfo,
-  action: 'type' | 'fill',
+  action: AndroidTextInputAction,
 ): Promise<void> {
   let state: AndroidKeyboardState;
   try {
@@ -294,7 +294,7 @@ const ANDROID_INPUT_TEXT_CHUNK_SIZE = 8;
 
 async function typeAndroidShell(
   device: DeviceInfo,
-  options: { action: 'type' | 'fill'; text: string; chunkSize: number; delayMs: number },
+  options: { action: AndroidTextInputAction; text: string; chunkSize: number; delayMs: number },
 ): Promise<void> {
   const parts = options.text.split('\n');
   for (const [partIndex, part] of parts.entries()) {
@@ -381,7 +381,7 @@ function chunkAndroidInputText(text: string, chunkSize: number): string[] {
 }
 
 function emitAndroidTextDiagnostic(
-  action: 'type' | 'fill',
+  action: AndroidTextInputAction,
   backend: 'provider-native' | 'adb-shell',
   text: string,
 ): void {

--- a/src/platforms/android/multitouch-helper.ts
+++ b/src/platforms/android/multitouch-helper.ts
@@ -5,6 +5,7 @@ import { AppError, normalizeError } from '../../utils/errors.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { findProjectRoot, readVersion } from '../../utils/version.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
+import type { TransformGestureParams } from '../../core/scroll-gesture.ts';
 import {
   installAndroidAdbPackage,
   resolveAndroidAdbExecutor,
@@ -98,15 +99,7 @@ export type AndroidRotateGestureOptions = {
   durationMs?: number;
 };
 
-export type AndroidTransformGestureOptions = {
-  x: number;
-  y: number;
-  dx: number;
-  dy: number;
-  scale: number;
-  degrees: number;
-  durationMs?: number;
-};
+export type AndroidTransformGestureOptions = TransformGestureParams;
 
 export type AndroidSwipeGestureOptions = {
   x1: number;

--- a/src/platforms/android/snapshot-helper-types.ts
+++ b/src/platforms/android/snapshot-helper-types.ts
@@ -3,6 +3,15 @@ import type { AndroidAdbExecutor, AndroidAdbProvider } from './adb-executor.ts';
 import type { AndroidSnapshotAnalysis } from './ui-hierarchy.ts';
 import type { AndroidSnapshotBackendMetadata } from './snapshot-types.ts';
 
+export type AndroidSnapshotHelperTransport = 'instrumentation' | 'persistent-session';
+export type AndroidSnapshotCaptureMode = 'interactive-windows' | 'active-window';
+export type AndroidSnapshotHelperInstallReason =
+  | 'missing'
+  | 'outdated'
+  | 'forced'
+  | 'current'
+  | 'skipped';
+
 export const ANDROID_SNAPSHOT_HELPER_NAME = 'android-snapshot-helper';
 export const ANDROID_SNAPSHOT_HELPER_PACKAGE = 'com.callstack.agentdevice.snapshothelper';
 export const ANDROID_SNAPSHOT_HELPER_RUNNER =
@@ -49,7 +58,7 @@ export type AndroidSnapshotHelperInstallResult = {
   versionCode: number;
   installedVersionCode?: number;
   installed: boolean;
-  reason: 'missing' | 'outdated' | 'forced' | 'current' | 'skipped';
+  reason: AndroidSnapshotHelperInstallReason;
 };
 
 export type AndroidSnapshotHelperCaptureOptions = {
@@ -79,12 +88,12 @@ export type AndroidSnapshotHelperMetadata = {
   maxDepth?: number;
   maxNodes?: number;
   rootPresent?: boolean;
-  captureMode?: 'interactive-windows' | 'active-window';
+  captureMode?: AndroidSnapshotCaptureMode;
   windowCount?: number;
   nodeCount?: number;
   truncated?: boolean;
   elapsedMs?: number;
-  transport?: 'instrumentation' | 'persistent-session';
+  transport?: AndroidSnapshotHelperTransport;
   sessionReused?: boolean;
 };
 

--- a/src/platforms/android/snapshot-types.ts
+++ b/src/platforms/android/snapshot-types.ts
@@ -1,18 +1,24 @@
+import type {
+  AndroidSnapshotCaptureMode,
+  AndroidSnapshotHelperInstallReason,
+  AndroidSnapshotHelperTransport,
+} from './snapshot-helper-types.ts';
+
 export type AndroidSnapshotBackendMetadata = {
   backend: 'android-helper' | 'uiautomator-dump';
   helperVersion?: string;
   helperApiVersion?: string;
-  helperTransport?: 'instrumentation' | 'persistent-session';
+  helperTransport?: AndroidSnapshotHelperTransport;
   helperSessionReused?: boolean;
   fallbackReason?: string;
-  installReason?: 'missing' | 'outdated' | 'forced' | 'current' | 'skipped';
+  installReason?: AndroidSnapshotHelperInstallReason;
   waitForIdleTimeoutMs?: number;
   waitForIdleQuietMs?: number;
   timeoutMs?: number;
   maxDepth?: number;
   maxNodes?: number;
   rootPresent?: boolean;
-  captureMode?: 'interactive-windows' | 'active-window';
+  captureMode?: AndroidSnapshotCaptureMode;
   windowCount?: number;
   nodeCount?: number;
   helperTruncated?: boolean;

--- a/src/platforms/ios/runner-contract.ts
+++ b/src/platforms/ios/runner-contract.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { AppError } from '../../utils/errors.ts';
 import type { ClickButton } from '../../core/click-button.ts';
 import type { DeviceRotation } from '../../core/device-rotation.ts';
+import type { ScrollDirection } from '../../core/scroll-gesture.ts';
 import { createRequestCanceledError, isRequestCanceled } from '../../daemon/request-cancel.ts';
 import { bootFailureHint, classifyBootFailure } from '../boot-diagnostics.ts';
 import type { RunnerSession } from './runner-session-types.ts';
@@ -67,7 +68,7 @@ export type RunnerCommand = {
   dx?: number;
   dy?: number;
   durationMs?: number;
-  direction?: 'up' | 'down' | 'left' | 'right';
+  direction?: ScrollDirection;
   orientation?: DeviceRotation;
   scale?: number;
   degrees?: number;

--- a/src/platforms/ios/runner-contract.ts
+++ b/src/platforms/ios/runner-contract.ts
@@ -3,6 +3,7 @@ import { AppError } from '../../utils/errors.ts';
 import type { ClickButton } from '../../core/click-button.ts';
 import type { DeviceRotation } from '../../core/device-rotation.ts';
 import type { ScrollDirection, SwipePattern } from '../../core/scroll-gesture.ts';
+import type { ElementSelectorKey } from '../../core/interactor-types.ts';
 import { createRequestCanceledError, isRequestCanceled } from '../../daemon/request-cancel.ts';
 import { bootFailureHint, classifyBootFailure } from '../boot-diagnostics.ts';
 import type { RunnerSession } from './runner-session-types.ts';
@@ -48,7 +49,7 @@ export type RunnerCommand = {
   statusCommandId?: string;
   appBundleId?: string;
   text?: string;
-  selectorKey?: 'id' | 'label' | 'text' | 'value';
+  selectorKey?: ElementSelectorKey;
   selectorValue?: string;
   allowNonHittableCoordinateFallback?: boolean;
   delayMs?: number;

--- a/src/platforms/ios/runner-contract.ts
+++ b/src/platforms/ios/runner-contract.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import { AppError } from '../../utils/errors.ts';
 import type { ClickButton } from '../../core/click-button.ts';
 import type { DeviceRotation } from '../../core/device-rotation.ts';
-import type { ScrollDirection } from '../../core/scroll-gesture.ts';
+import type { ScrollDirection, SwipePattern } from '../../core/scroll-gesture.ts';
 import { createRequestCanceledError, isRequestCanceled } from '../../daemon/request-cancel.ts';
 import { bootFailureHint, classifyBootFailure } from '../boot-diagnostics.ts';
 import type { RunnerSession } from './runner-session-types.ts';
@@ -62,7 +62,7 @@ export type RunnerCommand = {
   intervalMs?: number;
   doubleTap?: boolean;
   pauseMs?: number;
-  pattern?: 'one-way' | 'ping-pong';
+  pattern?: SwipePattern;
   x2?: number;
   y2?: number;
   dx?: number;

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -4,6 +4,7 @@ import { withKeyedLock } from '../../utils/keyed-lock.ts';
 import { Deadline } from '../../utils/retry.ts';
 import { isProcessAlive, isProcessGroupAlive } from '../../utils/process-identity.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
+import type { AppleRunnerLifecycleOptions } from './runner-provider.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import { buildSimctlArgsForDevice } from './simctl.ts';
 import { runAppleToolCommand, runXcrun } from './tool-provider.ts';
@@ -46,16 +47,7 @@ import type { RunnerSession } from './runner-session-types.ts';
 
 export type { RunnerSession } from './runner-session-types.ts';
 
-export type RunnerSessionOptions = {
-  verbose?: boolean;
-  logPath?: string;
-  traceLogPath?: string;
-  cleanStaleBundles?: boolean;
-  startupTimeoutMs?: number;
-  requestId?: string;
-  buildTimeoutMs?: number;
-  forceRunnerXctestrunRebuild?: boolean;
-};
+export type RunnerSessionOptions = AppleRunnerLifecycleOptions;
 
 const runnerSessions = new Map<string, RunnerSession>();
 const runnerSessionLocks = new Map<string, Promise<unknown>>();

--- a/src/platforms/linux/atspi-bridge.ts
+++ b/src/platforms/linux/atspi-bridge.ts
@@ -12,7 +12,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { AppError } from '../../utils/errors.ts';
-import type { RawSnapshotNode } from '../../utils/snapshot.ts';
+import type { RawSnapshotNode, Rect } from '../../utils/snapshot.ts';
 import { normalizeAtspiRole } from './role-map.ts';
 import { resolveLinuxToolProvider, runLinuxToolCommand } from './tool-provider.ts';
 import type {
@@ -72,7 +72,7 @@ type PythonNode = {
   role: string;
   label?: string;
   value?: string;
-  rect?: { x: number; y: number; width: number; height: number };
+  rect?: Rect;
   enabled?: boolean;
   selected?: boolean;
   hittable?: boolean;

--- a/src/platforms/linux/tool-provider.ts
+++ b/src/platforms/linux/tool-provider.ts
@@ -3,6 +3,7 @@ import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { AppError } from '../../utils/errors.ts';
 import { createScopedProvider } from '../../utils/scoped-provider.ts';
 import { sleep } from '../../utils/timeouts.ts';
+import type { ClickButton } from '../../core/click-button.ts';
 import type {
   LinuxAccessibilityTree,
   LinuxSnapshotSurface,
@@ -45,7 +46,7 @@ export type LinuxAccessibilityProvider = {
   ): Promise<LinuxAccessibilityTree>;
 };
 
-export type LinuxPointerButton = 'primary' | 'secondary' | 'middle';
+export type LinuxPointerButton = ClickButton;
 
 export type LinuxInputProvider = {
   click(x: number, y: number, button: LinuxPointerButton): Promise<void>;

--- a/src/remote-config-schema.ts
+++ b/src/remote-config-schema.ts
@@ -1,10 +1,16 @@
 import { buildPrimaryEnvVarName } from './utils/source-value.ts';
-import type { LeaseBackend } from './contracts.ts';
+import type {
+  DaemonServerMode,
+  DaemonTransportPreference,
+  LeaseBackend,
+  SessionIsolationMode,
+} from './contracts.ts';
 import type { DeviceTarget, PlatformSelector } from './utils/device.ts';
+import type { MetroPrepareKind } from './client-metro.ts';
 
 export type RemoteConfigMetroOptions = {
   metroProjectRoot?: string;
-  metroKind?: 'auto' | 'react-native' | 'expo';
+  metroKind?: MetroPrepareKind;
   metroPublicBaseUrl?: string;
   metroProxyBaseUrl?: string;
   metroBearerToken?: string;
@@ -22,10 +28,10 @@ export type RemoteConfigProfile = RemoteConfigMetroOptions & {
   stateDir?: string;
   daemonBaseUrl?: string;
   daemonAuthToken?: string;
-  daemonTransport?: 'auto' | 'socket' | 'http';
-  daemonServerMode?: 'socket' | 'http' | 'dual';
+  daemonTransport?: DaemonTransportPreference;
+  daemonServerMode?: DaemonServerMode;
   tenant?: string;
-  sessionIsolation?: 'none' | 'tenant';
+  sessionIsolation?: SessionIsolationMode;
   runId?: string;
   leaseId?: string;
   leaseBackend?: LeaseBackend;

--- a/src/remote-config-schema.ts
+++ b/src/remote-config-schema.ts
@@ -1,4 +1,6 @@
 import { buildPrimaryEnvVarName } from './utils/source-value.ts';
+import type { LeaseBackend } from './contracts.ts';
+import type { DeviceTarget, PlatformSelector } from './utils/device.ts';
 
 export type RemoteConfigMetroOptions = {
   metroProjectRoot?: string;
@@ -26,9 +28,9 @@ export type RemoteConfigProfile = RemoteConfigMetroOptions & {
   sessionIsolation?: 'none' | 'tenant';
   runId?: string;
   leaseId?: string;
-  leaseBackend?: 'ios-simulator' | 'ios-instance' | 'android-instance';
-  platform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple';
-  target?: 'mobile' | 'tv' | 'desktop';
+  leaseBackend?: LeaseBackend;
+  platform?: PlatformSelector;
+  target?: DeviceTarget;
   device?: string;
   udid?: string;
   serial?: string;

--- a/src/utils/cli-flags.ts
+++ b/src/utils/cli-flags.ts
@@ -1,8 +1,16 @@
 import { SESSION_SURFACES, type SessionSurface } from '../core/session-surface.ts';
 import type { BackMode } from '../core/back-mode.ts';
 import type { ClickButton } from '../core/click-button.ts';
+import type { SwipePattern } from '../core/scroll-gesture.ts';
 import type { DeviceTarget, PlatformSelector } from './device.ts';
-import type { DaemonInstallSource, LeaseBackend } from '../contracts.ts';
+import type {
+  DaemonInstallSource,
+  DaemonServerMode,
+  DaemonTransportPreference,
+  LeaseBackend,
+  NetworkIncludeMode,
+  SessionIsolationMode,
+} from '../contracts.ts';
 import type { RemoteConfigMetroOptions } from '../remote-config-schema.ts';
 import {
   SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS,
@@ -21,10 +29,10 @@ export type CliFlags = RemoteConfigMetroOptions &
     stateDir?: string;
     daemonBaseUrl?: string;
     daemonAuthToken?: string;
-    daemonTransport?: 'auto' | 'socket' | 'http';
-    daemonServerMode?: 'socket' | 'http' | 'dual';
+    daemonTransport?: DaemonTransportPreference;
+    daemonServerMode?: DaemonServerMode;
     tenant?: string;
-    sessionIsolation?: 'none' | 'tenant';
+    sessionIsolation?: SessionIsolationMode;
     runId?: string;
     leaseId?: string;
     leaseBackend?: LeaseBackend;
@@ -53,7 +61,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     snapshotScope?: string;
     snapshotRaw?: boolean;
     snapshotForceFull?: boolean;
-    networkInclude?: 'summary' | 'headers' | 'body' | 'all';
+    networkInclude?: NetworkIncludeMode;
     baseline?: string;
     threshold?: string;
     appsFilter?: 'user-installed' | 'all';
@@ -70,7 +78,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     clickButton?: ClickButton;
     backMode?: BackMode;
     pauseMs?: number;
-    pattern?: 'one-way' | 'ping-pong';
+    pattern?: SwipePattern;
     activity?: string;
     launchConsole?: string;
     launchArgs?: string[];

--- a/src/utils/cli-flags.ts
+++ b/src/utils/cli-flags.ts
@@ -1,5 +1,8 @@
-import { SESSION_SURFACES } from '../core/session-surface.ts';
-import type { DaemonInstallSource } from '../contracts.ts';
+import { SESSION_SURFACES, type SessionSurface } from '../core/session-surface.ts';
+import type { BackMode } from '../core/back-mode.ts';
+import type { ClickButton } from '../core/click-button.ts';
+import type { DeviceTarget, PlatformSelector } from './device.ts';
+import type { DaemonInstallSource, LeaseBackend } from '../contracts.ts';
 import type { RemoteConfigMetroOptions } from '../remote-config-schema.ts';
 import {
   SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS,
@@ -24,14 +27,14 @@ export type CliFlags = RemoteConfigMetroOptions &
     sessionIsolation?: 'none' | 'tenant';
     runId?: string;
     leaseId?: string;
-    leaseBackend?: 'ios-simulator' | 'ios-instance' | 'android-instance';
+    leaseBackend?: LeaseBackend;
     force?: boolean;
     noLogin?: boolean;
     sessionLock?: 'reject' | 'strip';
     sessionLocked?: boolean;
     sessionLockConflicts?: 'reject' | 'strip';
-    platform?: 'ios' | 'macos' | 'android' | 'linux' | 'apple';
-    target?: 'mobile' | 'tv' | 'desktop';
+    platform?: PlatformSelector;
+    target?: DeviceTarget;
     device?: string;
     udid?: string;
     serial?: string;
@@ -64,8 +67,8 @@ export type CliFlags = RemoteConfigMetroOptions &
     jitterPx?: number;
     pixels?: number;
     doubleTap?: boolean;
-    clickButton?: 'primary' | 'secondary' | 'middle';
-    backMode?: 'in-app' | 'system';
+    clickButton?: ClickButton;
+    backMode?: BackMode;
     pauseMs?: number;
     pattern?: 'one-way' | 'ping-pong';
     activity?: string;
@@ -77,7 +80,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     saveScript?: boolean | string;
     shutdown?: boolean;
     relaunch?: boolean;
-    surface?: 'app' | 'frontmost-app' | 'desktop' | 'menubar';
+    surface?: SessionSurface;
     headless?: boolean;
     restart?: boolean;
     noRecord?: boolean;

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -4,7 +4,8 @@ export type ApplePlatform = 'ios' | 'macos';
 export type Platform = ApplePlatform | 'android' | 'linux';
 export type PlatformSelector = Platform | 'apple';
 export type DeviceKind = 'simulator' | 'emulator' | 'device';
-export type DeviceTarget = 'mobile' | 'tv' | 'desktop';
+export const DEVICE_TARGETS = ['mobile', 'tv', 'desktop'] as const;
+export type DeviceTarget = (typeof DEVICE_TARGETS)[number];
 
 export type DeviceInfo = {
   platform: Platform;

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -6,7 +6,8 @@ import {
 import { AppError, normalizeError, type NormalizedError } from './errors.ts';
 import { detectPossibleRepeatedNavSubtree } from './repeated-nav-subtree.ts';
 import { buildSnapshotDisplayLines, formatSnapshotLine } from './snapshot-lines.ts';
-import type { SnapshotNode, SnapshotUnchanged, SnapshotVisibility } from './snapshot.ts';
+import type { Rect, SnapshotNode, SnapshotUnchanged, SnapshotVisibility } from './snapshot.ts';
+import type { MovementRange } from './screenshot-diff-ocr.ts';
 import type { ScreenshotDiffResult } from './screenshot-diff.ts';
 import type { ScreenshotDiffRegion } from './screenshot-diff-regions.ts';
 import { styleText } from 'node:util';
@@ -487,7 +488,7 @@ function formatScreenshotDiffNonTextLines(data: ScreenshotDiffResult, useColor: 
   return lines;
 }
 
-function formatRect(rect: { x: number; y: number; width: number; height: number }): string {
+function formatRect(rect: Rect): string {
   return `x=${rect.x},y=${rect.y},w=${rect.width},h=${rect.height}`;
 }
 
@@ -532,7 +533,7 @@ function formatNonTextHint(delta: {
   return `${delta.likelyKind}${anchor}${region}`;
 }
 
-function formatRange(range: { min: number; max: number }): string {
+function formatRange(range: MovementRange): string {
   return range.min === range.max
     ? formatSignedPixels(range.min)
     : `${formatSignedPixels(range.min)}..${formatSignedPixels(range.max)}`;

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -17,14 +17,7 @@ type JsonResult =
   | { success: true; data?: unknown }
   | {
       success: false;
-      error: {
-        code: string;
-        message: string;
-        hint?: string;
-        diagnosticId?: string;
-        logPath?: string;
-        details?: Record<string, unknown>;
-      };
+      error: NormalizedError;
     };
 
 export function printJson(result: JsonResult): void {

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -71,10 +71,7 @@ export function readDeviceTarget(record: Record<string, unknown>, key: string): 
   return readOptional(record, key, parseDeviceTarget) ?? 'mobile';
 }
 
-export function readRect(
-  record: Record<string, unknown>,
-  key: string,
-): Rect | undefined {
+export function readRect(record: Record<string, unknown>, key: string): Rect | undefined {
   const value = record[key];
   if (!isRecord(value)) return undefined;
   const x = readNumberField(value, 'x');

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -1,6 +1,6 @@
 import { AppError } from './errors.ts';
 import type { DeviceKind, DeviceTarget, Platform } from './device.ts';
-import type { Point } from './snapshot.ts';
+import type { Point, Rect } from './snapshot.ts';
 
 function readRequired<T>(
   record: Record<string, unknown>,
@@ -74,7 +74,7 @@ export function readDeviceTarget(record: Record<string, unknown>, key: string): 
 export function readRect(
   record: Record<string, unknown>,
   key: string,
-): { x: number; y: number; width: number; height: number } | undefined {
+): Rect | undefined {
   const value = record[key];
   if (!isRecord(value)) return undefined;
   const x = readNumberField(value, 'x');

--- a/src/utils/screenshot-diff-non-text.ts
+++ b/src/utils/screenshot-diff-non-text.ts
@@ -9,6 +9,7 @@ import {
   rectCenter,
   squaredDistance,
   unionRects,
+  type ImageDimensions,
 } from './screenshot-geometry.ts';
 
 export type ScreenshotNonTextDelta = {
@@ -251,7 +252,7 @@ function classifyLikelyKind(
   rect: Rect,
   slot: ScreenshotNonTextDelta['slot'],
   differentPixels: number,
-  image: { width: number; height: number },
+  image: ImageDimensions,
 ): NonTextKind {
   const aspect = rect.width / rect.height;
   const density = differentPixels / (rect.width * rect.height);
@@ -293,7 +294,7 @@ function scoreNonTextDelta(
     rect: Rect;
   },
   differentPixels: number,
-  image: { width: number; height: number },
+  image: ImageDimensions,
 ): number {
   const sizePenalty = isLargeResidual(delta.rect, image) ? LARGE_RESIDUAL_SCORE_PENALTY : 0;
   const regionScore = delta.regionIndex ? REGION_OVERLAP_SCORE : 0;
@@ -306,7 +307,7 @@ function scoreNonTextDelta(
   );
 }
 
-function isLargeResidual(rect: Rect, image: { width: number; height: number }): boolean {
+function isLargeResidual(rect: Rect, image: ImageDimensions): boolean {
   return (
     rect.width >= image.width * LARGE_RESIDUAL_WIDTH_RATIO ||
     rect.height >= image.height * LARGE_RESIDUAL_HEIGHT_RATIO

--- a/src/utils/screenshot-diff-ocr.ts
+++ b/src/utils/screenshot-diff-ocr.ts
@@ -1,5 +1,7 @@
 import type { Rect } from './snapshot.ts';
 import { runCmd, whichCmd } from './exec.ts';
+
+export type MovementRange = { min: number; max: number };
 import { rectCenter, squaredDistance, unionRects } from './screenshot-geometry.ts';
 
 export type ScreenshotOcrBlock = {
@@ -13,15 +15,15 @@ export type ScreenshotOcrTextMatch = {
   text: string;
   baselineRect: Rect;
   currentRect: Rect;
-  delta: { x: number; y: number; width: number; height: number };
+  delta: Rect;
   confidence: number;
   possibleTextMetricMismatch: boolean;
 };
 
 export type ScreenshotOcrMovementCluster = {
   texts: string[];
-  xRange: { min: number; max: number };
-  yRange: { min: number; max: number };
+  xRange: MovementRange;
+  yRange: MovementRange;
 };
 
 export type ScreenshotOcrSummary = {

--- a/src/utils/screenshot-diff-regions.ts
+++ b/src/utils/screenshot-diff-regions.ts
@@ -1,4 +1,5 @@
 import type { PNG } from './png.ts';
+import type { Rect } from './snapshot.ts';
 import { findConnectedMaskComponents } from './screenshot-diff-components.ts';
 import { splitLargeDiffRegions } from './screenshot-diff-region-split.ts';
 import type { MutableDiffRegion } from './screenshot-diff-region-types.ts';
@@ -13,8 +14,8 @@ type ScreenshotDiffColor = {
 
 export type ScreenshotDiffRegion = {
   index: number;
-  rect: { x: number; y: number; width: number; height: number };
-  normalizedRect: { x: number; y: number; width: number; height: number };
+  rect: Rect;
+  normalizedRect: Rect;
   differentPixels: number;
   shareOfDiffPercentage: number;
   densityPercentage: number;
@@ -33,7 +34,7 @@ export type ScreenshotDiffRegionOverlayMatch = {
   ref: string;
   label?: string;
   regionCoveragePercentage: number;
-  rect: { x: number; y: number; width: number; height: number };
+  rect: Rect;
 };
 
 const DEFAULT_MAX_DIFF_REGIONS = 8;

--- a/src/utils/screenshot-diff.ts
+++ b/src/utils/screenshot-diff.ts
@@ -9,10 +9,11 @@ import {
 } from './screenshot-diff-non-text.ts';
 import { summarizeScreenshotOcr, type ScreenshotOcrSummary } from './screenshot-diff-ocr.ts';
 import { summarizeDiffRegions, type ScreenshotDiffRegion } from './screenshot-diff-regions.ts';
+import type { ImageDimensions } from './screenshot-geometry.ts';
 
 export type ScreenshotDimensionMismatch = {
-  expected: { width: number; height: number };
-  actual: { width: number; height: number };
+  expected: ImageDimensions;
+  actual: ImageDimensions;
 };
 
 export type ScreenshotDiffResult = {

--- a/src/utils/screenshot-geometry.ts
+++ b/src/utils/screenshot-geometry.ts
@@ -1,5 +1,7 @@
 import type { Rect } from './snapshot.ts';
 
+export type ImageDimensions = { width: number; height: number };
+
 export function unionRects(rects: Rect[]): Rect {
   let minX = Number.POSITIVE_INFINITY;
   let minY = Number.POSITIVE_INFINITY;

--- a/src/utils/scroll-edge-state.ts
+++ b/src/utils/scroll-edge-state.ts
@@ -4,6 +4,7 @@ import {
 } from './mobile-snapshot-semantics.ts';
 import { AppError } from './errors.ts';
 import { isScrollableNodeLike } from './scrollable.ts';
+import type { ScrollDirection } from '../core/scroll-gesture.ts';
 import type { HiddenContentHint, Point, RawSnapshotNode, SnapshotNode } from './snapshot.ts';
 
 export type ScrollEdge = 'top' | 'bottom';
@@ -111,7 +112,7 @@ export async function runScrollEdgePasses<TResult>(params: {
 }
 
 export function formatScrollEdgeMessage(
-  direction: 'up' | 'down' | 'left' | 'right',
+  direction: ScrollDirection,
   edge: ScrollEdge | undefined,
   passes: number,
   amount: number | undefined,


### PR DESCRIPTION
## Summary

A pure type-consolidation refactor: replaces duplicated TypeScript types across `src/` with shared canonical types / aliases / type-only imports. Goal is **single source of truth + type safety** with no behavior change. All new imports are type-only (erase at runtime under `verbatimModuleSyntax`).

Found via a discovery sweep of `src/` (69 verified consolidation opportunities); ~48 were implemented here. Every change was checked with `tsc`, and the whole diff was run through an adversarial semantic review — **verdict: clean, zero regressions**.

- **71 files**, +470/−443, 2 new leaf modules (`core/back-mode.ts`, `commands/log-command-contract.ts`)
- `tsc` ✓, `oxlint` ✓
- Net line count is roughly flat (union reuse trades an inline literal for an `import` line); the win is ~48 type concepts now single-sourced instead of duplicated.

## What changed (by theme)

**String-literal unions → one definition, reused everywhere**
`SessionSurface`, `ClickButton`, `DeviceRotation`, `BackMode`, `ScrollDirection` / `ScrollInputDirection` / `SwipePreset` / `SwipePattern`, `Platform` / `PlatformSelector` / `DeviceTarget`, `AlertAction`, `LeaseBackend`, `DaemonServerMode` / `DaemonTransportPreference` / `SessionIsolationMode` / `NetworkIncludeMode` (promoted to `contracts.ts`, the client↔daemon boundary, so the daemon and client/CLI stop redefining them), `MetroPrepareKind`, `ElementSelectorKey`, `GestureKind`, `AndroidTextInputAction`, `NetworkLogBackend`, `JsonRpcId` / `JsonRpcRequestEnvelope`, `LogAction`, Android snapshot-helper metadata unions. Runtime enum tuples gained `as const satisfies readonly T[]` drift-guards (behavior-neutral).

**Geometry**
Reuse canonical `Rect`; one `GestureReferenceFrame` (`TouchReferenceFrame` is now an alias); new `ImageDimensions` / `MovementRange`. Normalized-vs-absolute point literals were deliberately **left untouched** (different meaning).

**Result / options / function shapes** (the LOC-reducing part)
`BackendResultEnvelope` mix-in (~17 result types), one shared `toBackendResult` (was 5 copies), generic `PlatformProviderResolver<T>` (was 6 near-identical types), `TransformGestureParams`, `RepeatedInput`, `DaemonError` / `NormalizedError` reuse, `DaemonFailureResponse`, `ReplayActionBlockInvoker`, `RunnerSessionOptions = AppleRunnerLifecycleOptions`, `SelectorSnapshotInput`, `ExecResult`.

## Notes for the reviewer

- **Behavior preserved.** No runtime logic changed; the only value-level move is `toBackendResult` (identical logic, param widened `BackendActionResult` → `unknown`, which is safe for all callers) and reusing the existing `GESTURE_KINDS` tuple in place of an identical local copy.
- **Naming smell (not fixed here):** `NetworkLogBackend` is reused for the app-log backend union (same members) despite the name — candidate for a future rename.
- **Remaining tail:** ~21 low-value clusters (mostly 0–6 lines each, e.g. `daemon-invoke-fn`, `internal-result-failure-response`, `shutdown-command-result`, `envmap-record`) were intentionally deferred; happy to do them in a follow-up if wanted.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:unit` (green in uncontended runs; a few process-spawning android/ios tests time out flakily under load but pass in isolation — pre-existing, unrelated to these type-only changes)
- [x] Adversarial semantic review of the full diff — clean
