### PR TITLE
fix: stream replay suite progress

### DIFF
--- a/src/__tests__/cli-network.test.ts
+++ b/src/__tests__/cli-network.test.ts
@@ -105,7 +105,7 @@ test('test command prints suite summary and exits non-zero on failures', async (
   assert.equal(result.code, 1);
   assert.equal(result.calls.length, 1);
   assert.equal(result.calls[0]?.meta?.requestProgress, 'replay-test');
-  assert.match(result.stderr, /Running replay suite\.\.\./);
+  assert.doesNotMatch(result.stderr, /Running replay suite\.\.\./);
   assert.match(result.stdout, /PASS 01-pass\.ad \(0\.01s\)/);
   assert.match(
     result.stdout,
@@ -124,7 +124,7 @@ test('test command --verbose prints all test statuses', async () => {
 
   assert.equal(result.code, 1);
   assert.equal(result.calls[0]?.meta?.debug, false);
-  assert.match(result.stderr, /Running replay suite\.\.\./);
+  assert.doesNotMatch(result.stderr, /Running replay suite\.\.\./);
   assert.match(result.stdout, /PASS 01-pass\.ad \(0\.01s\)/);
   assert.match(result.stdout, /SKIP 03-skip\.ad/);
 });
@@ -352,7 +352,7 @@ test('test command reports flaky passed-on-retry cases in the default summary', 
   }));
 
   assert.equal(result.code, null);
-  assert.match(result.stderr, /Running replay suite\.\.\./);
+  assert.doesNotMatch(result.stderr, /Running replay suite\.\.\./);
   assert.doesNotMatch(result.stdout, /FLAKY/);
   assert.match(
     result.stdout,
@@ -489,7 +489,7 @@ test('test --maestro forwards Maestro backend and platform for directory suites'
     assert.equal(result.calls[0]?.flags?.replayBackend, 'maestro');
     assert.equal(result.calls[0]?.flags?.platform, 'android');
     assert.equal(result.calls[0]?.meta?.requestProgress, 'replay-test');
-    assert.match(result.stderr, /Running replay suite\.\.\./);
+    assert.doesNotMatch(result.stderr, /Running replay suite\.\.\./);
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }

--- a/src/__tests__/cli-test-progress.test.ts
+++ b/src/__tests__/cli-test-progress.test.ts
@@ -50,6 +50,15 @@ test('formatReplayTestProgressEvent renders replay test start context with shard
   );
 });
 
