### PR TITLE
docs: document issue label workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,11 @@ Minimal operating guide for AI coding agents in this repo.
 
 ### Issue tracker
 
-Issues and PRDs live in GitHub Issues for `callstackincubator/agent-device`. See `docs/agents/issue-tracker.md`.
+Issues and PRDs live in GitHub Issues for `callstack/agent-device`. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
-Use the default Matt Pocock skills triage vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+Follow the issue label workflow in `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,11 @@ Use `pnpm test-app:maestro:android` for Android, passing the same extra
 - Add/adjust integration tests when introducing new commands.
 - Prefer built-in Node APIs over new packages.
 
+## Issue Labels
+
+Issue labels describe workflow state, not who will do the work. See
+`docs/agents/triage-labels.md` for the label meanings and state flow.
+
 ## Reporting issues
 
 Please include:

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue Tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues in `callstackincubator/agent-device`. Use the `gh` CLI for issue operations.
+Issues and PRDs for this repo live as GitHub issues in `callstack/agent-device`. Use the `gh` CLI for issue operations.
 
 ## Conventions
 
@@ -10,5 +10,7 @@ Issues and PRDs for this repo live as GitHub issues in `callstackincubator/agent
 - Comment with `gh issue comment <number> --body "..."`.
 - Apply or remove labels with `gh issue edit <number> --add-label "..."` or `--remove-label "..."`.
 - Close with `gh issue close <number> --comment "..."`.
+
+For label meanings and state flow, see `docs/agents/triage-labels.md`.
 
 When a skill says "publish to the issue tracker", create a GitHub issue.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,13 +1,20 @@
-# Triage Labels
+# Issue Label Workflow
 
-The skills use five canonical triage roles. This repo currently maps them directly to label strings.
+This repo uses labels for issue state, not executor type.
 
-| Skills role | GitHub label | Meaning |
-| --- | --- | --- |
-| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
-| `needs-info` | `needs-info` | Waiting on reporter for more information |
-| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
-| `ready-for-human` | `ready-for-human` | Requires human implementation |
-| `wontfix` | `wontfix` | Will not be actioned |
+| GitHub label | Meaning |
+| --- | --- |
+| `needs-triage` | New or unreviewed issue; maintainer needs to evaluate it |
+| `in-progress` | Someone has started work on the issue |
+| `needs-info` | Waiting on reporter or external input |
+| `wontfix` | Will not be actioned after an explicit maintainer decision |
 
-When a skill mentions a role, use the corresponding GitHub label from this table.
+Default flow:
+
+1. New issues get `needs-triage`.
+2. Remove `needs-triage` once the issue is understood and valid.
+3. Add `in-progress` and assign the active owner when work starts.
+4. Leave a triaged, unassigned issue without a state label when it is available work.
+5. Remove `in-progress` when the issue closes or the work is abandoned.
+
+Do not use `ready-for-agent`, `ready-for-human`, or other executor-specific labels.


### PR DESCRIPTION
## Summary

Document the simplified issue-label workflow for contributors and agents: new issues start with needs-triage, active work uses in-progress, and executor-specific labels like ready-for-agent are not used.

Align the agent issue-tracker docs with the callstack/agent-device repository location.

Touched-file count: 4.

## Validation

git diff --check passed. Docs-only change; no tests required.