### PR TITLE
fix: use full-screen reference frame for recording touch overlays

### DIFF
--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -935,6 +935,67 @@ test('press coordinates appends touch-visualization events while recording', asy
   }
 });
 
+test('press coordinates on iOS recording captures a non-compact snapshot for the touch reference frame', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-direct-press-frame';
+  const session = makeSession(sessionName);
+  session.snapshot = undefined;
+  session.recording = {
+    platform: 'ios',
+    outPath: '/tmp/demo.mp4',
+    startedAt: Date.now() - 1_000,
+    showTouches: true,
+    gestureEvents: [],
+    child: { kill: () => {} } as any,
+    wait: Promise.resolve({ stdout: '', stderr: '', exitCode: 0 }),
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockResolvedValue({ x: 220, y: 600 });
+  // Regression: a compact snapshot has no Application/Window node, so viewport inference would
+  // return a leaf-element bounding box and the recording overlay would misplace tap markers.
+  mockCaptureSnapshotForSession.mockResolvedValueOnce({
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'XCUIElementTypeApplication',
+        rect: { x: 0, y: 0, width: 440, height: 956 },
+      },
+      {
+        index: 1,
+        type: 'XCUIElementTypeCell',
+        rect: { x: 16, y: 156, width: 370, height: 52 },
+        hittable: true,
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'xctest',
+  });
+
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'press',
+      positionals: ['220', '600'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(mockCaptureSnapshotForSession.mock.calls[0]?.[4]).toEqual({
+    interactiveOnly: true,
+    compact: false,
+  });
+  const event = sessionStore.get(sessionName)?.recording?.gestureEvents[0];
+  expect(event?.kind).toBe('tap');
+  expect(event?.referenceWidth).toBe(440);
+  expect(event?.referenceHeight).toBe(956);
+});
+
 test('press coordinates on Android recording uses physical screen size when no snapshot exists', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'android-direct-press-frame';

--- a/src/daemon/handlers/interaction-snapshot.ts
+++ b/src/daemon/handlers/interaction-snapshot.ts
@@ -11,7 +11,7 @@ export type CaptureSnapshotForSession = (
   flags: CommandFlags | undefined,
   sessionStore: SessionStore,
   contextFromFlags: ContextFromFlags,
-  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
+  options: { interactiveOnly: boolean; compact?: boolean; androidFreshnessMode?: 'ref-refresh' },
 ) => Promise<SnapshotState>;
 
 export async function captureSnapshotForSession(
@@ -19,12 +19,12 @@ export async function captureSnapshotForSession(
   flags: CommandFlags | undefined,
   sessionStore: SessionStore,
   contextFromFlags: ContextFromFlags,
-  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
+  options: { interactiveOnly: boolean; compact?: boolean; androidFreshnessMode?: 'ref-refresh' },
 ): Promise<SnapshotState> {
   const effectiveFlags = {
     ...(flags ?? {}),
     snapshotInteractiveOnly: options.interactiveOnly,
-    snapshotCompact: options.interactiveOnly,
+    snapshotCompact: options.compact ?? options.interactiveOnly,
   };
   const dispatchContext = contextFromFlags(
     effectiveFlags,

--- a/src/daemon/handlers/interaction-touch-reference-frame.ts
+++ b/src/daemon/handlers/interaction-touch-reference-frame.ts
@@ -48,8 +48,11 @@ async function resolveDirectTouchReferenceFrame(params: {
     return undefined;
   }
 
+  // Compact snapshots prune Application/Window containers, leaving viewport inference to fall
+  // back to a bounding box of leaf elements — a garbage reference frame for screen-point touches.
   const snapshot = await captureSnapshotForSession(session, flags, sessionStore, contextFromFlags, {
     interactiveOnly: true,
+    compact: false,
   });
   const referenceFrame = getSnapshotReferenceFrame(snapshot);
   if (referenceFrame && session.recording) {


### PR DESCRIPTION
## What

iOS simulator screen recordings with touch overlays rendered tap markers at the wrong position — y clamped to the video's bottom edge (repro: `record start`, `press 220 600` on a 440×956pt device, marker burned in at bottom-center instead of ~(110, 301) in the 220×480 video).

## Why

For coordinate presses during recording with no prior snapshot, `resolveDirectTouchReferenceFrame` captured the reference-frame snapshot with `interactiveOnly: true`, which `captureSnapshotForSession` coupled to **compact mode**. Compact pruning drops `Application`/`Window` container nodes, so `inferViewportRect` fell back to a bounding box of leaf elements (e.g. 386×208.33 in the Settings app instead of the screen size). The overlay renderer (`recording-overlay.swift`) then scaled marker coordinates with that garbage frame: x looked nearly right by coincidence (bbox width ≈ screen width), while y scaled ~2× past the canvas and clamped.

## How

- `captureSnapshotForSession` accepts an optional `compact` override (default unchanged: `compact = interactiveOnly`).
- `resolveDirectTouchReferenceFrame` requests `compact: false`, so the Application node survives and the inferred frame is the real full-screen point size — matching the coordinate space of the recorded touch events and the recorded video.
- Regression test: an iOS coordinate press during recording must capture a non-compact snapshot and stamp the gesture event with the Application-node frame.

The leaf-bbox fallback in `inferViewportRect` is left as is — Android snapshots have no Application/Window-typed nodes and rely on it (there the bbox approximates the screen).

## Validation (iPhone 17 simulator, iOS 27, 402×874pt screen, 220×480 video)

- Before: `<video>.gesture-telemetry.json` carried `referenceWidth: 386, referenceHeight: 208.33`; marker clamped at the bottom edge.
- After: telemetry carries `402×874`; the burned-in marker measures at **(121, 329)** in the frame vs expected (120.4, 329.5) — within a pixel.
- `pnpm typecheck` clean; daemon unit suites pass (734 tests).
