### PR TITLE
test(maestro): cover runtime target resolution and point parsing behaviors

### DIFF
--- a/src/compat/maestro/__tests__/points.test.ts
+++ b/src/compat/maestro/__tests__/points.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { test, expect } from 'vitest';
+import { AppError } from '../../../utils/errors.ts';
+import { parseAbsolutePoint, parseMaestroPoint } from '../points.ts';
+
+test('parseMaestroPoint parses absolute pixel coordinates', () => {
+  expect(parseMaestroPoint('100,200')).toEqual({ kind: 'absolute', x: 100, y: 200 });
+  expect(parseMaestroPoint(' 320 , 640 ')).toEqual({ kind: 'absolute', x: 320, y: 640 });
+});
+
+test('parseMaestroPoint parses percentage coordinates including decimals', () => {
+  expect(parseMaestroPoint('50%,75%')).toEqual({ kind: 'percent', x: 50, y: 75 });
+  expect(parseMaestroPoint('12.5%, 99.9%')).toEqual({ kind: 'percent', x: 12.5, y: 99.9 });
+});
+
+test('parseMaestroPoint rejects mixed or malformed coordinate expressions', () => {
+  for (const value of ['50%,75', '100;200', '-10,20', '']) {
+    assert.throws(
+      () => parseMaestroPoint(value),
+      (error) =>
+        error instanceof AppError &&
+        error.code === 'INVALID_ARGS' &&
+        error.message.includes(
+          'Only Maestro swipe coordinates like "100,200" or "50%,75%" are supported.',
+        ),
+      `expected rejection for ${JSON.stringify(value)}`,
+    );
+  }
+});
+
+test('parseAbsolutePoint accepts only absolute pixel coordinates', () => {
+  expect(parseAbsolutePoint('100,200')).toEqual({ x: 100, y: 200 });
+  assert.throws(
+    () => parseAbsolutePoint('50%,50%'),
+    (error) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message.includes('Only absolute Maestro point selectors like "100,200" are supported.'),
+  );
+});

