### PR TITLE
fix: stabilize Android Maestro replay reliability

### DIFF
--- a/android-snapshot-helper/README.md
+++ b/android-snapshot-helper/README.md
@@ -43,6 +43,9 @@ The `-t` install flag is required because the helper is a test-only instrumentat
 Devices or providers that block test-package installs must allow this package before helper capture
 can run.
 
+`waitForIdleTimeoutMs` defaults to `500`, which is a maximum wait, not a fixed sleep. Direct helper
+invocations can pass `0` when immediate capture during ongoing animation is preferred.
+
 ## Output Contract
 
 The APK emits instrumentation status records using

--- a/android-snapshot-helper/src/main/java/com/callstack/agentdevice/snapshothelper/SnapshotInstrumentation.java
+++ b/android-snapshot-helper/src/main/java/com/callstack/agentdevice/snapshothelper/SnapshotInstrumentation.java
@@ -30,8 +30,8 @@ public final class SnapshotInstrumentation extends Instrumentation {
   private static final String OUTPUT_FORMAT = "uiautomator-xml";
   private static final String HELPER_API_VERSION = "1";
   private static final int CHUNK_SIZE = 2 * 1024;
-  // Match the host defaults: long enough to avoid mid-transition RN snapshots, but still bounded
-  // below the stock uiautomator idle wait so busy apps do not stall every capture.
+  // Match the host default: bounded wait for microinteraction reliability without the stock
+  // uiautomator idle tax. Direct callers can pass 0 when immediate capture is preferred.
   private static final long DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS = 500;
   private static final long DEFAULT_WAIT_FOR_IDLE_QUIET_MS = 100;
   private static final long DEFAULT_TIMEOUT_MS = 8_000;

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -78,6 +78,7 @@ async function invokeNativeMaestroVisibleWaitWithSnapshotFallback(
   const nativeStartedAt = Date.now();
   const nativeResponse = await runNativeVisibleWait(params, args, nativeWaitQuery);
   if (nativeResponse.ok) {
+    rememberMaestroVisibleContext(params.scope, args.selector);
     return visibleAssertionResponse(
       {
         ok: true,

--- a/src/daemon/__tests__/post-gesture-stabilization.test.ts
+++ b/src/daemon/__tests__/post-gesture-stabilization.test.ts
@@ -62,6 +62,32 @@ test('capturePostGestureStabilizedSnapshot retries until rects stop moving', asy
   assert.equal(session.postGestureStabilization, undefined);
 });
 
+test('capturePostGestureStabilizedSnapshot samples again after a slow first capture', async () => {
+  vi.useFakeTimers();
+  const session = makeSession('android');
+  markPostGestureStabilization(session, 'click', [], { postGestureStabilization: true });
+  let captures = 0;
+
+  const promise = capturePostGestureStabilizedSnapshot({
+    session,
+    capture: async () => {
+      captures += 1;
+      if (captures === 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1_600));
+      }
+      return makeSnapshot(100);
+    },
+  });
+
+  await vi.advanceTimersByTimeAsync(1_600);
+  await vi.advanceTimersByTimeAsync(200);
+  const snapshot = await promise;
+
+  assert.equal(captures, 2);
+  assert.equal(snapshot.nodes[1]?.rect?.y, 100);
+  assert.equal(session.postGestureStabilization, undefined);
+});
+
 function makeSession(platform: 'ios' | 'android' = 'ios'): SessionState {
   return {
     name: platform,

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1050,6 +1050,77 @@ test('runReplayScriptFile captures a fresh Maestro snapshot for tapOn after asse
   );
 });
 
+test('runReplayScriptFile scopes duplicate tap targets after native Maestro assertVisible', async () => {
+  const { response, calls } = await runReplayFixture({
+    label: 'maestro-native-assert-context-duplicate-tap',
+    script: ['appId: demo.app', '---', '- assertVisible: Albums', '- tapOn: Push article', ''].join(
+      '\n',
+    ),
+    flags: { replayBackend: 'maestro', platform: 'android' },
+    invoke: async (req) => {
+      if (req.command === 'wait') {
+        return { ok: true, data: { matched: true } };
+      }
+      if (req.command === 'snapshot') {
+        return {
+          ok: true,
+          data: {
+            nodes: [
+              {
+                index: 1,
+                depth: 1,
+                type: 'android.widget.ScrollView',
+                rect: { x: 0, y: 0, width: 390, height: 844 },
+              },
+              {
+                index: 2,
+                depth: 2,
+                parentIndex: 1,
+                type: 'android.widget.TextView',
+                label: 'Albums',
+                rect: { x: 24, y: 120, width: 120, height: 40 },
+              },
+              {
+                index: 3,
+                depth: 2,
+                parentIndex: 1,
+                type: 'android.widget.TextView',
+                label: 'Push article',
+                rect: { x: 32, y: 220, width: 160, height: 44 },
+              },
+              {
+                index: 10,
+                depth: 1,
+                type: 'android.widget.ScrollView',
+                rect: { x: 0, y: 0, width: 390, height: 844 },
+              },
+              {
+                index: 11,
+                depth: 2,
+                parentIndex: 10,
+                type: 'android.widget.TextView',
+                label: 'Push article',
+                rect: { x: 32, y: 520, width: 160, height: 44 },
+              },
+            ],
+          },
+        };
+      }
+      return { ok: true, data: {} };
+    },
+  });
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(
+    calls.map((call) => [call.command, call.positionals]),
+    [
+      ['wait', ['Albums', '17000']],
+      ['snapshot', []],
+      ['click', ['112', '242']],
+    ],
+  );
+});
+
 test('runReplayScriptFile treats absent Maestro assertNotVisible targets as passing', async () => {
   const calls: CapturedInvocation[] = [];
   const { response } = await runReplayFixture({

--- a/src/daemon/post-gesture-stabilization.ts
+++ b/src/daemon/post-gesture-stabilization.ts
@@ -10,6 +10,7 @@ import type { SessionState } from './types.ts';
 
 const STABILIZATION_DEADLINE_MS = 1_500;
 const STABILIZATION_INTERVAL_MS = 200;
+const STABILIZATION_MIN_ATTEMPTS = 2;
 
 export function markPostGestureStabilization(
   session: SessionState,
@@ -58,7 +59,10 @@ export async function capturePostGestureStabilizedResult<T>(params: {
   let previous = params.initial ?? (await capture());
   let previousSignature = buildInteractionSurfaceSignature(params.readSnapshot(previous).nodes);
 
-  while (Date.now() - startedAt < STABILIZATION_DEADLINE_MS) {
+  while (
+    attempts < STABILIZATION_MIN_ATTEMPTS ||
+    Date.now() - startedAt < STABILIZATION_DEADLINE_MS
+  ) {
     await sleep(STABILIZATION_INTERVAL_MS);
     attempts += 1;
     const current = await capture();

--- a/src/platforms/android/snapshot-helper-types.ts
+++ b/src/platforms/android/snapshot-helper-types.ts
@@ -18,6 +18,8 @@ export const ANDROID_SNAPSHOT_HELPER_RUNNER =
   'com.callstack.agentdevice.snapshothelper/.SnapshotInstrumentation';
 export const ANDROID_SNAPSHOT_HELPER_PROTOCOL = 'android-snapshot-helper-v1';
 export const ANDROID_SNAPSHOT_HELPER_OUTPUT_FORMAT = 'uiautomator-xml';
+// Keep common snapshots biased toward post-microinteraction reliability. The
+// value is a max wait; callers that need immediate capture can explicitly pass 0.
 export const ANDROID_SNAPSHOT_HELPER_WAIT_FOR_IDLE_TIMEOUT_MS = 500;
 export const ANDROID_SNAPSHOT_HELPER_WAIT_FOR_IDLE_QUIET_MS = 100;
 export const ANDROID_SNAPSHOT_HELPER_COMMAND_OVERHEAD_MS = 5_000;


### PR DESCRIPTION
## Summary

Rebased the PR onto current `main` and updated the scope to match the real delta: Android helper default/docs clarification plus Android Maestro replay reliability fixes.

The helper-side `waitForIdleTimeoutMs` default stays reliability-biased at `500` for direct/common snapshots, with docs/comments clarifying that this is a maximum bounded idle wait and that callers can still pass `0` when immediate capture during ongoing animation is preferred. The persistent-session timeout budget change is not part of this PR anymore because it already landed via #796.

New runtime fixes:
- Native Maestro `assertVisible` now records the visible selector context, so a following `tapOn` can disambiguate duplicate labels on stacked/animated navigation surfaces.
- Post-gesture stabilization now takes at least two samples, so a slow first snapshot does not immediately exit stabilization with one stale sample.

Touched-file count: 7. Scope is Android snapshot helper defaults/docs and Android Maestro replay stabilization.

## Validation

Rebased checks passed: focused Vitest for post-gesture stabilization and Maestro replay context (`80` tests), plus `pnpm check:quick`.

Earlier checks for this final patch also passed before rebase: `pnpm check:unit` (`262` unit files + `8` smoke tests), `pnpm format`, and `pnpm build`.

Live Android validation with the local built CLI passed the focused React Navigation Maestro subset covering the CI failure and flaky navigation patterns: `6/6` passed in `80.0s` (`auth-flow`, `drawer-master-detail`, `native-stack-card-modal`, `showcase-material-top-tabs`, `stack-card-modal`, `tab-view-custom-tab-bar`). The previously failing `native-stack-card-modal.yml` passed in `13.4s`.

Residual risk: the local emulator did not reproduce the GitHub Actions flake directly, so this fix is based on CI artifacts plus focused live validation rather than a before/after failing local repro.
