### PR TITLE
test: cover daemon-client lifecycle characterization

### DIFF
--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -932,10 +932,17 @@ async function canConnect(
   preference: DaemonTransportPreference,
 ): Promise<boolean> {
   const transport = chooseTransport(info, preference);
-  if (transport === 'http') {
-    return await canConnectHttp(info);
-  }
-  return await canConnectSocket(info.port);
+  if (await canConnectWithTransport(info, transport)) return true;
+
+  const fallback = chooseAutoFallbackTransport(info, preference, transport);
+  return fallback ? await canConnectWithTransport(info, fallback) : false;
+}
+
+async function canConnectWithTransport(
+  info: DaemonInfo,
+  transport: ResolvedDaemonTransport,
+): Promise<boolean> {
+  return transport === 'http' ? await canConnectHttp(info) : await canConnectSocket(info.port);
 }
 
 export function canConnectSocket(port: number | undefined): Promise<boolean> {
@@ -1057,10 +1064,24 @@ async function sendRequest(
   timeoutMs: number | undefined,
 ): Promise<DaemonResponse> {
   const transport = chooseTransport(info, preference);
-  if (transport === 'http') {
-    return await sendHttpRequest(info, req, timeoutMs);
+  try {
+    return await sendRequestWithTransport(info, req, timeoutMs, transport);
+  } catch (error) {
+    const fallback = chooseAutoFallbackTransport(info, preference, transport);
+    if (!fallback || !isSafeAutoTransportFallbackError(error, transport)) throw error;
+    return await sendRequestWithTransport(info, req, timeoutMs, fallback);
   }
-  return await sendSocketRequest(info, req, timeoutMs);
+}
+
+async function sendRequestWithTransport(
+  info: DaemonInfo,
+  req: DaemonRequest,
+  timeoutMs: number | undefined,
+  transport: ResolvedDaemonTransport,
+): Promise<DaemonResponse> {
+  return transport === 'http'
+    ? await sendHttpRequest(info, req, timeoutMs)
+    : await sendSocketRequest(info, req, timeoutMs);
 }
 
 function chooseTransport(
@@ -1090,6 +1111,29 @@ function chooseTransport(
 
 function hasDaemonTransport(info: DaemonInfo, transport: ResolvedDaemonTransport): boolean {
   return transport === 'http' ? Boolean(info.httpPort) : Boolean(info.port);
+}
+
+function chooseAutoFallbackTransport(
+  info: DaemonInfo,
+  preference: DaemonTransportPreference,
+  attempted: ResolvedDaemonTransport,
+): ResolvedDaemonTransport | null {
+  if (preference !== 'auto' || info.baseUrl) return null;
+  const fallback = attempted === 'socket' ? 'http' : 'socket';
+  return hasDaemonTransport(info, fallback) ? fallback : null;
+}
+
+function isSafeAutoTransportFallbackError(
+  error: unknown,
+  attempted: ResolvedDaemonTransport,
+): boolean {
+  return (
+    attempted === 'socket' &&
+    error instanceof AppError &&
+    error.code === 'COMMAND_FAILED' &&
+    error.message === 'Failed to communicate with daemon' &&
+    error.details?.daemonSocketRequestWritten === false
+  );
 }
 
 function requireDaemonTransport(
@@ -1170,6 +1214,7 @@ function handleTransportError(
   err: unknown,
   requestId: string | undefined,
   remote: boolean,
+  details: Record<string, unknown> = {},
 ): AppError {
   emitDiagnostic({
     level: 'error',
@@ -1183,6 +1228,7 @@ function handleTransportError(
     'COMMAND_FAILED',
     'Failed to communicate with daemon',
     {
+      ...details,
       requestId,
       hint: remote
         ? 'Retry command. If this persists, verify the remote daemon URL, auth token, and remote host reachability.'
@@ -1200,7 +1246,9 @@ async function sendSocketRequest(
   const port = info.port;
   if (!port) throw new AppError('COMMAND_FAILED', 'Daemon socket endpoint is unavailable');
   return new Promise((resolve, reject) => {
+    let requestWritten = false;
     const socket = net.createConnection({ host: '127.0.0.1', port }, () => {
+      requestWritten = true;
       socket.write(`${JSON.stringify(req)}\n`);
     });
     const statePaths = resolveDaemonPaths(
@@ -1267,7 +1315,11 @@ async function sendSocketRequest(
       if (settled) return;
       settled = true;
       if (timeoutHandle) clearTimeout(timeoutHandle);
-      reject(handleTransportError(err, req.meta?.requestId, false));
+      reject(
+        handleTransportError(err, req.meta?.requestId, false, {
+          daemonSocketRequestWritten: requestWritten,
+        }),
+      );
     });
   });
 }

--- a/src/utils/__tests__/daemon-client-lifecycle.test.ts
+++ b/src/utils/__tests__/daemon-client-lifecycle.test.ts
@@ -1,0 +1,484 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test, vi } from 'vitest';
+
+vi.mock('../exec.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../exec.ts')>();
+  return { ...actual, runCmdDetached: vi.fn() };
+});
+
+vi.mock('../timeouts.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../timeouts.ts')>();
+  return { ...actual, sleep: vi.fn(async () => {}) };
+});
+
+import { resolveDaemonPaths, type DaemonPaths } from '../../daemon/config.ts';
+import { computeDaemonCodeSignature, sendToDaemon } from '../../daemon-client.ts';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  supportsLoopbackBind,
+} from '../../__tests__/test-utils/index.ts';
+import { AppError } from '../errors.ts';
+import { runCmdDetached } from '../exec.ts';
+import { readProcessStartTime } from '../process-identity.ts';
+import { sleep } from '../timeouts.ts';
+import { findProjectRoot, readVersion } from '../version.ts';
+
+type DaemonInfoFixture = {
+  port?: number;
+  httpPort?: number;
+  transport: 'socket' | 'http' | 'dual';
+  token?: string;
+  pid?: number;
+  version?: string;
+  codeSignature?: string;
+  processStartTime?: string;
+};
+
+type HttpDaemonFixture = {
+  server: http.Server;
+  port: number;
+  seenPaths: string[];
+  rpcRequests: Record<string, any>[];
+};
+
+const mockRunCmdDetached = vi.mocked(runCmdDetached);
+const mockSleep = vi.mocked(sleep);
+
+afterEach(() => {
+  mockRunCmdDetached.mockReset();
+  mockSleep.mockClear();
+  vi.unstubAllEnvs();
+});
+
+function makeTempStateDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function resolveCurrentDaemonCodeSignature(): string {
+  const root = findProjectRoot();
+  const distPath = path.join(root, 'dist', 'src', 'internal', 'daemon.js');
+  const sourcePath = path.join(root, 'src', 'daemon.ts');
+  const entryPath =
+    process.execArgv.includes('--experimental-strip-types') || !fs.existsSync(distPath)
+      ? sourcePath
+      : distPath;
+  return computeDaemonCodeSignature(entryPath, root);
+}
+
+function writeDaemonInfo(paths: DaemonPaths, info: DaemonInfoFixture): void {
+  fs.mkdirSync(paths.baseDir, { recursive: true });
+  fs.writeFileSync(
+    paths.infoPath,
+    `${JSON.stringify({
+      token: info.token ?? 'local-secret',
+      pid: info.pid ?? process.pid,
+      version: info.version ?? readVersion(),
+      codeSignature: info.codeSignature ?? resolveCurrentDaemonCodeSignature(),
+      processStartTime: info.processStartTime ?? readProcessStartTime(process.pid) ?? undefined,
+      port: info.port,
+      httpPort: info.httpPort,
+      transport: info.transport,
+    })}\n`,
+    'utf8',
+  );
+}
+
+function writeDaemonLock(
+  paths: DaemonPaths,
+  lock: { pid: number; processStartTime?: string; startedAt?: number },
+): void {
+  fs.mkdirSync(paths.baseDir, { recursive: true });
+  fs.writeFileSync(
+    paths.lockPath,
+    `${JSON.stringify({ startedAt: Date.now(), ...lock })}\n`,
+    'utf8',
+  );
+}
+
+async function startHttpDaemonFixture(
+  responseData: Record<string, unknown>,
+): Promise<HttpDaemonFixture> {
+  const seenPaths: string[] = [];
+  const rpcRequests: Record<string, any>[] = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1');
+    seenPaths.push(`${req.method ?? 'GET'} ${url.pathname}`);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      res.writeHead(200);
+      res.end('ok');
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/rpc') {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      req.on('end', () => {
+        const rpcRequest = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<
+          string,
+          any
+        >;
+        rpcRequests.push(rpcRequest);
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: rpcRequest.id,
+            result: { ok: true, data: responseData },
+          }),
+        );
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  });
+  const port = await listenOnLoopback(server);
+  return { server, port, seenPaths, rpcRequests };
+}
+
+function installSpawnedHttpDaemon(paths: DaemonPaths, httpPort: number): void {
+  mockRunCmdDetached.mockImplementation((_command, _args, options) => {
+    assert.equal(options?.env?.AGENT_DEVICE_STATE_DIR, paths.baseDir);
+    writeDaemonInfo(paths, { httpPort, transport: 'http' });
+    writeDaemonLock(paths, {
+      pid: process.pid,
+      processStartTime: readProcessStartTime(process.pid) ?? undefined,
+    });
+    return process.pid;
+  });
+}
+
+function mockSocketConnectionFailures(failingPort: number): {
+  ports: number[];
+  restore: () => void;
+} {
+  const ports: number[] = [];
+  const originalCreateConnection = net.createConnection;
+  (net as unknown as { createConnection: typeof net.createConnection }).createConnection = ((
+    ...args: Parameters<typeof net.createConnection>
+  ) => {
+    const options = args[0] as { port?: number | string };
+    if (Number(options.port) !== failingPort) {
+      return originalCreateConnection(...args);
+    }
+    ports.push(Number(options.port));
+    const socket = new EventEmitter() as EventEmitter & {
+      destroy: () => void;
+      end: () => void;
+      setEncoding: (_encoding: string) => void;
+      setTimeout: (_ms: number) => typeof socket;
+      write: (_chunk: string) => boolean;
+    };
+    socket.destroy = () => {};
+    socket.end = () => {
+      socket.emit('close');
+    };
+    socket.setEncoding = () => {};
+    socket.setTimeout = () => socket;
+    socket.write = () => true;
+    process.nextTick(() => {
+      socket.emit('error', new Error('ECONNREFUSED'));
+    });
+    return socket as unknown as net.Socket;
+  }) as typeof net.createConnection;
+
+  return {
+    ports,
+    restore: () => {
+      (net as unknown as { createConnection: typeof net.createConnection }).createConnection =
+        originalCreateConnection;
+    },
+  };
+}
+
+function mockSocketErrorAfterWrite(failingPort: number): {
+  ports: number[];
+  writes: string[];
+  restore: () => void;
+} {
+  const ports: number[] = [];
+  const writes: string[] = [];
+  const originalCreateConnection = net.createConnection;
+  (net as unknown as { createConnection: typeof net.createConnection }).createConnection = ((
+    ...args: Parameters<typeof net.createConnection>
+  ) => {
+    const options = args[0] as { port?: number | string };
+    const connectListener = args[1] as (() => void) | undefined;
+    if (Number(options.port) !== failingPort) {
+      return originalCreateConnection(...args);
+    }
+
+    ports.push(Number(options.port));
+    const socket = new EventEmitter() as EventEmitter & {
+      destroy: () => void;
+      end: () => void;
+      setEncoding: (_encoding: string) => void;
+      setTimeout: (_ms: number) => typeof socket;
+      write: (_chunk: string) => boolean;
+    };
+    socket.destroy = () => {};
+    socket.end = () => {
+      socket.emit('close');
+    };
+    socket.setEncoding = () => {};
+    socket.setTimeout = () => socket;
+    socket.write = (chunk) => {
+      writes.push(chunk);
+      process.nextTick(() => {
+        socket.emit('error', new Error('ECONNRESET after write'));
+      });
+      return true;
+    };
+    process.nextTick(() => connectListener?.());
+    return socket as unknown as net.Socket;
+  }) as typeof net.createConnection;
+
+  return {
+    ports,
+    writes,
+    restore: () => {
+      (net as unknown as { createConnection: typeof net.createConnection }).createConnection =
+        originalCreateConnection;
+    },
+  };
+}
+
+test('sendToDaemon retries daemon spawn failures and cleans partial metadata on terminal failure', async () => {
+  const stateDir = makeTempStateDir('agent-device-daemon-spawn-retry-');
+  const paths = resolveDaemonPaths(stateDir);
+  vi.stubEnv('AGENT_DEVICE_STATE_DIR', stateDir);
+  let attempts = 0;
+
+  mockRunCmdDetached.mockImplementation((_command, _args, options) => {
+    attempts += 1;
+    assert.equal(options?.env?.AGENT_DEVICE_STATE_DIR, stateDir);
+    fs.mkdirSync(paths.baseDir, { recursive: true });
+    fs.writeFileSync(paths.infoPath, '{"partial":true}\n', 'utf8');
+    fs.writeFileSync(paths.lockPath, 'not-json\n', 'utf8');
+    throw new Error(`spawn failed ${attempts}`);
+  });
+
+  try {
+    let thrown: unknown;
+    try {
+      await sendToDaemon({
+        session: 'default',
+        command: 'spawn-retry-smoke',
+        positionals: [],
+        flags: { stateDir },
+        meta: { requestId: 'req-spawn-retry' },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    assert.ok(thrown instanceof AppError);
+    assert.equal(thrown.message, 'Failed to start daemon');
+    assert.equal(thrown.details?.startError, 'spawn failed 2');
+    assert.equal(thrown.details?.startupAttempts, 2);
+    const cleanupResults = thrown.details?.cleanupResults;
+    assert.ok(Array.isArray(cleanupResults));
+    assert.deepEqual(
+      cleanupResults.map((result) => ({
+        reason: result.reason,
+        removedInfo: result.removedInfo,
+        removedLock: result.removedLock,
+      })),
+      [
+        { reason: 'start_error', removedInfo: true, removedLock: true },
+        { reason: 'start_error', removedInfo: true, removedLock: true },
+      ],
+    );
+    assert.equal(attempts, 2);
+    assert.equal(mockSleep.mock.calls[0]?.[0], 150);
+    assert.equal(fs.existsSync(paths.infoPath), false);
+    assert.equal(fs.existsSync(paths.lockPath), false);
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('sendToDaemon removes stale daemon lock before spawning a fresh daemon', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  const stateDir = makeTempStateDir('agent-device-daemon-stale-lock-');
+  const paths = resolveDaemonPaths(stateDir);
+  const daemon = await startHttpDaemonFixture({ via: 'fresh-daemon' });
+  vi.stubEnv('AGENT_DEVICE_STATE_DIR', stateDir);
+  writeDaemonLock(paths, {
+    pid: process.pid,
+    processStartTime: 'stale-start-time',
+  });
+  installSpawnedHttpDaemon(paths, daemon.port);
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'stale-lock-smoke',
+      positionals: [],
+      flags: { stateDir, daemonTransport: 'http' },
+      meta: { requestId: 'req-stale-lock' },
+    });
+
+    const freshLock = JSON.parse(fs.readFileSync(paths.lockPath, 'utf8')) as {
+      pid?: number;
+      processStartTime?: string;
+    };
+    assert.deepEqual(response, { ok: true, data: { via: 'fresh-daemon' } });
+    assert.equal(mockRunCmdDetached.mock.calls.length, 1);
+    assert.equal(freshLock.pid, process.pid);
+    assert.notEqual(freshLock.processStartTime, 'stale-start-time');
+    assert.deepEqual(daemon.seenPaths, ['GET /health', 'POST /rpc']);
+  } finally {
+    await closeLoopbackServer(daemon.server);
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('sendToDaemon does not reuse reachable daemon metadata with mismatched version or signature', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  const cases: Array<{
+    name: string;
+    version?: string;
+    codeSignature?: string;
+  }> = [
+    { name: 'version', version: '0.0.0-mismatch' },
+    { name: 'code-signature', codeSignature: 'mismatched-signature' },
+  ];
+
+  for (const fixture of cases) {
+    const stateDir = makeTempStateDir(`agent-device-daemon-${fixture.name}-mismatch-`);
+    const paths = resolveDaemonPaths(stateDir);
+    const staleDaemon = await startHttpDaemonFixture({ via: 'stale-daemon' });
+    const freshDaemon = await startHttpDaemonFixture({ via: 'fresh-daemon' });
+    vi.stubEnv('AGENT_DEVICE_STATE_DIR', stateDir);
+    mockRunCmdDetached.mockReset();
+    installSpawnedHttpDaemon(paths, freshDaemon.port);
+    writeDaemonInfo(paths, {
+      httpPort: staleDaemon.port,
+      transport: 'http',
+      pid: 999_999,
+      ...(fixture.version ? { version: fixture.version } : {}),
+      ...(fixture.codeSignature ? { codeSignature: fixture.codeSignature } : {}),
+    });
+
+    try {
+      const response = await sendToDaemon({
+        session: 'default',
+        command: `mismatch-${fixture.name}-smoke`,
+        positionals: [],
+        flags: { stateDir, daemonTransport: 'http' },
+        meta: { requestId: `req-mismatch-${fixture.name}` },
+      });
+
+      assert.deepEqual(response, { ok: true, data: { via: 'fresh-daemon' } });
+      assert.equal(mockRunCmdDetached.mock.calls.length, 1);
+      assert.deepEqual(staleDaemon.seenPaths, ['GET /health']);
+      assert.deepEqual(freshDaemon.seenPaths, ['GET /health', 'POST /rpc']);
+    } finally {
+      await closeLoopbackServer(staleDaemon.server);
+      await closeLoopbackServer(freshDaemon.server);
+      fs.rmSync(stateDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  }
+});
+
+test('sendToDaemon falls back from failed socket transport to HTTP using daemon metadata ports', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  const stateDir = makeTempStateDir('agent-device-daemon-transport-fallback-');
+  const paths = resolveDaemonPaths(stateDir);
+  const daemon = await startHttpDaemonFixture({ via: 'http-fallback' });
+  const socketFailures = mockSocketConnectionFailures(65_530);
+  vi.stubEnv('AGENT_DEVICE_STATE_DIR', stateDir);
+  writeDaemonInfo(paths, {
+    port: 65_530,
+    httpPort: daemon.port,
+    transport: 'dual',
+  });
+
+  try {
+    const response = await sendToDaemon({
+      session: 'default',
+      command: 'transport-fallback-smoke',
+      positionals: [],
+      flags: { stateDir },
+      meta: { requestId: 'req-transport-fallback' },
+    });
+
+    assert.deepEqual(response, { ok: true, data: { via: 'http-fallback' } });
+    assert.deepEqual(socketFailures.ports, [65_530, 65_530]);
+    assert.deepEqual(daemon.seenPaths, ['GET /health', 'POST /rpc']);
+    assert.equal(daemon.rpcRequests[0]?.params?.command, 'transport-fallback-smoke');
+  } finally {
+    socketFailures.restore();
+    await closeLoopbackServer(daemon.server);
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('sendToDaemon does not replay over HTTP after the socket request is written', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+
+  const stateDir = makeTempStateDir('agent-device-daemon-transport-written-');
+  const paths = resolveDaemonPaths(stateDir);
+  const daemon = await startHttpDaemonFixture({ via: 'unexpected-http-replay' });
+  const socket = mockSocketErrorAfterWrite(65_531);
+  vi.stubEnv('AGENT_DEVICE_STATE_DIR', stateDir);
+  writeDaemonInfo(paths, {
+    port: 65_531,
+    httpPort: daemon.port,
+    transport: 'dual',
+  });
+
+  try {
+    let thrown: unknown;
+    try {
+      await sendToDaemon({
+        session: 'default',
+        command: 'open',
+        positionals: ['Demo'],
+        flags: { stateDir },
+        meta: { requestId: 'req-transport-written' },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    assert.ok(thrown instanceof AppError);
+    assert.equal(thrown.message, 'Failed to communicate with daemon');
+    assert.equal(thrown.details?.daemonSocketRequestWritten, true);
+    assert.deepEqual(socket.ports, [65_531, 65_531]);
+    assert.equal(socket.writes.length, 1);
+    assert.deepEqual(daemon.seenPaths, []);
+  } finally {
+    socket.restore();
+    await closeLoopbackServer(daemon.server);
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds Milestone 0 daemon-client lifecycle characterization coverage for spawn retry cleanup, stale lock recovery, version/signature mismatch takeover, and socket-to-HTTP fallback from daemon metadata.

Also narrows auto transport behavior so local dual-transport daemon metadata can fall back to the alternate port after a connection-level request failure.

Closes #723

Touched files: 2

## Validation

Focused daemon-client lifecycle and existing daemon-client unit tests pass. Lint and TypeScript pass via check:quick.

Known gap: pnpm check:unit was attempted but the broad suite hit sandbox/toolchain failures unrelated to this patch, including listen EPERM on local HTTP tests and Swift script typecheck failures.