--- a/src/compat/maestro/__tests__/points.test.ts
+++ b/src/compat/maestro/__tests__/points.test.ts
@@ -14,7 +14,7 @@ test('parseMaestroPoint parses percentage coordinates including decimals', () =>
 });
 
 test('parseMaestroPoint rejects mixed or malformed coordinate expressions', () => {
-  for (const value of ['50%,75', '100;200', '-10,20', '']) {
+  for (const value of ['50%,75', '50,75%', '100;200', '-10,20', '100.5,200', '']) {
     assert.throws(
       () => parseMaestroPoint(value),
       (error) =>

--- a/src/compat/maestro/__tests__/runtime-targets.test.ts
+++ b/src/compat/maestro/__tests__/runtime-targets.test.ts
@@ -14,6 +14,7 @@ const IOS_TAB_FRAME = { referenceWidth: 402, referenceHeight: 874 } as const;
 
 type SnapshotNodeFixture = Omit<SnapshotNode, 'ref'> & { ref?: string };
 type ResolveMaestroOptions = NonNullable<Parameters<typeof resolveMaestroNodeFromSnapshot>[5]>;
+type MaestroTapOptions = Parameters<typeof resolveMaestroNodeFromSnapshot>[2];
 
 function makeSnapshot(nodes: SnapshotNodeFixture[]): SnapshotState {
   return {
@@ -39,6 +40,14 @@ function resolveIosTabTarget(
     IOS_TAB_FRAME,
     options,
   );
+}
+
+function resolveIosNode(
+  snapshot: SnapshotState,
+  selector: string,
+  options: MaestroTapOptions = {},
+) {
+  return resolveMaestroNodeFromSnapshot(snapshot, selector, options, 'ios', IOS_TAB_FRAME);
 }
 
 test('resolveVisibleMaestroNodeFromSnapshot treats app content behind React Native overlays as hidden', () => {
@@ -1306,10 +1315,17 @@ test('resolveMaestroNodeFromSnapshot infers leading breadcrumb slot when selecte
   });
 });
 
-test('readMaestroSelectorPlatform defaults to iOS unless flags request Android', () => {
+test('readMaestroSelectorPlatform defaults to iOS unless flags request exactly "android"', () => {
+  const flagsWithPlatform = (platform: string) =>
+    ({ platform }) as Parameters<typeof readMaestroSelectorPlatform>[0];
+
   expect(readMaestroSelectorPlatform({ platform: 'android' })).toBe('android');
   expect(readMaestroSelectorPlatform({ platform: 'ios' })).toBe('ios');
   expect(readMaestroSelectorPlatform(undefined)).toBe('ios');
+  // The comparison is case-sensitive and exact: anything but lowercase
+  // 'android' falls back to iOS.
+  expect(readMaestroSelectorPlatform(flagsWithPlatform('Android'))).toBe('ios');
+  expect(readMaestroSelectorPlatform(flagsWithPlatform('tvos'))).toBe('ios');
 });
 
 test('extractMaestroVisibleTextQuery extracts the shared text from text selector chains', () => {
@@ -1367,16 +1383,17 @@ test('resolveMaestroFuzzyTextNodeFromSnapshot reports unmatched and blank fuzzy 
     },
   ]);
 
+  const blankQuery = ' '.repeat(3);
   const missing = resolveMaestroFuzzyTextNodeFromSnapshot(
     snapshot,
     'Checkout',
     'ios',
     IOS_TAB_FRAME,
   );
-  const blank = resolveMaestroFuzzyTextNodeFromSnapshot(snapshot, '   ', 'ios', IOS_TAB_FRAME);
+  const blank = resolveMaestroFuzzyTextNodeFromSnapshot(snapshot, blankQuery, 'ios', IOS_TAB_FRAME);
 
   expect(missing).toEqual({ ok: false, message: 'Maestro fuzzy text did not match: Checkout' });
-  expect(blank).toEqual({ ok: false, message: 'Maestro fuzzy text did not match:    ' });
+  expect(blank).toEqual({ ok: false, message: `Maestro fuzzy text did not match: ${blankQuery}` });
 });
 
 test('resolveMaestroNodeFromSnapshot index option selects matches in snapshot order', () => {
@@ -1397,20 +1414,8 @@ test('resolveMaestroNodeFromSnapshot index option selects matches in snapshot or
     },
   ]);
 
-  const first = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'label="Delete"',
-    { index: 0 },
-    'ios',
-    IOS_TAB_FRAME,
-  );
-  const second = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'label="Delete"',
-    { index: 1 },
-    'ios',
-    IOS_TAB_FRAME,
-  );
+  const first = resolveIosNode(snapshot, 'label="Delete"', { index: 0 });
+  const second = resolveIosNode(snapshot, 'label="Delete"', { index: 1 });
 
   expect(first).toMatchObject({
     ok: true,
@@ -1435,13 +1440,7 @@ test('resolveMaestroNodeFromSnapshot reports the requested index when out of ran
     },
   ]);
 
-  const target = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'label="Delete"',
-    { index: 5 },
-    'ios',
-    IOS_TAB_FRAME,
-  );
+  const target = resolveIosNode(snapshot, 'label="Delete"', { index: 5 });
 
   expect(target).toEqual({
     ok: false,
@@ -1461,13 +1460,7 @@ test('resolveMaestroNodeFromSnapshot reports missing childOf parents', () => {
     },
   ]);
 
-  const target = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'id="action"',
-    { childOf: 'id="missing-parent"' },
-    'ios',
-    IOS_TAB_FRAME,
-  );
+  const target = resolveIosNode(snapshot, 'id="action"', { childOf: 'id="missing-parent"' });
 
   expect(target).toEqual({
     ok: false,
@@ -1481,13 +1474,7 @@ test('resolveMaestroNodeFromSnapshot inherits the nearest ancestor rect for rect
     { index: 2, type: 'Button', label: 'Submit', hittable: true, depth: 2, parentIndex: 1 },
   ]);
 
-  const target = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'label="Submit"',
-    {},
-    'ios',
-    IOS_TAB_FRAME,
-  );
+  const target = resolveIosNode(snapshot, 'label="Submit"');
 
   expect(target).toMatchObject({
     ok: true,
@@ -1507,13 +1494,7 @@ test('resolveMaestroNodeFromSnapshot reports matches hidden by zero-size rects',
     },
   ]);
 
-  const target = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'label="Ghost"',
-    {},
-    'ios',
-    IOS_TAB_FRAME,
-  );
+  const target = resolveIosNode(snapshot, 'label="Ghost"');
 
   expect(target).toEqual({
     ok: false,
@@ -1532,20 +1513,8 @@ test('resolveMaestroNodeFromSnapshot treats regex-looking text terms as regular 
     },
   ]);
 
-  const regex = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'label="^Subtotal.*"',
-    {},
-    'ios',
-    IOS_TAB_FRAME,
-  );
-  const invalidRegex = resolveMaestroNodeFromSnapshot(
-    snapshot,
-    'label="^[unclosed"',
-    {},
-    'ios',
-    IOS_TAB_FRAME,
-  );
+  const regex = resolveIosNode(snapshot, 'label="^Subtotal.*"');
+  const invalidRegex = resolveIosNode(snapshot, 'label="^[unclosed"');
 
   expect(regex).toMatchObject({
     ok: true,
@@ -1558,7 +1527,7 @@ test('resolveMaestroNodeFromSnapshot treats regex-looking text terms as regular 
   });
 });
 
