### PR TITLE
refactor(types): documentary NormalizedRect/NormalizedPoint aliases

### DIFF
--- a/src/utils/screenshot-diff-ocr.ts
+++ b/src/utils/screenshot-diff-ocr.ts
@@ -1,4 +1,4 @@
-import type { Rect } from './snapshot.ts';
+import type { NormalizedPoint, NormalizedRect, Rect } from './snapshot.ts';
 import { runCmd, whichCmd } from './exec.ts';
 
 export type MovementRange = { min: number; max: number };
@@ -8,7 +8,7 @@ export type ScreenshotOcrBlock = {
   text: string;
   confidence: number;
   rect: Rect;
-  normalizedRect: Rect;
+  normalizedRect: NormalizedRect;
 };
 
 export type ScreenshotOcrTextMatch = {
@@ -240,10 +240,10 @@ function findBestCurrentMatch(
     if (usedCurrent.has(index)) continue;
     const currentBlock = currentBlocks[index]!;
     if (normalizeTextForMatching(currentBlock.text) !== normalizedText) continue;
-    const distance = squaredDistance(
-      rectCenter(baselineBlock.normalizedRect),
-      rectCenter(currentBlock.normalizedRect),
-    );
+    // Centers are in normalized [0..100] space; compare like-for-like.
+    const baselineCenter: NormalizedPoint = rectCenter(baselineBlock.normalizedRect);
+    const currentCenter: NormalizedPoint = rectCenter(currentBlock.normalizedRect);
+    const distance = squaredDistance(baselineCenter, currentCenter);
     if (distance >= bestDistance) continue;
     bestIndex = index;
     bestDistance = distance;

--- a/src/utils/screenshot-diff-ocr.ts
+++ b/src/utils/screenshot-diff-ocr.ts
@@ -1,8 +1,14 @@
-import type { NormalizedPoint, NormalizedRect, Rect } from './snapshot.ts';
+import type { Rect } from './snapshot.ts';
 import { runCmd, whichCmd } from './exec.ts';
 
 export type MovementRange = { min: number; max: number };
-import { rectCenter, squaredDistance, unionRects } from './screenshot-geometry.ts';
+import {
+  rectCenter,
+  squaredDistance,
+  unionRects,
+  type NormalizedPoint,
+  type NormalizedRect,
+} from './screenshot-geometry.ts';
 
 export type ScreenshotOcrBlock = {
   text: string;

--- a/src/utils/screenshot-diff-regions.ts
+++ b/src/utils/screenshot-diff-regions.ts
@@ -1,5 +1,6 @@
 import type { PNG } from './png.ts';
-import type { NormalizedRect, Rect } from './snapshot.ts';
+import type { Rect } from './snapshot.ts';
+import type { NormalizedRect } from './screenshot-geometry.ts';
 import { findConnectedMaskComponents } from './screenshot-diff-components.ts';
 import { splitLargeDiffRegions } from './screenshot-diff-region-split.ts';
 import type { MutableDiffRegion } from './screenshot-diff-region-types.ts';

--- a/src/utils/screenshot-diff-regions.ts
+++ b/src/utils/screenshot-diff-regions.ts
@@ -1,5 +1,5 @@
 import type { PNG } from './png.ts';
-import type { Rect } from './snapshot.ts';
+import type { NormalizedRect, Rect } from './snapshot.ts';
 import { findConnectedMaskComponents } from './screenshot-diff-components.ts';
 import { splitLargeDiffRegions } from './screenshot-diff-region-split.ts';
 import type { MutableDiffRegion } from './screenshot-diff-region-types.ts';
@@ -15,7 +15,7 @@ type ScreenshotDiffColor = {
 export type ScreenshotDiffRegion = {
   index: number;
   rect: Rect;
-  normalizedRect: Rect;
+  normalizedRect: NormalizedRect;
   differentPixels: number;
   shareOfDiffPercentage: number;
   densityPercentage: number;

--- a/src/utils/screenshot-geometry.ts
+++ b/src/utils/screenshot-geometry.ts
@@ -1,6 +1,18 @@
-import type { Rect } from './snapshot.ts';
+import type { Point, Rect } from './snapshot.ts';
 
 export type ImageDimensions = { width: number; height: number };
+
+/**
+ * A rect whose coordinates are normalized percentages [0..100] of the screenshot
+ * image's dimensions (as produced by the screenshot-diff regions/OCR code), NOT
+ * absolute pixels. Documentary alias of {@link Rect} — it conveys coordinate
+ * space to readers but is not enforced by the type system (still structurally a
+ * Rect).
+ */
+export type NormalizedRect = Rect;
+
+/** A point in normalized [0..100] screenshot-image space. Documentary alias of {@link Point}. */
+export type NormalizedPoint = Point;
 
 export function unionRects(rects: Rect[]): Rect {
   let minX = Number.POSITIVE_INFINITY;

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -10,17 +10,6 @@ export type Point = {
   y: number;
 };
 
-/**
- * A rect whose coordinates are normalized percentages [0..100] of the viewport
- * (as used by screenshot-diff regions/OCR), NOT absolute pixels. Documentary
- * alias of {@link Rect} — it conveys coordinate space to readers but is not
- * enforced by the type system (still structurally a Rect).
- */
-export type NormalizedRect = Rect;
-
-/** A point in normalized [0..100] viewport space. Documentary alias of {@link Point}. */
-export type NormalizedPoint = Point;
-
 export type SnapshotOptions = {
   interactiveOnly?: boolean;
   compact?: boolean;

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -10,6 +10,17 @@ export type Point = {
   y: number;
 };
 
+/**
+ * A rect whose coordinates are normalized percentages [0..100] of the viewport
+ * (as used by screenshot-diff regions/OCR), NOT absolute pixels. Documentary
+ * alias of {@link Rect} — it conveys coordinate space to readers but is not
+ * enforced by the type system (still structurally a Rect).
+ */
+export type NormalizedRect = Rect;
+
+/** A point in normalized [0..100] viewport space. Documentary alias of {@link Point}. */
+export type NormalizedPoint = Point;
+
 export type SnapshotOptions = {
   interactiveOnly?: boolean;
   compact?: boolean;


### PR DESCRIPTION
## Summary

Follow-up to the type-consolidation work (#717). Adds **documentary** `NormalizedRect` / `NormalizedPoint` aliases of `Rect` / `Point` to convey coordinate space at the two sites that hold normalized percentages `[0..100]` but were typed as absolute `Rect`:

- `ScreenshotDiffRegion.normalizedRect`
- the OCR block `normalizedRect` and its center-distance path (`screenshot-diff-ocr.ts`)

3 files, type-only, behavior-preserving.

## Why documentary, not enforced

I scoped a full nominal brand (so normalized-vs-absolute mixing would be a *compile error*) and judged it disproportionate:

- The normalized surface is **2 fields**, with **no actual cross-space mixing today** (OCR compares two normalized centers; non-text diff compares two absolute centers — each call site is internally consistent).
- `rectCenter()` / `squaredDistance()` are intentionally **space-agnostic** helpers shared by both spaces.
- Real enforcement would require branding `Rect`/`Point` themselves (`& { __space }`) and threading a cast through **~33 files** + the generic helpers — large churn/risk for a tiny, bug-free surface.

So these aliases convey intent to readers (and give a place to hang the "[0..100], not pixels" doc) without the invasive brand. If you'd prefer the enforced version later, it's a clean follow-up.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`
- [x] `pnpm test:unit` screenshot-diff suites green
