### PR TITLE
ci: enforce lint and formatting, add warn-only layering guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,43 @@ jobs:
             exit 1
           fi
 
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Run oxlint
+        run: pnpm lint
+
+      - name: Check formatting
+        run: pnpm format:check
+
+  layering-guard:
+    name: Layering Guard (warn-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Warn on commands/ imports below the CLI surface layer
+        run: |
+          # daemon/ and platforms/ should not depend on the CLI commands layer.
+          # Warn-only until the shared contracts move out of src/commands/;
+          # flip to a hard failure once existing imports are migrated.
+          matches=$(rg -n "from '.*commands/" src/daemon src/platforms --glob '!**/__tests__/**' --glob '!*.test.ts' || true)
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            count=$(printf '%s\n' "$matches" | wc -l)
+            echo "::warning title=Layering drift::$count import(s) of src/commands/* from src/daemon or src/platforms. New code should depend on shared contracts instead."
+          fi
+
   fallow:
     name: Fallow Code Quality
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "perf:android": "node --experimental-strip-types scripts/perf/run.ts --platform android",
     "lint": "oxlint . --deny-warnings",
     "format": "oxfmt --write src test skills package.json tsconfig.json tsconfig.lib.json rslib.config.ts vitest.config.ts .github/actions/setup-node-pnpm/action.yml .oxlintrc.json .oxfmtrc.json '!test/skillgym/.skillgym-results/**'",
+    "format:check": "oxfmt --check src test skills package.json tsconfig.json tsconfig.lib.json rslib.config.ts vitest.config.ts .github/actions/setup-node-pnpm/action.yml .oxlintrc.json .oxfmtrc.json '!test/skillgym/.skillgym-results/**'",
     "fallow": "fallow --summary",
     "fallow:baseline": "(fallow dead-code --save-baseline fallow-baselines/dead-code.json --summary || true) && (fallow health --save-baseline fallow-baselines/health.json --summary || true)",
     "check:fallow": "fallow audit",


### PR DESCRIPTION
## Summary

The repo has `oxlint --deny-warnings` and oxfmt configured, but no CI workflow ran either — a drive-by PR could land lint warnings or format drift that every later contributor inherits. This adds:

- A **Lint & Format** job to `ci.yml`: `pnpm lint` plus a new `format:check` script (same target list as the existing `format` script, `--check` instead of `--write`).
- A **warn-only layering guard** job that flags imports of `src/commands/*` from `src/daemon/` and `src/platforms/` (currently 10+ daemon files and 5 platform files). It emits a workflow warning, never fails — it flips to a hard failure once the shared contracts move out of the commands layer (#726).

Touched files: 2 (`ci.yml`, `package.json`).

## Validation

`pnpm lint` and `pnpm format:check` both pass on the current tree (818 / 791 files, 0 issues), so the new job is green from day one. The guard's `rg` pattern was verified locally to match exactly the known cross-layer imports and nothing in tests.

Part of #722.

https://claude.ai/code/session_01LXZXzxi55sZ11DSyqWyBA2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXZXzxi55sZ11DSyqWyBA2)_