### PR TITLE
refactor(types): deepen type consolidation

### DIFF
--- a/src/cli/auth-session.ts
+++ b/src/cli/auth-session.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { runCmd } from '../utils/exec.ts';
 import { AppError } from '../utils/errors.ts';
 import type { CliFlags } from '../utils/cli-flags.ts';
+import type { EnvMap } from '../utils/env-map.ts';
 
 const DEFAULT_CLOUD_BASE_URL = 'https://cloud.agent-device.dev';
 const DEVICE_AUTH_START_PATH = '/api/control-plane/device-auth/start';
@@ -30,8 +31,6 @@ export type RemoteAuthResolution = {
   flags: CliFlags;
   source: 'flag' | 'env' | 'cli-session' | 'login' | 'none';
 };
-
-type EnvMap = Record<string, string | undefined>;
 
 type DeviceAuthStartResponse = {
   deviceCode: string;

--- a/src/cli/auth-session.ts
+++ b/src/cli/auth-session.ts
@@ -4,6 +4,7 @@ import { runCmd } from '../utils/exec.ts';
 import { AppError } from '../utils/errors.ts';
 import type { CliFlags } from '../utils/cli-flags.ts';
 import type { EnvMap } from '../utils/env-map.ts';
+import { readCloudJsonResponse } from './cloud-response.ts';
 
 const DEFAULT_CLOUD_BASE_URL = 'https://cloud.agent-device.dev';
 const DEVICE_AUTH_START_PATH = '/api/control-plane/device-auth/start';
@@ -454,27 +455,10 @@ async function postJson<T>(options: {
     body: JSON.stringify(options.body),
     signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
   });
-  const text = await response.text();
-  let parsed: unknown = {};
-  if (text.trim().length > 0) {
-    try {
-      parsed = JSON.parse(text);
-    } catch (error) {
-      throw new AppError(
-        'COMMAND_FAILED',
-        `Cloud auth endpoint returned invalid JSON (${response.status}).`,
-        { status: response.status },
-        error instanceof Error ? error : undefined,
-      );
-    }
-  }
-  if (!response.ok) {
-    throw new AppError('UNAUTHORIZED', `Cloud auth endpoint rejected the request.`, {
-      status: response.status,
-      response: parsed,
-    });
-  }
-  return parsed as T;
+  return await readCloudJsonResponse<T>(response, {
+    invalidJsonMessage: `Cloud auth endpoint returned invalid JSON (${response.status}).`,
+    rejectedMessage: 'Cloud auth endpoint rejected the request.',
+  });
 }
 
 function assertDeviceAuthStart(response: DeviceAuthStartResponse): void {

--- a/src/cli/cloud-connection-profile.ts
+++ b/src/cli/cloud-connection-profile.ts
@@ -6,6 +6,7 @@ import type { RemoteConfigProfile, ResolvedRemoteConfigProfile } from '../remote
 import { profileToCliFlags } from '../utils/remote-config.ts';
 import { AppError, asAppError } from '../utils/errors.ts';
 import type { CliFlags } from '../utils/cli-flags.ts';
+import type { EnvMap } from '../utils/env-map.ts';
 import { resolveCloudAccessForConnect } from './auth-session.ts';
 
 const CONNECTION_PROFILE_PATH = '/api/control-plane/connection-profile';
@@ -16,8 +17,6 @@ type CloudConnectionProfileResponse = {
     remoteConfigProfile?: unknown;
   };
 };
