### PR TITLE
refactor: bundle snapshot capture annotations

### DIFF
--- a/src/__tests__/client-shared.test.ts
+++ b/src/__tests__/client-shared.test.ts
@@ -130,3 +130,24 @@ test('serializeSnapshotResult includes Android backend metadata', () => {
     },
   });
 });
+
+test('serializeSnapshotResult maps capture quality annotation to public snapshotQuality', () => {
+  const snapshotQuality = {
+    state: 'healthy',
+    backend: 'tree',
+  } as const;
+  const data = serializeSnapshotResult({
+    nodes: [],
+    truncated: false,
+    quality: snapshotQuality,
+    identifiers: {
+      session: 'qa',
+    },
+  } as Parameters<typeof serializeSnapshotResult>[0] & { quality: typeof snapshotQuality });
+
+  assert.deepEqual(data, {
+    nodes: [],
+    truncated: false,
+    snapshotQuality,
+  });
+});

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -623,6 +623,30 @@ test('client capture.snapshot preserves visibility metadata from daemon response
   });
 });
 
+test('client capture.snapshot preserves snapshot quality annotation from daemon responses', async () => {
+  const snapshotQuality = {
+    state: 'recovered',
+    backend: 'queries',
+    reason: 'tree was sparse',
+    reasonCode: 'sparse-tree',
+    effectiveDepth: 2,
+    collapsedLeafIndexes: [7],
+  } as const;
+  const setup = createTransport(async () => ({
+    ok: true,
+    data: {
+      nodes: [],
+      truncated: false,
+      snapshotQuality,
+    },
+  }));
+  const client = createAgentDeviceClient(setup.config, { transport: setup.transport });
+
+  const result = await client.capture.snapshot();
+
+  assert.deepEqual(result.snapshotQuality, snapshotQuality);
+});
+
 test('client capture.snapshot forwards force-full as snapshotForceFull flag', async () => {
   const setup = createTransport(async () => ({
     ok: true,

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -1,5 +1,3 @@
-import type { SnapshotQualityVerdict } from './utils/snapshot-quality.ts';
-import type { AndroidSnapshotBackendMetadata } from './platforms/android/snapshot-types.ts';
 import type { AlertAction, AlertInfo } from './alert-contract.ts';
 import type { AppsFilter } from './contracts/app-inventory.ts';
 import type {
@@ -17,6 +15,11 @@ import type { ClickButton } from './core/click-button.ts';
 import type { DeviceRotation } from './core/device-rotation.ts';
 import type { ScrollDirection } from './core/scroll-gesture.ts';
 import type { SessionSurface } from './core/session-surface.ts';
+import type {
+  SnapshotCaptureAnalysis,
+  SnapshotCaptureAnnotations,
+  SnapshotCaptureFreshness,
+} from './snapshot-capture-annotations.ts';
 
 export type AgentDeviceBackendPlatform = Platform;
 
@@ -44,30 +47,17 @@ export type BackendSnapshotResult = {
   truncated?: boolean;
   backend?: string;
   snapshot?: SnapshotState;
-  analysis?: BackendSnapshotAnalysis;
-  androidSnapshot?: AndroidSnapshotBackendMetadata;
-  freshness?: BackendSnapshotFreshness;
-  warnings?: string[];
-  quality?: SnapshotQualityVerdict;
   appName?: string;
   appBundleId?: string;
-};
+} & SnapshotCaptureAnnotations;
 
 export type BackendSnapshotOptions = SnapshotOptions & {
   outPath?: string;
 };
 
-export type BackendSnapshotAnalysis = {
-  rawNodeCount?: number;
-  maxDepth?: number;
-};
+export type BackendSnapshotAnalysis = SnapshotCaptureAnalysis;
 
-export type BackendSnapshotFreshness = {
-  action: string;
-  retryCount: number;
-  staleAfterRetries: boolean;
-  reason?: 'empty-interactive' | 'sharp-drop' | 'stuck-route';
-};
+export type BackendSnapshotFreshness = SnapshotCaptureFreshness;
 
 export type BackendReadTextResult = {
   text: string;

--- a/src/client-shared.ts
+++ b/src/client-shared.ts
@@ -10,7 +10,10 @@ import type {
   CaptureSnapshotResult,
   SessionCloseResult,
 } from './client-types.ts';
-import { publicSnapshotCaptureAnnotations } from './snapshot-capture-annotations.ts';
+import {
+  publicSnapshotCaptureAnnotations,
+  type SnapshotCaptureAnnotations,
+} from './snapshot-capture-annotations.ts';
 import type { Platform } from './utils/device.ts';
 import { successText, withSuccessText } from './utils/success-text.ts';
 
@@ -173,10 +176,17 @@ export function serializeSnapshotResult(result: CaptureSnapshotResult): Record<s
     ...(result.appName ? { appName: result.appName } : {}),
     ...(result.appBundleId ? { appBundleId: result.appBundleId } : {}),
     ...(result.visibility ? { visibility: result.visibility } : {}),
-    ...publicSnapshotCaptureAnnotations({
-      ...result,
-      quality: result.snapshotQuality,
-    }),
+    ...publicSnapshotCaptureAnnotations(snapshotResultAnnotations(result)),
     ...(result.unchanged ? { unchanged: result.unchanged } : {}),
+  };
+}
+
+function snapshotResultAnnotations(
+  result: CaptureSnapshotResult,
+): Partial<SnapshotCaptureAnnotations> {
+  const annotations = result as CaptureSnapshotResult & Partial<SnapshotCaptureAnnotations>;
+  return {
+    ...annotations,
+    ...(result.snapshotQuality ? { quality: result.snapshotQuality } : {}),
   };
 }

--- a/src/client-shared.ts
+++ b/src/client-shared.ts
@@ -10,6 +10,7 @@ import type {
   CaptureSnapshotResult,
   SessionCloseResult,
 } from './client-types.ts';
+import { publicSnapshotCaptureAnnotations } from './snapshot-capture-annotations.ts';
 import type { Platform } from './utils/device.ts';
 import { successText, withSuccessText } from './utils/success-text.ts';
 
@@ -172,9 +173,10 @@ export function serializeSnapshotResult(result: CaptureSnapshotResult): Record<s
     ...(result.appName ? { appName: result.appName } : {}),
     ...(result.appBundleId ? { appBundleId: result.appBundleId } : {}),
     ...(result.visibility ? { visibility: result.visibility } : {}),
-    ...(result.androidSnapshot ? { androidSnapshot: result.androidSnapshot } : {}),
-    ...(result.snapshotQuality ? { snapshotQuality: result.snapshotQuality } : {}),
-    ...(result.warnings && result.warnings.length > 0 ? { warnings: result.warnings } : {}),
+    ...publicSnapshotCaptureAnnotations({
+      ...result,
+      quality: result.snapshotQuality,
+    }),
     ...(result.unchanged ? { unchanged: result.unchanged } : {}),
   };
 }

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -1,4 +1,4 @@
-import type { SnapshotQualityVerdict } from './utils/snapshot-quality.ts';
+import type { PublicSnapshotCaptureAnnotations } from './snapshot-capture-annotations.ts';
 import type {
   DaemonResponseData,
   DaemonInstallSource,
@@ -26,7 +26,6 @@ import type { ScrollInputDirection } from './commands/interaction-gestures.ts';
 import type { LogAction } from './contracts/logs.ts';
 import type { SessionSurface } from './core/session-surface.ts';
 import type { FindLocator } from './utils/finders.ts';
-import type { AndroidSnapshotBackendMetadata } from './platforms/android/snapshot-types.ts';
 import type {
   ScreenshotOverlayRef,
   SnapshotNode,
@@ -335,12 +334,9 @@ export type CaptureSnapshotResult = {
   appName?: string;
   appBundleId?: string;
   visibility?: SnapshotVisibility;
-  androidSnapshot?: AndroidSnapshotBackendMetadata;
-  warnings?: string[];
   unchanged?: SnapshotUnchanged;
   identifiers: AgentDeviceIdentifiers;
-  snapshotQuality?: SnapshotQualityVerdict;
-};
+} & PublicSnapshotCaptureAnnotations;
 
 export type CaptureScreenshotOptions = AgentDeviceRequestOverrides & {
   path?: string;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,3 @@
-import { readSnapshotQualityVerdict } from './utils/snapshot-quality.ts';
 import { sendToDaemon } from './daemon-client.ts';
 import { prepareMetroRuntime, reloadMetro } from './client-metro.ts';
 import { resolveDaemonPaths } from './daemon/config.ts';
@@ -42,6 +41,7 @@ import type {
   MaterializationReleaseOptions,
   MetroPrepareOptions,
 } from './client-types.ts';
+import { readSerializedSnapshotCaptureAnnotations } from './snapshot-capture-annotations.ts';
 
 export function createAgentDeviceClient(
   config: AgentDeviceClientConfig = {},
@@ -342,20 +342,11 @@ function optionalSnapshotResponseFields(
   >
 > {
   const visibility = readObject(data.visibility);
-  const androidSnapshot = readObject(data.androidSnapshot);
   const unchanged = readObject(data.unchanged);
-  const warnings = Array.isArray(data.warnings)
-    ? data.warnings.filter((entry): entry is string => typeof entry === 'string')
-    : undefined;
-  const snapshotQuality = readSnapshotQualityVerdict(data.snapshotQuality);
   return {
     ...(visibility ? { visibility: visibility as CaptureSnapshotResult['visibility'] } : {}),
-    ...(snapshotQuality ? { snapshotQuality } : {}),
-    ...(androidSnapshot
-      ? { androidSnapshot: androidSnapshot as CaptureSnapshotResult['androidSnapshot'] }
-      : {}),
+    ...readSerializedSnapshotCaptureAnnotations(data),
     ...(unchanged ? { unchanged: unchanged as CaptureSnapshotResult['unchanged'] } : {}),
-    ...(warnings ? { warnings } : {}),
   };
 }
 

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -1,9 +1,13 @@
 import type { BackendSnapshotResult } from '../backend.ts';
-import type { AndroidSnapshotBackendMetadata } from '../platforms/android/snapshot-types.ts';
 import type { AgentDeviceRuntime, CommandSessionRecord } from '../runtime-contract.ts';
 import {
+  publicSnapshotCaptureAnnotations,
+  snapshotCaptureAnnotationsFrom,
+  type PublicSnapshotCaptureAnnotations,
+  type SnapshotCaptureAnnotations,
+} from '../snapshot-capture-annotations.ts';
+import {
   renderSnapshotQualityWarnings,
-  type SnapshotQualityVerdict,
 } from '../utils/snapshot-quality.ts';
 import { AppError } from '../utils/errors.ts';
 import { buildSnapshotDiff, countSnapshotComparableLines } from '../utils/snapshot-diff.ts';
@@ -35,11 +39,8 @@ export type SnapshotCommandResult = {
   appName?: string;
   appBundleId?: string;
   visibility?: SnapshotVisibility;
-  androidSnapshot?: AndroidSnapshotBackendMetadata;
-  warnings?: string[];
   unchanged?: SnapshotUnchanged;
-  snapshotQuality?: SnapshotQualityVerdict;
-};
+} & PublicSnapshotCaptureAnnotations;
 
 export type DiffSnapshotCommandResult = {
   mode: 'snapshot';
@@ -53,6 +54,7 @@ type SnapshotCapture = {
   snapshot: SnapshotState;
   result: BackendSnapshotResult;
   session: CommandSessionRecord | undefined;
+  annotations: SnapshotCaptureAnnotations;
   warnings: string[];
 };
 
@@ -79,9 +81,10 @@ export const snapshotCommand: RuntimeCommand<
       backend: capture.snapshot.backend,
       snapshotRaw: options.raw,
     }),
-    ...(capture.result.androidSnapshot ? { androidSnapshot: capture.result.androidSnapshot } : {}),
-    ...(capture.result.quality ? { snapshotQuality: capture.result.quality } : {}),
-    ...(capture.warnings.length > 0 ? { warnings: capture.warnings } : {}),
+    ...publicSnapshotCaptureAnnotations({
+      ...capture.annotations,
+      warnings: capture.warnings,
+    }),
     ...(unchanged ? { unchanged } : {}),
     ...snapshotAppFields(capture),
   };
@@ -158,13 +161,16 @@ async function captureRuntimeSnapshot(
     normalizeBackendSnapshot(result, runtime),
     options,
   );
+  const annotations = snapshotCaptureAnnotationsFrom(result);
   const warningTime = now(runtime);
   return {
     snapshot,
     result,
     session,
+    annotations,
     warnings: buildSnapshotWarnings({
       result,
+      annotations,
       snapshot,
       options,
       session,
@@ -215,24 +221,27 @@ function snapshotAppFields(capture: SnapshotCapture): {
 
 function buildSnapshotWarnings(params: {
   result: BackendSnapshotResult;
+  annotations: SnapshotCaptureAnnotations;
   snapshot: SnapshotState;
   options: SnapshotCommandOptions;
   session: CommandSessionRecord | undefined;
   capturedAt: number;
   runtimeNow: number;
 }): string[] {
-  const warnings = [...(params.result.warnings ?? [])];
-  if (params.result.quality) {
-    warnings.push(...renderSnapshotQualityWarnings(params.result.quality, params.snapshot.nodes));
+  const warnings = [...(params.annotations.warnings ?? [])];
+  if (params.annotations.quality) {
+    warnings.push(...renderSnapshotQualityWarnings(params.annotations.quality, params.snapshot.nodes));
   }
   warnings.push(...buildEmptyAndroidInteractiveWarnings(params));
-  if (!params.result.quality) {
+  if (!params.annotations.quality) {
     // Legacy runners without a structured verdict keep the old daemon-side heuristics.
     warnings.push(...buildSparseIosInteractiveWarnings(params));
     warnings.push(...buildMergedAccessibilityLeafWarnings(params.snapshot.nodes));
   }
 
-  const helperFallbackWarning = formatAndroidHelperFallbackWarning(params.result.androidSnapshot);
+  const helperFallbackWarning = formatAndroidHelperFallbackWarning(
+    params.annotations.androidSnapshot,
+  );
   if (helperFallbackWarning) warnings.push(helperFallbackWarning);
 
   const reactNativeOverlayWarning = formatReactNativeOverlayWarning(params.snapshot.nodes);
@@ -241,7 +250,7 @@ function buildSnapshotWarnings(params: {
   const recentDropWarning = formatRecentSnapshotDropWarning(params);
   if (recentDropWarning) warnings.push(recentDropWarning);
 
-  warnings.push(...formatFreshnessWarnings(params.result.freshness, params.snapshot.backend));
+  warnings.push(...formatFreshnessWarnings(params.annotations.freshness, params.snapshot.backend));
   return Array.from(new Set(warnings));
 }
 
@@ -295,11 +304,11 @@ function buildMergedAccessibilityLeafWarnings(nodes: SnapshotState['nodes']): st
 }
 
 function buildEmptyAndroidInteractiveWarnings(params: {
-  result: BackendSnapshotResult;
+  annotations: SnapshotCaptureAnnotations;
   snapshot: SnapshotState;
   options: SnapshotCommandOptions;
 }): string[] {
-  const analysis = params.result.analysis;
+  const analysis = params.annotations.analysis;
   if (
     params.snapshot.backend !== 'android' ||
     params.options.interactiveOnly !== true ||
@@ -326,7 +335,7 @@ function buildEmptyAndroidInteractiveWarnings(params: {
 }
 
 function formatAndroidHelperFallbackWarning(
-  androidSnapshot: AndroidSnapshotBackendMetadata | undefined,
+  androidSnapshot: SnapshotCaptureAnnotations['androidSnapshot'],
 ): string | undefined {
   if (androidSnapshot?.backend !== 'uiautomator-dump') return undefined;
   const reason = androidSnapshot.fallbackReason ? ` Reason: ${androidSnapshot.fallbackReason}` : '';
@@ -334,7 +343,7 @@ function formatAndroidHelperFallbackWarning(
 }
 
 function formatRecentSnapshotDropWarning(params: {
-  result: BackendSnapshotResult;
+  annotations: SnapshotCaptureAnnotations;
   snapshot: SnapshotState;
   session: CommandSessionRecord | undefined;
   capturedAt: number;
@@ -342,7 +351,7 @@ function formatRecentSnapshotDropWarning(params: {
 }): string | undefined {
   const previousSnapshot = params.session?.snapshot;
   if (
-    !params.result.freshness &&
+    !params.annotations.freshness &&
     previousSnapshot &&
     hasSameSnapshotPresentation(previousSnapshot, params.snapshot) &&
     isRecentSnapshot(previousSnapshot, params.capturedAt, params.runtimeNow) &&

--- a/src/commands/capture-snapshot.ts
+++ b/src/commands/capture-snapshot.ts
@@ -6,9 +6,7 @@ import {
   type PublicSnapshotCaptureAnnotations,
   type SnapshotCaptureAnnotations,
 } from '../snapshot-capture-annotations.ts';
-import {
-  renderSnapshotQualityWarnings,
-} from '../utils/snapshot-quality.ts';
+import { renderSnapshotQualityWarnings } from '../utils/snapshot-quality.ts';
 import { AppError } from '../utils/errors.ts';
 import { buildSnapshotDiff, countSnapshotComparableLines } from '../utils/snapshot-diff.ts';
 import type { SnapshotDiffLine, SnapshotDiffSummary } from '../utils/snapshot-diff.ts';
@@ -230,7 +228,9 @@ function buildSnapshotWarnings(params: {
 }): string[] {
   const warnings = [...(params.annotations.warnings ?? [])];
   if (params.annotations.quality) {
-    warnings.push(...renderSnapshotQualityWarnings(params.annotations.quality, params.snapshot.nodes));
+    warnings.push(
+      ...renderSnapshotQualityWarnings(params.annotations.quality, params.snapshot.nodes),
+    );
   }
   warnings.push(...buildEmptyAndroidInteractiveWarnings(params));
   if (!params.annotations.quality) {

--- a/src/core/interactors/android.ts
+++ b/src/core/interactors/android.ts
@@ -31,6 +31,7 @@ import { screenshotAndroid } from '../../platforms/android/screenshot.ts';
 import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import type { Interactor } from '../interactor-types.ts';
+import { snapshotCaptureAnnotationsFrom } from '../../snapshot-capture-annotations.ts';
 
 export function createAndroidInteractor(device: DeviceInfo): Interactor {
   return {
@@ -78,8 +79,7 @@ export function createAndroidInteractor(device: DeviceInfo): Interactor {
         nodes: result.nodes ?? [],
         truncated: result.truncated ?? false,
         backend: 'android',
-        analysis: result.analysis,
-        androidSnapshot: result.androidSnapshot,
+        ...snapshotCaptureAnnotationsFrom(result),
       };
     },
     back: (_mode) => backAndroid(device),

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -12,6 +12,8 @@ import { AppError } from '../../../utils/errors.ts';
 import { buildSnapshotSignatures } from '../../android-snapshot-freshness.ts';
 import { buildInteractionSurfaceSignature } from '../../interaction-outcome-policy.ts';
 import { buildSnapshotPresentationKey } from '../../../utils/snapshot.ts';
+import { snapshotCliOutput } from '../../../commands/client-output.ts';
+import type { CaptureSnapshotResult } from '../../../client-types.ts';
 
 vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
@@ -427,6 +429,83 @@ test('snapshot surfaces filtered-to-zero Android guidance for interactive snapsh
       'Interactive output is empty at depth 3; retry without -d.',
     ]);
   }
+});
+
+test('snapshot annotations survive pending interaction capture into CLI JSON', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-interaction-annotation-bundle';
+  const session = makeSession(sessionName, androidDevice);
+  const baselineNodes = [
+    {
+      ref: 'e1',
+      index: 0,
+      depth: 0,
+      type: 'android.widget.Button',
+      label: 'Open albums',
+      hittable: true,
+      rect: { x: 20, y: 120, width: 160, height: 48 },
+    },
+  ];
+  const changedNodes = [
+    {
+      index: 0,
+      depth: 0,
+      type: 'android.widget.TextView',
+      label: 'Albums',
+      rect: { x: 32, y: 240, width: 180, height: 52 },
+    },
+  ];
+  const snapshotQuality = { state: 'healthy', backend: 'tree' };
+  session.pendingInteractionOutcome = {
+    action: 'click',
+    command: 'press',
+    positionals: ['100', '144'],
+    flags: { platform: 'android' },
+    markedAt: Date.now(),
+    attemptsRemaining: 2,
+    preSignature: buildInteractionSurfaceSignature(baselineNodes),
+  };
+  sessionStore.set(sessionName, session);
+
+  mockDispatch.mockResolvedValue({
+    nodes: changedNodes,
+    truncated: false,
+    backend: 'android',
+    analysis: { rawNodeCount: 1, maxDepth: 0 },
+    quality: snapshotQuality,
+    warnings: ['backend warning from interaction capture'],
+  });
+
+  const response = await handleSnapshotCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'snapshot',
+      positionals: [],
+      flags: {},
+    },
+    sessionName,
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+  });
+
+  expect(response?.ok).toBe(true);
+  if (!response?.ok) return;
+
+  expect(response.data?.snapshotQuality).toEqual(snapshotQuality);
+  expect(response.data?.warnings).toEqual(['backend warning from interaction capture']);
+
+  const cliOutput = snapshotCliOutput({
+    result: response.data as unknown as CaptureSnapshotResult,
+  });
+  expect(cliOutput.jsonData).toMatchObject({
+    nodes: [expect.objectContaining({ label: 'Albums' })],
+    truncated: false,
+    snapshotQuality,
+    warnings: ['backend warning from interaction capture'],
+  });
+  expect(cliOutput.jsonData).not.toHaveProperty('analysis');
+  expect(cliOutput.jsonData).not.toHaveProperty('freshness');
 });
 
 test('snapshot timeout captures Android screenshot evidence with overlay refs', async () => {

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -2,8 +2,6 @@ import { dispatchCommand, type CommandFlags } from '../../core/dispatch.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import { runMacOsSnapshotAction } from '../../platforms/ios/macos-helper.ts';
 import { snapshotLinux } from '../../platforms/linux/snapshot.ts';
-import type { AndroidSnapshotBackendMetadata } from '../../platforms/android/snapshot-types.ts';
-import type { AndroidSnapshotAnalysis } from '../../platforms/android/ui-hierarchy.ts';
 import {
   attachRefs,
   buildSnapshotPresentationKey,
@@ -26,7 +24,6 @@ import {
   isLikelySnapshotStuckOnPreviousRoute,
   isLikelyStaleSnapshotDrop,
   isNavigationSensitiveAction,
-  type AndroidFreshnessCaptureMeta,
 } from '../android-snapshot-freshness.ts';
 import { contextFromFlags } from '../context.ts';
 import {
@@ -46,6 +43,10 @@ import {
 } from '../../utils/snapshot-processing.ts';
 import { errorResponse, type DaemonFailureResponse } from './response.ts';
 import { presentIosInteractiveSnapshot } from '../snapshot-presentation/ios/index.ts';
+import {
+  snapshotCaptureAnnotationsFrom,
+  type SnapshotCaptureAnnotations,
+} from '../../snapshot-capture-annotations.ts';
 
 type CaptureSnapshotParams = {
   device: SessionState['device'];
@@ -61,26 +62,18 @@ type SnapshotData = {
   nodes?: RawSnapshotNode[];
   truncated?: boolean;
   backend?: SnapshotBackend;
-  analysis?: AndroidSnapshotAnalysis;
-  androidSnapshot?: AndroidSnapshotBackendMetadata;
-  warnings?: string[];
   quality?: unknown;
-};
+} & Omit<SnapshotCaptureAnnotations, 'quality'>;
 
 type SnapshotAttempt = {
   data: SnapshotData;
   snapshot: SnapshotState;
-  freshness?: AndroidFreshnessCaptureMeta;
+  annotations: SnapshotCaptureAnnotations;
 };
 
 type CaptureSnapshotResult = {
   snapshot: SnapshotState;
-  analysis?: AndroidSnapshotAnalysis;
-  androidSnapshot?: AndroidSnapshotBackendMetadata;
-  freshness?: AndroidFreshnessCaptureMeta;
-  warnings?: string[];
-  quality?: unknown;
-};
+} & SnapshotCaptureAnnotations;
 
 type AndroidFreshnessReason = 'empty-interactive' | 'sharp-drop' | 'stuck-route';
 type AndroidFreshnessMode = 'default' | 'ref-refresh';
@@ -92,14 +85,11 @@ export async function captureSnapshot(
   const postActionResult = await capturePostActionAwareSnapshot(params);
   if (postActionResult) return postActionResult;
 
-  const data = await captureSnapshotData(params);
+  const latest = await captureSnapshotAttempt(params);
   clearAndroidSnapshotFreshness(params.session);
   return {
-    snapshot: buildSnapshotState(data, resolveSnapshotStateFlags(params)),
-    analysis: data.analysis,
-    androidSnapshot: data.androidSnapshot,
-    warnings: data.warnings,
-    quality: data.quality,
+    snapshot: latest.snapshot,
+    ...latest.annotations,
   };
 }
 
@@ -168,7 +158,7 @@ async function captureInteractionOutcomeAwareSnapshot(
     capture: async () => await capturePostActionSnapshotAttempt(params),
     readSnapshot: (attempt) => attempt.snapshot,
   });
-  if (outcome.change !== 'ambiguous' && latest.freshness?.staleAfterRetries !== true) {
+  if (outcome.change !== 'ambiguous' && latest.annotations.freshness?.staleAfterRetries !== true) {
     clearAndroidSnapshotFreshness(session);
   }
   if (outcome.change === 'unchanged') {
@@ -184,11 +174,7 @@ async function captureInteractionOutcomeAwareSnapshot(
 
   return {
     snapshot: latest.snapshot,
-    analysis: latest.data.analysis,
-    androidSnapshot: latest.data.androidSnapshot,
-    freshness: latest.freshness,
-    warnings: latest.data.warnings,
-    quality: latest.data.quality,
+    ...latest.annotations,
   };
 }
 
@@ -250,11 +236,7 @@ async function captureAndroidFreshnessAwareSnapshot(
   const latest = await captureAndroidFreshnessAwareAttempt(params, freshness);
   return {
     snapshot: latest.snapshot,
-    analysis: latest.data.analysis,
-    androidSnapshot: latest.data.androidSnapshot,
-    freshness: latest.freshness,
-    warnings: latest.data.warnings,
-    quality: latest.data.quality,
+    ...latest.annotations,
   };
 }
 
@@ -281,17 +263,21 @@ async function captureAndroidFreshnessAwareAttempt(
     clearAndroidSnapshotFreshness(params.session);
   }
 
+  const freshnessAnnotation =
+    retryCount > 0 || Boolean(suspiciousReason)
+      ? {
+          action: freshness.action,
+          retryCount,
+          staleAfterRetries: Boolean(suspiciousReason),
+          reason: suspiciousReason ?? undefined,
+        }
+      : undefined;
   return {
     ...latest,
-    freshness:
-      retryCount > 0 || Boolean(suspiciousReason)
-        ? {
-            action: freshness.action,
-            retryCount,
-            staleAfterRetries: Boolean(suspiciousReason),
-            reason: suspiciousReason ?? undefined,
-          }
-        : undefined,
+    annotations: {
+      ...latest.annotations,
+      ...snapshotCaptureAnnotationsFrom({ freshness: freshnessAnnotation }),
+    },
   };
 }
 
@@ -305,11 +291,7 @@ async function capturePostGestureAwareSnapshot(
   });
   return {
     snapshot: latest.snapshot,
-    analysis: latest.data.analysis,
-    androidSnapshot: latest.data.androidSnapshot,
-    freshness: latest.freshness,
-    warnings: latest.data.warnings,
-    quality: latest.data.quality,
+    ...latest.annotations,
   };
 }
 
@@ -328,6 +310,7 @@ async function captureSnapshotAttempt(params: CaptureSnapshotParams): Promise<Sn
   return {
     data,
     snapshot: buildSnapshotState(data, resolveSnapshotStateFlags(params)),
+    annotations: snapshotCaptureAnnotationsFrom(data),
   };
 }
 
@@ -344,12 +327,12 @@ function resolveSnapshotStateFlags(
 }
 
 function getAndroidFreshnessReason(
-  attempt: { data: SnapshotData; snapshot: SnapshotState },
+  attempt: SnapshotAttempt,
   freshness: NonNullable<SessionState['androidSnapshotFreshness']>,
   params: Pick<CaptureSnapshotParams, 'flags' | 'androidFreshnessMode'>,
 ): AndroidFreshnessReason | null {
   const interactiveOnly = params.flags?.snapshotInteractiveOnly === true;
-  const analysis = attempt.data.analysis;
+  const analysis = attempt.annotations.analysis;
 
   // When interactive-only filtering produces zero visible nodes from ≥12 raw nodes,
   // the dump likely captured a transitional frame.  The 12-node floor avoids

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -8,7 +8,7 @@ import type { DaemonRequest, DaemonResponse, DaemonResponseData, SessionState } 
 import { SessionStore } from './session-store.ts';
 import { errorResponse } from './handlers/response.ts';
 import { captureSnapshot, resolveSnapshotScope } from './handlers/snapshot-capture.ts';
-import { readSnapshotQualityVerdict } from '../utils/snapshot-quality.ts';
+import { snapshotCaptureAnnotationsFrom } from '../snapshot-capture-annotations.ts';
 import {
   buildSnapshotSession,
   resolveSessionDevice,
@@ -288,11 +288,7 @@ function createDaemonSnapshotBackend(params: {
       });
       return {
         snapshot: capture.snapshot,
-        analysis: capture.analysis,
-        androidSnapshot: capture.androidSnapshot,
-        freshness: capture.freshness,
-        warnings: capture.warnings,
-        quality: readSnapshotQualityVerdict(capture.quality),
+        ...snapshotCaptureAnnotationsFrom(capture),
         appName: session?.appBundleId ? (session.appName ?? session.appBundleId) : undefined,
         appBundleId: session?.appBundleId,
       };

--- a/src/snapshot-capture-annotations.ts
+++ b/src/snapshot-capture-annotations.ts
@@ -1,0 +1,86 @@
+import type { AndroidSnapshotBackendMetadata } from './platforms/android/snapshot-types.ts';
+import {
+  readSnapshotQualityVerdict,
+  type SnapshotQualityVerdict,
+} from './utils/snapshot-quality.ts';
+
+export type SnapshotCaptureAnalysis = {
+  rawNodeCount: number;
+  maxDepth: number;
+};
+
+export type SnapshotCaptureFreshness = {
+  action: string;
+  retryCount: number;
+  staleAfterRetries: boolean;
+  reason?: 'empty-interactive' | 'sharp-drop' | 'stuck-route';
+};
+
+export type SnapshotCaptureAnnotations = {
+  analysis?: SnapshotCaptureAnalysis;
+  androidSnapshot?: AndroidSnapshotBackendMetadata;
+  freshness?: SnapshotCaptureFreshness;
+  quality?: SnapshotQualityVerdict;
+  warnings?: string[];
+};
+
+export type PublicSnapshotCaptureAnnotations = Pick<
+  SnapshotCaptureAnnotations,
+  'androidSnapshot' | 'warnings'
+> & {
+  snapshotQuality?: SnapshotQualityVerdict;
+};
+
+export function snapshotCaptureAnnotationsFrom(
+  source: Partial<Omit<SnapshotCaptureAnnotations, 'quality'>> & { quality?: unknown },
+): SnapshotCaptureAnnotations {
+  const quality = readSnapshotQualityVerdict(source.quality);
+  return {
+    ...(source.analysis ? { analysis: source.analysis } : {}),
+    ...(source.androidSnapshot ? { androidSnapshot: source.androidSnapshot } : {}),
+    ...(source.freshness ? { freshness: source.freshness } : {}),
+    ...(quality ? { quality } : {}),
+    ...(source.warnings ? { warnings: source.warnings } : {}),
+  };
+}
+
+export function publicSnapshotCaptureAnnotations(
+  annotations: Partial<SnapshotCaptureAnnotations>,
+): PublicSnapshotCaptureAnnotations {
+  return {
+    ...(annotations.androidSnapshot ? { androidSnapshot: annotations.androidSnapshot } : {}),
+    ...(annotations.quality ? { snapshotQuality: annotations.quality } : {}),
+    ...(annotations.warnings && annotations.warnings.length > 0
+      ? { warnings: annotations.warnings }
+      : {}),
+  };
+}
+
+export function serializeSnapshotCaptureAnnotations(
+  annotations: Partial<SnapshotCaptureAnnotations>,
+): Record<string, unknown> {
+  return publicSnapshotCaptureAnnotations(annotations);
+}
+
+export function readSerializedSnapshotCaptureAnnotations(
+  data: Record<string, unknown>,
+): PublicSnapshotCaptureAnnotations {
+  const androidSnapshot = readObject(data.androidSnapshot);
+  const warnings = Array.isArray(data.warnings)
+    ? data.warnings.filter((entry): entry is string => typeof entry === 'string')
+    : undefined;
+  const quality = readSnapshotQualityVerdict(data.snapshotQuality);
+  return publicSnapshotCaptureAnnotations({
+    ...(androidSnapshot
+      ? { androidSnapshot: androidSnapshot as AndroidSnapshotBackendMetadata }
+      : {}),
+    ...(quality ? { quality } : {}),
+    ...(warnings ? { warnings } : {}),
+  });
+}
+
+function readObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/src/snapshot-capture-annotations.ts
+++ b/src/snapshot-capture-annotations.ts
@@ -56,12 +56,6 @@ export function publicSnapshotCaptureAnnotations(
   };
 }
 
-export function serializeSnapshotCaptureAnnotations(
-  annotations: Partial<SnapshotCaptureAnnotations>,
-): Record<string, unknown> {
-  return publicSnapshotCaptureAnnotations(annotations);
-}
-
 export function readSerializedSnapshotCaptureAnnotations(
   data: Record<string, unknown>,
 ): PublicSnapshotCaptureAnnotations {


### PR DESCRIPTION
## Summary

Refactors snapshot capture side-channel plumbing into one `SnapshotCaptureAnnotations` bundle, carried through daemon capture attempts, backend adapters, runtime snapshot output, serialization, and client response mapping.

Closes #774

Details:
- Touched 10 files.
- Public behavior is intended to be unchanged: healthy/degraded text and `--json` continue to expose the same public fields. Internal `analysis`, `freshness`, and `quality` remain internal annotations; public serialization still emits only existing public snapshot annotations.
- Docs/skills were not updated because this is internal runtime plumbing with no user-facing CLI or workflow change.

## Validation

Required checks passed:
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run src/daemon/handlers/__tests__/snapshot-handler.test.ts src/__tests__/runtime-snapshot.test.ts src/__tests__/client-shared.test.ts src/__tests__/client.test.ts` - 4 files, 91 tests
- `pnpm format`
- `pnpm check:unit` - 248 unit files / 2442 tests plus 8 smoke tests
- `pnpm build`
- `pnpm clean:daemon`
- `git diff --check`

Behavior-preserving evidence:
- Healthy/annotation JSON shape is asserted by regression test through mocked platform capture -> daemon response -> CLI JSON: `nodes`, `truncated`, `androidSnapshot`, and `warnings` survive; `analysis` and `freshness` are explicitly absent from public CLI JSON.
- Degraded snapshot warning shape is still covered by existing focused handler assertions: `Interactive snapshot is empty after filtering 42 raw Android nodes...` plus `Interactive output is empty at depth 3; retry without -d.`
- Real iOS simulator smoke after build/clean:
  - `node bin/agent-device.mjs --platform ios --udid C25DBB5B-9254-4293-A8D5-2785C78DE03A open settings --session codex-774-smoke-2 --json`
  - `node bin/agent-device.mjs --platform ios --udid C25DBB5B-9254-4293-A8D5-2785C78DE03A snapshot --session codex-774-smoke-2 -i -c -d 1 --json`
  - JSON proof: `success: true`, `nodes.length: 4`, `truncated: true`, `appName: settings`, `appBundleId: com.apple.Preferences`, `visibility.totalNodeCount: 4`.
  - Text proof: `Page: settings`, `App: com.apple.Preferences`, `Snapshot: 4 nodes (truncated)`, refs `@e1` through `@e4`.
  - Closed with `node bin/agent-device.mjs --platform ios --udid C25DBB5B-9254-4293-A8D5-2785C78DE03A close --session codex-774-smoke-2 --json`.

Residual risk:
- Live smoke covered healthy iOS output only. Degraded output compatibility is covered by focused daemon/runtime tests, not a live degraded device scenario.
- First attempted simulator `D74E0B66-57EB-4EC1-92DC-DA0A30581FE7` was blocked by an existing runner owner (`ownerPid 39494`); the opened `codex-774-smoke` session was closed before retrying another simulator.