-test('resolveMaestroNodeFromSnapshot rejects malformed selector expressions with INVALID_ARGS', () => {
+test('resolveMaestroNodeFromSnapshot propagates selector parser errors uncaught', () => {
   const snapshot = makeSnapshot([
     {
       index: 1,
@@ -1568,29 +1537,16 @@ test('resolveMaestroNodeFromSnapshot rejects malformed selector expressions with
       depth: 3,
     },
   ]);
-  const resolve = (selector: string) => () =>
-    resolveMaestroNodeFromSnapshot(snapshot, selector, {}, 'ios', IOS_TAB_FRAME);
 
+  // Exact parser wording is owned by src/daemon/selectors-parse.ts and pinned
+  // in src/daemon/__tests__/selectors.test.ts; here we only assert that the
+  // parser error reaches the caller unchanged.
   assert.throws(
-    resolve(''),
+    () => resolveIosNode(snapshot, 'bogus="Save"'),
     (error) =>
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&
-      error.message === 'Selector expression cannot be empty',
-  );
-  assert.throws(
-    resolve('bogus="Save"'),
-    (error) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      error.message === 'Unknown selector key: bogus',
-  );
-  assert.throws(
-    resolve('label="Save'),
-    (error) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      error.message === 'Unclosed quote in selector: label="Save',
+      /Unknown selector key/i.test(error.message),
   );
 });
 

--- a/src/compat/maestro/__tests__/runtime-targets.test.ts
+++ b/src/compat/maestro/__tests__/runtime-targets.test.ts
@@ -1,6 +1,11 @@
+import assert from 'node:assert/strict';
 import { test, expect } from 'vitest';
 import type { SnapshotNode, SnapshotState } from '../../../utils/snapshot.ts';
+import { AppError } from '../../../utils/errors.ts';
 import {
+  extractMaestroVisibleTextQuery,
+  readMaestroSelectorPlatform,
+  resolveMaestroFuzzyTextNodeFromSnapshot,
   resolveMaestroNodeFromSnapshot,
   resolveVisibleMaestroNodeFromSnapshot,
 } from '../runtime-targets.ts';
@@ -1298,6 +1303,327 @@ test('resolveMaestroNodeFromSnapshot infers leading breadcrumb slot when selecte
     ok: true,
     node: expect.objectContaining({ index: 1 }),
     rect: { x: 0, y: 58.33333333333333, width: 168, height: 58.33333333333333 },
+  });
+});
+
+test('readMaestroSelectorPlatform defaults to iOS unless flags request Android', () => {
+  expect(readMaestroSelectorPlatform({ platform: 'android' })).toBe('android');
+  expect(readMaestroSelectorPlatform({ platform: 'ios' })).toBe('ios');
+  expect(readMaestroSelectorPlatform(undefined)).toBe('ios');
+});
+
+test('extractMaestroVisibleTextQuery extracts the shared text from text selector chains', () => {
+  expect(extractMaestroVisibleTextQuery('label="Save" || text="Save" || id="Save"')).toBe('Save');
+  expect(extractMaestroVisibleTextQuery('label="Save"')).toBe('Save');
+});
+
+test('extractMaestroVisibleTextQuery keeps exact selector paths for mixed selectors', () => {
+  expect(extractMaestroVisibleTextQuery('id="row-1"')).toBeNull();
+  expect(extractMaestroVisibleTextQuery('label="Save" || text="Cancel"')).toBeNull();
+  expect(extractMaestroVisibleTextQuery('role="button" label="Save"')).toBeNull();
+});
+
+test('resolveMaestroFuzzyTextNodeFromSnapshot prefers exact normalized text over partial matches', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'StaticText',
+      label: 'Sign In Now',
+      rect: { x: 24, y: 100, width: 200, height: 44 },
+      depth: 3,
+    },
+    {
+      index: 2,
+      type: 'StaticText',
+      label: 'sign  in',
+      rect: { x: 24, y: 200, width: 200, height: 44 },
+      depth: 3,
+    },
+  ]);
+
+  const exact = resolveMaestroFuzzyTextNodeFromSnapshot(snapshot, 'Sign In', 'ios', IOS_TAB_FRAME);
+  const partial = resolveMaestroFuzzyTextNodeFromSnapshot(snapshot, 'In Now', 'ios', IOS_TAB_FRAME);
+
+  expect(exact).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 2 }),
+    rect: { x: 24, y: 200, width: 200, height: 44 },
+  });
+  expect(partial).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 1 }),
+    rect: { x: 24, y: 100, width: 200, height: 44 },
+  });
+});
+
+test('resolveMaestroFuzzyTextNodeFromSnapshot reports unmatched and blank fuzzy queries', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'StaticText',
+      label: 'Welcome',
+      rect: { x: 24, y: 100, width: 200, height: 44 },
+      depth: 3,
+    },
+  ]);
+
+  const missing = resolveMaestroFuzzyTextNodeFromSnapshot(
+    snapshot,
+    'Checkout',
+    'ios',
+    IOS_TAB_FRAME,
+  );
+  const blank = resolveMaestroFuzzyTextNodeFromSnapshot(snapshot, '   ', 'ios', IOS_TAB_FRAME);
+
+  expect(missing).toEqual({ ok: false, message: 'Maestro fuzzy text did not match: Checkout' });
+  expect(blank).toEqual({ ok: false, message: 'Maestro fuzzy text did not match:    ' });
+});
+
+test('resolveMaestroNodeFromSnapshot index option selects matches in snapshot order', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'Button',
+      label: 'Delete',
+      rect: { x: 24, y: 100, width: 120, height: 44 },
+      depth: 3,
+    },
+    {
+      index: 2,
+      type: 'Button',
+      label: 'Delete',
+      rect: { x: 24, y: 300, width: 120, height: 44 },
+      depth: 3,
+    },
+  ]);
+
+  const first = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="Delete"',
+    { index: 0 },
+    'ios',
+    IOS_TAB_FRAME,
+  );
+  const second = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="Delete"',
+    { index: 1 },
+    'ios',
+    IOS_TAB_FRAME,
+  );
+
+  expect(first).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 1 }),
+    rect: { x: 24, y: 100, width: 120, height: 44 },
+  });
+  expect(second).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 2 }),
+    rect: { x: 24, y: 300, width: 120, height: 44 },
+  });
+});
+
+test('resolveMaestroNodeFromSnapshot reports the requested index when out of range', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'Button',
+      label: 'Delete',
+      rect: { x: 24, y: 100, width: 120, height: 44 },
+      depth: 3,
+    },
+  ]);
+
+  const target = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="Delete"',
+    { index: 5 },
+    'ios',
+    IOS_TAB_FRAME,
+  );
+
+  expect(target).toEqual({
+    ok: false,
+    message: 'Maestro selector did not match index 5: label="Delete"',
+  });
+});
+
+test('resolveMaestroNodeFromSnapshot reports missing childOf parents', () => {
+  const snapshot = makeSnapshot([
+    { index: 1, identifier: 'row', rect: { x: 0, y: 0, width: 320, height: 80 }, depth: 2 },
+    {
+      index: 2,
+      parentIndex: 1,
+      identifier: 'action',
+      rect: { x: 240, y: 16, width: 64, height: 48 },
+      depth: 3,
+    },
+  ]);
+
+  const target = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'id="action"',
+    { childOf: 'id="missing-parent"' },
+    'ios',
+    IOS_TAB_FRAME,
+  );
+
+  expect(target).toEqual({
+    ok: false,
+    message: 'Maestro childOf parent did not match: id="missing-parent"',
+  });
+});
+
+test('resolveMaestroNodeFromSnapshot inherits the nearest ancestor rect for rectless matches', () => {
+  const snapshot = makeSnapshot([
+    { index: 1, type: 'Other', rect: { x: 10, y: 20, width: 300, height: 50 }, depth: 1 },
+    { index: 2, type: 'Button', label: 'Submit', hittable: true, depth: 2, parentIndex: 1 },
+  ]);
+
+  const target = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="Submit"',
+    {},
+    'ios',
+    IOS_TAB_FRAME,
+  );
+
+  expect(target).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 2 }),
+    rect: { x: 10, y: 20, width: 300, height: 50 },
+  });
+});
+
+test('resolveMaestroNodeFromSnapshot reports matches hidden by zero-size rects', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'StaticText',
+      label: 'Ghost',
+      rect: { x: 0, y: 0, width: 0, height: 0 },
+      depth: 2,
+    },
+  ]);
+
+  const target = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="Ghost"',
+    {},
+    'ios',
+    IOS_TAB_FRAME,
+  );
+
+  expect(target).toEqual({
+    ok: false,
+    message: 'Maestro selector matched 1 element(s), but none were visible: label="Ghost"',
+  });
+});
+
+test('resolveMaestroNodeFromSnapshot treats regex-looking text terms as regular expressions', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'StaticText',
+      label: 'Subtotal: $42.10',
+      rect: { x: 24, y: 100, width: 240, height: 44 },
+      depth: 3,
+    },
+  ]);
+
+  const regex = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="^Subtotal.*"',
+    {},
+    'ios',
+    IOS_TAB_FRAME,
+  );
+  const invalidRegex = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    'label="^[unclosed"',
+    {},
+    'ios',
+    IOS_TAB_FRAME,
+  );
+
+  expect(regex).toMatchObject({
+    ok: true,
+    node: expect.objectContaining({ index: 1 }),
+    rect: { x: 24, y: 100, width: 240, height: 44 },
+  });
+  expect(invalidRegex).toEqual({
+    ok: false,
+    message: 'Maestro selector did not match index 0: label="^[unclosed"',
+  });
+});
+
+test('resolveMaestroNodeFromSnapshot rejects malformed selector expressions with INVALID_ARGS', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'Button',
+      label: 'Save',
+      rect: { x: 24, y: 100, width: 120, height: 44 },
+      depth: 3,
+    },
+  ]);
+  const resolve = (selector: string) => () =>
+    resolveMaestroNodeFromSnapshot(snapshot, selector, {}, 'ios', IOS_TAB_FRAME);
+
+  assert.throws(
+    resolve(''),
+    (error) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Selector expression cannot be empty',
+  );
+  assert.throws(
+    resolve('bogus="Save"'),
+    (error) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown selector key: bogus',
+  );
+  assert.throws(
+    resolve('label="Save'),
+    (error) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unclosed quote in selector: label="Save',
+  );
+});
+
+test('resolveVisibleMaestroNodeFromSnapshot reports the visible match count and prefers tap targets', () => {
+  const snapshot = makeSnapshot([
+    {
+      index: 1,
+      type: 'StaticText',
+      label: 'Save',
+      rect: { x: 24, y: 100, width: 120, height: 44 },
+      depth: 3,
+    },
+    {
+      index: 2,
+      type: 'Button',
+      label: 'Save',
+      rect: { x: 24, y: 300, width: 120, height: 44 },
+      depth: 3,
+    },
+  ]);
+
+  const target = resolveVisibleMaestroNodeFromSnapshot(
+    snapshot,
+    maestroTextSelector('Save'),
+    'ios',
+    IOS_TAB_FRAME,
+  );
+
+  expect(target).toMatchObject({
+    ok: true,
+    matches: 2,
+    node: expect.objectContaining({ index: 2 }),
+    rect: { x: 24, y: 300, width: 120, height: 44 },
   });
 });
 