+test('formatReplayTestProgressEvent ignores unknown progress event types', () => {
+  const line = formatReplayTestProgressEvent({
+    type: 'future-progress-event',
+    status: 'start',
+  } as unknown as RequestProgressEvent);
+
+  assert.equal(line, undefined);
+});
+
 test('formatReplayTestProgressEvent renders pass, retry, fail, and skip cases', () => {
   const cases: Array<{ event: RequestProgressEvent; expected: RegExp }> = [
     {

--- a/src/__tests__/cli-test-progress.test.ts
+++ b/src/__tests__/cli-test-progress.test.ts
@@ -1,0 +1,116 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { formatReplayTestProgressEvent } from '../cli-test-progress.ts';
+import type { RequestProgressEvent } from '../daemon/request-progress.ts';
+
+test('formatReplayTestProgressEvent renders replay suite start context', () => {
+  const line = formatReplayTestProgressEvent({
+    type: 'replay-test-suite',
+    status: 'start',
+    total: 4,
+    runnable: 3,
+    skipped: 1,
+    artifactsDir: '/tmp/replay-suite',
+    shardMode: 'split',
+    shardCount: 2,
+  });
+
+  assert.equal(
+    line,
+    [
+      'Running replay suite: 4 files',
+      '  sharding: split across 2 devices',
+      '  artifacts: /tmp/replay-suite',
+    ].join('\n'),
+  );
+});
+
+test('formatReplayTestProgressEvent renders replay test start context with shard metadata', () => {
+  const line = formatReplayTestProgressEvent({
+    type: 'replay-test',
+    file: '/tmp/auth-flow.yml',
+    title: 'Authentication flow',
+    status: 'start',
+    index: 2,
+    total: 5,
+    session: 'maestro-test:test:suite:2:attempt-1',
+    artifactsDir: '/tmp/replay-suite/auth-flow',
+    shardIndex: 1,
+    shardCount: 2,
+    deviceId: 'E140A942-965C-4A92-AC63-F3B23756BE02',
+  });
+
+  assert.equal(
+    line,
+    [
+      '[2/5] START "Authentication flow" in auth-flow.yml [shard 2/2 E140A942-965C-4A92-AC63-F3B23756BE02]',
+      '  session: maestro-test:test:suite:2:attempt-1',
+      '  artifacts: /tmp/replay-suite/auth-flow',
+    ].join('\n'),
+  );
+});
+
+test('formatReplayTestProgressEvent renders pass, retry, fail, and skip cases', () => {
+  const cases: Array<{ event: RequestProgressEvent; expected: RegExp }> = [
+    {
+      event: {
+        type: 'replay-test',
+        file: '/tmp/01-login.ad',
+        status: 'pass',
+        index: 1,
+        total: 3,
+        attempt: 2,
+        maxAttempts: 2,
+        durationMs: 12_345,
+      },
+      expected: /^\[1\/3] PASS 01-login\.ad after 2 attempts \(total 12\.3s\)$/,
+    },
+    {
+      event: {
+        type: 'replay-test',
+        file: '/tmp/02-checkout.ad',
+        status: 'fail',
+        index: 2,
+        total: 3,
+        attempt: 1,
+        maxAttempts: 2,
+        durationMs: 1_234,
+        retrying: true,
+        message: 'first attempt failed',
+      },
+      expected: /^\[2\/3] RETRY 02-checkout\.ad attempt 1\/2 \(1\.23s\)\n  first attempt failed$/,
+    },
+    {
+      event: {
+        type: 'replay-test',
+        file: '/tmp/03-payment.ad',
+        status: 'fail',
+        index: 3,
+        total: 3,
+        attempt: 2,
+        maxAttempts: 2,
+        durationMs: 9_876,
+        message: 'assertVisible failed',
+        session: 'maestro-test:test:suite:3:attempt-2',
+        artifactsDir: '/tmp/replay-suite/payment',
+      },
+      expected:
+        /^\[3\/3] FAIL 03-payment\.ad after 2 attempts \(total 9\.88s\)\n  assertVisible failed\n  session: maestro-test:test:suite:3:attempt-2\n  artifacts: \/tmp\/replay-suite\/payment$/,
+    },
+    {
+      event: {
+        type: 'replay-test',
+        file: '/tmp/04-skip.ad',
+        status: 'skip',
+        index: 4,
+        total: 5,
+        message: 'missing platform metadata for --platform ios',
+      },
+      expected: /^\[4\/5] SKIP 04-skip\.ad\n  missing platform metadata for --platform ios$/,
+    },
+  ];
+
+  for (const { event, expected } of cases) {
+    assert.match(formatReplayTestProgressEvent(event) ?? '', expected);
+  }
+});

--- a/src/__tests__/daemon-client-progress.test.ts
+++ b/src/__tests__/daemon-client-progress.test.ts
@@ -99,7 +99,7 @@ test('readDaemonSocketProgressResponse parses split progress lines before respon
     assert.deepEqual(await responsePromise, { ok: true, data: { via: 'socket-progress' } });
     assert.equal(socket.encoding, 'utf8');
     assert.equal(socket.ended, true);
-    assert.match(stderr, /FAIL "Login flow" attempt 1\/2 retrying \(1\.23s\)/);
+    assert.match(stderr, /\[1\/2] RETRY "Login flow" in 01-login\.ad attempt 1\/2 \(1\.23s\)/);
     assert.match(stderr, /  first attempt failed/);
   } finally {
     process.stderr.write = originalStderrWrite;

--- a/src/cli-test-progress.ts
+++ b/src/cli-test-progress.ts
@@ -2,9 +2,23 @@ import path from 'node:path';
 import type { RequestProgressEvent } from './daemon/request-progress.ts';
 import { formatDurationSeconds } from './utils/duration-format.ts';
 
+type ReplayTestCaseProgressEvent = Extract<RequestProgressEvent, { type: 'replay-test' }>;
+type ReplayTestCaseStatus = ReplayTestCaseProgressEvent['status'];
+
+const REPLAY_TEST_STATUS_LABELS: Record<ReplayTestCaseStatus, string> = {
+  start: 'START',
+  pass: 'PASS',
+  fail: 'FAIL',
+  skip: 'SKIP',
+};
+
 export function formatReplayTestProgressEvent(event: RequestProgressEvent): string | undefined {
   if (event.type === 'replay-test-suite') {
     return formatReplayTestSuiteProgressEvent(event);
+  }
+  const eventType = (event as { type?: string }).type;
+  if (eventType !== 'replay-test') {
+    return undefined;
   }
   return formatReplayTestCaseProgressEvent(event);
 }
@@ -20,64 +34,56 @@ function formatReplayTestSuiteProgressEvent(
   return lines.join('\n');
 }
 
-function formatReplayTestCaseProgressEvent(
-  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
-): string {
-  const name = formatReplayTestProgressName(event);
-  const indexPrefix = `[${event.index}/${event.total}]`;
-  const statusLabel = formatReplayTestProgressStatusLabel(event);
-  const shardSuffix = formatReplayTestProgressShardSuffix(event);
-  const durationSuffix =
-    event.durationMs !== undefined ? ` (${formatReplayProgressDuration(event)})` : '';
-  const attemptSuffix = formatReplayProgressAttemptSuffix(event);
-  const message = event.message?.replace(/\s+/g, ' ').trim();
-  const lines = [
-    `${indexPrefix} ${statusLabel} ${name}${shardSuffix}${attemptSuffix}${durationSuffix}`,
-  ];
+function formatReplayTestCaseProgressEvent(event: ReplayTestCaseProgressEvent): string {
+  const lines = [formatReplayTestCaseSummaryLine(event)];
+  addReplayTestCaseDetailLines(lines, event);
+  return lines.join('\n');
+}
 
+function addReplayTestCaseDetailLines(lines: string[], event: ReplayTestCaseProgressEvent): void {
   if (event.status === 'start') {
     if (event.session) lines.push(`  session: ${event.session}`);
     if (event.artifactsDir) lines.push(`  artifacts: ${event.artifactsDir}`);
-    return lines.join('\n');
+    return;
   }
 
+  const message = event.message?.replace(/\s+/g, ' ').trim();
   if (message) lines.push(`  ${message}`);
   if (event.status === 'fail' && !event.retrying) {
     if (event.session) lines.push(`  session: ${event.session}`);
     if (event.artifactsDir) lines.push(`  artifacts: ${event.artifactsDir}`);
   }
-  return lines.join('\n');
 }
 
-function formatReplayTestProgressName(
-  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
-): string {
+function formatReplayTestCaseSummaryLine(event: ReplayTestCaseProgressEvent): string {
+  const indexPrefix = `[${event.index}/${event.total}]`;
+  const statusLabel = formatReplayTestProgressStatusLabel(event);
+  const name = formatReplayTestProgressName(event);
+  const shardSuffix = formatReplayTestProgressShardSuffix(event);
+  const attemptSuffix = formatReplayProgressAttemptSuffix(event);
+  const durationSuffix =
+    event.durationMs !== undefined ? ` (${formatReplayProgressDuration(event)})` : '';
+  return `${indexPrefix} ${statusLabel} ${name}${shardSuffix}${attemptSuffix}${durationSuffix}`;
+}
+
+function formatReplayTestProgressName(event: ReplayTestCaseProgressEvent): string {
   const title = event.title?.trim();
   const file = path.basename(event.file);
   return title ? `${JSON.stringify(title)} in ${file}` : file;
 }
 
-function formatReplayTestProgressStatusLabel(
-  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
-): string {
-  if (event.status === 'start') return 'START';
-  if (event.status === 'pass') return 'PASS';
-  if (event.status === 'skip') return 'SKIP';
-  return event.retrying ? 'RETRY' : 'FAIL';
+function formatReplayTestProgressStatusLabel(event: ReplayTestCaseProgressEvent): string {
+  return event.retrying ? 'RETRY' : REPLAY_TEST_STATUS_LABELS[event.status];
 }
 
-function formatReplayTestProgressShardSuffix(
-  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
-): string {
+function formatReplayTestProgressShardSuffix(event: ReplayTestCaseProgressEvent): string {
   if (typeof event.shardIndex !== 'number') return '';
   const shardCount = typeof event.shardCount === 'number' ? event.shardCount : '?';
   const device = typeof event.deviceId === 'string' ? ` ${event.deviceId}` : '';
   return ` [shard ${event.shardIndex + 1}/${shardCount}${device}]`;
 }
 
-function formatReplayProgressAttemptSuffix(
-  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
-): string {
+function formatReplayProgressAttemptSuffix(event: ReplayTestCaseProgressEvent): string {
   if (event.attempt === undefined) return '';
   if (event.status === 'start') return '';
   if (event.status === 'fail' && event.retrying && event.maxAttempts !== undefined) {
@@ -87,9 +93,7 @@ function formatReplayProgressAttemptSuffix(
   return '';
 }
 
-function formatReplayProgressDuration(
-  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
-): string {
+function formatReplayProgressDuration(event: ReplayTestCaseProgressEvent): string {
   const duration = formatDurationSeconds(event.durationMs ?? 0);
   return event.attempt && event.attempt > 1 && !event.retrying ? `total ${duration}` : duration;
 }

--- a/src/cli-test-progress.ts
+++ b/src/cli-test-progress.ts
@@ -3,45 +3,93 @@ import type { RequestProgressEvent } from './daemon/request-progress.ts';
 import { formatDurationSeconds } from './utils/duration-format.ts';
 
 export function formatReplayTestProgressEvent(event: RequestProgressEvent): string | undefined {
-  if (event.type !== 'replay-test') return undefined;
-  if (event.status === 'pass') return undefined;
-  if (event.status === 'fail' && !event.retrying) return undefined;
+  if (event.type === 'replay-test-suite') {
+    return formatReplayTestSuiteProgressEvent(event);
+  }
+  return formatReplayTestCaseProgressEvent(event);
+}
 
+function formatReplayTestSuiteProgressEvent(
+  event: Extract<RequestProgressEvent, { type: 'replay-test-suite' }>,
+): string {
+  const lines = [`Running replay suite: ${event.total} ${event.total === 1 ? 'file' : 'files'}`];
+  if (event.shardMode && event.shardCount && event.shardCount > 1) {
+    lines.push(`  sharding: ${event.shardMode} across ${event.shardCount} devices`);
+  }
+  lines.push(`  artifacts: ${event.artifactsDir}`);
+  return lines.join('\n');
+}
+
+function formatReplayTestCaseProgressEvent(
+  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
+): string {
   const name = formatReplayTestProgressName(event);
+  const indexPrefix = `[${event.index}/${event.total}]`;
+  const statusLabel = formatReplayTestProgressStatusLabel(event);
+  const shardSuffix = formatReplayTestProgressShardSuffix(event);
   const durationSuffix =
     event.durationMs !== undefined ? ` (${formatReplayProgressDuration(event)})` : '';
   const attemptSuffix = formatReplayProgressAttemptSuffix(event);
   const message = event.message?.replace(/\s+/g, ' ').trim();
+  const lines = [
+    `${indexPrefix} ${statusLabel} ${name}${shardSuffix}${attemptSuffix}${durationSuffix}`,
+  ];
 
-  if (event.status === 'skip') {
-    return [`SKIP ${name}`, message ? `  ${message}` : ''].filter(Boolean).join('\n');
+  if (event.status === 'start') {
+    if (event.session) lines.push(`  session: ${event.session}`);
+    if (event.artifactsDir) lines.push(`  artifacts: ${event.artifactsDir}`);
+    return lines.join('\n');
   }
 
-  return [
-    `FAIL ${name}${attemptSuffix}${durationSuffix}`,
-    message ? `  ${message}` : '',
-    event.artifactsDir ? `  artifacts: ${event.artifactsDir}` : '',
-  ]
-    .filter(Boolean)
-    .join('\n');
+  if (message) lines.push(`  ${message}`);
+  if (event.status === 'fail' && !event.retrying) {
+    if (event.session) lines.push(`  session: ${event.session}`);
+    if (event.artifactsDir) lines.push(`  artifacts: ${event.artifactsDir}`);
+  }
+  return lines.join('\n');
 }
 
-function formatReplayTestProgressName(event: RequestProgressEvent): string {
+function formatReplayTestProgressName(
+  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
+): string {
   const title = event.title?.trim();
-  if (title) return JSON.stringify(title);
-  return path.basename(event.file);
+  const file = path.basename(event.file);
+  return title ? `${JSON.stringify(title)} in ${file}` : file;
 }
 
-function formatReplayProgressAttemptSuffix(event: RequestProgressEvent): string {
+function formatReplayTestProgressStatusLabel(
+  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
+): string {
+  if (event.status === 'start') return 'START';
+  if (event.status === 'pass') return 'PASS';
+  if (event.status === 'skip') return 'SKIP';
+  return event.retrying ? 'RETRY' : 'FAIL';
+}
+
+function formatReplayTestProgressShardSuffix(
+  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
+): string {
+  if (typeof event.shardIndex !== 'number') return '';
+  const shardCount = typeof event.shardCount === 'number' ? event.shardCount : '?';
+  const device = typeof event.deviceId === 'string' ? ` ${event.deviceId}` : '';
+  return ` [shard ${event.shardIndex + 1}/${shardCount}${device}]`;
+}
+
+function formatReplayProgressAttemptSuffix(
+  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
+): string {
   if (event.attempt === undefined) return '';
+  if (event.status === 'start') return '';
   if (event.status === 'fail' && event.retrying && event.maxAttempts !== undefined) {
-    return ` attempt ${event.attempt}/${event.maxAttempts} retrying`;
+    return ` attempt ${event.attempt}/${event.maxAttempts}`;
   }
   if (event.attempt > 1) return ` after ${event.attempt} attempts`;
   return '';
 }
 
-function formatReplayProgressDuration(event: RequestProgressEvent): string {
+function formatReplayProgressDuration(
+  event: Extract<RequestProgressEvent, { type: 'replay-test' }>,
+): string {
   const duration = formatDurationSeconds(event.durationMs ?? 0);
   return event.attempt && event.attempt > 1 && !event.retrying ? `total ${duration}` : duration;
 }

--- a/src/cli-test.ts
+++ b/src/cli-test.ts
@@ -10,10 +10,6 @@ type PassedReplayTestResult = Extract<ReplaySuiteTestResult, { status: 'passed' 
 type FailedReplayTestResult = Extract<ReplaySuiteTestResult, { status: 'failed' }>;
 type ReplayTestError = FailedReplayTestResult['error'];
 
-export function announceReplayTestRun(options: { json?: boolean }): void {
-  void options;
-}
-
 export function renderReplayTestResponse(options: {
   suite: ReplaySuiteResult;
   json?: boolean;

--- a/src/cli-test.ts
+++ b/src/cli-test.ts
@@ -11,9 +11,7 @@ type FailedReplayTestResult = Extract<ReplaySuiteTestResult, { status: 'failed' 
 type ReplayTestError = FailedReplayTestResult['error'];
 
 export function announceReplayTestRun(options: { json?: boolean }): void {
-  if (!options.json) {
-    process.stderr.write('Running replay suite...\n');
-  }
+  void options;
 }
 
 export function renderReplayTestResponse(options: {

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -1,5 +1,5 @@
 import type { CommandRequestResult } from '../../client.ts';
-import { announceReplayTestRun, renderReplayTestResponse } from '../../cli-test.ts';
+import { renderReplayTestResponse } from '../../cli-test.ts';
 import { runCliCommandWithOutput } from '../../commands/cli-runner.ts';
 import type { CommandName } from '../../commands/command-metadata.ts';
 import type { CliOutput } from '../../commands/command-contract.ts';
@@ -16,9 +16,6 @@ export async function runGenericClientBackedCommand({
   flags,
   client,
 }: ClientCommandParams & { command: ClientBackedCliCommandName }): Promise<boolean> {
-  if (command === 'test') {
-    announceReplayTestRun({ json: flags.json });
-  }
   const { result, cliOutput } = await runCliCommandWithOutput({
     client,
     command: command as CommandName,

--- a/src/compat/maestro/__tests__/runtime-interactions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-interactions.test.ts
@@ -367,6 +367,31 @@ test('invokeMaestroSwipeScreen preserves vertical percentage endpoints', async (
   expect(swipeFlags[0]?.postGestureStabilization).toBeUndefined();
 });
 
+test('invokeMaestroSwipeScreen keeps iOS horizontal percentage swipes away from screen edges', async () => {
+  const swipes: string[][] = [];
+  const response = await invokeMaestroSwipeScreen({
+    baseReq: {
+      token: 'test',
+      session: 'ios-pager',
+      flags: { platform: 'ios' },
+    },
+    positionals: ['percent', '10', '50', '90', '50', '300'],
+    invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
+      if (req.command === 'snapshot') {
+        return { ok: true, data: fullScreenSnapshot(400, 800) };
+      }
+      if (req.command === 'swipe') {
+        swipes.push(req.positionals ?? []);
+        return { ok: true, data: {} };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  expect(response.ok).toBe(true);
+  expect(swipes).toEqual([['60', '400', '340', '400', '300']]);
+});
+
 test('invokeMaestroSwipeScreen keeps Android horizontal percentage swipes on the content lane', async () => {
   const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -341,12 +341,26 @@ function resolvePercentScreenSwipe(
   }
   const [x1, y1, x2, y2] = values as [number, number, number, number];
   const lane = maestroHorizontalContentSwipeLanePercent(platform, x1, y1, x2, y2);
+  const marginPx = maestroPercentSwipeMarginPx(platform, frame, x1, y1, x2, y2);
   return {
     ok: true,
-    start: pointFromPercent(frame, x1, lane.startY, { marginPx: 1 }),
-    end: pointFromPercent(frame, x2, lane.endY, { marginPx: 1 }),
+    start: pointFromPercent(frame, x1, lane.startY, { marginPx }),
+    end: pointFromPercent(frame, x2, lane.endY, { marginPx }),
     durationMs,
   };
+}
+
+function maestroPercentSwipeMarginPx(
+  platform: string,
+  frame: GestureReferenceFrame,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): number {
+  if (platform !== 'ios') return 1;
+  if (y1 !== y2 || Math.abs(x2 - x1) < 30) return 1;
+  return Math.max(1, Math.round(frame.referenceWidth * 0.15));
 }
 
 function maestroHorizontalContentSwipeLanePercent(

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1560,7 +1560,7 @@ test('runReplayScriptFile resolves Maestro screen swipes from the snapshot frame
     [
       ['gesture', ['swipe', 'left', '300']],
       ['snapshot', []],
-      ['swipe', ['360', '400', '40', '400', '300']],
+      ['swipe', ['340', '400', '60', '400', '300']],
     ],
   );
 });

--- a/src/daemon/handlers/__tests__/session-test-suite.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-suite.test.ts
@@ -249,49 +249,59 @@ test('test stops the suite when the parent request is canceled during an active 
 
   const parentRequestId = 'suite-parent-cancel';
   const invokedRequestIds: string[] = [];
+  const events: RequestProgressEvent[] = [];
   registerRequestAbort(parentRequestId);
 
   try {
-    const response = await handleSessionCommands({
-      req: {
-        token: 't',
-        session: 'default',
-        command: 'test',
-        positionals: [root],
-        meta: { cwd: root, requestId: parentRequestId },
-      },
-      sessionName: 'default',
-      logPath: path.join(os.tmpdir(), 'daemon.log'),
-      sessionStore,
-      invoke: async (req) => {
-        const nestedRequestId = req.meta?.requestId;
-        expect(nestedRequestId).toBeTypeOf('string');
-        invokedRequestIds.push(String(nestedRequestId));
-        const signal = getRequestSignal(nestedRequestId);
-        expect(signal).toBeDefined();
-        queueMicrotask(() => {
-          markRequestCanceled(parentRequestId);
-        });
-        await new Promise<void>((resolve) => {
-          if (signal?.aborted) {
-            resolve();
-            return;
-          }
-          signal?.addEventListener('abort', () => resolve(), { once: true });
-        });
-        return {
-          ok: false,
-          error: {
-            code: 'COMMAND_FAILED',
-            message: 'request canceled',
-            details: { reason: 'request_canceled' },
+    const response = await withRequestProgressSink(
+      (event) => events.push(event),
+      async () =>
+        await handleSessionCommands({
+          req: {
+            token: 't',
+            session: 'default',
+            command: 'test',
+            positionals: [root],
+            meta: { cwd: root, requestId: parentRequestId },
           },
-        };
-      },
-    });
+          sessionName: 'default',
+          logPath: path.join(os.tmpdir(), 'daemon.log'),
+          sessionStore,
+          invoke: async (req) => {
+            const nestedRequestId = req.meta?.requestId;
+            expect(nestedRequestId).toBeTypeOf('string');
+            invokedRequestIds.push(String(nestedRequestId));
+            const signal = getRequestSignal(nestedRequestId);
+            expect(signal).toBeDefined();
+            queueMicrotask(() => {
+              markRequestCanceled(parentRequestId);
+            });
+            await new Promise<void>((resolve) => {
+              if (signal?.aborted) {
+                resolve();
+                return;
+              }
+              signal?.addEventListener('abort', () => resolve(), { once: true });
+            });
+            return {
+              ok: false,
+              error: {
+                code: 'COMMAND_FAILED',
+                message: 'request canceled',
+                details: { reason: 'request_canceled' },
+              },
+            };
+          },
+        }),
+    );
 
     const data = expectOkData(response);
     expect(invokedRequestIds).toHaveLength(1);
+    expect(
+      events.some(
+        (event) => event.type === 'replay-test' && event.status === 'fail' && event.retrying,
+      ),
+    ).toBe(false);
     expect(data.failed).toBe(1);
     expect(data.notRun).toBe(1);
   } finally {

--- a/src/daemon/handlers/__tests__/session-test-suite.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-suite.test.ts
@@ -6,6 +6,12 @@ import { handleSessionCommands } from '../session.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, DaemonResponse, DaemonResponseData } from '../../types.ts';
 import { type RequestProgressEvent, withRequestProgressSink } from '../../request-progress.ts';
+import {
+  clearRequestCanceled,
+  getRequestSignal,
+  markRequestCanceled,
+  registerRequestAbort,
+} from '../../request-cancel.ts';
 import { withDeviceInventoryProvider } from '../../../core/dispatch-resolve.ts';
 import type { DeviceInfo } from '../../../utils/device.ts';
 
@@ -156,8 +162,16 @@ test('test emits progress when attempts retry and pass', async () => {
       durationMs: expect.any(Number),
     },
   ]);
-  expect(events.map((event) => event.status)).toEqual(['fail', 'pass']);
   expect(events[0]).toMatchObject({
+    type: 'replay-test-suite',
+    status: 'start',
+    total: 1,
+    runnable: 1,
+    skipped: 0,
+  });
+  const testEvents = events.filter((event) => event.type === 'replay-test');
+  expect(testEvents.map((event) => event.status)).toEqual(['start', 'fail', 'pass']);
+  expect(testEvents[1]).toMatchObject({
     type: 'replay-test',
     title: undefined,
     status: 'fail',
@@ -169,7 +183,7 @@ test('test emits progress when attempts retry and pass', async () => {
     retrying: true,
     message: 'Replay failed at step 1 (open "Demo"): first attempt failed',
   });
-  expect(events[1]).toMatchObject({
+  expect(testEvents[2]).toMatchObject({
     type: 'replay-test',
     title: undefined,
     status: 'pass',
@@ -208,15 +222,81 @@ test('test emits skip progress without synthetic duration', async () => {
 
   const data = expectOkData(response);
   expect(data.skipped).toBe(1);
-  expect(events.map((event) => event.status)).toEqual(['skip', 'pass']);
   expect(events[0]).toMatchObject({
+    type: 'replay-test-suite',
+    status: 'start',
+    total: 2,
+    runnable: 1,
+    skipped: 1,
+  });
+  const testEvents = events.filter((event) => event.type === 'replay-test');
+  expect(testEvents.map((event) => event.status)).toEqual(['skip', 'start', 'pass']);
+  expect(testEvents[0]).toMatchObject({
     type: 'replay-test',
     status: 'skip',
     index: 1,
     total: 2,
     message: 'missing platform metadata for --platform android',
   });
-  expect(events[0]?.durationMs).toBeUndefined();
+  expect(testEvents[0]?.durationMs).toBeUndefined();
+});
+
+test('test stops the suite when the parent request is canceled during an active replay attempt', async () => {
+  const sessionStore = makeSessionStore();
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-test-suite-parent-cancel-'));
+  fs.writeFileSync(path.join(root, '01-first.ad'), 'context platform=ios\nopen "Demo"\n');
+  fs.writeFileSync(path.join(root, '02-second.ad'), 'context platform=ios\nopen "Demo"\n');
+
+  const parentRequestId = 'suite-parent-cancel';
+  const invokedRequestIds: string[] = [];
+  registerRequestAbort(parentRequestId);
+
+  try {
+    const response = await handleSessionCommands({
+      req: {
+        token: 't',
+        session: 'default',
+        command: 'test',
+        positionals: [root],
+        meta: { cwd: root, requestId: parentRequestId },
+      },
+      sessionName: 'default',
+      logPath: path.join(os.tmpdir(), 'daemon.log'),
+      sessionStore,
+      invoke: async (req) => {
+        const nestedRequestId = req.meta?.requestId;
+        expect(nestedRequestId).toBeTypeOf('string');
+        invokedRequestIds.push(String(nestedRequestId));
+        const signal = getRequestSignal(nestedRequestId);
+        expect(signal).toBeDefined();
+        queueMicrotask(() => {
+          markRequestCanceled(parentRequestId);
+        });
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return {
+          ok: false,
+          error: {
+            code: 'COMMAND_FAILED',
+            message: 'request canceled',
+            details: { reason: 'request_canceled' },
+          },
+        };
+      },
+    });
+
+    const data = expectOkData(response);
+    expect(invokedRequestIds).toHaveLength(1);
+    expect(data.failed).toBe(1);
+    expect(data.notRun).toBe(1);
+  } finally {
+    clearRequestCanceled(parentRequestId);
+  }
 });
 
 test('test --shard-all runs each runnable entry on each selected device', async () => {

--- a/src/daemon/handlers/session-test-attempt.ts
+++ b/src/daemon/handlers/session-test-attempt.ts
@@ -82,6 +82,7 @@ async function runReplayTestCaseAttempts(
   params: ReplayTestCaseParams,
   context: ReplayTestCaseContext,
 ): Promise<ReplayTestCaseOutcome> {
+  emitReplayTestStartProgress(params, context);
   const outcome: ReplayTestCaseOutcome = {
     finalSessionName: '',
     attempts: 0,
@@ -116,18 +117,20 @@ async function runSingleReplayTestAttempt(
   );
   const attemptArtifactsDir = path.join(context.testArtifactsDir, `attempt-${attempt}`);
   prepareReplayTestAttemptArtifacts(entry.path, attemptArtifactsDir);
+  const attemptRequestId = buildReplayTestAttemptRequestId({
+    requestId,
+    suiteInvocationId,
+    filePath: entry.path,
+    caseIndex,
+    attemptIndex,
+    shardIndex: shard?.shardIndex,
+  });
 
   const response = await runReplayTestAttempt({
     filePath: entry.path,
     sessionName: testSessionName,
-    requestId: buildReplayTestAttemptRequestId({
-      requestId,
-      suiteInvocationId,
-      filePath: entry.path,
-      caseIndex,
-      attemptIndex,
-      shardIndex: shard?.shardIndex,
-    }),
+    requestId: attemptRequestId,
+    parentRequestId: requestId,
     timeoutMs,
     platform: entry.metadata.platform,
     target: entry.metadata.target,
@@ -147,6 +150,26 @@ async function runSingleReplayTestAttempt(
     attemptArtifactsDir,
   });
   return { response, sessionName: testSessionName, attempt, durationMs };
+}
+
+function emitReplayTestStartProgress(
+  params: ReplayTestCaseParams,
+  context: ReplayTestCaseContext,
+): void {
+  const { entry, sessionName, suiteInvocationId, caseIndex, suiteIndex, suiteTotal, shard } =
+    params;
+  emitRequestProgress({
+    type: 'replay-test',
+    file: entry.path,
+    title: entry.title,
+    status: 'start',
+    index: suiteIndex,
+    total: suiteTotal,
+    maxAttempts: context.maxAttempts,
+    session: buildReplayTestSessionName(sessionName, suiteInvocationId, entry.path, caseIndex),
+    artifactsDir: context.testArtifactsDir,
+    ...replayTestProgressShardMetadata(shard),
+  });
 }
 
 function updateReplayTestCaseOutcome(
@@ -191,6 +214,9 @@ function emitReplayTestRetryProgress(
     durationMs: attempt.durationMs,
     retrying: true,
     message: attempt.response.error.message,
+    session: attempt.sessionName,
+    artifactsDir: context.testArtifactsDir,
+    ...replayTestProgressShardMetadata(params.shard),
   });
 }
 
@@ -225,7 +251,9 @@ function buildReplayTestPassedResult(
     attempt: outcome.attempts,
     maxAttempts: context.maxAttempts,
     durationMs,
+    session: outcome.finalSessionName,
     artifactsDir: context.testArtifactsDir,
+    ...replayTestProgressShardMetadata(shard),
   });
   return {
     file: entry.path,
@@ -262,8 +290,10 @@ function buildReplayTestFailedResult(
     attempt: outcome.attempts,
     maxAttempts: context.maxAttempts,
     durationMs,
+    session: outcome.finalSessionName,
     artifactsDir: context.testArtifactsDir,
     message: error.message,
+    ...replayTestProgressShardMetadata(shard),
   });
   return {
     file: entry.path,
@@ -294,6 +324,12 @@ function replayTestWarningsResultMetadata(
 }
 
 function replayTestShardResultMetadata(
+  shard: ReplayTestShardContext | undefined,
+): Pick<ReplaySuiteTestFailed, 'shardIndex' | 'shardCount' | 'deviceId'> {
+  return replayTestProgressShardMetadata(shard);
+}
+
+function replayTestProgressShardMetadata(
   shard: ReplayTestShardContext | undefined,
 ): Pick<ReplaySuiteTestFailed, 'shardIndex' | 'shardCount' | 'deviceId'> {
   return shard

--- a/src/daemon/handlers/session-test-attempt.ts
+++ b/src/daemon/handlers/session-test-attempt.ts
@@ -15,6 +15,7 @@ import { isReplayInfrastructureFailure } from './session-test-infrastructure.ts'
 import { runReplayTestAttempt } from './session-test-runtime.ts';
 import type { ReplayTestRuntimeDependencies } from './session-test-types.ts';
 import type { ReplayTestShardContext } from './session-test-sharding.ts';
+import { isRequestCanceled } from '../request-cancel.ts';
 
 type ReplayTestCaseResult = Extract<ReplaySuiteTestResult, { status: 'passed' | 'failed' }>;
 type ReplayTestAttemptFailure = NonNullable<
@@ -91,9 +92,10 @@ async function runReplayTestCaseAttempts(
   };
 
   for (let attemptIndex = 0; attemptIndex <= params.retries; attemptIndex += 1) {
+    if (isRequestCanceled(params.requestId)) break;
     const attempt = await runSingleReplayTestAttempt(params, context, attemptIndex);
     updateReplayTestCaseOutcome(outcome, attempt);
-    if (shouldStopReplayTestAttempts(attempt.response, attemptIndex, params.retries)) break;
+    if (shouldStopReplayTestAttempts(params, attempt.response, attemptIndex)) break;
     emitReplayTestRetryProgress(params, context, attempt);
   }
 
@@ -189,11 +191,16 @@ function updateReplayTestCaseOutcome(
 }
 
 function shouldStopReplayTestAttempts(
+  params: ReplayTestCaseParams,
   response: DaemonResponse,
   attemptIndex: number,
-  retries: number,
 ): boolean {
-  return response.ok || isReplayInfrastructureFailure(response) || attemptIndex >= retries;
+  return (
+    response.ok ||
+    isRequestCanceled(params.requestId) ||
+    isReplayInfrastructureFailure(response) ||
+    attemptIndex >= params.retries
+  );
 }
 
 function emitReplayTestRetryProgress(

--- a/src/daemon/handlers/session-test-runtime.ts
+++ b/src/daemon/handlers/session-test-runtime.ts
@@ -5,6 +5,7 @@ import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { normalizeError } from '../../utils/errors.ts';
 import {
   clearRequestCanceled,
+  getRequestSignal,
   markRequestCanceled,
   registerRequestAbort,
 } from '../request-cancel.ts';
@@ -25,6 +26,7 @@ export async function runReplayTestAttempt(
     filePath: string;
     sessionName: string;
     requestId: string;
+    parentRequestId?: string;
     timeoutMs?: number;
     platform?: ReplayScriptMetadata['platform'];
     target?: ReplayScriptMetadata['target'];
@@ -36,6 +38,7 @@ export async function runReplayTestAttempt(
     filePath,
     sessionName,
     requestId,
+    parentRequestId,
     timeoutMs,
     platform,
     target,
@@ -46,6 +49,7 @@ export async function runReplayTestAttempt(
     finalizeAttempt,
   } = params;
   registerRequestAbort(requestId);
+  const clearParentAbortRelay = relayReplayTestAbortFromParent(requestId, parentRequestId);
   const artifactPaths = new Set<string>();
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
@@ -80,6 +84,7 @@ export async function runReplayTestAttempt(
       } satisfies DaemonResponse;
     })
     .finally(() => {
+      clearParentAbortRelay();
       clearRequestCanceled(requestId);
     });
 
@@ -186,6 +191,27 @@ export async function runReplayTestAttempt(
       },
     }
   );
+}
+
+function relayReplayTestAbortFromParent(
+  requestId: string,
+  parentRequestId: string | undefined,
+): () => void {
+  if (!parentRequestId || parentRequestId === requestId) return () => {};
+  const parentSignal = getRequestSignal(parentRequestId);
+  if (!parentSignal) return () => {};
+
+  const cancelRequest = () => {
+    markRequestCanceled(requestId);
+  };
+  if (parentSignal.aborted) {
+    cancelRequest();
+    return () => {};
+  }
+  parentSignal.addEventListener('abort', cancelRequest, { once: true });
+  return () => {
+    parentSignal.removeEventListener('abort', cancelRequest);
+  };
 }
 
 async function waitForReplayAfterTimeout(replayPromise: Promise<DaemonResponse>): Promise<boolean> {

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -20,8 +20,13 @@ import { isReplayInfrastructureFailure } from './session-test-infrastructure.ts'
 import { runReplayTestCase } from './session-test-attempt.ts';
 import type { ReplayTestRuntimeDependencies } from './session-test-types.ts';
 import { buildReplayTestShardPlan, type ReplayTestShardContext } from './session-test-sharding.ts';
+import { isRequestCanceled } from '../request-cancel.ts';
 
 type ReplayTestEntry = ReturnType<typeof discoverReplayTestEntries>[number];
+type ReplayTestQueuedEntry = {
+  entry: ReplayTestRunEntry;
+  suiteIndex: number;
+};
 
 export async function runReplayTestSuite(
   params: {
@@ -51,8 +56,20 @@ export async function runReplayTestSuite(
 
     const suiteStartedAt = Date.now();
     const skipped = entries.filter((entry) => entry.kind === 'skip');
-    const runnable = entries.filter((entry): entry is ReplayTestRunEntry => entry.kind === 'run');
+    const runnable = entries.flatMap((entry, entryIndex) =>
+      entry.kind === 'run' ? [{ entry, suiteIndex: entryIndex + 1 }] : [],
+    );
     const shardPlan = await buildReplayTestShardPlan(req.flags, runnable, skipped.length);
+    emitRequestProgress({
+      type: 'replay-test-suite',
+      status: 'start',
+      total: shardPlan?.total ?? entries.length,
+      runnable: runnable.length,
+      skipped: skipped.length,
+      artifactsDir: suiteArtifactsDir,
+      shardMode: shardPlan?.mode,
+      shardCount: shardPlan?.shardCount,
+    });
     const results: ReplaySuiteTestResult[] = shardPlan
       ? emitSkippedReplayTestResults({
           entries,
@@ -135,7 +152,7 @@ function emitSkippedReplayTestResults(params: {
 
 async function runReplayTestShards(
   params: {
-    shards: Array<ReplayTestShardContext & { entries: ReplayTestRunEntry[] }>;
+    shards: Array<ReplayTestShardContext & { entries: ReplayTestQueuedEntry[] }>;
     sessionName: string;
     suiteInvocationId: string;
     cwd?: string;
@@ -156,13 +173,13 @@ async function runReplayTestShards(
 }
 
 function buildUnexpectedShardFailure(
-  shard: ReplayTestShardContext & { entries: ReplayTestRunEntry[] },
+  shard: ReplayTestShardContext & { entries: ReplayTestQueuedEntry[] },
   sessionName: string,
   reason: unknown,
 ): ReplaySuiteTestFailed {
   const appErr = normalizeError(reason);
   return {
-    file: shard.entries[0]?.path ?? `shard-${shard.shardIndex + 1}`,
+    file: shard.entries[0]?.entry.path ?? `shard-${shard.shardIndex + 1}`,
     session: formatReplayTestShardSessionName(sessionName, shard),
     status: 'failed',
     durationMs: 0,
@@ -183,7 +200,7 @@ function buildUnexpectedShardFailure(
 
 async function runReplayTestShard(
   params: {
-    shard: ReplayTestShardContext & { entries: ReplayTestRunEntry[] };
+    shard: ReplayTestShardContext & { entries: ReplayTestQueuedEntry[] };
     sessionName: string;
     suiteInvocationId: string;
     cwd?: string;
@@ -237,6 +254,7 @@ async function runReplayTestEntriesInDiscoveryOrder(
   const results: ReplaySuiteTestResult[] = [];
   let executed = 0;
   for (const [entryIndex, entry] of discoveryEntries.entries()) {
+    if (isRequestCanceled(requestId)) break;
     if (entry.kind === 'skip') {
       emitRequestProgress({
         type: 'replay-test',
@@ -273,14 +291,14 @@ async function runReplayTestEntriesInDiscoveryOrder(
       finalizeAttempt,
     });
     results.push(result);
-    if (flags?.failFast === true || isReplayInfrastructureFailure(result)) break;
+    if (shouldStopReplayTestExecution(result, flags, requestId)) break;
   }
   return results;
 }
 
 async function runReplayTestEntries(
   params: {
-    entries: ReplayTestRunEntry[];
+    entries: ReplayTestQueuedEntry[];
     sessionName: string;
     suiteInvocationId: string;
     cwd?: string;
@@ -306,7 +324,9 @@ async function runReplayTestEntries(
     finalizeAttempt,
   } = params;
   const results: ReplaySuiteTestResult[] = [];
-  for (const [entryIndex, entry] of entries.entries()) {
+  for (const [entryIndex, queued] of entries.entries()) {
+    if (isRequestCanceled(requestId)) break;
+    const { entry, suiteIndex } = queued;
     const result = await runReplayTestCase({
       entry,
       sessionName,
@@ -317,7 +337,7 @@ async function runReplayTestEntries(
       retries: resolveReplayTestRetries(flags?.retries, entry.metadata.retries),
       timeoutMs: resolveReplayTestTimeout(flags?.timeoutMs, entry.metadata.timeoutMs),
       suiteArtifactsDir,
-      suiteIndex: entryIndex + 1,
+      suiteIndex,
       suiteTotal,
       shard,
       runReplay,
@@ -325,9 +345,21 @@ async function runReplayTestEntries(
       finalizeAttempt,
     });
     results.push(result);
-    if (flags?.failFast === true || isReplayInfrastructureFailure(result)) break;
+    if (shouldStopReplayTestExecution(result, flags, requestId)) break;
   }
   return results;
+}
+
+function shouldStopReplayTestExecution(
+  result: ReplaySuiteTestResult,
+  flags: DaemonRequest['flags'],
+  requestId: string | undefined,
+): boolean {
+  return (
+    isRequestCanceled(requestId) ||
+    flags?.failFast === true ||
+    isReplayInfrastructureFailure(result)
+  );
 }
 
 function summarizeReplayTestResults(

--- a/src/daemon/handlers/session-test.ts
+++ b/src/daemon/handlers/session-test.ts
@@ -19,13 +19,26 @@ import {
 import { isReplayInfrastructureFailure } from './session-test-infrastructure.ts';
 import { runReplayTestCase } from './session-test-attempt.ts';
 import type { ReplayTestRuntimeDependencies } from './session-test-types.ts';
-import { buildReplayTestShardPlan, type ReplayTestShardContext } from './session-test-sharding.ts';
+import {
+  buildReplayTestShardPlan,
+  type ReplayTestShardContext,
+  type ReplayTestShardPlan,
+} from './session-test-sharding.ts';
 import { isRequestCanceled } from '../request-cancel.ts';
 
 type ReplayTestEntry = ReturnType<typeof discoverReplayTestEntries>[number];
 type ReplayTestQueuedEntry = {
   entry: ReplayTestRunEntry;
   suiteIndex: number;
+};
+
+type ReplayTestSuitePlan = {
+  entries: ReplayTestEntry[];
+  runnable: ReplayTestQueuedEntry[];
+  shardPlan: ReplayTestShardPlan<ReplayTestQueuedEntry> | undefined;
+  suiteArtifactsDir: string;
+  suiteInvocationId: string;
+  total: number;
 };
 
 export async function runReplayTestSuite(
@@ -40,54 +53,27 @@ export async function runReplayTestSuite(
   }
 
   try {
-    const entries = discoverReplayTestEntries({
-      inputs: req.positionals,
-      cwd: req.meta?.cwd,
-      platformFilter: req.flags?.platform,
-      replayBackend: req.flags?.replayBackend,
-    });
-    const suiteInvocationId = buildReplayTestInvocationId(req.meta?.requestId);
-    const suiteArtifactsDir = resolveReplayTestArtifactsDir({
-      artifactsDir:
-        typeof req.flags?.artifactsDir === 'string' ? req.flags.artifactsDir : undefined,
-      cwd: req.meta?.cwd,
-      suiteInvocationId,
-    });
-
     const suiteStartedAt = Date.now();
-    const skipped = entries.filter((entry) => entry.kind === 'skip');
-    const runnable = entries.flatMap((entry, entryIndex) =>
-      entry.kind === 'run' ? [{ entry, suiteIndex: entryIndex + 1 }] : [],
-    );
-    const shardPlan = await buildReplayTestShardPlan(req.flags, runnable, skipped.length);
-    emitRequestProgress({
-      type: 'replay-test-suite',
-      status: 'start',
-      total: shardPlan?.total ?? entries.length,
-      runnable: runnable.length,
-      skipped: skipped.length,
-      artifactsDir: suiteArtifactsDir,
-      shardMode: shardPlan?.mode,
-      shardCount: shardPlan?.shardCount,
-    });
-    const results: ReplaySuiteTestResult[] = shardPlan
+    const plan = await prepareReplayTestSuitePlan(req);
+    emitReplayTestSuiteStart(plan);
+    const results: ReplaySuiteTestResult[] = plan.shardPlan
       ? emitSkippedReplayTestResults({
-          entries,
-          total: shardPlan.total,
+          entries: plan.entries,
+          total: plan.total,
         })
       : [];
 
-    if (shardPlan) {
+    if (plan.shardPlan) {
       results.push(
         ...(await runReplayTestShards({
-          shards: shardPlan.shards,
+          shards: plan.shardPlan.shards,
           sessionName,
-          suiteInvocationId,
+          suiteInvocationId: plan.suiteInvocationId,
           cwd: req.meta?.cwd,
           requestId: req.meta?.requestId,
           flags: req.flags,
-          suiteArtifactsDir,
-          suiteTotal: shardPlan.total,
+          suiteArtifactsDir: plan.suiteArtifactsDir,
+          suiteTotal: plan.total,
           runReplay,
           cleanupSession,
           finalizeAttempt,
@@ -96,14 +82,14 @@ export async function runReplayTestSuite(
     } else {
       results.push(
         ...(await runReplayTestEntriesInDiscoveryOrder({
-          discoveryEntries: entries,
+          discoveryEntries: plan.entries,
           sessionName,
-          suiteInvocationId,
+          suiteInvocationId: plan.suiteInvocationId,
           cwd: req.meta?.cwd,
           requestId: req.meta?.requestId,
           flags: req.flags,
-          suiteArtifactsDir,
-          suiteTotal: entries.length,
+          suiteArtifactsDir: plan.suiteArtifactsDir,
+          suiteTotal: plan.total,
           runReplay,
           cleanupSession,
           finalizeAttempt,
@@ -111,16 +97,64 @@ export async function runReplayTestSuite(
       );
     }
 
-    const data = summarizeReplayTestResults(
-      shardPlan?.total ?? entries.length,
-      results,
-      Date.now() - suiteStartedAt,
-    );
+    const data = summarizeReplayTestResults(plan.total, results, Date.now() - suiteStartedAt);
     return { ok: true, data };
   } catch (err) {
     const appErr = asAppError(err);
     return errorResponse(appErr.code, appErr.message);
   }
+}
+
+async function prepareReplayTestSuitePlan(req: DaemonRequest): Promise<ReplayTestSuitePlan> {
+  const entries = discoverReplayTestSuiteEntries(req);
+  const runnable = runnableReplayTestEntries(entries);
+  const skippedCount = entries.length - runnable.length;
+  const suiteInvocationId = buildReplayTestInvocationId(req.meta?.requestId);
+  const shardPlan = await buildReplayTestShardPlan(req.flags, runnable, skippedCount);
+  return {
+    entries,
+    runnable,
+    shardPlan,
+    suiteInvocationId,
+    suiteArtifactsDir: replayTestSuiteArtifactsDir(req, suiteInvocationId),
+    total: shardPlan?.total ?? entries.length,
+  };
+}
+
+function discoverReplayTestSuiteEntries(req: DaemonRequest): ReplayTestEntry[] {
+  return discoverReplayTestEntries({
+    inputs: req.positionals ?? [],
+    cwd: req.meta?.cwd,
+    platformFilter: req.flags?.platform,
+    replayBackend: req.flags?.replayBackend,
+  });
+}
+
+function runnableReplayTestEntries(entries: ReplayTestEntry[]): ReplayTestQueuedEntry[] {
+  return entries.flatMap((entry, entryIndex) =>
+    entry.kind === 'run' ? [{ entry, suiteIndex: entryIndex + 1 }] : [],
+  );
+}
+
+function replayTestSuiteArtifactsDir(req: DaemonRequest, suiteInvocationId: string): string {
+  return resolveReplayTestArtifactsDir({
+    artifactsDir: typeof req.flags?.artifactsDir === 'string' ? req.flags.artifactsDir : undefined,
+    cwd: req.meta?.cwd,
+    suiteInvocationId,
+  });
+}
+
+function emitReplayTestSuiteStart(plan: ReplayTestSuitePlan): void {
+  emitRequestProgress({
+    type: 'replay-test-suite',
+    status: 'start',
+    total: plan.total,
+    runnable: plan.runnable.length,
+    skipped: plan.entries.length - plan.runnable.length,
+    artifactsDir: plan.suiteArtifactsDir,
+    shardMode: plan.shardPlan?.mode,
+    shardCount: plan.shardPlan?.shardCount,
+  });
 }
 
 function emitSkippedReplayTestResults(params: {

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -8,6 +8,7 @@ import type { DaemonInstallSource, DaemonInvokeFn, DaemonRequest } from './types
 import { normalizeTenantId } from './config.ts';
 import {
   clearRequestCanceled,
+  isRequestCanceled,
   markRequestCanceled,
   registerRequestAbort,
   resolveRequestTrackingId,
@@ -69,6 +70,7 @@ type HttpAuthDecision =
 const MAX_HTTP_RPC_BODY_BYTES = 1024 * 1024;
 const CLIENT_DISCONNECT_ABORT_POLL_INTERVAL_MS = 200;
 const CLIENT_DISCONNECT_ABORT_MAX_WINDOW_MS = 15_000;
+const IOS_RUNNER_ABORT_REPLAY_COMMANDS = new Set(['replay', 'test']);
 const COMMAND_RPC_METHODS = new Set(['agent_device.command', 'agent-device.command']);
 const INSTALL_FROM_SOURCE_RPC_METHODS = new Set([
   'agent_device.install_from_source',
@@ -558,6 +560,7 @@ export async function createDaemonHttpServer(options: {
       }
 
       let requestIdForCleanup: string | undefined;
+      let handlerCompleted = false;
       try {
         const params = rpcRequest.params as Record<string, unknown>;
         const daemonRequest = methodToDaemonRequest(rpcRequest.method, params, req.headers);
@@ -582,22 +585,6 @@ export async function createDaemonHttpServer(options: {
           requestId: requestIdForCleanup,
         };
         registerRequestAbort(requestIdForCleanup);
-        let canceledInFlight = false;
-        const markCanceledIfResponseIncomplete = () => {
-          if (res.writableFinished || canceledInFlight) return;
-          canceledInFlight = true;
-          markRequestCanceled(requestIdForCleanup);
-          emitDiagnostic({
-            level: 'warn',
-            phase: 'request_client_disconnected',
-            data: {
-              requestId: requestIdForCleanup,
-            },
-          });
-          void abortInFlightIosRunnerSessionsWhileDisconnected(res);
-        };
-        req.on('aborted', markCanceledIfResponseIncomplete);
-        res.on('close', markCanceledIfResponseIncomplete);
 
         const authResult = await runHttpAuthHook(authHook, {
           headers: req.headers,
@@ -619,6 +606,32 @@ export async function createDaemonHttpServer(options: {
           };
         }
 
+        const abortIosRunnerOnDisconnect = shouldAbortIosRunnerSessionsOnDisconnect(daemonRequest);
+        let canceledInFlight = false;
+        const markCanceledIfResponseIncomplete = () => {
+          if (handlerCompleted || res.writableFinished || canceledInFlight) return;
+          canceledInFlight = true;
+          markRequestCanceled(requestIdForCleanup);
+          emitDiagnostic({
+            level: 'warn',
+            phase: 'request_client_disconnected',
+            data: {
+              requestId: requestIdForCleanup,
+              abortIosRunnerSessions: abortIosRunnerOnDisconnect,
+            },
+          });
+          if (abortIosRunnerOnDisconnect) {
+            void abortInFlightIosRunnerSessionsWhileDisconnected(requestIdForCleanup);
+          }
+        };
+        req.on('aborted', markCanceledIfResponseIncomplete);
+        res.on('close', () => {
+          if (res.headersSent) markCanceledIfResponseIncomplete();
+        });
+        if (req.aborted || (res.destroyed && res.headersSent)) {
+          markCanceledIfResponseIncomplete();
+        }
+
         const streamProgress = shouldStreamRequestProgress(daemonRequest);
         if (streamProgress) {
           res.statusCode = 200;
@@ -627,6 +640,7 @@ export async function createDaemonHttpServer(options: {
             (event) => writeProgressEnvelope(res, event),
             async () => await handleRequest(daemonRequest),
           );
+          handlerCompleted = true;
           const rpcResponse = daemonResponse.ok
             ? ({
                 jsonrpc: '2.0',
@@ -644,6 +658,7 @@ export async function createDaemonHttpServer(options: {
         }
 
         const daemonResponse = await handleRequest(daemonRequest);
+        handlerCompleted = true;
         if (daemonResponse.ok) {
           sendJson(res, { jsonrpc: '2.0', id: rpcRequest.id ?? null, result: daemonResponse });
           return;
@@ -659,6 +674,7 @@ export async function createDaemonHttpServer(options: {
           statusCodeForNormalizedError(daemonResponse.error.code),
         );
       } catch (error) {
+        handlerCompleted = true;
         const normalized = normalizeError(error);
         if (res.headersSent) {
           writeRpcResponseEnvelope(
@@ -771,14 +787,14 @@ async function handleArtifactDownload(
 }
 
 async function abortInFlightIosRunnerSessionsWhileDisconnected(
-  res: http.ServerResponse<http.IncomingMessage>,
+  requestId: string | undefined,
 ): Promise<void> {
   try {
     const deadline = Date.now() + CLIENT_DISCONNECT_ABORT_MAX_WINDOW_MS;
-    while (!res.writableFinished && Date.now() < deadline) {
+    while (isRequestCanceled(requestId) && Date.now() < deadline) {
       const { abortAllIosRunnerSessions } = await import('../platforms/ios/runner-client.ts');
       await abortAllIosRunnerSessions();
-      if (res.writableFinished) break;
+      if (!isRequestCanceled(requestId)) break;
       await sleep(CLIENT_DISCONNECT_ABORT_POLL_INTERVAL_MS);
     }
   } catch (error) {
@@ -790,6 +806,12 @@ async function abortInFlightIosRunnerSessionsWhileDisconnected(
       },
     });
   }
+}
+
+function shouldAbortIosRunnerSessionsOnDisconnect(req: DaemonRequest): boolean {
+  if (req.flags?.platform === 'android') return false;
+  if (req.flags?.platform === 'ios') return true;
+  return IOS_RUNNER_ABORT_REPLAY_COMMANDS.has(req.command);
 }
 
 async function authorizeAuxiliaryHttpRequest(params: {

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -1,6 +1,7 @@
 import http, { type IncomingHttpHeaders } from 'node:http';
 import fs from 'node:fs';
 import { AppError, normalizeError, toAppErrorCode } from '../utils/errors.ts';
+import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { timingSafeStringEqual } from '../utils/timing-safe-equal.ts';
 import type { JsonRpcId, JsonRpcRequestEnvelope, LeaseBackend } from '../contracts.ts';
 import type { DaemonInstallSource, DaemonInvokeFn, DaemonRequest } from './types.ts';
@@ -13,6 +14,7 @@ import {
 } from './request-cancel.ts';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { sleep } from '../utils/timeouts.ts';
 import {
   cleanupDownloadableArtifact,
   prepareDownloadableArtifact,
@@ -65,6 +67,8 @@ type HttpAuthDecision =
   | { ok: false; statusCode: number; response: JsonRpcResponse };
 
 const MAX_HTTP_RPC_BODY_BYTES = 1024 * 1024;
+const CLIENT_DISCONNECT_ABORT_POLL_INTERVAL_MS = 200;
+const CLIENT_DISCONNECT_ABORT_MAX_WINDOW_MS = 15_000;
 const COMMAND_RPC_METHODS = new Set(['agent_device.command', 'agent-device.command']);
 const INSTALL_FROM_SOURCE_RPC_METHODS = new Set([
   'agent_device.install_from_source',
@@ -578,10 +582,19 @@ export async function createDaemonHttpServer(options: {
           requestId: requestIdForCleanup,
         };
         registerRequestAbort(requestIdForCleanup);
+        let canceledInFlight = false;
         const markCanceledIfResponseIncomplete = () => {
-          if (!res.writableFinished) {
-            markRequestCanceled(requestIdForCleanup);
-          }
+          if (res.writableFinished || canceledInFlight) return;
+          canceledInFlight = true;
+          markRequestCanceled(requestIdForCleanup);
+          emitDiagnostic({
+            level: 'warn',
+            phase: 'request_client_disconnected',
+            data: {
+              requestId: requestIdForCleanup,
+            },
+          });
+          void abortInFlightIosRunnerSessionsWhileDisconnected(res);
         };
         req.on('aborted', markCanceledIfResponseIncomplete);
         res.on('close', markCanceledIfResponseIncomplete);
@@ -754,6 +767,28 @@ async function handleArtifactDownload(
   } catch (error) {
     const normalized = normalizeError(error);
     sendRestJsonError(res, normalized);
+  }
+}
+
+async function abortInFlightIosRunnerSessionsWhileDisconnected(
+  res: http.ServerResponse<http.IncomingMessage>,
+): Promise<void> {
+  try {
+    const deadline = Date.now() + CLIENT_DISCONNECT_ABORT_MAX_WINDOW_MS;
+    while (!res.writableFinished && Date.now() < deadline) {
+      const { abortAllIosRunnerSessions } = await import('../platforms/ios/runner-client.ts');
+      await abortAllIosRunnerSessions();
+      if (res.writableFinished) break;
+      await sleep(CLIENT_DISCONNECT_ABORT_POLL_INTERVAL_MS);
+    }
+  } catch (error) {
+    emitDiagnostic({
+      level: 'error',
+      phase: 'request_client_disconnect_abort_failed',
+      data: {
+        message: error instanceof Error ? error.message : String(error),
+      },
+    });
   }
 }
 

--- a/src/daemon/request-progress.ts
+++ b/src/daemon/request-progress.ts
@@ -1,10 +1,21 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
+export type ReplayTestSuiteProgressEvent = {
+  type: 'replay-test-suite';
+  status: 'start';
+  total: number;
+  runnable: number;
+  skipped: number;
+  artifactsDir: string;
+  shardMode?: 'all' | 'split';
+  shardCount?: number;
+};
+
 export type ReplayTestProgressEvent = {
   type: 'replay-test';
   file: string;
   title?: string;
-  status: 'pass' | 'fail' | 'skip';
+  status: 'start' | 'pass' | 'fail' | 'skip';
   index: number;
   total: number;
   attempt?: number;
@@ -12,10 +23,14 @@ export type ReplayTestProgressEvent = {
   durationMs?: number;
   retrying?: boolean;
   message?: string;
+  session?: string;
   artifactsDir?: string;
+  shardIndex?: number;
+  shardCount?: number;
+  deviceId?: string;
 };
 
-export type RequestProgressEvent = ReplayTestProgressEvent;
+export type RequestProgressEvent = ReplayTestSuiteProgressEvent | ReplayTestProgressEvent;
 export type RequestProgressSink = (event: RequestProgressEvent) => void;
 
 const requestProgress = new AsyncLocalStorage<RequestProgressSink | undefined>();

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -1294,7 +1294,24 @@ test('openIosApp appends launchArgs alongside --payload-url for iOS device deep 
   }
 });
 
-test('openIosApp launches iOS simulator app before opening URL', async () => {
+test('openIosApp opens custom-scheme iOS simulator URLs directly when launch args are absent', async () => {
+  mockEnsureBootedSimulator.mockResolvedValue();
+  mockRunCmd.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+  await openIosApp(IOS_TEST_SIMULATOR, 'MyApp', {
+    appBundleId: 'com.example.app',
+    url: 'myapp://item/42',
+  });
+
+  assert.equal(mockRunCmd.mock.calls.length, 1);
+  assert.deepEqual(mockRunCmd.mock.calls[0], [
+    'xcrun',
+    ['simctl', 'openurl', 'sim-1', 'myapp://item/42'],
+    undefined,
+  ]);
+});
+
+test('openIosApp launches iOS simulator app before opening custom-scheme URL with launchArgs', async () => {
   mockEnsureBootedSimulator.mockResolvedValue();
   mockRunCmd.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
 

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -13,7 +13,11 @@ import {
 import { requireLocationCoordinates } from '../../utils/location-coordinates.ts';
 import { resolveIosSimulatorDeviceSetPath } from '../../utils/device-isolation.ts';
 import { Deadline, retryWithPolicy } from '../../utils/retry.ts';
-import { isDeepLinkTarget, resolveIosDeviceDeepLinkBundleId } from '../../core/open-target.ts';
+import {
+  isDeepLinkTarget,
+  isWebUrl,
+  resolveIosDeviceDeepLinkBundleId,
+} from '../../core/open-target.ts';
 import { getUnsupportedMacOsSettingMessage } from '../../core/settings-contract.ts';
 import {
   parsePermissionAction,
@@ -200,10 +204,12 @@ export async function openIosApp(
       throw new AppError('INVALID_ARGS', 'open <app> <url> requires a valid URL target');
     }
     if (device.kind === 'simulator') {
-      const bundleId = options?.appBundleId ?? (await resolveIosApp(device, app));
-      await launchIosSimulatorApp(device, bundleId, {
-        ...(launchArgs ? { launchArgs } : {}),
-      });
+      if (launchArgs || isWebUrl(explicitUrl)) {
+        const bundleId = options?.appBundleId ?? (await resolveIosApp(device, app));
+        await launchIosSimulatorApp(device, bundleId, {
+          ...(launchArgs ? { launchArgs } : {}),
+        });
+      }
       await openIosSimulatorUrl(device, explicitUrl, undefined);
       return;
     }

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -496,7 +496,7 @@ test('sendToDaemon prints replay test progress before the socket response', asyn
     });
 
     assert.deepEqual(response, { ok: true, data: { via: 'socket' } });
-    assert.match(stderr, /FAIL "Login flow" attempt 1\/2 retrying \(1\.23s\)/);
+    assert.match(stderr, /\[1\/2] RETRY "Login flow" in 01-login\.ad attempt 1\/2 \(1\.23s\)/);
     assert.match(stderr, /  first attempt failed/);
   } finally {
     (net as unknown as { createConnection: typeof net.createConnection }).createConnection =
@@ -598,7 +598,7 @@ test('sendToDaemon ignores terminal replay test progress before the HTTP NDJSON 
       assert.deepEqual(response, { ok: true, data: { via: 'http-progress' } });
     });
     assert.deepEqual(seenPaths, ['GET /agent-device/health', 'POST /agent-device/rpc']);
-    assert.doesNotMatch(stderr, /PASS "Payments flow" \(2\.50s\)/);
+    assert.match(stderr, /\[2\/3] PASS "Payments flow" in 02-payments\.ad \(2\.50s\)/);
   } finally {
     (http as unknown as { request: typeof http.request }).request = originalHttpRequest;
     process.stderr.write = originalStderrWrite;

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -506,7 +506,7 @@ test('sendToDaemon prints replay test progress before the socket response', asyn
   }
 });
 
-test('sendToDaemon ignores terminal replay test progress before the HTTP NDJSON response', async () => {
+test('sendToDaemon prints replay test progress before the HTTP NDJSON response', async () => {
   let stderr = '';
   const seenPaths: string[] = [];
   const originalStderrWrite = process.stderr.write.bind(process.stderr);


### PR DESCRIPTION
## Summary

Stream bounded replay-suite progress for `agent-device test --maestro`: suite start, per-file start/pass/fail/skip, attempts/retries, session names, and artifact paths now appear while the suite is still running. Ctrl-C/client disconnect now cancels parent replay work and best-effort aborts active iOS runner sessions so simulator-driving work does not continue detached.

Also fixes two iOS Maestro runtime issues found while validating the React Navigation suite: custom-scheme simulator deep links no longer pre-launch stale app state before `simctl openurl`, and horizontal percentage swipes avoid the iOS interactive-back edge. Scope: 17 files. Closes #794.

## Validation

Focused tests passed: progress/client/session-test/cancellation/Maestro runtime/iOS open tests, 9 files and 230 tests. `pnpm format`, `pnpm check:quick`, `pnpm build`, and `node --test test/integration/smoke-*.test.ts` passed.

Live iOS simulator validation on iPhone 17 Pro `C25DBB5B-9254-4293-A8D5-2785C78DE03A`: full React Navigation Maestro suite passed `38 passed, 0 failed in 532.0s` with streaming progress and artifact/session paths. Ctrl-C verification exited immediately with code 130, and a follow-up one-file Maestro run on the same simulator passed in 14.9s, showing no active simulator-driving work was left blocking the device.

Local `pnpm check:unit` wrapper could not run because pnpm 11.1.2 signature verification/fetch is blocked in this environment; the direct underlying unit command also has sandbox/environment failures unrelated to this change (localhost listen EPERM, Swift typecheck, Android helper/upload/materialization suites).