### PR TITLE
fix: route replay path commands correctly

### DIFF
--- a/src/__tests__/cli-client-commands.test.ts
+++ b/src/__tests__/cli-client-commands.test.ts
@@ -5,6 +5,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { PNG } from '../utils/png.ts';
 import { tryRunClientBackedCommand } from '../cli/commands/router.ts';
+import { runCliCapture } from './cli-capture.ts';
 import type {
   AgentDeviceClient,
   AppInstallFromSourceOptions,
@@ -661,6 +662,35 @@ click text="Continue"
   assert.equal(stdout, `${outPath}\n`);
   assert.match(yaml, /appId: com\.example\.app/);
   assert.match(yaml, /text: Continue/);
+});
+
+test('replay without a path reaches replay validation instead of unknown command', async () => {
+  const result = await runCliCapture(['replay']);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.calls.length, 0);
+  assert.match(result.stderr, /replay requires path/);
+  assert.doesNotMatch(result.stderr, /Unknown command: replay/);
+});
+
+test('replay path falls through to the generic client command route', async () => {
+  const missingPath = '/tmp/does-not-exist.ad';
+  const result = await runCliCapture(['replay', missingPath], async (request) => {
+    assert.equal(request.command, 'replay');
+    assert.deepEqual(request.positionals, [missingPath]);
+    return {
+      ok: false,
+      error: {
+        code: 'UNKNOWN',
+        message: `ENOENT: no such file or directory, open '${missingPath}'`,
+      },
+    };
+  });
+
+  assert.equal(result.code, 1);
+  assert.equal(result.calls.length, 1);
+  assert.match(result.stderr, /ENOENT/);
+  assert.doesNotMatch(result.stderr, /Unknown command: replay/);
 });
 
 test('replay rejects extra plain replay paths before daemon dispatch', async () => {

--- a/src/__tests__/cli-diff.test.ts
+++ b/src/__tests__/cli-diff.test.ts
@@ -120,6 +120,14 @@ describe('cli diff commands', () => {
     assert.equal(result.stderr, '');
   });
 
+  test('diff decline path falls through to generic diff validation', async () => {
+    const result = await runCliCapture(['diff', 'unknown']);
+    assert.equal(result.code, 1);
+    assert.equal(result.calls.length, 0);
+    assert.match(result.stderr, /Only diff snapshot is available through this parser/);
+    assert.doesNotMatch(result.stderr, /Unknown command: diff/);
+  });
+
   test('snapshot --diff renders human-readable unified diff text', async () => {
     const result = await runCliCapture(['snapshot', '--diff']);
     assert.equal(result.code, null);

--- a/src/cli/commands/router-types.ts
+++ b/src/cli/commands/router-types.ts
@@ -8,5 +8,9 @@ export type ClientCommandParams = {
   client: AgentDeviceClient;
 };
 
+/**
+ * Returns true after producing command output. Returning false means the handler
+ * intentionally produced no output and declined so the router can try the generic route.
+ */
 export type ClientCommandHandler = (params: ClientCommandParams) => Promise<boolean>;
 export type ClientCommandHandlerMap = Partial<Record<CliCommandName, ClientCommandHandler>>;

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -36,7 +36,8 @@ export async function tryRunClientBackedCommand(params: {
   const dedicatedHandler =
     dedicatedCliCommandHandlers[params.command as keyof typeof dedicatedCliCommandHandlers];
   if (dedicatedHandler) {
-    return await dedicatedHandler({ ...params, flags });
+    const handled = await dedicatedHandler({ ...params, flags });
+    if (handled) return true;
   }
   if (isClientBackedCliCommandName(params.command)) {
     return await runGenericClientBackedCommand({ ...params, command: params.command, flags });


### PR DESCRIPTION
## Summary

Fixes dedicated CLI handler decline semantics so a handler can explicitly return `false` after producing no output, allowing the router to try the shared generic client-backed command path. This restores normal `agent-device replay <path>` routing and also preserves the same fallthrough behavior for other declined dedicated handlers such as `diff`.

`replay export ...`, `diff snapshot`, and `diff screenshot` remain handled by their dedicated local handlers. Declined `replay` and `diff` paths now use the command grammar/projection route instead of falling through to `Unknown command`.

Closes #771

Touched files: 4 (`src/cli/commands/router.ts`, `src/cli/commands/router-types.ts`, `src/__tests__/cli-client-commands.test.ts`, `src/__tests__/cli-diff.test.ts`).
Docs/skills impact: none; this restores existing CLI behavior and documents the internal handler contract without changing user-facing workflow guidance.
Residual risk: low; no device/simulator verification was needed because the regression is CLI routing before platform interaction.

## Validation

Before: issue #771 reports 0.17.2 produced `Error (INVALID_ARGS): Unknown command: replay` for `agent-device replay` and `agent-device replay <path>`.

After CLI evidence:

```text
$ node --experimental-strip-types src/bin.ts replay
Error (INVALID_ARGS): replay requires path
```

```text
$ node --experimental-strip-types src/bin.ts replay /tmp/does-not-exist.ad --state-dir /private/tmp/agent-device-replay-771
Error (UNKNOWN): ENOENT: no such file or directory, open '/tmp/does-not-exist.ad'
```

Checks passed:

```text
pnpm exec vitest run src/__tests__/cli-client-commands.test.ts src/__tests__/cli-diff.test.ts src/__tests__/cli-grammar.test.ts src/utils/__tests__/args.test.ts
pnpm format
pnpm check:quick
git diff --check
```

Cleaned daemon state after the isolated CLI evidence with `pnpm clean:daemon --state-dir /private/tmp/agent-device-replay-771`.