### PR TITLE
refactor: extract daemon artifact client

### DIFF
--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -151,12 +151,17 @@
         "count": 1
       }
     },
+    "src/daemon-artifacts.ts": {
+      "crap_moderate": {
+        "count": 2
+      }
+    },
     "src/daemon-client.ts": {
       "complexity_moderate": {
         "count": 5
       },
       "crap_moderate": {
-        "count": 9
+        "count": 5
       }
     },
     "src/daemon/__tests__/network-log.test.ts": {

--- a/src/daemon-artifacts.ts
+++ b/src/daemon-artifacts.ts
@@ -1,0 +1,399 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import https from 'node:https';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { AppError } from './utils/errors.ts';
+import type { DaemonArtifact, DaemonRequest, DaemonResponse } from './daemon/types.ts';
+import { uploadArtifact } from './upload-client.ts';
+
+const REMOTE_ARTIFACT_DOWNLOAD_TIMEOUT_MS = 90_000;
+
+export type DaemonArtifactEndpoint = {
+  baseUrl?: string;
+  token: string;
+};
+
+type PreparedRemoteRequest = {
+  positionals: string[];
+  flags?: DaemonRequest['flags'];
+  installSource?: NonNullable<DaemonRequest['meta']>['installSource'];
+  uploadedArtifactId?: string;
+  clientArtifactPaths?: Record<string, string>;
+};
+
+export async function prepareRemoteRequestArtifacts(
+  req: Omit<DaemonRequest, 'token'>,
+  info: DaemonArtifactEndpoint,
+): Promise<PreparedRemoteRequest> {
+  const positionals = [...(req.positionals ?? [])];
+  let flags = req.flags ? { ...req.flags } : undefined;
+  let installSource = req.meta?.installSource;
+  const clientArtifactPaths: Record<string, string> = {};
+  let uploadedArtifactId: string | undefined;
+
+  if (!isRemoteDaemon(info)) {
+    return createPreparedRemoteRequest({
+      positionals,
+      flags,
+      installSource,
+      uploadedArtifactId,
+      clientArtifactPaths,
+    });
+  }
+
+  flags = applyRemoteArtifactCommand(req, positionals, flags, clientArtifactPaths);
+  const remoteInstallSource = await prepareRemoteInstallSource(req, info);
+  if (remoteInstallSource) {
+    installSource = remoteInstallSource.installSource;
+    uploadedArtifactId = remoteInstallSource.uploadedArtifactId ?? uploadedArtifactId;
+  }
+
+  const baseResult = (): PreparedRemoteRequest =>
+    createPreparedRemoteRequest({
+      positionals,
+      flags,
+      installSource,
+      uploadedArtifactId,
+      clientArtifactPaths,
+    });
+
+  if (req.command !== 'install' && req.command !== 'reinstall') return baseResult();
+  const installPackageResult = await prepareRemoteInstallPackage(req, info, positionals);
+  uploadedArtifactId = installPackageResult ?? uploadedArtifactId;
+  return baseResult();
+}
+
+async function prepareRemoteInstallPackage(
+  req: Omit<DaemonRequest, 'token'>,
+  info: DaemonArtifactEndpoint,
+  positionals: string[],
+): Promise<string | undefined> {
+  const rawPath = positionals[1];
+  if (rawPath === undefined) return undefined;
+  if (rawPath.startsWith('remote:')) {
+    positionals[1] = rawPath.slice('remote:'.length);
+    return undefined;
+  }
+
+  const localPath = resolveLocalInstallPath(rawPath, req.meta?.cwd);
+  if (!localPath) return undefined;
+
+  return await uploadArtifact({
+    localPath,
+    baseUrl: info.baseUrl!,
+    token: info.token,
+    platform: req.flags?.platform,
+  });
+}
+
+function applyRemoteArtifactCommand(
+  req: Omit<DaemonRequest, 'token'>,
+  positionals: string[],
+  flags: DaemonRequest['flags'] | undefined,
+  clientArtifactPaths: Record<string, string>,
+): DaemonRequest['flags'] | undefined {
+  const remoteArtifact = prepareRemoteArtifactCommand(req, positionals);
+  if (!remoteArtifact) return flags;
+  if (remoteArtifact.positionalPath !== undefined) {
+    positionals[remoteArtifact.positionalIndex] = remoteArtifact.positionalPath;
+  }
+  const nextFlags = applyRemoteArtifactOutFlag(flags, remoteArtifact.flagPath);
+  clientArtifactPaths[remoteArtifact.field] = remoteArtifact.localPath;
+  return nextFlags;
+}
+
+function applyRemoteArtifactOutFlag(
+  flags: DaemonRequest['flags'] | undefined,
+  flagPath: string | undefined,
+): DaemonRequest['flags'] | undefined {
+  if (flagPath === undefined) return flags;
+  return { ...(flags ?? {}), out: flagPath };
+}
+
+function resolveLocalInstallPath(rawPath: string, cwd: string | undefined): string | undefined {
+  const localPath = path.isAbsolute(rawPath)
+    ? rawPath
+    : path.resolve(cwd ?? process.cwd(), rawPath);
+  return fs.existsSync(localPath) ? localPath : undefined;
+}
+
+function createPreparedRemoteRequest(
+  result: PreparedRemoteRequest & { clientArtifactPaths: Record<string, string> },
+): PreparedRemoteRequest {
+  return {
+    positionals: result.positionals,
+    flags: result.flags,
+    installSource: result.installSource,
+    uploadedArtifactId: result.uploadedArtifactId,
+    ...(Object.keys(result.clientArtifactPaths).length > 0
+      ? { clientArtifactPaths: result.clientArtifactPaths }
+      : {}),
+  };
+}
+
+async function prepareRemoteInstallSource(
+  req: Omit<DaemonRequest, 'token'>,
+  info: DaemonArtifactEndpoint,
+): Promise<{
+  installSource: NonNullable<DaemonRequest['meta']>['installSource'];
+  uploadedArtifactId?: string;
+} | null> {
+  const source = req.meta?.installSource;
+  if (req.command !== 'install_source' || !source || source.kind !== 'path') {
+    return null;
+  }
+
+  const rawPath = source.path.trim();
+  if (!rawPath) {
+    return { installSource: source };
+  }
+  if (rawPath.startsWith('remote:')) {
+    return {
+      installSource: {
+        ...source,
+        path: rawPath.slice('remote:'.length),
+      },
+    };
+  }
+
+  const localPath = path.isAbsolute(rawPath)
+    ? rawPath
+    : path.resolve(req.meta?.cwd ?? process.cwd(), rawPath);
+  if (!fs.existsSync(localPath)) {
+    return {
+      installSource: {
+        ...source,
+        path: localPath,
+      },
+    };
+  }
+
+  const uploadedArtifactId = await uploadArtifact({
+    localPath,
+    baseUrl: info.baseUrl!,
+    token: info.token,
+    platform: req.flags?.platform,
+  });
+  return {
+    installSource: {
+      ...source,
+      path: localPath,
+    },
+    uploadedArtifactId,
+  };
+}
+
+function prepareRemoteArtifactCommand(
+  req: Omit<DaemonRequest, 'token'>,
+  positionals: string[],
+): {
+  field: string;
+  localPath: string;
+  positionalIndex: number;
+  positionalPath?: string;
+  flagPath?: string;
+} | null {
+  if (req.command === 'screenshot') {
+    const localPath = resolveClientArtifactOutputPath(req, 'path', '.png');
+    if (positionals[0]) {
+      return {
+        field: 'path',
+        localPath,
+        positionalIndex: 0,
+        positionalPath: buildRemoteTempArtifactPath('screenshot', '.png'),
+      };
+    }
+    return {
+      field: 'path',
+      localPath,
+      positionalIndex: 0,
+      flagPath: buildRemoteTempArtifactPath('screenshot', '.png'),
+    };
+  }
+  if (req.command === 'record' && (positionals[0] ?? '').toLowerCase() === 'start') {
+    const localPath = resolveClientArtifactOutputPath(req, 'outPath', '.mp4', 1);
+    return {
+      field: 'outPath',
+      localPath,
+      positionalIndex: 1,
+      positionalPath: buildRemoteTempArtifactPath('recording', path.extname(localPath) || '.mp4'),
+    };
+  }
+  return null;
+}
+
+function resolveClientArtifactOutputPath(
+  req: Omit<DaemonRequest, 'token'>,
+  field: 'path' | 'outPath',
+  fallbackExtension: string,
+  positionalIndex: number = 0,
+): string {
+  const requested = req.positionals?.[positionalIndex] ?? req.flags?.out;
+  const fallbackName = `${field === 'path' ? 'screenshot' : 'recording'}-${Date.now()}${fallbackExtension}`;
+  const rawPath = requested && requested.trim().length > 0 ? requested : fallbackName;
+  return path.isAbsolute(rawPath) ? rawPath : path.resolve(req.meta?.cwd ?? process.cwd(), rawPath);
+}
+
+function buildRemoteTempArtifactPath(prefix: string, extension: string): string {
+  const safeExtension = extension.startsWith('.') ? extension : `.${extension}`;
+  return path.posix.join(
+    '/tmp',
+    `agent-device-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${safeExtension}`,
+  );
+}
+
+export async function materializeRemoteArtifacts(
+  info: DaemonArtifactEndpoint,
+  req: DaemonRequest,
+  response: Extract<DaemonResponse, { ok: true }>,
+): Promise<DaemonResponse> {
+  const artifacts = Array.isArray(response.data?.artifacts) ? response.data.artifacts : [];
+  if (artifacts.length === 0 || !info.baseUrl) return response;
+  const nextData = response.data ? { ...response.data } : {};
+  const nextArtifacts: DaemonArtifact[] = [];
+  for (const artifact of artifacts) {
+    if (!artifact || typeof artifact !== 'object' || typeof artifact.artifactId !== 'string') {
+      nextArtifacts.push(artifact);
+      continue;
+    }
+    const localPath = resolveMaterializedArtifactPath(artifact, req);
+    await downloadRemoteArtifact({
+      baseUrl: info.baseUrl,
+      token: info.token,
+      artifactId: artifact.artifactId,
+      destinationPath: localPath,
+      requestId: req.meta?.requestId,
+    });
+    nextData[artifact.field] = localPath;
+    nextArtifacts.push({
+      ...artifact,
+      localPath,
+    });
+  }
+  nextData.artifacts = nextArtifacts;
+  return { ok: true, data: nextData };
+}
+
+function resolveMaterializedArtifactPath(artifact: DaemonArtifact, req: DaemonRequest): string {
+  if (artifact.localPath && artifact.localPath.trim().length > 0) {
+    return artifact.localPath;
+  }
+  const requestedPath = req.meta?.clientArtifactPaths?.[artifact.field];
+  if (requestedPath && requestedPath.trim().length > 0) {
+    return requestedPath;
+  }
+  const fallbackName = artifact.fileName?.trim() || `${artifact.field}-${Date.now()}`;
+  return path.resolve(req.meta?.cwd ?? process.cwd(), fallbackName);
+}
+
+export async function downloadRemoteArtifact(params: {
+  baseUrl: string;
+  token: string;
+  artifactId: string;
+  destinationPath: string;
+  requestId?: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const artifactUrl = new URL(buildDaemonArtifactUrl(params.baseUrl, params.artifactId));
+  const transport = artifactUrl.protocol === 'https:' ? https : http;
+  await fs.promises.mkdir(path.dirname(params.destinationPath), { recursive: true });
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeoutMs = params.timeoutMs ?? REMOTE_ARTIFACT_DOWNLOAD_TIMEOUT_MS;
+    const settle = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutHandle);
+      if (error) {
+        void fs.promises.rm(params.destinationPath, { force: true }).finally(() => reject(error));
+        return;
+      }
+      resolve();
+    };
+    const request = transport.request(
+      {
+        protocol: artifactUrl.protocol,
+        host: artifactUrl.hostname,
+        port: artifactUrl.port,
+        method: 'GET',
+        path: artifactUrl.pathname + artifactUrl.search,
+        headers: params.token
+          ? {
+              authorization: `Bearer ${params.token}`,
+              'x-agent-device-token': params.token,
+            }
+          : undefined,
+      },
+      (res) => {
+        if ((res.statusCode ?? 500) >= 400) {
+          let body = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk) => {
+            body += chunk;
+          });
+          res.on('end', () => {
+            settle(
+              new AppError('COMMAND_FAILED', 'Failed to download remote artifact', {
+                artifactId: params.artifactId,
+                statusCode: res.statusCode,
+                requestId: params.requestId,
+                body,
+              }),
+            );
+          });
+          return;
+        }
+        res.on('aborted', () => {
+          settle(
+            new AppError('COMMAND_FAILED', 'Remote artifact download was interrupted', {
+              artifactId: params.artifactId,
+              requestId: params.requestId,
+            }),
+          );
+        });
+        void pipeline(res, fs.createWriteStream(params.destinationPath)).then(
+          () => settle(),
+          (error: unknown) => settle(error instanceof Error ? error : new Error(String(error))),
+        );
+      },
+    );
+    const timeoutHandle = setTimeout(() => {
+      const timeoutError = new AppError('COMMAND_FAILED', 'Remote artifact download timed out', {
+        artifactId: params.artifactId,
+        requestId: params.requestId,
+        timeoutMs,
+      });
+      settle(timeoutError);
+      request.destroy(timeoutError);
+    }, timeoutMs);
+    request.on('error', (error) => {
+      if (error instanceof AppError) {
+        settle(error);
+        return;
+      }
+      settle(
+        new AppError(
+          'COMMAND_FAILED',
+          'Failed to download remote artifact',
+          {
+            artifactId: params.artifactId,
+            requestId: params.requestId,
+            timeoutMs,
+          },
+          error instanceof Error ? error : undefined,
+        ),
+      );
+    });
+    request.end();
+  });
+}
+
+function buildDaemonArtifactUrl(baseUrl: string, artifactId: string): string {
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL(`artifacts/${encodeURIComponent(artifactId)}`, normalizedBase).toString();
+}
+
+function isRemoteDaemon(info: DaemonArtifactEndpoint): boolean {
+  return typeof info.baseUrl === 'string' && info.baseUrl.length > 0;
+}

