### PR TITLE
fix: avoid focusing booted iOS simulators

### DIFF
--- a/src/daemon/__tests__/request-router-open.test.ts
+++ b/src/daemon/__tests__/request-router-open.test.ts
@@ -68,6 +68,7 @@ test('open returns and creates the session state directory', async () => {
   const response = await handler(openRequest('session-a', { platform: 'ios' }, 'req-open-state'));
 
   expect(response.ok).toBe(true);
+  expect(mockEnsureDeviceReady.mock.calls[0]?.[1]).toEqual({ deviceHub: false });
   if (response.ok) {
     expect(response.data?.session).toBe('session-a');
     expect(response.data?.sessionStateDir).toEqual(expect.stringContaining('session-a'));

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -2134,6 +2134,7 @@ test('open custom URL on existing iOS simulator session preserves app bundle id 
 
   expect(response).toBeTruthy();
   expect(response?.ok).toBe(true);
+  expect(mockEnsureDeviceReady.mock.calls[0]?.[1]).toEqual({ deviceHub: false });
   const updated = sessionStore.get(sessionName);
   expect(updated?.appBundleId).toBe('com.example.app');
   expect(updated?.appName).toBe('myapp://item/42');

--- a/src/daemon/handlers/session-open-prepare.ts
+++ b/src/daemon/handlers/session-open-prepare.ts
@@ -110,7 +110,6 @@ export async function prepareOpenCommandDetails(params: {
   const { req, sessionName, sessionStore, device, surface, openTarget, existingSession } = params;
   await ensureDeviceReady(device, {
     deviceHub: req.flags?.deviceHub === true,
-    focusExisting: true,
   });
   const { appBundleId, appName } = await resolvePreparedOpenIdentity({
     device,


### PR DESCRIPTION
## Summary

Avoid stealing macOS focus when an iOS simulator is already booted and a daemon open command prepares or reuses a session.

Before: daemon open preparation always requested focusExisting, so follow-up commands could foreground Simulator or Device Hub.

After: open preparation only ensures device readiness; the existing cold-boot path still foregrounds the simulator when it is opened from scratch.

Touched 3 files. Scope stayed in daemon open preparation and regression coverage.

## Validation

Targeted daemon regression tests pass: ./node_modules/.bin/vitest run src/daemon/__tests__/request-router-open.test.ts src/daemon/handlers/__tests__/session.test.ts.

Static checks pass: pnpm check:quick. Formatting was applied with ./node_modules/.bin/oxfmt --write and git diff --check is clean.

pnpm check:unit was attempted after network escalation for pnpm verification, but failed in unrelated Android/iOS platform tests with 14 mocked command timeouts/failures; the touched daemon tests passed separately.