### PR DESCRIPTION
## Summary

Test-only: pins previously untested behavior in the Maestro compat layer (kept long-term per #722 decisions). 17 new tests / ~36 behavior assertions on top of the existing 26 in `runtime-targets.test.ts`, plus a new `points.test.ts` for the point/percentage target variant (previously zero coverage):

- selector platform resolution (including case-sensitivity boundaries), fuzzy-text exact-vs-partial precedence with exact error messages, `index` selection and out-of-range errors, `childOf` misses, ancestor-rect inheritance, zero-size-rect visibility rejection, regex selectors (including invalid-regex safety), parser-error propagation, duplicate-match type ranking
- point parsing: absolute and percent forms (decimals), and rejection of mixed/decimal-absolute/negative/malformed inputs

The second commit applies review findings: exact-wording assertions on another module's parser errors reduced to one tolerant propagation case, invisible trailing-whitespace literal made explicit, a tautology test made informative with boundary cases, repeated 6-arg call boilerplate factored into a local helper, and two high-risk rejection cases (`50,75%`, `100.5,200`) added.

Suspected production quirks found and pinned (not fixed): malformed selector expressions throw through `resolveMaestroNodeFromSnapshot` instead of returning its usual `{ ok: false }` shape, and blank fuzzy queries produce a trailing-whitespace error message. Worth a follow-up decision.

Touched files: 2 (both tests).

## Validation

`pnpm exec vitest run --project unit src/compat`: 9 files, 117 tests passed. Full `pnpm test:unit`: 233 files, 2176 passed / 4 skipped. Typecheck/lint/format clean. Fixture paths were verified against production code so each test exercises the intended branch (not an early exit).

Closes #730. Part of #722.

https://claude.ai/code/session_01LXZXzxi55sZ11DSyqWyBA2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXZXzxi55sZ11DSyqWyBA2)_