--- a/src/daemon-artifacts.ts
+++ b/src/daemon-artifacts.ts
@@ -7,6 +7,7 @@ import { AppError } from './utils/errors.ts';
 import type { DaemonArtifact, DaemonRequest, DaemonResponse } from './daemon/types.ts';
 import { uploadArtifact } from './upload-client.ts';
 
+// Mirrors the current daemon RPC timeout, but artifact download timeouts may diverge.
 const REMOTE_ARTIFACT_DOWNLOAD_TIMEOUT_MS = 90_000;
 
 export type DaemonArtifactEndpoint = {

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -4,13 +4,11 @@ import https from 'node:https';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { pipeline } from 'node:stream/promises';
 import { sleep } from './utils/timeouts.ts';
 import { AppError, toAppErrorCode } from './utils/errors.ts';
 import { consumeTextLines } from './utils/line-stream.ts';
 import { readNodeHttpResponseBody } from './utils/node-http.ts';
 import type {
-  DaemonArtifact,
   DaemonRequest as SharedDaemonRequest,
   DaemonResponse as SharedDaemonResponse,
 } from './daemon/types.ts';
@@ -26,7 +24,6 @@ import {
   type DaemonServerMode,
   type DaemonTransportPreference,
 } from './daemon/config.ts';
-import { uploadArtifact } from './upload-client.ts';
 import { computeDaemonCodeSignature } from './daemon/code-signature.ts';
 import { PUBLIC_COMMANDS } from './command-catalog.ts';
 import { shellQuote } from './utils/shell-quote.ts';
@@ -39,7 +36,9 @@ import {
   isDaemonProgressEnvelope,
   isDaemonResponseEnvelope,
 } from './daemon/request-progress-protocol.ts';
+import { materializeRemoteArtifacts, prepareRemoteRequestArtifacts } from './daemon-artifacts.ts';
 export { computeDaemonCodeSignature } from './daemon/code-signature.ts';
+export { downloadRemoteArtifact } from './daemon-artifacts.ts';
 export type DaemonRequest = SharedDaemonRequest;
 export type DaemonResponse = SharedDaemonResponse;
 
@@ -145,7 +144,7 @@ export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<D
     { requestId, session: req.session },
   );
   const info = daemon.info;
