### PR TITLE
refactor(ios): share snapshot filter predicates

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -107,34 +107,21 @@ extension RunnerTests {
     let typeName = elementTypeName(rawElementType: rawType)
     let enabled = privateAXBool(rawNode["enabled"]) ?? true
     let visible = isVisibleInViewport(rect, viewport)
-    let hasContent = !label.isEmpty || !identifier.isEmpty || !value.isEmpty
-    let isRoot = parentIndex == nil
-
-    // Scope selects a subtree, matching regular snapshot semantics: once a node matches,
-    // every descendant is inside scope and only the normal option filters apply to it.
-    let scope = options.scope?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let scopeActive = (scope?.isEmpty == false)
-    let matchesScope: Bool
-    if scopeActive, let scope {
-      let haystack = [label, identifier, value].joined(separator: "\n")
-      matchesScope = haystack.localizedCaseInsensitiveContains(scope)
-    } else {
-      matchesScope = false
-    }
-    let nowInsideScope = insideMatchedScope || matchesScope
-
-    let include: Bool
-    if isRoot {
-      include = true
-    } else if scopeActive && !nowInsideScope {
-      include = false
-    } else if options.interactiveOnly && !visible {
-      include = false
-    } else if options.compact {
-      include = hasContent || privateAXLikelyInteractive(rawElementType: rawType)
-    } else {
-      include = true
-    }
+    let compactCandidate = privateAXFlatCompactCandidate(rawElementType: rawType)
+    let filterDecision = flatSnapshotFilterDecision(
+      FlatSnapshotFilterNode(
+        isRoot: parentIndex == nil,
+        label: label,
+        identifier: identifier,
+        valueText: value.isEmpty ? nil : value,
+        visible: visible,
+        compactCandidate: compactCandidate
+      ),
+      options: options,
+      insideMatchedScope: insideMatchedScope
+    )
+    let include = filterDecision.include
+    let nowInsideScope = filterDecision.insideMatchedScope
 
     let currentIndex: Int?
     if include {
@@ -150,7 +137,7 @@ extension RunnerTests {
           enabled: enabled,
           focused: privateAXBool(rawNode["focused"]) == true ? true : nil,
           selected: privateAXBool(rawNode["selected"]) == true ? true : nil,
-          hittable: visible && enabled && privateAXLikelyInteractive(rawElementType: rawType),
+          hittable: visible && enabled && compactCandidate,
           depth: depth,
           parentIndex: parentIndex,
           hiddenContentAbove: nil,
@@ -178,21 +165,10 @@ extension RunnerTests {
   }
 
   private func elementTypeName(rawElementType: Int) -> String {
-    if let raw = UInt(exactly: rawElementType),
-      let type = XCUIElement.ElementType(rawValue: raw)
-    {
+    if let type = flatSnapshotElementType(rawElementType: rawElementType) {
       return elementTypeName(type)
     }
     return "Element(\(rawElementType))"
-  }
-
-  private func privateAXLikelyInteractive(rawElementType: Int) -> Bool {
-    guard let raw = UInt(exactly: rawElementType),
-      let type = XCUIElement.ElementType(rawValue: raw)
-    else {
-      return false
-    }
-    return interactiveTypes.contains(type) || Self.scrollContainerTypes.contains(type)
   }
 
   private func privateAXString(_ value: Any?) -> String {
@@ -267,5 +243,89 @@ extension RunnerTests {
     // Descendants of the matched scope are included even when they do not contain the text.
     XCTAssertTrue(labels.contains("Post body without the scope text"))
     XCTAssertFalse(labels.contains("unrelated sibling"))
+  }
+
+  func testPrivateAXCompactInteractiveFiltersLoginLikeHiddenDrawer() {
+    let tree: [String: Any] = [
+      "type": Int(XCUIElement.ElementType.application.rawValue),
+      "label": "Blue Sky",
+      "frame": ["x": 0, "y": 0, "width": 390, "height": 844],
+      "children": [
+        [
+          "type": Int(XCUIElement.ElementType.scrollView.rawValue),
+          "frame": ["x": 0, "y": 0, "width": 390, "height": 844],
+          "children": [
+            [
+              "type": Int(XCUIElement.ElementType.image.rawValue),
+              "label": "Callstack",
+              "frame": ["x": 145, "y": 104, "width": 100, "height": 100],
+              "children": [],
+            ],
+            [
+              "type": Int(XCUIElement.ElementType.staticText.rawValue),
+              "label": "Welcome back",
+              "frame": ["x": 32, "y": 260, "width": 326, "height": 32],
+              "children": [],
+            ],
+            [
+              "type": Int(XCUIElement.ElementType.textField.rawValue),
+              "label": "Email",
+              "identifier": "login.email",
+              "frame": ["x": 32, "y": 348, "width": 326, "height": 48],
+              "children": [],
+            ],
+            [
+              "type": Int(XCUIElement.ElementType.secureTextField.rawValue),
+              "label": "Password",
+              "identifier": "login.password",
+              "frame": ["x": 32, "y": 412, "width": 326, "height": 48],
+              "children": [],
+            ],
+            [
+              "type": Int(XCUIElement.ElementType.button.rawValue),
+              "label": "Sign in",
+              "identifier": "login.submit",
+              "frame": ["x": 32, "y": 492, "width": 326, "height": 52],
+              "children": [],
+            ],
+            [
+              "type": Int(XCUIElement.ElementType.link.rawValue),
+              "label": "Forgot password?",
+              "frame": ["x": 128, "y": 568, "width": 134, "height": 32],
+              "children": [],
+            ],
+            [
+              "type": Int(XCUIElement.ElementType.button.rawValue),
+              "label": "Admin settings",
+              "frame": ["x": -260, "y": 184, "width": 220, "height": 44],
+              "children": [],
+            ],
+            [
+              "type": Int(XCUIElement.ElementType.other.rawValue),
+              "frame": ["x": 16, "y": 184, "width": 220, "height": 44],
+              "children": [],
+            ],
+          ],
+        ]
+      ],
+    ]
+    var nodes: [SnapshotNode] = []
+    appendPrivateAXNode(
+      tree,
+      to: &nodes,
+      options: SnapshotOptions(
+        interactiveOnly: true, compact: true, depth: nil, scope: nil, raw: false),
+      viewport: CGRect(x: 0, y: 0, width: 390, height: 844),
+      depth: 0,
+      parentIndex: nil,
+      insideMatchedScope: false
+    )
+
+    let labels = nodes.compactMap { $0.label }
+    XCTAssertEqual(
+      labels,
+      ["Blue Sky", "Callstack", "Welcome back", "Email", "Password", "Sign in", "Forgot password?"]
+    )
+    XCTAssertFalse(labels.contains("Admin settings"))
   }
 }

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+FlatSnapshotFiltering.swift
@@ -1,0 +1,195 @@
+import XCTest
+
+struct FlatSnapshotFilterNode {
+  let isRoot: Bool
+  let label: String
+  let identifier: String
+  let valueText: String?
+  let visible: Bool
+  let compactCandidate: Bool
+
+  var hasContent: Bool {
+    return !label.isEmpty || !identifier.isEmpty || valueText != nil
+  }
+
+  func matchesScope(_ scope: String) -> Bool {
+    let haystack = [label, identifier, valueText ?? ""].joined(separator: "\n")
+    return haystack.localizedCaseInsensitiveContains(scope)
+  }
+}
+
+struct FlatSnapshotFilterDecision {
+  let include: Bool
+  let insideMatchedScope: Bool
+}
+
+extension RunnerTests {
+  func flatSnapshotFilterDecision(
+    _ node: FlatSnapshotFilterNode,
+    options: SnapshotOptions,
+    insideMatchedScope: Bool
+  ) -> FlatSnapshotFilterDecision {
+    let scope = options.scope?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let scopeActive = scope?.isEmpty == false
+    let matchesScope: Bool
+    if scopeActive, let scope {
+      matchesScope = node.matchesScope(scope)
+    } else {
+      matchesScope = false
+    }
+    let nowInsideScope = insideMatchedScope || matchesScope
+
+    let include: Bool
+    if node.isRoot {
+      include = true
+    } else if scopeActive && !nowInsideScope {
+      include = false
+    } else if options.interactiveOnly && !node.visible {
+      include = false
+    } else if options.compact {
+      include = node.hasContent || node.compactCandidate
+    } else {
+      include = true
+    }
+
+    return FlatSnapshotFilterDecision(include: include, insideMatchedScope: nowInsideScope)
+  }
+
+  func querySweepFlatCompactCandidate(
+    elementType: XCUIElement.ElementType,
+    hittable: Bool
+  ) -> Bool {
+    return hittable || interactiveTypes.contains(elementType)
+  }
+
+  func privateAXFlatCompactCandidate(rawElementType: Int) -> Bool {
+    guard let type = flatSnapshotElementType(rawElementType: rawElementType) else {
+      return false
+    }
+    return interactiveTypes.contains(type) || Self.scrollContainerTypes.contains(type)
+  }
+
+  func flatSnapshotElementType(rawElementType: Int) -> XCUIElement.ElementType? {
+    guard let raw = UInt(exactly: rawElementType),
+      let type = XCUIElement.ElementType(rawValue: raw)
+    else {
+      return nil
+    }
+    return type
+  }
+
+  func testFlatSnapshotFilterDecisionMatrixCoversOptions() {
+    let visibleContent = FlatSnapshotFilterNode(
+      isRoot: false,
+      label: "Welcome back",
+      identifier: "",
+      valueText: nil,
+      visible: true,
+      compactCandidate: false
+    )
+    let hiddenInteractive = FlatSnapshotFilterNode(
+      isRoot: false,
+      label: "Hidden menu",
+      identifier: "",
+      valueText: nil,
+      visible: false,
+      compactCandidate: true
+    )
+    let decorative = FlatSnapshotFilterNode(
+      isRoot: false,
+      label: "",
+      identifier: "",
+      valueText: nil,
+      visible: true,
+      compactCandidate: false
+    )
+
+    XCTAssertTrue(
+      flatSnapshotFilterDecision(
+        visibleContent,
+        options: SnapshotOptions(
+          interactiveOnly: false, compact: true, depth: nil, scope: nil, raw: false),
+        insideMatchedScope: false
+      ).include
+    )
+    XCTAssertFalse(
+      flatSnapshotFilterDecision(
+        hiddenInteractive,
+        options: SnapshotOptions(
+          interactiveOnly: true, compact: true, depth: nil, scope: nil, raw: false),
+        insideMatchedScope: false
+      ).include
+    )
+    XCTAssertFalse(
+      flatSnapshotFilterDecision(
+        decorative,
+        options: SnapshotOptions(
+          interactiveOnly: false, compact: true, depth: nil, scope: nil, raw: false),
+        insideMatchedScope: false
+      ).include
+    )
+    XCTAssertTrue(
+      flatSnapshotFilterDecision(
+        decorative,
+        options: SnapshotOptions(
+          interactiveOnly: false, compact: false, depth: nil, scope: nil, raw: false),
+        insideMatchedScope: false
+      ).include
+    )
+  }
+
+  func testFlatSnapshotFilterDecisionCarriesSubtreeScopeState() {
+    let scopeRoot = FlatSnapshotFilterNode(
+      isRoot: false,
+      label: "",
+      identifier: "homeScreen",
+      valueText: nil,
+      visible: true,
+      compactCandidate: false
+    )
+    let unmatchedDescendant = FlatSnapshotFilterNode(
+      isRoot: false,
+      label: "Post body without the scope text",
+      identifier: "",
+      valueText: nil,
+      visible: true,
+      compactCandidate: false
+    )
+    let options = SnapshotOptions(
+      interactiveOnly: false, compact: false, depth: nil, scope: "homeScreen", raw: false)
+
+    let rootDecision = flatSnapshotFilterDecision(
+      scopeRoot,
+      options: options,
+      insideMatchedScope: false
+    )
+    XCTAssertTrue(rootDecision.include)
+    XCTAssertTrue(rootDecision.insideMatchedScope)
+
+    XCTAssertTrue(
+      flatSnapshotFilterDecision(
+        unmatchedDescendant,
+        options: options,
+        insideMatchedScope: rootDecision.insideMatchedScope
+      ).include
+    )
+    XCTAssertFalse(
+      flatSnapshotFilterDecision(
+        unmatchedDescendant,
+        options: options,
+        insideMatchedScope: false
+      ).include
+    )
+  }
+
+  func testFlatSnapshotCompactCandidatesPreserveBackendInputs() {
+    XCTAssertFalse(
+      querySweepFlatCompactCandidate(elementType: .scrollView, hittable: false),
+      "query sweep should not newly admit contentless scroll containers"
+    )
+    XCTAssertTrue(
+      privateAXFlatCompactCandidate(rawElementType: Int(XCUIElement.ElementType.scrollView.rawValue)),
+      "private AX keeps its existing scroll-container compact candidate behavior"
+    )
+  }
+}

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -1113,18 +1113,19 @@ extension RunnerTests {
       let label = element.label.trimmingCharacters(in: .whitespacesAndNewlines)
       let identifier = element.identifier.trimmingCharacters(in: .whitespacesAndNewlines)
       let valueText = snapshotValueText(element)
-      let hasContent = !label.isEmpty || !identifier.isEmpty || valueText != nil
       let elementType = element.elementType
       let enabled = element.isEnabled
       let hittable = visible && enabled && element.isHittable
-      if options.compact && !hasContent && !hittable && !interactiveTypes.contains(elementType) {
+      let filterNode = FlatSnapshotFilterNode(
+        isRoot: false,
+        label: label,
+        identifier: identifier,
+        valueText: valueText,
+        visible: visible,
+        compactCandidate: querySweepFlatCompactCandidate(elementType: elementType, hittable: hittable)
+      )
+      if !flatSnapshotFilterDecision(filterNode, options: options, insideMatchedScope: false).include {
         return
-      }
-      if let scope = options.scope?.trimmingCharacters(in: .whitespacesAndNewlines), !scope.isEmpty {
-        let haystack = [label, identifier, valueText ?? ""].joined(separator: "\n")
-        if !haystack.localizedCaseInsensitiveContains(scope) {
-          return
-        }
       }
 
       node = SnapshotNode(


### PR DESCRIPTION
## Summary

Refactors the flat iOS snapshot option filters on top of `refactor/ios-snapshot-capture-plan`, preserving the blocker branch's subtree scope semantics instead of freezing the old per-node private-AX behavior.

Before/after:
- Before: private-AX carried subtree scope locally via `insideMatchedScope`, while the shared predicate forced old per-node scope matching.
- After: shared flat filter decision carries `insideMatchedScope`, so query sweep still uses per-node scope and private-AX can include matched subtrees.
- Query sweep keeps its cheap `interactiveOnly && !visible` early-out before fetching labels/ids/values.
- Query sweep no longer newly admits contentless scroll containers; private-AX keeps its existing backend-specific scroll-container compact input.

Closes #775.

Touched files: 3. Scope remains local to flat iOS snapshot filtering; recursive tree-walk visibility logic was not moved or rewritten. Docs/skills unchanged.

## Validation

- `pnpm build:xcuitest`
- Focused XCTest on iOS 26 iPhone 17 Pro Max `E140A942-965C-4A92-AC63-F3B23756BE02`: 5 flat/private-AX tests passed, including the blocker branch's subtree-scope regression and a direct production-login-like `appendPrivateAXNode` fixture.
- Existing snapshot XCTest selection on the same simulator: 3 tests passed.
- `pnpm exec vitest run src/__tests__/runtime-snapshot.test.ts src/daemon/handlers/__tests__/snapshot-handler.test.ts`: 64 tests passed.
- `pnpm format`
- `pnpm build`
- `pnpm clean:daemon`
- `git diff --check`

Real simulator smoke after rebuild/daemon clean:
- eToro `com.etoro.etoroplus` on iOS 26 iPhone 17 Pro Max `E140A942-965C-4A92-AC63-F3B23756BE02`, command: `snapshot -i -c`, session `codex-775-etoro-smoke`. Result: bounded login output with 6 nodes: Show password, Sign in, Google, Apple, Meta, plus app root. The screen still reported the existing budget/sparse warning.
- Bluesky `xyz.blueskyweb.app` on the same simulator, command: `snapshot -i -c`, session `codex-775-bluesky-smoke`. Result: private-AX fallback reproduced on logged-in feed with 25 visible nodes, including Open drawer menu, feeds, Compose new post, feed items, Load new posts, and Home/Search/Chat/Notifications/Profile.

Known gap:
- `pnpm check:unit` was attempted after the rebase but failed outside this change area with 26 process/tooling failures/timeouts across Android install/device tests, artifact materialization, screenshot diff, runner cache locking, and status-bar screenshot tests. Focused snapshot tests and XCTest coverage above passed.
