### PR TITLE
docs: document daemon trust model and auth hook threat model

### DIFF
--- a/website/docs/docs/security-trust.md
+++ b/website/docs/docs/security-trust.md
@@ -13,6 +13,17 @@ description: Security and trust guidance for agent-device local app automation, 
 - The MCP server exposes direct structured tools for `agent-device` commands. Tools use command contracts through `AgentDeviceClient`; local-only workflows stay CLI-only rather than subprocess fallbacks. It does not expose generic shell execution over MCP.
 - Mutating commands should run serially against one session. Use separate sessions/devices for parallel work.
 
+## Daemon trust model
+
+CLI commands run through a per-user background daemon:
+
+- The daemon binds to `127.0.0.1` only, on ephemeral ports, for both its socket and HTTP transports. It is never reachable from the network unless you deliberately front it with your own proxy.
+- Every request must present a token generated fresh on each daemon boot (24 random bytes). The token is stored in `~/.agent-device/daemon.json` with `0600` permissions; whoever can read that file already has your user account.
+- A client only reuses a running daemon when the daemon's version and binary code signature match its own; otherwise the daemon is restarted. This prevents a stale or tampered daemon from silently serving new clients.
+- Artifact uploads are size-capped, filenames are sanitized, and archive extraction rejects path-traversal entries. Artifact downloads resolve through server-side IDs, never client-supplied paths.
+
+For remote or cloud deployments, the daemon supports a custom auth hook: `AGENT_DEVICE_HTTP_AUTH_HOOK` names a module path that is dynamically imported and invoked for each HTTP request (with `AGENT_DEVICE_HTTP_AUTH_EXPORT` selecting the export). The hook runs with the daemon's full privileges, so treat it as part of your trusted computing base: point it only at a read-only path you control, never at a location writable by less-trusted users or processes. Whoever controls the daemon's environment controls the hook.
+
 ## Sensitive artifacts
 
 Screenshots, recordings, traces, logs, network dumps, replay files, and reports can contain private UI state, credentials, tokens, request data, or customer information. Store them in a controlled directory, review before sharing, and avoid committing artifacts unless they are intentionally sanitized fixtures.

--- a/website/docs/docs/security-trust.md
+++ b/website/docs/docs/security-trust.md
@@ -18,7 +18,7 @@ description: Security and trust guidance for agent-device local app automation, 
 CLI commands run through a per-user background daemon:
 
 - The daemon binds to `127.0.0.1` only, on ephemeral ports, for both its socket and HTTP transports. It is never reachable from the network unless you deliberately front it with your own proxy.
-- Every request must present a token generated fresh on each daemon boot (24 random bytes). The token is stored in `daemon.json` inside the daemon state directory (`~/.agent-device` for packaged installs; source checkouts use a worktree-scoped directory under `~/.agent-device/dev/`) with `0600` permissions; whoever can read that file already has your user account.
+- Command (RPC), upload, and artifact-download requests must present a token generated fresh on each daemon boot (24 random bytes). The only unauthenticated endpoint is `GET /health`, which intentionally returns a bare liveness response and nothing else; like the rest of the server it is reachable only via loopback. The token is stored in `daemon.json` inside the daemon state directory (`~/.agent-device` for packaged installs; source checkouts use a worktree-scoped directory under `~/.agent-device/dev/`) with `0600` permissions; whoever can read that file already has your user account.
 - A client only reuses a running daemon when the daemon's version and binary code signature match its own; otherwise the daemon is restarted. This prevents a stale or tampered daemon from silently serving new clients.
 - Artifact uploads are size-capped, filenames are sanitized, and archive extraction rejects path-traversal entries. Artifact downloads resolve through server-side IDs, never client-supplied paths.
 

--- a/website/docs/docs/security-trust.md
+++ b/website/docs/docs/security-trust.md
@@ -18,7 +18,7 @@ description: Security and trust guidance for agent-device local app automation, 
 CLI commands run through a per-user background daemon:
 
 - The daemon binds to `127.0.0.1` only, on ephemeral ports, for both its socket and HTTP transports. It is never reachable from the network unless you deliberately front it with your own proxy.
-- Every request must present a token generated fresh on each daemon boot (24 random bytes). The token is stored in `~/.agent-device/daemon.json` with `0600` permissions; whoever can read that file already has your user account.
+- Every request must present a token generated fresh on each daemon boot (24 random bytes). The token is stored in `daemon.json` inside the daemon state directory (`~/.agent-device` for packaged installs; source checkouts use a worktree-scoped directory under `~/.agent-device/dev/`) with `0600` permissions; whoever can read that file already has your user account.
 - A client only reuses a running daemon when the daemon's version and binary code signature match its own; otherwise the daemon is restarted. This prevents a stale or tampered daemon from silently serving new clients.
 - Artifact uploads are size-capped, filenames are sanitized, and archive extraction rejects path-traversal entries. Artifact downloads resolve through server-side IDs, never client-supplied paths.
 


### PR DESCRIPTION
## Summary

Adds a "Daemon trust model" section to the Security & Trust docs page covering behavior that previously existed only in code: loopback-only binding, the per-boot random token and its `0600` info file, the version + code-signature daemon-reuse rule, and artifact upload/download safeguards. Also documents the `AGENT_DEVICE_HTTP_AUTH_HOOK` threat model — the hook runs with full daemon privileges, so deployers should point it only at read-only paths they control. Relevant now that remote/cloud deployments are near.

Touched files: 1 (`website/docs/docs/security-trust.md`).

## Validation

Docs-only change; statements cross-checked against the implementation (`src/daemon/transport.ts`, `src/daemon-runtime.ts`, `src/daemon/server-lifecycle.ts`, `src/daemon-client.ts:604-610`, `src/daemon/http-server.ts:460-482`) during the audit.

Part of #722.

https://claude.ai/code/session_01LXZXzxi55sZ11DSyqWyBA2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXZXzxi55sZ11DSyqWyBA2)_