-  const preparedRemoteRequest = await prepareRemoteRequest(req, info);
+  const preparedRemoteRequest = await prepareRemoteRequestArtifacts(req, info);
 
   const request = {
     ...req,
@@ -262,235 +261,6 @@ export async function openApp(options: OpenAppOptions = {}): Promise<DaemonRespo
       ...(lockPlatform !== undefined ? { lockPlatform } : {}),
     },
   });
-}
-
-async function prepareRemoteRequest(
-  req: Omit<DaemonRequest, 'token'>,
-  info: DaemonInfo,
-): Promise<PreparedRemoteRequest> {
-  const positionals = [...(req.positionals ?? [])];
-  let flags = req.flags ? { ...req.flags } : undefined;
-  let installSource = req.meta?.installSource;
-  const clientArtifactPaths: Record<string, string> = {};
-  let uploadedArtifactId: string | undefined;
-
-  if (!isRemoteDaemon(info)) {
-    return createPreparedRemoteRequest({
-      positionals,
-      flags,
-      installSource,
-      uploadedArtifactId,
-      clientArtifactPaths,
-    });
-  }
-
-  flags = applyRemoteArtifactCommand(req, positionals, flags, clientArtifactPaths);
-  const remoteInstallSource = await prepareRemoteInstallSource(req, info);
-  if (remoteInstallSource) {
-    installSource = remoteInstallSource.installSource;
-    uploadedArtifactId = remoteInstallSource.uploadedArtifactId ?? uploadedArtifactId;
-  }
-
-  const baseResult = (): PreparedRemoteRequest =>
-    createPreparedRemoteRequest({
-      positionals,
-      flags,
-      installSource,
-      uploadedArtifactId,
-      clientArtifactPaths,
-    });
-
-  if (req.command !== 'install' && req.command !== 'reinstall') return baseResult();
-  const installPackageResult = await prepareRemoteInstallPackage(req, info, positionals);
-  uploadedArtifactId = installPackageResult ?? uploadedArtifactId;
-  return baseResult();
-}
-
-async function prepareRemoteInstallPackage(
-  req: Omit<DaemonRequest, 'token'>,
-  info: DaemonInfo,
-  positionals: string[],
-): Promise<string | undefined> {
-  const rawPath = positionals[1];
-  if (rawPath === undefined) return undefined;
-  if (rawPath.startsWith('remote:')) {
-    positionals[1] = rawPath.slice('remote:'.length);
-    return undefined;
-  }
-
-  const localPath = resolveLocalInstallPath(rawPath, req.meta?.cwd);
-  if (!localPath) return undefined;
-
-  return await uploadArtifact({
-    localPath,
-    baseUrl: info.baseUrl!,
-    token: info.token,
-    platform: req.flags?.platform,
-  });
-}
-
-function applyRemoteArtifactCommand(
-  req: Omit<DaemonRequest, 'token'>,
-  positionals: string[],
-  flags: DaemonRequest['flags'] | undefined,
-  clientArtifactPaths: Record<string, string>,
-): DaemonRequest['flags'] | undefined {
-  const remoteArtifact = prepareRemoteArtifactCommand(req, positionals);
-  if (!remoteArtifact) return flags;
-  if (remoteArtifact.positionalPath !== undefined) {
-    positionals[remoteArtifact.positionalIndex] = remoteArtifact.positionalPath;
-  }
-  const nextFlags = applyRemoteArtifactOutFlag(flags, remoteArtifact.flagPath);
-  clientArtifactPaths[remoteArtifact.field] = remoteArtifact.localPath;
-  return nextFlags;
-}
-
-function applyRemoteArtifactOutFlag(
-  flags: DaemonRequest['flags'] | undefined,
-  flagPath: string | undefined,
-): DaemonRequest['flags'] | undefined {
-  if (flagPath === undefined) return flags;
-  return { ...(flags ?? {}), out: flagPath };
-}
-
-function resolveLocalInstallPath(rawPath: string, cwd: string | undefined): string | undefined {
-  const localPath = path.isAbsolute(rawPath)
-    ? rawPath
-    : path.resolve(cwd ?? process.cwd(), rawPath);
-  return fs.existsSync(localPath) ? localPath : undefined;
-}
-
-type PreparedRemoteRequest = {
-  positionals: string[];
-  flags?: DaemonRequest['flags'];
-  installSource?: NonNullable<DaemonRequest['meta']>['installSource'];
-  uploadedArtifactId?: string;
-  clientArtifactPaths?: Record<string, string>;
-};
-
-function createPreparedRemoteRequest(
-  result: PreparedRemoteRequest & { clientArtifactPaths: Record<string, string> },
-): PreparedRemoteRequest {
-  return {
-    positionals: result.positionals,
-    flags: result.flags,
-    installSource: result.installSource,
-    uploadedArtifactId: result.uploadedArtifactId,
-    ...(Object.keys(result.clientArtifactPaths).length > 0
-      ? { clientArtifactPaths: result.clientArtifactPaths }
-      : {}),
-  };
-}
-
-async function prepareRemoteInstallSource(
-  req: Omit<DaemonRequest, 'token'>,
-  info: DaemonInfo,
-): Promise<{
-  installSource: NonNullable<DaemonRequest['meta']>['installSource'];
-  uploadedArtifactId?: string;
-} | null> {
-  const source = req.meta?.installSource;
-  if (req.command !== 'install_source' || !source || source.kind !== 'path') {
-    return null;
-  }
-
-  const rawPath = source.path.trim();
-  if (!rawPath) {
-    return { installSource: source };
-  }
-  if (rawPath.startsWith('remote:')) {
-    return {
-      installSource: {
-        ...source,
-        path: rawPath.slice('remote:'.length),
-      },
-    };
-  }
-
-  const localPath = path.isAbsolute(rawPath)
-    ? rawPath
-    : path.resolve(req.meta?.cwd ?? process.cwd(), rawPath);
-  if (!fs.existsSync(localPath)) {
-    return {
-      installSource: {
-        ...source,
-        path: localPath,
-      },
-    };
-  }
-
-  const uploadedArtifactId = await uploadArtifact({
-    localPath,
-    baseUrl: info.baseUrl!,
-    token: info.token,
-    platform: req.flags?.platform,
-  });
-  return {
-    installSource: {
-      ...source,
-      path: localPath,
-    },
-    uploadedArtifactId,
-  };
-}
-
-function prepareRemoteArtifactCommand(
-  req: Omit<DaemonRequest, 'token'>,
-  positionals: string[],
-): {
-  field: string;
-  localPath: string;
-  positionalIndex: number;
-  positionalPath?: string;
-  flagPath?: string;
-} | null {
-  if (req.command === 'screenshot') {
-    const localPath = resolveClientArtifactOutputPath(req, 'path', '.png');
-    if (positionals[0]) {
-      return {
-        field: 'path',
-        localPath,
-        positionalIndex: 0,
-        positionalPath: buildRemoteTempArtifactPath('screenshot', '.png'),
-      };
-    }
-    return {
-      field: 'path',
-      localPath,
-      positionalIndex: 0,
-      flagPath: buildRemoteTempArtifactPath('screenshot', '.png'),
-    };
-  }
-  if (req.command === 'record' && (positionals[0] ?? '').toLowerCase() === 'start') {
-    const localPath = resolveClientArtifactOutputPath(req, 'outPath', '.mp4', 1);
-    return {
-      field: 'outPath',
-      localPath,
-      positionalIndex: 1,
-      positionalPath: buildRemoteTempArtifactPath('recording', path.extname(localPath) || '.mp4'),
-    };
-  }
-  return null;
-}
-
-function resolveClientArtifactOutputPath(
-  req: Omit<DaemonRequest, 'token'>,
-  field: 'path' | 'outPath',
-  fallbackExtension: string,
-  positionalIndex: number = 0,
-): string {
-  const requested = req.positionals?.[positionalIndex] ?? req.flags?.out;
-  const fallbackName = `${field === 'path' ? 'screenshot' : 'recording'}-${Date.now()}${fallbackExtension}`;
-  const rawPath = requested && requested.trim().length > 0 ? requested : fallbackName;
-  return path.isAbsolute(rawPath) ? rawPath : path.resolve(req.meta?.cwd ?? process.cwd(), rawPath);
-}
-
-function buildRemoteTempArtifactPath(prefix: string, extension: string): string {
-  const safeExtension = extension.startsWith('.') ? extension : `.${extension}`;
-  return path.posix.join(
-    '/tmp',
-    `agent-device-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${safeExtension}`,
-  );
 }
 
 function resolveClientSettings(req: Omit<DaemonRequest, 'token'>): DaemonClientSettings {
@@ -1676,157 +1446,6 @@ function buildDaemonHttpUrl(baseUrl: string, route: 'health' | 'rpc'): string {
   // URL(base, relative) treats a base without trailing slash as a file path, so normalize to a directory-like base.
   const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
   return new URL(route, normalizedBase).toString();
-}
-
-function buildDaemonArtifactUrl(baseUrl: string, artifactId: string): string {
-  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-  return new URL(`artifacts/${encodeURIComponent(artifactId)}`, normalizedBase).toString();
-}
-
-async function materializeRemoteArtifacts(
-  info: DaemonInfo,
-  req: DaemonRequest,
-  response: Extract<DaemonResponse, { ok: true }>,
-): Promise<DaemonResponse> {
-  const artifacts = Array.isArray(response.data?.artifacts) ? response.data.artifacts : [];
-  if (artifacts.length === 0 || !info.baseUrl) return response;
-  const nextData = response.data ? { ...response.data } : {};
-  const nextArtifacts: DaemonArtifact[] = [];
-  for (const artifact of artifacts) {
-    if (!artifact || typeof artifact !== 'object' || typeof artifact.artifactId !== 'string') {
-      nextArtifacts.push(artifact);
-      continue;
-    }
-    const localPath = resolveMaterializedArtifactPath(artifact, req);
-    await downloadRemoteArtifact({
-      baseUrl: info.baseUrl,
-      token: info.token,
-      artifactId: artifact.artifactId,
-      destinationPath: localPath,
-      requestId: req.meta?.requestId,
-    });
-    nextData[artifact.field] = localPath;
-    nextArtifacts.push({
-      ...artifact,
-      localPath,
-    });
-  }
-  nextData.artifacts = nextArtifacts;
-  return { ok: true, data: nextData };
-}
-
-function resolveMaterializedArtifactPath(artifact: DaemonArtifact, req: DaemonRequest): string {
-  if (artifact.localPath && artifact.localPath.trim().length > 0) {
-    return artifact.localPath;
-  }
-  const requestedPath = req.meta?.clientArtifactPaths?.[artifact.field];
-  if (requestedPath && requestedPath.trim().length > 0) {
-    return requestedPath;
-  }
-  const fallbackName = artifact.fileName?.trim() || `${artifact.field}-${Date.now()}`;
-  return path.resolve(req.meta?.cwd ?? process.cwd(), fallbackName);
-}
-
-export async function downloadRemoteArtifact(params: {
-  baseUrl: string;
-  token: string;
-  artifactId: string;
-  destinationPath: string;
-  requestId?: string;
-  timeoutMs?: number;
-}): Promise<void> {
-  const artifactUrl = new URL(buildDaemonArtifactUrl(params.baseUrl, params.artifactId));
-  const transport = artifactUrl.protocol === 'https:' ? https : http;
-  await fs.promises.mkdir(path.dirname(params.destinationPath), { recursive: true });
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const timeoutMs = params.timeoutMs ?? REQUEST_TIMEOUT_MS;
-    const settle = (error?: Error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutHandle);
-      if (error) {
-        void fs.promises.rm(params.destinationPath, { force: true }).finally(() => reject(error));
-        return;
-      }
-      resolve();
-    };
-    const request = transport.request(
-      {
-        protocol: artifactUrl.protocol,
-        host: artifactUrl.hostname,
-        port: artifactUrl.port,
-        method: 'GET',
-        path: artifactUrl.pathname + artifactUrl.search,
-        headers: params.token
-          ? {
-              authorization: `Bearer ${params.token}`,
-              'x-agent-device-token': params.token,
-            }
-          : undefined,
-      },
-      (res) => {
-        if ((res.statusCode ?? 500) >= 400) {
-          let body = '';
-          res.setEncoding('utf8');
-          res.on('data', (chunk) => {
-            body += chunk;
-          });
-          res.on('end', () => {
-            settle(
-              new AppError('COMMAND_FAILED', 'Failed to download remote artifact', {
-                artifactId: params.artifactId,
-                statusCode: res.statusCode,
-                requestId: params.requestId,
-                body,
-              }),
-            );
-          });
-          return;
-        }
-        res.on('aborted', () => {
-          settle(
-            new AppError('COMMAND_FAILED', 'Remote artifact download was interrupted', {
-              artifactId: params.artifactId,
-              requestId: params.requestId,
-            }),
-          );
-        });
-        void pipeline(res, fs.createWriteStream(params.destinationPath)).then(
-          () => settle(),
-          (error: unknown) => settle(error instanceof Error ? error : new Error(String(error))),
-        );
-      },
-    );
-    const timeoutHandle = setTimeout(() => {
-      const timeoutError = new AppError('COMMAND_FAILED', 'Remote artifact download timed out', {
-        artifactId: params.artifactId,
-        requestId: params.requestId,
-        timeoutMs,
-      });
-      settle(timeoutError);
-      request.destroy(timeoutError);
-    }, timeoutMs);
-    request.on('error', (error) => {
-      if (error instanceof AppError) {
-        settle(error);
-        return;
-      }
-      settle(
-        new AppError(
-          'COMMAND_FAILED',
-          'Failed to download remote artifact',
-          {
-            artifactId: params.artifactId,
-            requestId: params.requestId,
-            timeoutMs,
-          },
-          error instanceof Error ? error : undefined,
-        ),
-      );
-    });
-    request.end();
-  });
 }
 
 export function resolveDaemonStartupHint(


### PR DESCRIPTION
## Summary

Extracts the first #727 daemon-client seam into `src/daemon-artifacts.ts`: remote artifact upload preparation, artifact output materialization, and remote artifact download now live outside `src/daemon-client.ts` while `daemon-client.ts` remains the public facade and re-exports `downloadRemoteArtifact`.

The PR now targets `main` after #741 merged. The change touches 3 files and keeps the scope to the artifact seam. No docs or skills were updated because this is an internal refactor with no user-facing CLI/workflow change.

Refs #727

## Validation

Focused artifact/client coverage passed with `pnpm exec vitest run src/utils/__tests__/daemon-client.test.ts src/__tests__/upload-client.test.ts` (42 tests). Broader gates passed with `pnpm check:quick`, `pnpm check:fallow --base origin/main`, `pnpm format`, and `git diff --check`.
