### PR TITLE
test: cover artifact transfer characterization

### DIFF
--- a/src/__tests__/upload-client.test.ts
+++ b/src/__tests__/upload-client.test.ts
@@ -304,6 +304,73 @@ test('uploadArtifact fails cleanly on the sixth upload redirect', async () => {
   }
 });
 
+test('uploadArtifact falls back to legacy upload when direct upload exceeds redirect limit', async () => {
+  const content = 'direct-upload-redirect-limit-fallback';
+  const artifactPath = createTempFile('app.apk', content);
+  const requests: string[] = [];
+
+  const server = await startServer(async (req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    if (req.method === 'POST' && req.url === '/upload/preflight') {
+      await readRequestBody(req);
+      sendJson(res, {
+        ok: true,
+        cacheHit: false,
+        uploadId: 'direct-redirect-ticket',
+        upload: {
+          url: `${server.baseUrl}/direct-redirect-1`,
+          headers: {
+            'x-signed-ticket': 'redirect-ticket-header',
+          },
+        },
+      });
+      return;
+    }
+    const redirectMatch = req.url?.match(/^\/direct-redirect-(\d+)$/);
+    if (req.method === 'PUT' && redirectMatch) {
+      const redirectIndex = Number(redirectMatch[1]);
+      await readRequestBody(req);
+      res.statusCode = 307;
+      res.setHeader('location', `/direct-redirect-${redirectIndex + 1}`);
+      res.end();
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/upload') {
+      assert.equal((await readRequestBody(req)).toString('utf8'), content);
+      sendJson(res, { ok: true, uploadId: 'legacy-after-direct-redirect-limit' });
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/upload/finalize') {
+      res.statusCode = 500;
+      res.end('direct upload should not finalize after redirect-limit fallback');
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  try {
+    const uploadId = await uploadArtifact({
+      localPath: artifactPath,
+      baseUrl: server.baseUrl,
+      token: TEST_TOKEN,
+    });
+    assert.equal(uploadId, 'legacy-after-direct-redirect-limit');
+    assert.deepEqual(requests, [
+      'POST /upload/preflight',
+      'PUT /direct-redirect-1',
+      'PUT /direct-redirect-2',
+      'PUT /direct-redirect-3',
+      'PUT /direct-redirect-4',
+      'PUT /direct-redirect-5',
+      'PUT /direct-redirect-6',
+      'POST /upload',
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
 test('uploadArtifact uses direct upload ticket and finalize flow', async () => {
   const content = 'direct-upload-apk';
   const artifactPath = createTempFile('app.apk', content);
@@ -378,6 +445,85 @@ test('uploadArtifact uses direct upload ticket and finalize flow', async () => {
     await server.close();
   }
 });
+
+test.each([
+  {
+    name: 'x-upload-offset',
+    writeResumeHeaders: (res: ServerResponse, payloadSize: number) => {
+      res.setHeader('x-upload-offset', String(payloadSize));
+    },
+  },
+  {
+    name: 'range',
+    writeResumeHeaders: (res: ServerResponse, payloadSize: number) => {
+      res.setHeader('range', `bytes=0-${payloadSize - 1}`);
+    },
+  },
+])(
+  'uploadArtifact finalizes when direct upload reports the full payload size with $name',
+  async ({ writeResumeHeaders }) => {
+    const content = 'direct-upload-already-complete';
+    const artifactPath = createTempFile('app.apk', content);
+    const payloadSize = Buffer.byteLength(content);
+    const requests: string[] = [];
+    let uploadAttempts = 0;
+
+    const server = await startServer(async (req, res) => {
+      requests.push(`${req.method} ${req.url}`);
+      if (req.method === 'POST' && req.url === '/upload/preflight') {
+        await readRequestBody(req);
+        sendJson(res, {
+          ok: true,
+          cacheHit: false,
+          uploadId: 'complete-resume-ticket',
+          upload: {
+            url: `${server.baseUrl}/already-complete-upload`,
+            headers: {
+              'x-signed-ticket': 'complete-ticket-header',
+            },
+          },
+        });
+        return;
+      }
+      if (req.method === 'PUT' && req.url === '/already-complete-upload') {
+        uploadAttempts += 1;
+        assert.equal(req.headers['content-range'], undefined);
+        assert.equal((await readRequestBody(req)).toString('utf8'), content);
+        res.statusCode = 308;
+        writeResumeHeaders(res, payloadSize);
+        res.end();
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/upload/finalize') {
+        const body = JSON.parse((await readRequestBody(req)).toString('utf8')) as {
+          uploadId: string;
+        };
+        assert.equal(body.uploadId, 'complete-resume-ticket');
+        sendJson(res, { ok: true, uploadId: 'upload-already-complete' });
+        return;
+      }
+      res.statusCode = 404;
+      res.end('not found');
+    });
+
+    try {
+      const uploadId = await uploadArtifact({
+        localPath: artifactPath,
+        baseUrl: server.baseUrl,
+        token: TEST_TOKEN,
+      });
+      assert.equal(uploadId, 'upload-already-complete');
+      assert.equal(uploadAttempts, 1);
+      assert.deepEqual(requests, [
+        'POST /upload/preflight',
+        'PUT /already-complete-upload',
+        'POST /upload/finalize',
+      ]);
+    } finally {
+      await server.close();
+    }
+  },
+);
 
 test('uploadArtifact resumes a direct upload from the server-reported offset', async () => {
   const content = 'direct-upload-resume-payload';

--- a/src/__tests__/upload-client.test.ts
+++ b/src/__tests__/upload-client.test.ts
@@ -188,6 +188,122 @@ test('uploadArtifact falls back to upload when preflight fails', async () => {
   }
 });
 
+test('uploadArtifact follows up to five upload redirects', async () => {
+  const content = 'redirected-upload-payload';
+  const artifactPath = createTempFile('app.apk', content);
+  const requests: string[] = [];
+
+  const server = await startServer(async (req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    if (req.method === 'POST' && req.url === '/upload/preflight') {
+      await readRequestBody(req);
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/upload') {
+      await readRequestBody(req);
+      res.statusCode = 307;
+      res.setHeader('location', '/upload-redirect-1');
+      res.end();
+      return;
+    }
+    const redirectMatch = req.url?.match(/^\/upload-redirect-(\d+)$/);
+    if (req.method === 'POST' && redirectMatch) {
+      const redirectIndex = Number(redirectMatch[1]);
+      const body = (await readRequestBody(req)).toString('utf8');
+      assert.equal(body, content);
+      if (redirectIndex < 5) {
+        res.statusCode = 307;
+        res.setHeader('location', `/upload-redirect-${redirectIndex + 1}`);
+        res.end();
+        return;
+      }
+      sendJson(res, { ok: true, uploadId: 'upload-after-redirects' });
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  try {
+    const uploadId = await uploadArtifact({
+      localPath: artifactPath,
+      baseUrl: server.baseUrl,
+      token: TEST_TOKEN,
+    });
+    assert.equal(uploadId, 'upload-after-redirects');
+    assert.deepEqual(requests, [
+      'POST /upload/preflight',
+      'POST /upload',
+      'POST /upload-redirect-1',
+      'POST /upload-redirect-2',
+      'POST /upload-redirect-3',
+      'POST /upload-redirect-4',
+      'POST /upload-redirect-5',
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test('uploadArtifact fails cleanly on the sixth upload redirect', async () => {
+  const content = 'too-many-redirects-upload-payload';
+  const artifactPath = createTempFile('app.apk', content);
+  const requests: string[] = [];
+
+  const server = await startServer(async (req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    if (req.method === 'POST' && req.url === '/upload/preflight') {
+      await readRequestBody(req);
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/upload') {
+      await readRequestBody(req);
+      res.statusCode = 307;
+      res.setHeader('location', '/upload-redirect-1');
+      res.end();
+      return;
+    }
+    const redirectMatch = req.url?.match(/^\/upload-redirect-(\d+)$/);
+    if (req.method === 'POST' && redirectMatch) {
+      const redirectIndex = Number(redirectMatch[1]);
+      await readRequestBody(req);
+      res.statusCode = 307;
+      res.setHeader('location', `/upload-redirect-${redirectIndex + 1}`);
+      res.end();
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  try {
+    await assert.rejects(
+      async () =>
+        await uploadArtifact({
+          localPath: artifactPath,
+          baseUrl: server.baseUrl,
+          token: TEST_TOKEN,
+        }),
+      /redirect limit/i,
+    );
+    assert.deepEqual(requests, [
+      'POST /upload/preflight',
+      'POST /upload',
+      'POST /upload-redirect-1',
+      'POST /upload-redirect-2',
+      'POST /upload-redirect-3',
+      'POST /upload-redirect-4',
+      'POST /upload-redirect-5',
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
 test('uploadArtifact uses direct upload ticket and finalize flow', async () => {
   const content = 'direct-upload-apk';
   const artifactPath = createTempFile('app.apk', content);
@@ -256,6 +372,88 @@ test('uploadArtifact uses direct upload ticket and finalize flow', async () => {
     assert.deepEqual(requests, [
       'POST /upload/preflight',
       'PUT /signed-upload',
+      'POST /upload/finalize',
+    ]);
+  } finally {
+    await server.close();
+  }
+});
+
+test('uploadArtifact resumes a direct upload from the server-reported offset', async () => {
+  const content = 'direct-upload-resume-payload';
+  const artifactPath = createTempFile('app.apk', content);
+  const resumeOffset = 7;
+  const requests: string[] = [];
+  let uploadAttempts = 0;
+  let firstUploadBody = '';
+  let resumedUploadBody = '';
+
+  const server = await startServer(async (req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    if (req.method === 'POST' && req.url === '/upload/preflight') {
+      await readRequestBody(req);
+      sendJson(res, {
+        ok: true,
+        cacheHit: false,
+        uploadId: 'resume-ticket',
+        upload: {
+          url: `${server.baseUrl}/resumable-upload`,
+          headers: {
+            'x-signed-ticket': 'resume-ticket-header',
+          },
+        },
+      });
+      return;
+    }
+    if (req.method === 'PUT' && req.url === '/resumable-upload') {
+      uploadAttempts += 1;
+      if (uploadAttempts === 1) {
+        assert.equal(req.headers['content-range'], undefined);
+        firstUploadBody = (await readRequestBody(req)).toString('utf8');
+        res.statusCode = 308;
+        res.setHeader('range', `bytes=0-${resumeOffset - 1}`);
+        res.end();
+        return;
+      }
+
+      assert.equal(
+        req.headers['content-range'],
+        `bytes ${resumeOffset}-${Buffer.byteLength(content) - 1}/${Buffer.byteLength(content)}`,
+      );
+      assert.equal(
+        req.headers['content-length'],
+        String(Buffer.byteLength(content) - resumeOffset),
+      );
+      resumedUploadBody = (await readRequestBody(req)).toString('utf8');
+      res.statusCode = 200;
+      res.end('ok');
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/upload/finalize') {
+      const body = JSON.parse((await readRequestBody(req)).toString('utf8')) as {
+        uploadId: string;
+      };
+      assert.equal(body.uploadId, 'resume-ticket');
+      sendJson(res, { ok: true, uploadId: 'upload-resumed' });
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  try {
+    const uploadId = await uploadArtifact({
+      localPath: artifactPath,
+      baseUrl: server.baseUrl,
+      token: TEST_TOKEN,
+    });
+    assert.equal(uploadId, 'upload-resumed');
+    assert.equal(firstUploadBody, content);
+    assert.equal(resumedUploadBody, content.slice(resumeOffset));
+    assert.deepEqual(requests, [
+      'POST /upload/preflight',
+      'PUT /resumable-upload',
+      'PUT /resumable-upload',
       'POST /upload/finalize',
     ]);
   } finally {

--- a/src/upload-client.ts
+++ b/src/upload-client.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import http from 'node:http';
+import http, { type IncomingHttpHeaders } from 'node:http';
 import https from 'node:https';
 import path from 'node:path';
 import os from 'node:os';
@@ -14,6 +14,7 @@ const UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const UPLOAD_PREFLIGHT_TIMEOUT_MS = 30 * 1000;
 const ARTIFACT_HASH_ALGORITHM = 'sha256';
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
+const MAX_UPLOAD_REDIRECTS = 5;
 
 type UploadArtifactOptions = {
   localPath: string;
@@ -320,9 +321,32 @@ async function streamFileToHttpRequest(options: {
   errorMessage: string;
   errorHint?: string;
 }): Promise<{ statusCode: number; statusMessage?: string; body: string }> {
+  return await streamFileToHttpRequestAttempt({
+    ...options,
+    url: options.url,
+    redirectCount: 0,
+    startOffset: 0,
+  });
+}
+
+async function streamFileToHttpRequestAttempt(options: {
+  url: URL;
+  method: 'POST' | 'PUT';
+  headers: Record<string, string>;
+  payloadPath: string;
+  timeoutMessage: string;
+  timeoutHint?: string;
+  errorMessage: string;
+  errorHint?: string;
+  redirectCount: number;
+  startOffset: number;
+}): Promise<{ statusCode: number; statusMessage?: string; body: string }> {
   const transport = options.url.protocol === 'https:' ? https : http;
+  const payloadSize = fs.statSync(options.payloadPath).size;
+  const headers = buildUploadRequestHeaders(options.headers, options.startOffset, payloadSize);
 
   return await new Promise((resolve, reject) => {
+    let responseReceived = false;
     const req = transport.request(
       {
         protocol: options.url.protocol,
@@ -330,14 +354,57 @@ async function streamFileToHttpRequest(options: {
         port: options.url.port,
         method: options.method,
         path: options.url.pathname + options.url.search,
-        headers: options.headers,
+        headers,
       },
       (res) => {
+        responseReceived = true;
         void readNodeHttpResponseBody(res)
           .then((body) => {
             clearTimeout(timeout);
+            const statusCode = res.statusCode ?? 500;
+            const location = res.headers.location;
+            if (location && isUploadRedirectStatus(statusCode)) {
+              if (options.redirectCount >= MAX_UPLOAD_REDIRECTS) {
+                reject(
+                  new AppError('COMMAND_FAILED', 'Artifact upload exceeded redirect limit', {
+                    maxRedirects: MAX_UPLOAD_REDIRECTS,
+                    url: options.url.toString(),
+                  }),
+                );
+                return;
+              }
+              const redirectedUrl = new URL(location, options.url);
+              void streamFileToHttpRequestAttempt({
+                ...options,
+                url: redirectedUrl,
+                redirectCount: options.redirectCount + 1,
+              }).then(resolve, reject);
+              return;
+            }
+
+            const resumeOffset = isUploadResumeStatus(statusCode)
+              ? parseUploadResumeOffset(res.headers, payloadSize)
+              : undefined;
+            if (resumeOffset !== undefined) {
+              if (resumeOffset <= options.startOffset) {
+                reject(
+                  new AppError('COMMAND_FAILED', 'Artifact upload resume did not advance', {
+                    offset: resumeOffset,
+                    previousOffset: options.startOffset,
+                    url: options.url.toString(),
+                  }),
+                );
+                return;
+              }
+              void streamFileToHttpRequestAttempt({
+                ...options,
+                startOffset: resumeOffset,
+              }).then(resolve, reject);
+              return;
+            }
+
             resolve({
-              statusCode: res.statusCode ?? 500,
+              statusCode,
               statusMessage: res.statusMessage,
               body,
             });
@@ -357,6 +424,7 @@ async function streamFileToHttpRequest(options: {
     }, UPLOAD_TIMEOUT_MS);
 
     req.on('error', (err) => {
+      if (responseReceived) return;
       clearTimeout(timeout);
       reject(
         new AppError(
@@ -369,12 +437,67 @@ async function streamFileToHttpRequest(options: {
     });
     req.on('close', () => clearTimeout(timeout));
 
-    void pipeline(fs.createReadStream(options.payloadPath), req).catch((err: unknown) => {
+    void pipeline(
+      fs.createReadStream(options.payloadPath, { start: options.startOffset }),
+      req,
+    ).catch((err: unknown) => {
+      if (responseReceived) return;
       req.destroy();
       const error = err instanceof Error ? err : new Error(String(err));
       reject(new AppError('COMMAND_FAILED', 'Failed to read local artifact', {}, error));
     });
   });
+}
+
+function buildUploadRequestHeaders(
+  headers: Record<string, string>,
+  startOffset: number,
+  payloadSize: number,
+): Record<string, string | number> {
+  if (startOffset <= 0) return headers;
+  return {
+    ...headers,
+    'content-length': Math.max(payloadSize - startOffset, 0),
+    'content-range': `bytes ${startOffset}-${payloadSize - 1}/${payloadSize}`,
+  };
+}
+
+function isUploadRedirectStatus(statusCode: number): boolean {
+  return [301, 302, 303, 307, 308].includes(statusCode);
+}
+
+function isUploadResumeStatus(statusCode: number): boolean {
+  return statusCode === 308;
+}
+
+function parseUploadResumeOffset(
+  headers: IncomingHttpHeaders,
+  payloadSize: number,
+): number | undefined {
+  const explicitOffset = parseNonNegativeIntegerHeader(
+    headers['x-upload-offset'] ?? headers['upload-offset'],
+  );
+  if (explicitOffset !== undefined) {
+    return Math.min(explicitOffset, payloadSize);
+  }
+
+  const range = firstHeaderValue(headers.range);
+  const match = range?.match(/^bytes=0-(\d+)$/);
+  if (!match) return undefined;
+  const endOffset = Number(match[1]);
+  if (!Number.isSafeInteger(endOffset) || endOffset < 0) return undefined;
+  return Math.min(endOffset + 1, payloadSize);
+}
+
+function parseNonNegativeIntegerHeader(value: string | string[] | undefined): number | undefined {
+  const raw = firstHeaderValue(value);
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
 }
 
 async function finalizeDirectUpload(options: {

--- a/src/upload-client.ts
+++ b/src/upload-client.ts
@@ -386,6 +386,14 @@ async function streamFileToHttpRequestAttempt(options: {
               ? parseUploadResumeOffset(res.headers, payloadSize)
               : undefined;
             if (resumeOffset !== undefined) {
+              if (resumeOffset >= payloadSize) {
+                resolve({
+                  statusCode: 200,
+                  statusMessage: 'Upload already complete',
+                  body: '',
+                });
+                return;
+              }
               if (resumeOffset <= options.startOffset) {
                 reject(
                   new AppError('COMMAND_FAILED', 'Artifact upload resume did not advance', {

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -1225,10 +1225,14 @@ test('downloadRemoteArtifact times out stalled artifact responses and removes pa
   }
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-remote-artifact-timeout-'));
   const destinationPath = path.join(tempRoot, 'artifacts', 'screen.png');
-  const server = http.createServer((req, _res) => {
+  const server = http.createServer((req, res) => {
     if (req.url?.includes('/artifacts/')) {
+      res.statusCode = 200;
+      res.write('partial-png');
       return;
     }
+    res.statusCode = 404;
+    res.end('not found');
   });
   const port = await listenOnLoopback(server);
 
@@ -1246,6 +1250,50 @@ test('downloadRemoteArtifact times out stalled artifact responses and removes pa
       (error: unknown) => {
         assert.equal(error instanceof Error, true);
         assert.match(String((error as Error).message), /timed out/i);
+        return true;
+      },
+    );
+    assert.equal(fs.existsSync(destinationPath), false);
+  } finally {
+    await closeLoopbackServer(server);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('downloadRemoteArtifact removes partial files after mid-stream aborts', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-remote-artifact-abort-'));
+  const destinationPath = path.join(tempRoot, 'artifacts', 'screen.png');
+  const server = http.createServer((req, res) => {
+    if (req.url?.includes('/artifacts/')) {
+      res.statusCode = 200;
+      res.flushHeaders();
+      res.write('partial-png');
+      setImmediate(() => res.destroy(new Error('server aborted artifact stream')));
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+  const port = await listenOnLoopback(server);
+
+  try {
+    await assert.rejects(
+      async () =>
+        await downloadRemoteArtifact({
+          baseUrl: `http://127.0.0.1:${port}/agent-device`,
+          token: 'remote-secret',
+          artifactId: 'artifact-abort',
+          destinationPath,
+          requestId: 'req-remote-artifact-abort',
+          timeoutMs: 1_000,
+        }),
+      (error: unknown) => {
+        assert.equal(error instanceof Error, true);
+        assert.match(String((error as Error).message), /aborted|interrupted|premature|socket/i);
         return true;
       },
     );


### PR DESCRIPTION
## Summary

Add local HTTP characterization coverage for artifact upload resume/redirect behavior and remote artifact download abort/timeout cleanup.

Closes #724

Touched files: 3

## Validation

Ran `pnpm format`, focused artifact transfer unit tests, and `pnpm check:quick`. The focused tests passed against loopback stub HTTP servers outside the sandbox.
