### PR TITLE
fix(ios): recover sparse snapshot trees via element queries (React Native)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- iOS: `snapshot` now recovers from a sparse accessibility tree. When the public `XCUIElement.snapshot()` traversal collapses to only structural containers (application/window/other) while the screen is rendering content — common on React Native apps — the runner falls back to a query-based (`XCUIElementQuery`) flat traversal so `testID`s and on-screen controls remain visible instead of returning a 2–3 node tree. The recovered payload is marked `truncated` and carries an explanatory `message`.
+
 ## 0.15.0
 
 - Breaking: `apps` discovery and public app-list helpers now default to user-installed apps. Use `--all` or `filter: 'all'` to include system/OEM apps.

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -11,6 +11,16 @@ extension RunnerTests {
   private static let rawSnapshotMaxNodes = 5_000
   private static let rawSnapshotTooLargeHint =
     "Raw iOS snapshot exceeded the runner payload guard. Use regular snapshot for visible UI, or scope/depth-limit raw snapshot when inspecting a large accessibility tree."
+  private static let degenerateTreeRecoveryMessage =
+    "Recovered the snapshot through accessibility element queries: XCTest's snapshot tree was sparse (only structural containers) while the screen has rendered content. This is common on React Native apps, where XCUIElementQuery still resolves controls the public snapshot omits. Nodes below are a flattened, query-resolved view of the on-screen controls."
+  // Structural container types carry no actionable content on their own; a tree made up of only
+  // these (plus the application/window roots) is the signature of a sparse snapshot.
+  private static let structuralOnlyNodeTypes: Set<String> = [
+    "Application",
+    "Window",
+    "Other",
+    "ScrollView"
+  ]
   private static let collapsedTabCandidateTypes: Set<XCUIElement.ElementType> = [
     .button,
     .link,
@@ -243,10 +253,12 @@ extension RunnerTests {
 
     }
 
-    return DataPayload(
-      nodes: applyHiddenContentHints(hiddenContentHintsByNodeIndex, to: nodes),
-      truncated: false
-    )
+    let resolvedNodes = applyHiddenContentHints(hiddenContentHintsByNodeIndex, to: nodes)
+    if snapshotNodesAreDegenerate(resolvedNodes),
+      let recovered = snapshotQueryRecovery(app: app, options: options) {
+      return recovered
+    }
+    return DataPayload(nodes: resolvedNodes, truncated: false)
   }
 
   func snapshotRaw(app: XCUIApplication, options: SnapshotOptions) throws -> DataPayload {
@@ -378,6 +390,52 @@ extension RunnerTests {
       )
     }
     return DataPayload(nodes: nodes, truncated: truncated)
+  }
+
+  /// Detects the "sparse snapshot" signature: the public `XCUIElement.snapshot()` traversal
+  /// produced only structural container nodes (application/window/other/scrollView) with no
+  /// label, identifier, value, or hittable control — even though the app is foregrounded and
+  /// rendering content. React Native apps hit this regularly: the public snapshot API collapses
+  /// the host view's subtree, while `XCUIElementQuery` still resolves the underlying controls.
+  private func snapshotNodesAreDegenerate(_ nodes: [SnapshotNode]) -> Bool {
+    guard !nodes.isEmpty else { return false }
+    for node in nodes {
+      let hasContent = (node.label?.isEmpty == false)
+        || (node.identifier?.isEmpty == false)
+        || (node.value?.isEmpty == false)
+      if hasContent || node.hittable { return false }
+      // A concretely typed control (Button, StaticText, TextField, …) means the tree is not
+      // degenerate, even when it happens to carry no resolved content this frame.
+      if !Self.structuralOnlyNodeTypes.contains(node.type) { return false }
+    }
+    return true
+  }
+
+  /// Recovers a usable tree for a sparse snapshot by reusing the query-based flat traversal
+  /// (the same `XCUIElementQuery` path the collapsed-tab fallback already trusts). Returns `nil`
+  /// when queries see nothing more than the sparse tree, so the caller keeps the original result.
+  private func snapshotQueryRecovery(
+    app: XCUIApplication,
+    options: SnapshotOptions
+  ) -> DataPayload? {
+    let recovery = snapshotFlatInteractive(
+      app: app,
+      options: SnapshotOptions(
+        interactiveOnly: false,
+        compact: options.compact,
+        depth: options.depth ?? Int.max,
+        scope: options.scope,
+        raw: false
+      )
+    )
+    // nodes[0] is always the synthetic Application root; require at least one real control beyond it.
+    guard let nodes = recovery.nodes, nodes.count > 1 else { return nil }
+    NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_DEGENERATE_TREE_RECOVERED=%d", nodes.count)
+    return DataPayload(
+      message: Self.degenerateTreeRecoveryMessage,
+      nodes: nodes,
+      truncated: true
+    )
   }
 
   private func snapshotAccessibilityUnavailable(failure: SnapshotCaptureFailure) -> DataPayload {
@@ -552,6 +610,73 @@ extension RunnerTests {
     XCTAssertNil(payload?.runnerFatalReason)
     XCTAssertNotNil(currentApp)
     XCTAssertEqual(currentBundleId, "com.example.app")
+  }
+
+  private func makeTestSnapshotNode(
+    index: Int,
+    type: String,
+    label: String? = nil,
+    identifier: String? = nil,
+    value: String? = nil,
+    hittable: Bool = false
+  ) -> SnapshotNode {
+    SnapshotNode(
+      index: index,
+      type: type,
+      label: label,
+      identifier: identifier,
+      value: value,
+      rect: SnapshotRect(x: 0, y: 0, width: 402, height: 874),
+      enabled: true,
+      focused: nil,
+      selected: nil,
+      hittable: hittable,
+      depth: 0,
+      parentIndex: nil,
+      hiddenContentAbove: nil,
+      hiddenContentBelow: nil
+    )
+  }
+
+  func testSnapshotNodesAreDegenerateDetectsStructuralOnlyTree() {
+    let nodes = [
+      makeTestSnapshotNode(index: 0, type: "Application"),
+      makeTestSnapshotNode(index: 1, type: "Window"),
+      makeTestSnapshotNode(index: 2, type: "Other")
+    ]
+
+    XCTAssertTrue(snapshotNodesAreDegenerate(nodes))
+  }
+
+  func testSnapshotNodesAreNotDegenerateWhenContentPresent() {
+    let nodes = [
+      makeTestSnapshotNode(index: 0, type: "Application"),
+      makeTestSnapshotNode(index: 1, type: "StaticText", label: "Welcome back!")
+    ]
+
+    XCTAssertFalse(snapshotNodesAreDegenerate(nodes))
+  }
+
+  func testSnapshotNodesAreNotDegenerateWhenHittableControlPresent() {
+    let nodes = [
+      makeTestSnapshotNode(index: 0, type: "Application"),
+      makeTestSnapshotNode(index: 1, type: "Other", hittable: true)
+    ]
+
+    XCTAssertFalse(snapshotNodesAreDegenerate(nodes))
+  }
+
+  func testSnapshotNodesAreNotDegenerateWhenTypedControlPresent() {
+    let nodes = [
+      makeTestSnapshotNode(index: 0, type: "Application"),
+      makeTestSnapshotNode(index: 1, type: "Button")
+    ]
+
+    XCTAssertFalse(snapshotNodesAreDegenerate(nodes))
+  }
+
+  func testSnapshotNodesAreNotDegenerateWhenEmpty() {
+    XCTAssertFalse(snapshotNodesAreDegenerate([]))
   }
 
   private func compactInteractiveRootNode(rect: CGRect) -> SnapshotNode {

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -13,8 +13,6 @@ extension RunnerTests {
     "Raw iOS snapshot exceeded the runner payload guard. Use regular snapshot for visible UI, or scope/depth-limit raw snapshot when inspecting a large accessibility tree."
   private static let degenerateTreeRecoveryMessage =
     "Recovered the snapshot through accessibility element queries: XCTest's snapshot tree was sparse (only structural containers) while the screen has rendered content. This is common on React Native apps, where XCUIElementQuery still resolves controls the public snapshot omits. Nodes below are a flattened, query-resolved view of the on-screen controls."
-  // Structural container types carry no actionable content on their own; a tree made up of only
-  // these (plus the application/window roots) is the signature of a sparse snapshot.
   private static let structuralOnlyNodeTypes: Set<String> = [
     "Application",
     "Window",
@@ -392,11 +390,9 @@ extension RunnerTests {
     return DataPayload(nodes: nodes, truncated: truncated)
   }
 
-  /// Detects the "sparse snapshot" signature: the public `XCUIElement.snapshot()` traversal
-  /// produced only structural container nodes (application/window/other/scrollView) with no
-  /// label, identifier, value, or hittable control — even though the app is foregrounded and
-  /// rendering content. React Native apps hit this regularly: the public snapshot API collapses
-  /// the host view's subtree, while `XCUIElementQuery` still resolves the underlying controls.
+  // A tree of only structural containers with no content or hittable control is the signature of
+  // a sparse snapshot: the public XCUIElement.snapshot() API collapses the subtree (common on
+  // React Native) while XCUIElementQuery still resolves the underlying controls.
   private func snapshotNodesAreDegenerate(_ nodes: [SnapshotNode]) -> Bool {
     guard !nodes.isEmpty else { return false }
     for node in nodes {
@@ -404,16 +400,13 @@ extension RunnerTests {
         || (node.identifier?.isEmpty == false)
         || (node.value?.isEmpty == false)
       if hasContent || node.hittable { return false }
-      // A concretely typed control (Button, StaticText, TextField, …) means the tree is not
-      // degenerate, even when it happens to carry no resolved content this frame.
       if !Self.structuralOnlyNodeTypes.contains(node.type) { return false }
     }
     return true
   }
 
-  /// Recovers a usable tree for a sparse snapshot by reusing the query-based flat traversal
-  /// (the same `XCUIElementQuery` path the collapsed-tab fallback already trusts). Returns `nil`
-  /// when queries see nothing more than the sparse tree, so the caller keeps the original result.
+  // Recovers a sparse snapshot via the query-based flat traversal (the same XCUIElementQuery path
+  // collapsedTabFallbackNodes uses). Returns nil when queries see nothing more than the sparse tree.
   private func snapshotQueryRecovery(
     app: XCUIApplication,
     options: SnapshotOptions
@@ -428,7 +421,6 @@ extension RunnerTests {
         raw: false
       )
     )
-    // nodes[0] is always the synthetic Application root; require at least one real control beyond it.
     guard let nodes = recovery.nodes, nodes.count > 1 else { return nil }
     NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_DEGENERATE_TREE_RECOVERED=%d", nodes.count)
     return DataPayload(

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -390,9 +390,6 @@ extension RunnerTests {
     return DataPayload(nodes: nodes, truncated: truncated)
   }
 
-  // A tree of only structural containers with no content or hittable control is the signature of
-  // a sparse snapshot: the public XCUIElement.snapshot() API collapses the subtree (common on
-  // React Native) while XCUIElementQuery still resolves the underlying controls.
   private func snapshotNodesAreDegenerate(_ nodes: [SnapshotNode]) -> Bool {
     guard !nodes.isEmpty else { return false }
     for node in nodes {
@@ -405,8 +402,6 @@ extension RunnerTests {
     return true
   }
 
-  // Recovers a sparse snapshot via the query-based flat traversal (the same XCUIElementQuery path
-  // collapsedTabFallbackNodes uses). Returns nil when queries see nothing more than the sparse tree.
   private func snapshotQueryRecovery(
     app: XCUIApplication,
     options: SnapshotOptions


### PR DESCRIPTION
## Problem

On some apps — most reliably **React Native / Expo** apps — `agent-device snapshot` on iOS returns a degenerate 2–3 node tree (`application → window [→ other]`) even though the screen is foregrounded and fully rendered. The same screen at the same instant exposes 300+ nodes (with all `testID`s as accessibility identifiers) through Appium/WebDriverAgent's `/source`.

Everything that reads the tree is affected: selector `click`/`find`/`is`/`get`, and `react-native dismiss-overlay` (hangs to the daemon timeout when a LogBox toast is on screen). Coordinate taps are unaffected and work fine (thanks to the quiescence-skip fix in 0.17.0).

### Root cause (verified)

I patched the shipped runner source locally to rule out the usual suspects:

- **Idle/quiescence:** setting `waitForIdleTimeout = 0` (via KVC) around the capture still returns 2 nodes.
- **Main-thread watchdog:** raising `mainThreadExecutionTimeout` 30→120s — the snapshot completes `ok=1` in `runner.log`, payload still 2 nodes.

So the public `XCUIElement.snapshot()` API itself returns the sparse tree for these apps. WDA sees the full tree because it bypasses the public snapshot with its own raw accessibility traversal. Notably, **`XCUIElementQuery` still resolves the controls** on the same screen — which this runner already relies on elsewhere (`collapsedTabFallbackNodes` uses `descendants(matching:.any).allElementsBoundByIndex` precisely because the snapshot tree omits tab children).

## Change

Rather than introducing a private raw-AX traversal, this reuses the query path the codebase already trusts:

1. After `snapshotFast` builds its node list, detect the **sparse-tree signature** — only structural containers (`Application`/`Window`/`Other`/`ScrollView`) with no label/identifier/value and nothing hittable (`snapshotNodesAreDegenerate`).
2. When detected, recover via the existing query-based flat traversal (`snapshotFlatInteractive` with `interactiveOnly: false`) so on-screen controls and `testID`s come back instead of an empty tree (`snapshotQueryRecovery`).
3. Recovery is **conservative**: if queries reveal nothing more than the sparse tree, the original result is kept. The recovered payload is marked `truncated: true` and carries an explanatory `message`, mirroring the existing `snapshotDepthLimitedAccessibilityFallback` pattern.

Public XCUITest APIs only; no new dependencies; the non-sparse path is unchanged (the detector returns early as soon as any real content/control is seen).

## Tests

Added unit tests for the detector (`testSnapshotNodesAreDegenerate*`) covering: structural-only tree (degenerate), content present, hittable control present, typed control present, and empty input. `swiftc -parse` passes on the file.

## Validation status

⚠️ **Draft** — the Swift unit tests and a full on-device XCUITest build/run against a real RN app are pending (I couldn't run the full UI-test build in my environment). I have side-by-side evidence (agent-device snapshot vs WDA `/source` from the same screen, runner.log excerpts, and the patch diffs used to rule out idle/watchdog causes) and a perfect repro app — happy to share, and to iterate on the detection heuristic or the recovered payload shape. Opening as draft so you can validate on-device first.

Closes the sparse-tree half of the iOS RN snapshot issue.

Made with [Cursor](https://cursor.com)