-
-type EnvMap = Record<string, string | undefined>;
 
 export async function resolveCloudConnectProfile(options: {
   flags: CliFlags;

--- a/src/cli/cloud-connection-profile.ts
+++ b/src/cli/cloud-connection-profile.ts
@@ -8,6 +8,7 @@ import { AppError, asAppError } from '../utils/errors.ts';
 import type { CliFlags } from '../utils/cli-flags.ts';
 import type { EnvMap } from '../utils/env-map.ts';
 import { resolveCloudAccessForConnect } from './auth-session.ts';
+import { readCloudJsonResponse } from './cloud-response.ts';
 
 const CONNECTION_PROFILE_PATH = '/api/control-plane/connection-profile';
 const HTTP_TIMEOUT_MS = 15_000;
@@ -70,26 +71,10 @@ async function fetchConnectionProfile(options: {
     headers: { authorization: `Bearer ${options.accessToken}` },
     signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
   });
-  const text = await response.text();
-  let parsed: unknown = {};
-  if (text.trim()) {
-    try {
-      parsed = JSON.parse(text);
-    } catch (error) {
-      throw new AppError(
-        'COMMAND_FAILED',
-        `Cloud connection profile endpoint returned invalid JSON (${response.status}).`,
-        { status: response.status },
-        error instanceof Error ? error : undefined,
-      );
-    }
-  }
-  if (!response.ok) {
-    throw new AppError('UNAUTHORIZED', 'Cloud connection profile endpoint rejected the request.', {
-      status: response.status,
-      response: parsed,
-    });
-  }
+  const parsed = await readCloudJsonResponse<unknown>(response, {
+    invalidJsonMessage: `Cloud connection profile endpoint returned invalid JSON (${response.status}).`,
+    rejectedMessage: 'Cloud connection profile endpoint rejected the request.',
+  });
   return parseConnectionProfile(parsed);
 }
 

--- a/src/cli/cloud-response.ts
+++ b/src/cli/cloud-response.ts
@@ -1,0 +1,31 @@
+import { AppError } from '../utils/errors.ts';
+
+export async function readCloudJsonResponse<T>(
+  response: Response,
+  options: {
+    invalidJsonMessage: string;
+    rejectedMessage: string;
+  },
+): Promise<T> {
+  const text = await response.text();
+  let parsed: unknown = {};
+  if (text.trim().length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch (error) {
+      throw new AppError(
+        'COMMAND_FAILED',
+        options.invalidJsonMessage,
+        { status: response.status },
+        error instanceof Error ? error : undefined,
+      );
+    }
+  }
+  if (!response.ok) {
+    throw new AppError('UNAUTHORIZED', options.rejectedMessage, {
+      status: response.status,
+      response: parsed,
+    });
+  }
+  return parsed as T;
+}

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -12,6 +12,7 @@ import { successText } from '../utils/success-text.ts';
 import {
   toBackendResult,
   type BackendResultEnvelope,
+  type BackendResultVariant,
   type RuntimeCommand,
 } from './runtime-types.ts';
 import { resolveCommandInput } from './io-policy.ts';
@@ -40,12 +41,10 @@ export type AdminShutdownCommandOptions = CommandContext & {
   target?: BackendDeviceTarget;
 };
 
-export type AdminShutdownCommandResult = {
+export type AdminShutdownCommandResult = BackendResultVariant<{
   kind: 'deviceShutdown';
   target?: BackendDeviceTarget;
-  backendResult?: Record<string, unknown>;
-  message?: string;
-};
+}>;
 
 export type AdminInstallCommandOptions = CommandContext & {
   app: string;

--- a/src/commands/cli-grammar/observability.ts
+++ b/src/commands/cli-grammar/observability.ts
@@ -6,8 +6,9 @@ import type {
   RecordOptions,
 } from '../../client-types.ts';
 import { AppError } from '../../utils/errors.ts';
-import type { NetworkIncludeMode } from '../../contracts.ts';
-import type { LogAction } from '../log-command-contract.ts';
+import { NETWORK_INCLUDE_MODES, type NetworkIncludeMode } from '../../contracts.ts';
+import { parseStringMember } from '../../utils/string-enum.ts';
+import { LOG_ACTION_VALUES, type LogAction } from '../log-command-contract.ts';
 import {
   isPerfAction,
   isPerfArea,
@@ -123,17 +124,9 @@ function readPerfAction(
 
 function readLogsAction(value: string | undefined): LogAction | undefined {
   if (value === undefined) return undefined;
-  if (
-    value === 'path' ||
-    value === 'start' ||
-    value === 'stop' ||
-    value === 'doctor' ||
-    value === 'mark' ||
-    value === 'clear'
-  ) {
-    return value;
-  }
-  throw new AppError('INVALID_ARGS', 'logs requires path, start, stop, doctor, mark, or clear');
+  return parseStringMember(LOG_ACTION_VALUES, value, {
+    message: 'logs requires path, start, stop, doctor, mark, or clear',
+  });
 }
 
 function readNetworkAction(value: string | undefined): 'dump' | 'log' | undefined {
@@ -144,7 +137,7 @@ function readNetworkAction(value: string | undefined): 'dump' | 'log' | undefine
 
 function readNetworkInclude(value: string | undefined): NetworkIncludeMode | undefined {
   if (value === undefined) return undefined;
-  if (value === 'summary' || value === 'headers' || value === 'body' || value === 'all')
-    return value;
-  throw new AppError('INVALID_ARGS', 'network include mode must be summary, headers, body, or all');
+  return parseStringMember(NETWORK_INCLUDE_MODES, value, {
+    message: 'network include mode must be summary, headers, body, or all',
+  });
 }

--- a/src/commands/client-command-contracts.ts
+++ b/src/commands/client-command-contracts.ts
@@ -12,8 +12,7 @@ import type {
 import { defineExecutableCommand } from './command-contract.ts';
 import { optionalEnum } from './command-input.ts';
 import { clientCommandMetadata } from './client-command-metadata.ts';
-
-const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector'] as const;
+import { WAIT_KIND_VALUES } from './wait-command-contract.ts';
 
 type ClientCommandMetadata = (typeof clientCommandMetadata)[number];
 type ClientCommandName = ClientCommandMetadata['name'];

--- a/src/commands/client-command-metadata.ts
+++ b/src/commands/client-command-metadata.ts
@@ -1,5 +1,5 @@
 import type { MetroPrepareOptions, RecordOptions } from '../client-types.ts';
-import type { DaemonInstallSource } from '../contracts.ts';
+import { NETWORK_INCLUDE_MODES, type DaemonInstallSource } from '../contracts.ts';
 import { ALERT_ACTIONS } from '../alert-contract.ts';
 import { BACK_MODES } from '../core/back-mode.ts';
 import { DEVICE_ROTATIONS } from '../core/device-rotation.ts';
@@ -24,11 +24,10 @@ import {
 } from './command-input.ts';
 import { defineFieldCommandMetadata } from './field-command-contract.ts';
 import { PERF_ACTION_VALUES, PERF_AREA_VALUES } from './perf-command-contract.ts';
+import { WAIT_KIND_VALUES } from './wait-command-contract.ts';
 
-const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector'] as const;
 const CLIPBOARD_ACTION_VALUES = ['read', 'write'] as const;
 const NETWORK_ACTION_VALUES = ['dump', 'log'] as const;
-const NETWORK_INCLUDE_VALUES = ['summary', 'headers', 'body', 'all'] as const;
 const START_STOP_VALUES = ['start', 'stop'] as const;
 const REACT_NATIVE_ACTION_VALUES = ['dismiss-overlay'] as const;
 const METRO_ACTION_VALUES = ['prepare', 'reload'] as const;
@@ -189,7 +188,7 @@ export const clientCommandMetadata = [
   defineClientCommandMetadata('network', {
     action: enumField(NETWORK_ACTION_VALUES),
     limit: integerField(),
-    include: enumField(NETWORK_INCLUDE_VALUES),
+    include: enumField(NETWORK_INCLUDE_MODES),
   }),
   defineClientCommandMetadata('record', {
     action: requiredField(enumField(START_STOP_VALUES)),

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -4,16 +4,14 @@ import type {
   ElementTarget,
   InteractionTarget,
 } from '../client-types.ts';
-import { DEVICE_TARGETS, type DeviceTarget, type PlatformSelector } from '../utils/device.ts';
+import {
+  DEVICE_TARGETS,
+  PLATFORM_SELECTORS,
+  type DeviceTarget,
+  type PlatformSelector,
+} from '../utils/device.ts';
 import type { JsonSchema } from './command-contract.ts';
 
-const PLATFORM_VALUES = [
-  'ios',
-  'android',
-  'macos',
-  'linux',
-  'apple',
-] as const satisfies readonly PlatformSelector[];
 const INTERACTION_TARGET_KINDS = ['ref', 'selector', 'point'] as const;
 
 export type CommonCommandInput = Pick<
@@ -279,7 +277,7 @@ export function readCommonInput(
 ): CommonCommandInput {
   return {
     session: optionalString(record, 'session'),
-    platform: optionalEnum(record, 'platform', PLATFORM_VALUES),
+    platform: optionalEnum(record, 'platform', PLATFORM_SELECTORS),
     deviceTarget: readDeviceTarget(record, options),
     device: optionalString(record, 'device'),
     udid: optionalString(record, 'udid'),
@@ -564,7 +562,7 @@ function commonProperties(): Record<string, JsonSchema> {
     session: { type: 'string', description: 'Agent-device session name.' },
     platform: {
       type: 'string',
-      enum: PLATFORM_VALUES,
+      enum: PLATFORM_SELECTORS,
       description: 'Platform selector used to resolve a device.',
     },
     deviceTarget: {

--- a/src/commands/interaction-command-metadata.ts
+++ b/src/commands/interaction-command-metadata.ts
@@ -36,6 +36,7 @@ import {
   type SwipePreset,
 } from '../core/scroll-gesture.ts';
 import { SCROLL_INPUT_DIRECTIONS } from './interaction-gestures.ts';
+import { FIND_LOCATORS } from '../utils/finders.ts';
 
 const FIND_ACTION_VALUES = [
   'click',
@@ -47,7 +48,6 @@ const FIND_ACTION_VALUES = [
   'fill',
   'type',
 ] as const;
-const FIND_LOCATOR_VALUES = ['any', 'text', 'label', 'value', 'role', 'id'] as const;
 
 const clickFields = {
   target: requiredField(interactionTargetField()),
@@ -116,7 +116,7 @@ const isFields = {
 };
 
 const findFields = {
-  locator: enumField(FIND_LOCATOR_VALUES),
+  locator: enumField(FIND_LOCATORS),
   query: requiredField(stringField()),
   action: enumField(FIND_ACTION_VALUES),
   value: stringField(),

--- a/src/commands/interaction-gestures.ts
+++ b/src/commands/interaction-gestures.ts
@@ -23,6 +23,7 @@ import {
 import {
   toBackendResult,
   type BackendResultEnvelope,
+  type BackendResultVariant,
   type RuntimeCommand,
 } from './runtime-types.ts';
 import {
@@ -67,25 +68,23 @@ export type ScrollCommandOptions = CommandContext & {
 };
 
 export type ScrollCommandResult =
-  | {
+  | BackendResultVariant<{
       kind: 'viewport';
       direction: GestureDirection;
       edge?: 'top' | 'bottom';
       passes?: number;
       amount?: number;
       pixels?: number;
-      backendResult?: Record<string, unknown>;
-      message?: string;
-    }
-  | (ResolvedInteractionTarget & {
-      direction: GestureDirection;
-      edge?: 'top' | 'bottom';
-      passes?: number;
-      amount?: number;
-      pixels?: number;
-      backendResult?: Record<string, unknown>;
-      message?: string;
-    });
+    }>
+  | BackendResultVariant<
+      ResolvedInteractionTarget & {
+        direction: GestureDirection;
+        edge?: 'top' | 'bottom';
+        passes?: number;
+        amount?: number;
+        pixels?: number;
+      }
+    >;
 
 type ResolvedScrollTarget = { kind: 'viewport' } | ResolvedInteractionTarget;
 

--- a/src/commands/interactions.ts
+++ b/src/commands/interactions.ts
@@ -10,6 +10,7 @@ import { toBackendContext } from './selector-read-utils.ts';
 import {
   toBackendResult,
   type BackendResultEnvelope,
+  type BackendResultVariant,
   type RuntimeCommand,
 } from './runtime-types.ts';
 import type { RepeatedInput } from './command-input.ts';
@@ -55,9 +56,7 @@ export type PressCommandOptions = CommandContext &
 
 export type ClickCommandOptions = PressCommandOptions;
 
-export type PressCommandResult = ResolvedInteractionTarget & {
-  backendResult?: Record<string, unknown>;
-};
+export type PressCommandResult = BackendResultVariant<ResolvedInteractionTarget>;
 
 export type FillCommandOptions = CommandContext & {
   target: InteractionTarget;
@@ -65,11 +64,12 @@ export type FillCommandOptions = CommandContext & {
   delayMs?: number;
 };
 
-export type FillCommandResult = ResolvedInteractionTarget & {
-  text: string;
-  warning?: string;
-  backendResult?: Record<string, unknown>;
-};
+export type FillCommandResult = BackendResultVariant<
+  ResolvedInteractionTarget & {
+    text: string;
+    warning?: string;
+  }
+>;
 
 export type TypeTextCommandOptions = CommandContext & {
   text: string;

--- a/src/commands/perf-command-contract.ts
+++ b/src/commands/perf-command-contract.ts
@@ -1,7 +1,9 @@
-import { isStringMember } from '../utils/string-enum.ts';
+import { defineStringEnum } from '../utils/string-enum.ts';
 
 export const PERF_AREA_VALUES = ['metrics', 'frames'] as const;
 export const PERF_ACTION_VALUES = ['sample'] as const;
+const PERF_AREAS = defineStringEnum(PERF_AREA_VALUES);
+const PERF_ACTIONS = defineStringEnum(PERF_ACTION_VALUES);
 
 export type PerfArea = (typeof PERF_AREA_VALUES)[number];
 export type PerfAction = (typeof PERF_ACTION_VALUES)[number];
@@ -9,10 +11,6 @@ export type PerfAction = (typeof PERF_ACTION_VALUES)[number];
 export const PERF_AREA_ERROR_MESSAGE = 'perf area must be metrics or frames';
 export const PERF_ACTION_ERROR_MESSAGE = 'perf action must be sample';
 
-export function isPerfArea(value: string): value is PerfArea {
-  return isStringMember(PERF_AREA_VALUES, value);
-}
+export const isPerfArea = PERF_AREAS.is;
 
-export function isPerfAction(value: string): value is PerfAction {
-  return isStringMember(PERF_ACTION_VALUES, value);
-}
+export const isPerfAction = PERF_ACTIONS.is;

--- a/src/commands/recording.ts
+++ b/src/commands/recording.ts
@@ -9,7 +9,11 @@ import type { CommandContext } from '../runtime-contract.ts';
 import { AppError } from '../utils/errors.ts';
 import { successText } from '../utils/success-text.ts';
 import { requireIntInRange } from '../utils/validation.ts';
-import type { BackendResultEnvelope, RuntimeCommand } from './runtime-types.ts';
+import type {
+  BackendResultEnvelope,
+  BackendResultVariant,
+  RuntimeCommand,
+} from './runtime-types.ts';
 import { reserveCommandOutput } from './io-policy.ts';
 import { toBackendContext } from './selector-read-utils.ts';
 
@@ -26,16 +30,14 @@ export type RecordingTraceCommandOptions = CommandContext & {
   out?: FileOutputRef;
 };
 
-export type RecordingRecordCommandResult = {
+export type RecordingRecordCommandResult = BackendResultVariant<{
   kind: 'recordingStarted' | 'recordingStopped';
   action: 'start' | 'stop';
   path?: string;
   telemetryPath?: string;
   artifact?: ArtifactDescriptor;
-  backendResult?: Record<string, unknown>;
   warning?: string;
-  message?: string;
-};
+}>;
 
 export type RecordingTraceCommandResult = {
   kind: 'traceStarted' | 'traceStopped';
@@ -180,13 +182,12 @@ function formatLifecycleResult<
     startMessage: string;
     stopMessage: string;
   },
-): {
+): BackendResultVariant<{
   kind: TKind;
   action: 'start' | 'stop';
   artifact?: ArtifactDescriptor;
   backendResult: Record<string, unknown>;
-  message?: string;
-} {
+}> {
   return {
     kind: action === 'start' ? options.startKind : options.stopKind,
     action,

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -22,6 +22,8 @@ export type BackendResultEnvelope = {
   message?: string;
 };
 
+export type BackendResultVariant<T extends object> = T & BackendResultEnvelope;
+
 export type ScreenshotCommandOptions = CommandContext & {
   out?: FileOutputRef;
   fullscreen?: boolean;

--- a/src/commands/system.ts
+++ b/src/commands/system.ts
@@ -14,6 +14,7 @@ import { isKeyboardAction } from '../utils/keyboard-actions.ts';
 import {
   toBackendResult,
   type BackendResultEnvelope,
+  type BackendResultVariant,
   type RuntimeCommand,
 } from './runtime-types.ts';
 import { toBackendContext } from './selector-read-utils.ts';
@@ -48,26 +49,21 @@ export type SystemKeyboardCommandOptions = CommandContext & {
 };
 
 export type SystemKeyboardCommandResult =
-  | {
+  | BackendResultVariant<{
       kind: 'keyboardState';
       action: 'status' | 'get';
       state: BackendKeyboardResult;
-      backendResult?: Record<string, unknown>;
-    }
-  | {
+    }>
+  | BackendResultVariant<{
       kind: 'keyboardDismissed';
       action: 'dismiss';
       state: BackendKeyboardResult;
-      backendResult?: Record<string, unknown>;
-      message?: string;
-    }
-  | {
+    }>
+  | BackendResultVariant<{
       kind: 'keyboardEnterPressed';
       action: 'enter';
       state: BackendKeyboardResult;
-      backendResult?: Record<string, unknown>;
-      message?: string;
-    };
+    }>;
 
 export type SystemClipboardCommandOptions =
   | (CommandContext & {
@@ -84,13 +80,11 @@ export type SystemClipboardCommandResult =
       action: 'read';
       text: string;
     }
-  | {
+  | BackendResultVariant<{
       kind: 'clipboardUpdated';
       action: 'write';
       textLength: number;
-      backendResult?: Record<string, unknown>;
-      message?: string;
-    };
+    }>;
 
 export type SystemSettingsCommandOptions = CommandContext & {
   target?: string;
@@ -112,22 +106,20 @@ export type SystemAlertCommandResult =
       action: 'get';
       alert: BackendAlertInfo | null;
     }
-  | {
+  | BackendResultVariant<{
       kind: 'alertHandled';
       action: 'accept' | 'dismiss';
       handled: boolean;
       alert?: BackendAlertInfo;
       button?: string;
-      message?: string;
-    }
-  | {
+    }>
+  | BackendResultVariant<{
       kind: 'alertWait';
       action: 'wait';
       alert: BackendAlertInfo | null;
       waitedMs?: number;
       timedOut?: boolean;
-      message?: string;
-    };
+    }>;
 
 export type SystemAppSwitcherCommandOptions = CommandContext;
 

--- a/src/commands/wait-command-contract.ts
+++ b/src/commands/wait-command-contract.ts
@@ -1,0 +1,2 @@
+export const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector'] as const;
+export type WaitKind = (typeof WAIT_KIND_VALUES)[number];

--- a/src/compat/maestro/runtime-flow.ts
+++ b/src/compat/maestro/runtime-flow.ts
@@ -1,4 +1,4 @@
-import type { DaemonRequest, DaemonResponse, SessionReplayControl } from '../../daemon/types.ts';
+import type { DaemonInvokeFn, DaemonResponse, SessionReplayControl } from '../../daemon/types.ts';
 import { getSnapshotReferenceFrame } from '../../daemon/touch-reference-frame.ts';
 import { invokeReplayActionBlock } from '../../replay/control-flow-runtime.ts';
 import {
@@ -26,7 +26,7 @@ export async function invokeMaestroRunFlowWhenControl(params: {
   control: MaestroRunFlowWhenControl;
   line: number;
   step: number;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
   invokeReplayAction: MaestroReplayInvoker;
 }): Promise<DaemonResponse> {
   const conditionResult = await evaluateMaestroRunFlowWhenCondition(params, params.control);
@@ -43,7 +43,7 @@ export async function invokeMaestroRunFlowWhenControl(params: {
 async function evaluateMaestroRunFlowWhenCondition(
   params: {
     baseReq: ReplayBaseRequest;
-    invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+    invoke: DaemonInvokeFn;
   },
   condition: MaestroRunFlowWhenControl,
 ): Promise<{ ok: true; matched: boolean } | { ok: false; response: DaemonResponse }> {
@@ -64,7 +64,7 @@ async function evaluateMaestroRunFlowWhenCondition(
 async function waitForMaestroRunFlowVisibleCondition(
   params: {
     baseReq: ReplayBaseRequest;
-    invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+    invoke: DaemonInvokeFn;
   },
   condition: MaestroRunFlowWhenControl,
 ): Promise<{ ok: true; matched: boolean } | { ok: false; response: DaemonResponse }> {
@@ -86,7 +86,7 @@ async function waitForMaestroRunFlowVisibleCondition(
 async function readMaestroRunFlowVisibleCondition(
   params: {
     baseReq: ReplayBaseRequest;
-    invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+    invoke: DaemonInvokeFn;
   },
   selector: string,
 ): Promise<{ ok: true; matched: boolean } | { ok: false; response: DaemonResponse }> {

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -1,5 +1,5 @@
 import { getSnapshotReferenceFrame } from '../../daemon/touch-reference-frame.ts';
-import type { DaemonRequest, DaemonResponse } from '../../daemon/types.ts';
+import type { DaemonInvokeFn, DaemonResponse } from '../../daemon/types.ts';
 import {
   buildSwipeGesturePlan,
   clampGesturePoint,
@@ -108,7 +108,7 @@ export async function invokeMaestroScrollUntilVisible(
 export async function invokeMaestroTapPointPercent(params: {
   baseReq: ReplayBaseRequest;
   positionals: string[];
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
 }): Promise<DaemonResponse> {
   const [xValue, yValue] = params.positionals;
   const xPercent = Number(xValue);

--- a/src/compat/maestro/runtime-support.ts
+++ b/src/compat/maestro/runtime-support.ts
@@ -2,7 +2,12 @@ import {
   getSnapshotReferenceFrame,
   type TouchReferenceFrame,
 } from '../../daemon/touch-reference-frame.ts';
-import type { DaemonRequest, DaemonResponse, DaemonResponseData } from '../../daemon/types.ts';
+import type {
+  DaemonInvokeFn,
+  DaemonRequest,
+  DaemonResponse,
+  DaemonResponseData,
+} from '../../daemon/types.ts';
 import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayActionBlockInvoker } from '../../replay/control-flow-runtime.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
@@ -12,7 +17,7 @@ export type ReplayBaseRequest = Omit<DaemonRequest, 'command' | 'positionals'>;
 
 export type MaestroReplayInvoker = ReplayActionBlockInvoker;
 
-export type MaestroRuntimeInvoke = (req: DaemonRequest) => Promise<DaemonResponse>;
+export type MaestroRuntimeInvoke = DaemonInvokeFn;
 
 export type FailedDaemonResponse = DaemonFailureResponse;
 

--- a/src/compat/maestro/runtime.ts
+++ b/src/compat/maestro/runtime.ts
@@ -1,6 +1,6 @@
 import { asAppError } from '../../utils/errors.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
-import type { DaemonRequest, DaemonResponse } from '../../daemon/types.ts';
+import type { DaemonInvokeFn, DaemonResponse } from '../../daemon/types.ts';
 import { executeRunScriptFile } from './run-script.ts';
 import { MAESTRO_RUNTIME_COMMAND } from './runtime-commands.ts';
 import {
@@ -29,7 +29,7 @@ export async function invokeMaestroRuntimeCommand(params: {
   scope: ReplayVarScope;
   line: number;
   step: number;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
   invokeReplayAction: MaestroReplayInvoker;
 }): Promise<DaemonResponse | undefined> {
   switch (params.command) {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,6 +1,7 @@
 export type { AppErrorCode } from './utils/errors.ts';
 export { defaultHintForCode, normalizeError } from './utils/errors.ts';
 import type { PlatformSelector } from './utils/device.ts';
+import { PLATFORM_SELECTORS } from './utils/device.ts';
 
 export type SessionRuntimeHints = {
   platform?: 'ios' | 'android';
@@ -37,12 +38,18 @@ export type DaemonInstallSource =
         }
     ));
 
-export type DaemonLockPolicy = 'reject' | 'strip';
-export type LeaseBackend = 'ios-simulator' | 'ios-instance' | 'android-instance';
-export type DaemonServerMode = 'socket' | 'http' | 'dual';
-export type DaemonTransportPreference = 'auto' | 'socket' | 'http';
-export type SessionIsolationMode = 'none' | 'tenant';
-export type NetworkIncludeMode = 'summary' | 'headers' | 'body' | 'all';
+export const DAEMON_LOCK_POLICIES = ['reject', 'strip'] as const;
+export type DaemonLockPolicy = (typeof DAEMON_LOCK_POLICIES)[number];
+export const LEASE_BACKENDS = ['ios-simulator', 'ios-instance', 'android-instance'] as const;
+export type LeaseBackend = (typeof LEASE_BACKENDS)[number];
+export const DAEMON_SERVER_MODES = ['socket', 'http', 'dual'] as const;
+export type DaemonServerMode = (typeof DAEMON_SERVER_MODES)[number];
+export const DAEMON_TRANSPORT_PREFERENCES = ['auto', 'socket', 'http'] as const;
+export type DaemonTransportPreference = (typeof DAEMON_TRANSPORT_PREFERENCES)[number];
+export const SESSION_ISOLATION_MODES = ['none', 'tenant'] as const;
+export type SessionIsolationMode = (typeof SESSION_ISOLATION_MODES)[number];
+export const NETWORK_INCLUDE_MODES = ['summary', 'headers', 'body', 'all'] as const;
+export type NetworkIncludeMode = (typeof NETWORK_INCLUDE_MODES)[number];
 
 export type DaemonRequestMeta = {
   requestId?: string;
@@ -359,20 +366,11 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
             runId: optionalString(meta, 'runId', `${path}.meta`),
             leaseId: optionalString(meta, 'leaseId', `${path}.meta`),
             leaseTtlMs: optionalInteger(meta, 'leaseTtlMs', `${path}.meta`),
-            leaseBackend: optionalEnum(
-              meta,
-              'leaseBackend',
-              [
-                'ios-simulator',
-                'ios-instance',
-                'android-instance',
-              ] as const satisfies readonly LeaseBackend[],
-              `${path}.meta`,
-            ),
+            leaseBackend: optionalEnum(meta, 'leaseBackend', LEASE_BACKENDS, `${path}.meta`),
             sessionIsolation: optionalEnum(
               meta,
               'sessionIsolation',
-              ['none', 'tenant'] as const,
+              SESSION_ISOLATION_MODES,
               `${path}.meta`,
             ),
             uploadedArtifactId: optionalString(meta, 'uploadedArtifactId', `${path}.meta`),
@@ -395,24 +393,8 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
               `${path}.meta`,
             ),
             materializationId: optionalString(meta, 'materializationId', `${path}.meta`),
-            lockPolicy: optionalEnum(
-              meta,
-              'lockPolicy',
-              ['reject', 'strip'] as const,
-              `${path}.meta`,
-            ),
-            lockPlatform: optionalEnum(
-              meta,
-              'lockPlatform',
-              [
-                'ios',
-                'macos',
-                'android',
-                'linux',
-                'apple',
-              ] as const satisfies readonly PlatformSelector[],
-              `${path}.meta`,
-            ),
+            lockPolicy: optionalEnum(meta, 'lockPolicy', DAEMON_LOCK_POLICIES, `${path}.meta`),
+            lockPlatform: optionalEnum(meta, 'lockPlatform', PLATFORM_SELECTORS, `${path}.meta`),
           },
   };
 });
@@ -457,12 +439,7 @@ export const leaseAllocateSchema = schema<LeaseAllocatePayload>((input, path) =>
   return {
     ...parseLeaseScope(record, path),
     ttlMs: optionalInteger(record, 'ttlMs', path),
-    backend: optionalEnum(
-      record,
-      'backend',
-      ['ios-simulator', 'ios-instance', 'android-instance'] as const,
-      path,
-    ),
+    backend: optionalEnum(record, 'backend', LEASE_BACKENDS, path),
   };
 });
 

--- a/src/core/scroll-gesture.ts
+++ b/src/core/scroll-gesture.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../utils/errors.ts';
-import { parseStringMember } from '../utils/string-enum.ts';
+import { defineStringEnum } from '../utils/string-enum.ts';
 import type { Rect, SnapshotNode } from '../utils/snapshot.ts';
 
 export const SCROLL_DIRECTIONS = ['up', 'down', 'left', 'right'] as const;
@@ -8,6 +8,12 @@ export const SWIPE_PRESETS = ['left', 'right', 'left-edge', 'right-edge'] as con
 export type SwipePreset = (typeof SWIPE_PRESETS)[number];
 export const SWIPE_PATTERNS = ['one-way', 'ping-pong'] as const;
 export type SwipePattern = (typeof SWIPE_PATTERNS)[number];
+const SWIPE_PRESET_ENUM = defineStringEnum(SWIPE_PRESETS, {
+  message: 'gesture swipe requires left, right, left-edge, or right-edge',
+});
+const SCROLL_DIRECTION_ENUM = defineStringEnum(SCROLL_DIRECTIONS, {
+  message: (direction) => `Unknown direction: ${direction}`,
+});
 
 export type TransformGestureParams = {
   x: number;
@@ -150,9 +156,7 @@ export function buildSwipePresetGesturePlan(
 }
 
 export function parseSwipePreset(input: string | undefined): SwipePreset {
-  return parseStringMember(SWIPE_PRESETS, input, {
-    message: 'gesture swipe requires left, right, left-edge, or right-edge',
-  });
+  return SWIPE_PRESET_ENUM.parse(input);
 }
 
 export function inferGestureReferenceFrame(
@@ -192,9 +196,7 @@ export function clampGesturePoint(
 }
 
 export function parseScrollDirection(direction: string): ScrollDirection {
-  return parseStringMember(SCROLL_DIRECTIONS, direction, {
-    message: `Unknown direction: ${direction}`,
-  });
+  return SCROLL_DIRECTION_ENUM.parse(direction);
 }
 
 function scrollDirectionForFingerSwipe(direction: ScrollDirection): ScrollDirection {

--- a/src/core/session-surface.ts
+++ b/src/core/session-surface.ts
@@ -1,11 +1,12 @@
-import { parseStringMember } from '../utils/string-enum.ts';
+import { defineStringEnum } from '../utils/string-enum.ts';
 
 export const SESSION_SURFACES = ['app', 'frontmost-app', 'desktop', 'menubar'] as const;
 export type SessionSurface = (typeof SESSION_SURFACES)[number];
+const SESSION_SURFACE_ENUM = defineStringEnum(SESSION_SURFACES, {
+  normalize: (raw) => raw.trim().toLowerCase(),
+  message: (value) => `Invalid surface: ${value}. Use ${SESSION_SURFACES.join('|')}.`,
+});
 
 export function parseSessionSurface(value: string | undefined): SessionSurface {
-  return parseStringMember(SESSION_SURFACES, value, {
-    normalize: (raw) => raw.trim().toLowerCase(),
-    message: `Invalid surface: ${value}. Use ${SESSION_SURFACES.join('|')}.`,
-  });
+  return SESSION_SURFACE_ENUM.parse(value);
 }

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expandUserHomePath, resolveUserPath } from '../utils/path-resolution.ts';
 import { findProjectRoot } from '../utils/version.ts';
+import type { EnvMap } from '../utils/env-map.ts';
 
 import type {
   DaemonServerMode,
@@ -18,8 +19,6 @@ export type DaemonPaths = {
   logPath: string;
   sessionsDir: string;
 };
-
-type EnvMap = Record<string, string | undefined>;
 
 type ResolveDaemonPathsOptions = {
   env?: EnvMap;

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '../../../utils/errors.ts';
 import { runCmdBackground, type ExecBackgroundResult } from '../../../utils/exec.ts';
-import type { DaemonRequest, DaemonResponse, SessionAction } from '../../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionAction } from '../../types.ts';
 import type { CommandFlags } from '../../../core/dispatch.ts';
 import { SessionStore } from '../../session-store.ts';
 import {
@@ -35,7 +35,7 @@ async function runReplayFixture(params: {
   script: string;
   files?: Record<string, string>;
   flags?: CommandFlags;
-  invoke?: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke?: DaemonInvokeFn;
 }): Promise<{
   response: DaemonResponse;
   calls: CapturedInvocation[];

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -2,7 +2,7 @@ import { dispatchCommand, resolveTargetDevice } from '../../core/dispatch.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import { findBestMatchesByLocator, parseFindArgs, type FindLocator } from '../../utils/finders.ts';
 import { centerOfRect, type SnapshotState } from '../../utils/snapshot.ts';
-import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
@@ -27,7 +27,7 @@ type FindContext = {
   sessionName: string;
   logPath: string;
   sessionStore: SessionStore;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
   session: ReturnType<SessionStore['get']>;
   device: NonNullable<ReturnType<SessionStore['get']>>['device'];
   command: string;
@@ -53,7 +53,7 @@ export async function handleFindCommands(params: {
   sessionName: string;
   logPath: string;
   sessionStore: SessionStore;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
 }): Promise<DaemonResponse | null> {
   const { req, sessionName, logPath, sessionStore, invoke } = params;
   const command = req.command;

--- a/src/daemon/handlers/session-batch.ts
+++ b/src/daemon/handlers/session-batch.ts
@@ -1,10 +1,10 @@
 import { type BatchInvoke, runBatch } from '../../core/batch.ts';
-import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../types.ts';
 
 export async function runBatchCommands(
   req: DaemonRequest,
   sessionName: string,
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>,
+  invoke: DaemonInvokeFn,
 ): Promise<DaemonResponse> {
   return await runBatch(req, sessionName, invoke as BatchInvoke);
 }

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -21,7 +21,7 @@ import {
 } from '../app-log.ts';
 import { buildPerfFramesResponseData, buildPerfResponseData } from './session-perf.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
-import type { NetworkIncludeMode } from '../../contracts.ts';
+import { NETWORK_INCLUDE_MODES, type NetworkIncludeMode } from '../../contracts.ts';
 import type { LogBackend } from '../network-log.ts';
 import {
   LOG_ACTION_VALUES as LOG_ACTIONS,
@@ -31,12 +31,6 @@ import {
 const LOG_ACTIONS_MESSAGE = `logs requires ${LOG_ACTIONS.slice(0, -1).join(', ')}, or ${LOG_ACTIONS.at(-1)}`;
 const NETWORK_ACTIONS = ['dump', 'log'] as const;
 const NETWORK_ACTIONS_MESSAGE = `network requires ${NETWORK_ACTIONS.join(' or ')}`;
-const NETWORK_INCLUDE_MODES = [
-  'summary',
-  'headers',
-  'body',
-  'all',
-] as const satisfies readonly NetworkIncludeMode[];
 const NETWORK_INCLUDE_MESSAGE = `network include mode must be one of: ${NETWORK_INCLUDE_MODES.join(', ')}`;
 
 type ObservabilityParams = {

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -5,7 +5,7 @@ import {
   resolveReplayAction,
   type ReplayVarScope,
 } from '../../replay/vars.ts';
-import type { DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
 import { mergeParentFlags } from './handler-utils.ts';
 import { invokeMaestroRuntimeCommand } from '../../compat/maestro/runtime.ts';
 import { invokeMaestroRunFlowWhenControl } from '../../compat/maestro/runtime-flow.ts';
@@ -27,7 +27,7 @@ export async function invokeReplayAction(params: {
   line: number;
   step: number;
   tracePath?: string;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
 }): Promise<DaemonResponse> {
   const { req, sessionName, action, scope, filePath, line, step, tracePath, invoke } = params;
   const resolved = resolveReplayAction(action, scope, { file: filePath, line });
@@ -88,7 +88,7 @@ async function invokeResolvedReplayAction(params: {
   scope: ReplayVarScope;
   line: number;
   step: number;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
   invokeReplayAction: ReplayActionInvoker;
 }): Promise<DaemonResponse> {
   const { req, sessionName, resolved, scope, line, step, invoke, invokeReplayAction } = params;
@@ -137,7 +137,7 @@ async function invokeReplayControl(params: {
   baseReq: ReplayBaseRequest;
   line: number;
   step: number;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
   invokeReplayAction: ReplayActionInvoker;
 }): Promise<DaemonResponse | undefined> {
   const { control, baseReq, line, step, invoke, invokeReplayAction } = params;

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { type CommandFlags } from '../../core/dispatch.ts';
 import { parseReplayInput } from '../../compat/replay-input.ts';
 import { asAppError } from '../../utils/errors.ts';
-import type { DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { type ReplayScriptMetadata, writeReplayScript } from '../../replay/script.ts';
 import { healReplayAction } from './session-replay-heal.ts';
@@ -25,7 +25,7 @@ export async function runReplayScriptFile(params: {
   logPath: string;
   sessionStore: SessionStore;
   tracePath?: string;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
 }): Promise<DaemonResponse> {
   const { req, sessionName, logPath, sessionStore, tracePath, invoke } = params;
   const filePath = req.positionals?.[0];

--- a/src/daemon/handlers/session-replay.ts
+++ b/src/daemon/handlers/session-replay.ts
@@ -1,5 +1,5 @@
 import type { CommandFlags } from '../../core/dispatch.ts';
-import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { runReplayTestSuite } from './session-test.ts';
 import { handleCloseCommand } from './session-close.ts';
@@ -52,7 +52,7 @@ export async function handleSessionReplayCommands(params: {
   sessionName: string;
   logPath: string;
   sessionStore: SessionStore;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
 }): Promise<DaemonResponse | null> {
   const { req, sessionName, logPath, sessionStore, invoke } = params;
 

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -9,7 +9,7 @@ import {
 } from '../../platforms/ios/runner-client.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import { isApplePlatform, normalizePlatformSelector } from '../../utils/device.ts';
-import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
 import {
@@ -244,8 +244,8 @@ export async function handleSessionCommands(params: {
   sessionName: string;
   logPath: string;
   sessionStore: SessionStore;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
-  invokeReplayAction?: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
+  invokeReplayAction?: DaemonInvokeFn;
   androidAdbExecutor?: AndroidAdbExecutor;
 }): Promise<DaemonResponse | null> {
   const {

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import { AppError, normalizeError, toAppErrorCode } from '../utils/errors.ts';
 import { timingSafeStringEqual } from '../utils/timing-safe-equal.ts';
 import type { JsonRpcId, JsonRpcRequestEnvelope, LeaseBackend } from '../contracts.ts';
-import type { DaemonInstallSource, DaemonRequest, DaemonResponse } from './types.ts';
+import type { DaemonInstallSource, DaemonInvokeFn, DaemonRequest } from './types.ts';
 import { normalizeTenantId } from './config.ts';
 import {
   clearRequestCanceled,
@@ -483,7 +483,7 @@ async function loadHttpAuthHook(): Promise<HttpAuthHook | null> {
 }
 
 export async function createDaemonHttpServer(options: {
-  handleRequest: (req: DaemonRequest) => Promise<DaemonResponse>;
+  handleRequest: DaemonInvokeFn;
   token?: string;
 }): Promise<http.Server> {
   const authHook = await loadHttpAuthHook();

--- a/src/daemon/request-handler-chain.ts
+++ b/src/daemon/request-handler-chain.ts
@@ -5,7 +5,7 @@ import { getDaemonCommandRoute } from './daemon-command-registry.ts';
 import type { DaemonCommandContext } from './context.ts';
 import type { LeaseRegistry } from './lease-registry.ts';
 import type { SessionStore } from './session-store.ts';
-import type { DaemonRequest, DaemonResponse } from './types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from './types.ts';
 
 const loadLeaseHandlerModule = lazyImport(() => import('./handlers/lease.ts'));
 const loadSessionHandlerModule = lazyImport(() => import('./handlers/session.ts'));
@@ -21,8 +21,8 @@ type RequestHandlerChainParams = {
   logPath: string;
   sessionStore: SessionStore;
   leaseRegistry: LeaseRegistry;
-  invoke: (req: DaemonRequest) => Promise<DaemonResponse>;
-  invokeReplayAction?: (req: DaemonRequest) => Promise<DaemonResponse>;
+  invoke: DaemonInvokeFn;
+  invokeReplayAction?: DaemonInvokeFn;
   androidAdbExecutor?: AndroidAdbExecutor;
   contextFromFlags: (
     flags: CommandFlags | undefined,

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -4,7 +4,7 @@ import {
 } from '../core/dispatch-resolve.ts';
 import { AppError, normalizeError } from '../utils/errors.ts';
 import { timingSafeStringEqual } from '../utils/timing-safe-equal.ts';
-import type { DaemonRequest, DaemonResponse } from './types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from './types.ts';
 import { SessionStore } from './session-store.ts';
 import {
   type AndroidAdbProviderResolver,
@@ -56,9 +56,7 @@ export type RequestRouterDeps = {
   }) => string;
 };
 
-export function createRequestHandler(
-  deps: RequestRouterDeps,
-): (req: DaemonRequest) => Promise<DaemonResponse> {
+export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
   const {
     logPath,
     token,
@@ -176,7 +174,7 @@ export function createRequestHandler(
   function createReplayScopedActionInvoker(
     parentScope: LockedRequestScope,
     providerScope: RequestPlatformProviderScope,
-  ): (req: DaemonRequest) => Promise<DaemonResponse> {
+  ): DaemonInvokeFn {
     return async (req) => {
       if (!canRunReplayActionInCurrentScope(req, parentScope)) return await handleRequest(req);
       if (!timingSafeStringEqual(req.token, token)) {

--- a/src/daemon/transport.ts
+++ b/src/daemon/transport.ts
@@ -1,7 +1,7 @@
 import net from 'node:net';
 import type { Server as HttpServer } from 'node:http';
 import { AppError, normalizeError } from '../utils/errors.ts';
-import type { DaemonRequest, DaemonResponse } from './types.ts';
+import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from './types.ts';
 import {
   clearRequestCanceled,
   createRequestCanceledError,
@@ -27,9 +27,7 @@ export type DaemonServer = (net.Server | HttpServer) & {
   destroyConnections?: () => void;
 };
 
-export function createSocketServer(
-  handleRequest: (req: DaemonRequest) => Promise<DaemonResponse>,
-): DaemonServer {
+export function createSocketServer(handleRequest: DaemonInvokeFn): DaemonServer {
   const sockets = new Set<net.Socket>();
   const server: DaemonServer = net.createServer((socket) => {
     sockets.add(socket);

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -113,6 +113,7 @@ export type ReplaySuiteResult = {
 };
 
 export type DaemonResponse = PublicDaemonResponse;
+export type DaemonInvokeFn = (req: DaemonRequest) => Promise<DaemonResponse>;
 
 type RecordingTelemetryBase = {
   tMs: number;

--- a/src/platforms/ios/runner-xctestrun.ts
+++ b/src/platforms/ios/runner-xctestrun.ts
@@ -9,6 +9,7 @@ import { readProcessStartTime } from '../../utils/process-identity.ts';
 import { acquireProcessLock, type ProcessLockOwner } from '../../utils/process-lock.ts';
 import { isEnvTruthy } from '../../utils/retry.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
+import type { DefinedEnvMap as EnvMap } from '../../utils/env-map.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { findProjectRoot, readVersion } from '../../utils/version.ts';
@@ -57,7 +58,6 @@ const badRunnerArtifactsForRun = new Set<string>();
 const appleToolFingerprintCache = new Map<string, string>();
 export const runnerPrepProcesses = new Set<ExecBackgroundResult['child']>();
 
-type EnvMap = Record<string, string>;
 type XctestrunTarget = {
   TestBundlePath?: unknown;
   EnvironmentVariables?: EnvMap;

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { stripVTControlCharacters } from 'node:util';
 import { formatScreenshotDiffText, formatSnapshotDiffText, formatSnapshotText } from '../output.ts';
 import { formatRole, formatSnapshotLine } from '../snapshot-lines.ts';
+import { normalizedRect } from '../screenshot-geometry.ts';
 
 const DIFF_DATA = {
   mode: 'snapshot',
@@ -1462,7 +1463,7 @@ test('formatScreenshotDiffText renders mismatch with pixel counts without color'
         {
           index: 1,
           rect: { x: 10, y: 20, width: 100, height: 40 },
-          normalizedRect: { x: 10, y: 20, width: 100, height: 40 },
+          normalizedRect: normalizedRect({ x: 10, y: 20, width: 100, height: 40 }),
           differentPixels: 350,
           shareOfDiffPercentage: 70,
           densityPercentage: 8.75,

--- a/src/utils/__tests__/screenshot-diff-non-text.test.ts
+++ b/src/utils/__tests__/screenshot-diff-non-text.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { summarizeNonTextDiffDeltas } from '../screenshot-diff-non-text.ts';
+import { normalizedRect } from '../screenshot-geometry.ts';
 
 function paintMaskRect(
   mask: Uint8Array,
@@ -29,7 +30,7 @@ test('summarizeNonTextDiffDeltas masks OCR text and reports leading icon residua
       {
         index: 1,
         rect: { x: 0, y: 20, width: 180, height: 50 },
-        normalizedRect: { x: 0, y: 16.67, width: 81.82, height: 41.67 },
+        normalizedRect: normalizedRect({ x: 0, y: 16.67, width: 81.82, height: 41.67 }),
         differentPixels: 976,
         shareOfDiffPercentage: 100,
         densityPercentage: 10.84,
@@ -53,7 +54,7 @@ test('summarizeNonTextDiffDeltas masks OCR text and reports leading icon residua
           text: 'Wi-Fi',
           confidence: 90,
           rect: { x: 68, y: 28, width: 60, height: 24 },
-          normalizedRect: { x: 30.91, y: 23.33, width: 27.27, height: 20 },
+          normalizedRect: normalizedRect({ x: 30.91, y: 23.33, width: 27.27, height: 20 }),
         },
       ],
       matches: [],
@@ -88,7 +89,7 @@ test('summarizeNonTextDiffDeltas uses overlapping baseline text when current OCR
           text: 'Wi-Fi',
           confidence: 90,
           rect: { x: 68, y: 28, width: 60, height: 24 },
-          normalizedRect: { x: 30.91, y: 23.33, width: 27.27, height: 20 },
+          normalizedRect: normalizedRect({ x: 30.91, y: 23.33, width: 27.27, height: 20 }),
         },
       ],
       currentBlocksRaw: [],
@@ -116,7 +117,7 @@ test('summarizeNonTextDiffDeltas omits broad background residuals', () => {
       {
         index: 1,
         rect: { x: 10, y: 30, width: 180, height: 40 },
-        normalizedRect: { x: 4.55, y: 25, width: 81.82, height: 33.33 },
+        normalizedRect: normalizedRect({ x: 4.55, y: 25, width: 81.82, height: 33.33 }),
         differentPixels: 7200,
         shareOfDiffPercentage: 100,
         densityPercentage: 100,

--- a/src/utils/__tests__/screenshot-diff-ocr.test.ts
+++ b/src/utils/__tests__/screenshot-diff-ocr.test.ts
@@ -9,6 +9,7 @@ import {
   summarizeScreenshotOcr,
   summarizeOcrMovementClusters,
 } from '../screenshot-diff-ocr.ts';
+import { normalizedRect } from '../screenshot-geometry.ts';
 
 test('parseTesseractTsv groups word rows into text line blocks', () => {
   const blocks = parseTesseractTsv(
@@ -29,19 +30,19 @@ test('parseTesseractTsv groups word rows into text line blocks', () => {
     text: 'Airplane Mode',
     confidence: 95,
     rect: { x: 100, y: 200, width: 80, height: 20 },
-    normalizedRect: { x: 25, y: 25, width: 20, height: 2.5 },
+    normalizedRect: normalizedRect({ x: 25, y: 25, width: 20, height: 2.5 }),
   });
   assert.deepEqual(blocks[1], {
     text: 'Disconnected',
     confidence: 92,
     rect: { x: 300, y: 200, width: 90, height: 20 },
-    normalizedRect: { x: 75, y: 25, width: 22.5, height: 2.5 },
+    normalizedRect: normalizedRect({ x: 75, y: 25, width: 22.5, height: 2.5 }),
   });
   assert.deepEqual(blocks[2], {
     text: 'Wi-Fi',
     confidence: 90,
     rect: { x: 100, y: 240, width: 50, height: 20 },
-    normalizedRect: { x: 25, y: 30, width: 12.5, height: 2.5 },
+    normalizedRect: normalizedRect({ x: 25, y: 30, width: 12.5, height: 2.5 }),
   });
 });
 
@@ -52,7 +53,7 @@ test('matchOcrBlocks reports movement and OCR bbox size change', () => {
         text: 'Wi-Fi',
         confidence: 96,
         rect: { x: 100, y: 200, width: 50, height: 20 },
-        normalizedRect: { x: 25, y: 25, width: 12.5, height: 2.5 },
+        normalizedRect: normalizedRect({ x: 25, y: 25, width: 12.5, height: 2.5 }),
       },
     ],
     [
@@ -60,7 +61,7 @@ test('matchOcrBlocks reports movement and OCR bbox size change', () => {
         text: 'Wi-Fi',
         confidence: 94,
         rect: { x: 112, y: 192, width: 60, height: 20 },
-        normalizedRect: { x: 28, y: 24, width: 15, height: 2.5 },
+        normalizedRect: normalizedRect({ x: 28, y: 24, width: 15, height: 2.5 }),
       },
     ],
   );

--- a/src/utils/cli-config.ts
+++ b/src/utils/cli-config.ts
@@ -10,8 +10,7 @@ import {
   parseOptionValueFromSource,
 } from './cli-option-schema.ts';
 import { parseInstallSourceConfig } from './install-source-config.ts';
-
-type EnvMap = Record<string, string | undefined>;
+import type { EnvMap } from './env-map.ts';
 
 export function resolveConfigBackedFlagDefaults(options: {
   command: string | null;

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -3,8 +3,7 @@ import { mergeDefinedFlags } from './merge-flags.ts';
 import { finalizeParsedArgs, parseRawArgs } from './args.ts';
 import { resolveConfigBackedFlagDefaults } from './cli-config.ts';
 import { resolveRemoteConfigDefaults } from './remote-config.ts';
-
-type EnvMap = Record<string, string | undefined>;
+import type { EnvMap } from './env-map.ts';
 
 export function resolveCliOptions(
   argv: string[],

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,9 +1,12 @@
 import { AppError } from './errors.ts';
 
 export type ApplePlatform = 'ios' | 'macos';
-export type Platform = ApplePlatform | 'android' | 'linux';
-export type PlatformSelector = Platform | 'apple';
-export type DeviceKind = 'simulator' | 'emulator' | 'device';
+export const PLATFORMS = ['ios', 'macos', 'android', 'linux'] as const;
+export type Platform = (typeof PLATFORMS)[number];
+export const PLATFORM_SELECTORS = [...PLATFORMS, 'apple'] as const;
+export type PlatformSelector = (typeof PLATFORM_SELECTORS)[number];
+export const DEVICE_KINDS = ['simulator', 'emulator', 'device'] as const;
+export type DeviceKind = (typeof DEVICE_KINDS)[number];
 export const DEVICE_TARGETS = ['mobile', 'tv', 'desktop'] as const;
 export type DeviceTarget = (typeof DEVICE_TARGETS)[number];
 

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,11 +1,11 @@
 import { AppError } from './errors.ts';
 
 export type ApplePlatform = 'ios' | 'macos';
-export const PLATFORMS = ['ios', 'macos', 'android', 'linux'] as const;
+const PLATFORMS = ['ios', 'macos', 'android', 'linux'] as const;
 export type Platform = (typeof PLATFORMS)[number];
 export const PLATFORM_SELECTORS = [...PLATFORMS, 'apple'] as const;
 export type PlatformSelector = (typeof PLATFORM_SELECTORS)[number];
-export const DEVICE_KINDS = ['simulator', 'emulator', 'device'] as const;
+const DEVICE_KINDS = ['simulator', 'emulator', 'device'] as const;
 export type DeviceKind = (typeof DEVICE_KINDS)[number];
 export const DEVICE_TARGETS = ['mobile', 'tv', 'desktop'] as const;
 export type DeviceTarget = (typeof DEVICE_TARGETS)[number];

--- a/src/utils/env-map.ts
+++ b/src/utils/env-map.ts
@@ -1,0 +1,2 @@
+export type EnvMap = Record<string, string | undefined>;
+export type DefinedEnvMap = Record<string, string>;

--- a/src/utils/finders.ts
+++ b/src/utils/finders.ts
@@ -1,7 +1,15 @@
 import type { SnapshotNode } from './snapshot.ts';
 import { AppError } from './errors.ts';
 
-export type FindLocator = 'any' | 'text' | 'label' | 'value' | 'role' | 'id';
+export const FIND_LOCATORS = ['any', 'text', 'label', 'value', 'role', 'id'] as const;
+export type FindLocator = (typeof FIND_LOCATORS)[number];
+const FIND_LOCATOR_TOKENS = [
+  'text',
+  'label',
+  'value',
+  'role',
+  'id',
+] as const satisfies readonly FindLocator[];
 
 export type FindAction =
   | { kind: 'click' }
@@ -115,10 +123,9 @@ export function parseFindArgs(args: string[]): {
   value?: string;
   timeoutMs?: number;
 } {
-  const locatorTokens: FindLocator[] = ['text', 'label', 'value', 'role', 'id'];
   let locator: FindLocator = 'any';
   let queryIndex = 0;
-  if (locatorTokens.includes(args[0] as FindLocator)) {
+  if (FIND_LOCATOR_TOKENS.includes(args[0] as (typeof FIND_LOCATOR_TOKENS)[number])) {
     locator = args[0] as FindLocator;
     queryIndex = 1;
   }

--- a/src/utils/path-resolution.ts
+++ b/src/utils/path-resolution.ts
@@ -1,7 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
-
-type EnvMap = Record<string, string | undefined>;
+import type { EnvMap } from './env-map.ts';
 
 type PathResolutionOptions = {
   cwd?: string;

--- a/src/utils/screenshot-diff-ocr.ts
+++ b/src/utils/screenshot-diff-ocr.ts
@@ -3,6 +3,7 @@ import { runCmd, whichCmd } from './exec.ts';
 
 export type MovementRange = { min: number; max: number };
 import {
+  normalizedRect,
   rectCenter,
   squaredDistance,
   unionRects,
@@ -201,12 +202,12 @@ function toOcrBlock(
     text: sortedWords.map((word) => word.text).join(' '),
     confidence,
     rect,
-    normalizedRect: {
+    normalizedRect: normalizedRect({
       x: roundPercentage(rect.x / imageWidth),
       y: roundPercentage(rect.y / imageHeight),
       width: roundPercentage(rect.width / imageWidth),
       height: roundPercentage(rect.height / imageHeight),
-    },
+    }),
   };
 }
 

--- a/src/utils/screenshot-diff-regions.ts
+++ b/src/utils/screenshot-diff-regions.ts
@@ -1,6 +1,6 @@
 import type { PNG } from './png.ts';
 import type { Rect } from './snapshot.ts';
-import type { NormalizedRect } from './screenshot-geometry.ts';
+import { normalizedRect, type NormalizedRect } from './screenshot-geometry.ts';
 import { findConnectedMaskComponents } from './screenshot-diff-components.ts';
 import { splitLargeDiffRegions } from './screenshot-diff-region-split.ts';
 import type { MutableDiffRegion } from './screenshot-diff-region-types.ts';
@@ -222,12 +222,12 @@ function toScreenshotDiffRegion(
   return {
     index,
     rect,
-    normalizedRect: {
+    normalizedRect: normalizedRect({
       x: roundPercentage(rect.x / image.width),
       y: roundPercentage(rect.y / image.height),
       width: roundPercentage(rect.width / image.width),
       height: roundPercentage(rect.height / image.height),
-    },
+    }),
     differentPixels: region.differentPixels,
     shareOfDiffPercentage: roundPercentage(region.differentPixels / image.differentPixels),
     densityPercentage,

--- a/src/utils/screenshot-geometry.ts
+++ b/src/utils/screenshot-geometry.ts
@@ -19,10 +19,6 @@ export function normalizedRect(rect: Rect): NormalizedRect {
   return rect as NormalizedRect;
 }
 
-export function normalizedPoint(point: Point): NormalizedPoint {
-  return point as NormalizedPoint;
-}
-
 export function unionRects(rects: Rect[]): Rect {
   let minX = Number.POSITIVE_INFINITY;
   let minY = Number.POSITIVE_INFINITY;

--- a/src/utils/screenshot-geometry.ts
+++ b/src/utils/screenshot-geometry.ts
@@ -2,17 +2,26 @@ import type { Point, Rect } from './snapshot.ts';
 
 export type ImageDimensions = { width: number; height: number };
 
+declare const normalizedRectBrand: unique symbol;
+declare const normalizedPointBrand: unique symbol;
+
 /**
  * A rect whose coordinates are normalized percentages [0..100] of the screenshot
  * image's dimensions (as produced by the screenshot-diff regions/OCR code), NOT
- * absolute pixels. Documentary alias of {@link Rect} — it conveys coordinate
- * space to readers but is not enforced by the type system (still structurally a
- * Rect).
+ * absolute pixels.
  */
-export type NormalizedRect = Rect;
+export type NormalizedRect = Rect & { readonly [normalizedRectBrand]: 'normalized-rect' };
 
-/** A point in normalized [0..100] screenshot-image space. Documentary alias of {@link Point}. */
-export type NormalizedPoint = Point;
+/** A point in normalized [0..100] screenshot-image space. */
+export type NormalizedPoint = Point & { readonly [normalizedPointBrand]: 'normalized-point' };
+
+export function normalizedRect(rect: Rect): NormalizedRect {
+  return rect as NormalizedRect;
+}
+
+export function normalizedPoint(point: Point): NormalizedPoint {
+  return point as NormalizedPoint;
+}
 
 export function unionRects(rects: Rect[]): Rect {
   let minX = Number.POSITIVE_INFINITY;
@@ -46,7 +55,9 @@ export function intersectArea(left: Rect, right: Rect): number {
   return (maxX - minX) * (maxY - minY);
 }
 
-export function rectCenter(rect: Rect): { x: number; y: number } {
+export function rectCenter(rect: NormalizedRect): NormalizedPoint;
+export function rectCenter(rect: Rect): Point;
+export function rectCenter(rect: Rect): Point {
   return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
 }
 

--- a/src/utils/string-enum.ts
+++ b/src/utils/string-enum.ts
@@ -22,14 +22,36 @@ export function isStringMember<const T extends readonly string[]>(
 export function parseStringMember<const T extends readonly string[]>(
   values: T,
   value: string | undefined,
-  options: { normalize?: (raw: string) => string; message?: string } = {},
+  options: {
+    normalize?: (raw: string) => string;
+    message?: string | ((raw: string | undefined) => string);
+  } = {},
 ): T[number] {
   const normalized = value === undefined ? undefined : (options.normalize?.(value) ?? value);
   if (normalized !== undefined && isStringMember(values, normalized)) {
     return normalized;
   }
+  const message = typeof options.message === 'function' ? options.message(value) : options.message;
   throw new AppError(
     'INVALID_ARGS',
-    options.message ?? `Invalid value: ${value}. Use ${values.join('|')}.`,
+    message ?? `Invalid value: ${value}. Use ${values.join('|')}.`,
   );
+}
+
+export function defineStringEnum<const T extends readonly string[]>(
+  values: T,
+  options: {
+    normalize?: (raw: string) => string;
+    message?: string | ((raw: string | undefined) => string);
+  } = {},
+): {
+  readonly values: T;
+  is(value: string): value is T[number];
+  parse(value: string | undefined): T[number];
+} {
+  return {
+    values,
+    is: (value): value is T[number] => isStringMember(values, value),
+    parse: (value): T[number] => parseStringMember(values, value, options),
+  };
 }


### PR DESCRIPTION
## Summary

Deepens the follow-up refactor from the type/contract audit in one PR:
- makes runtime enum tuples canonical for contracts, device selectors, finder locators, wait kinds, and network include modes
- brands normalized screenshot rects/points so percent-space geometry cannot be mixed with pixel geometry by accident
- shares result envelopes, daemon invoker signatures, env-map aliases, and string-enum parsing helpers across modules

Touched-file count: 50. Scope intentionally spans command metadata/contracts, screenshot diff geometry, daemon/Maestro invocation types, and env/config helpers to cover the requested follow-ups together.

## Validation

Passed: `pnpm format`, `pnpm check:quick`, and focused unit coverage for screenshot/output paths with `pnpm exec vitest run --project unit src/utils/__tests__/screenshot-diff-ocr.test.ts src/utils/__tests__/screenshot-diff-non-text.test.ts src/utils/__tests__/output.test.ts`.

Attempted: `pnpm check:unit`. The first sandboxed run failed on local listener restrictions (`listen EPERM`). The unsandboxed rerun reduced this to 7 Android mocked-tool timeout failures in existing Android device/install tests, outside this refactor's touched areas.