### PR TITLE
fix: rotate synthesized iOS taps into native screen space

### DIFF
--- a/examples/test-app/app.json
+++ b/examples/test-app/app.json
@@ -3,7 +3,7 @@
     "name": "Agent Device Tester",
     "slug": "agent-device-test-app",
     "version": "1.0.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "plugins": ["expo-router"],

--- a/examples/test-app/src/screens/GestureLab.tsx
+++ b/examples/test-app/src/screens/GestureLab.tsx
@@ -137,10 +137,13 @@ export function GestureLab() {
   const panChanged = Math.abs(transform.offsetX) > 0 || Math.abs(transform.offsetY) > 0;
   const pinchChanged = Math.abs(transform.scale - 1) > 0.01;
   const rotateChanged = rotationDegrees !== 0;
+  const changeStatusLabel = `pan changed ${panChanged ? 'yes' : 'no'}, pinch changed ${
+    pinchChanged ? 'yes' : 'no'
+  }, rotate changed ${rotateChanged ? 'yes' : 'no'}`;
 
   return (
     <SectionCard
-      subtitle="Image target for pan, pinch, rotate, and fling."
+      subtitle={`Image target for pan, pinch, rotate, and fling. ${changeStatusLabel}`}
       title="Gesture lab"
       testID="gesture-lab-card"
     >
@@ -228,8 +231,7 @@ export function GestureLab() {
           fling {counts.fling}
         </Text>
         <Text style={styles.metric} testID="gesture-change-status">
-          pan changed {panChanged ? 'yes' : 'no'}, pinch changed{' '}
-          {pinchChanged ? 'yes' : 'no'}, rotate changed {rotateChanged ? 'yes' : 'no'}
+          {changeStatusLabel}
         </Text>
       </View>
     </SectionCard>

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.h
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.h
@@ -25,6 +25,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                    x:(double)x
                                                    y:(double)y;
 
+// UIInterfaceOrientation of the app (1 portrait, 2 upsideDown, 3 landscapeRight,
+// 4 landscapeLeft), or 0 if unreadable.
++ (NSInteger)interfaceOrientationForApplication:(id)application;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerSynthesizedGesture.m
@@ -131,6 +131,14 @@ static double RunnerSmoothStep(double t);
   }
 }
 
++ (NSInteger)interfaceOrientationForApplication:(id)application {
+  SEL selector = NSSelectorFromString(@"interfaceOrientation");
+  if (![application respondsToSelector:selector]) {
+    return 0;  // UIInterfaceOrientationUnknown
+  }
+  return ((RunnerMsgSendInteger)objc_msgSend)(application, selector);
+}
+
 + (NSString * _Nullable)trySynthesizeTransformWithApplication:(id)application
                                                             x:(double)x
                                                             y:(double)y

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -634,6 +634,31 @@ extension RunnerTests {
     return performCoordinateDrag(app: app, x: x, y: y, x2: x2, y2: y2, holdDuration: holdDuration)
   }
 
+  /// Rotates an interface-oriented point into the device-native (portrait) space the
+  /// synthesized event path consumes — synthesized events skip XCTest's orientation
+  /// handling, so without this a landscape tap lands in the wrong place.
+  func nativeSynthesizedPoint(
+    orientedX x: Double,
+    orientedY y: Double,
+    in frame: CGRect,
+    interfaceOrientation: Int
+  ) -> CGPoint {
+    let localX = x - Double(frame.minX)
+    let localY = y - Double(frame.minY)
+    let width = Double(frame.width)
+    let height = Double(frame.height)
+    switch interfaceOrientation {
+    case 3:  // landscapeRight
+      return CGPoint(x: height - localY, y: localX)
+    case 4:  // landscapeLeft
+      return CGPoint(x: localY, y: width - localX)
+    case 2:  // portraitUpsideDown
+      return CGPoint(x: width - localX, y: height - localY)
+    default:  // 1 portrait, 0 unknown
+      return CGPoint(x: localX, y: localY)
+    }
+  }
+
   func synthesizedDragAt(
     app: XCUIApplication,
     x: Double,
@@ -643,12 +668,16 @@ extension RunnerTests {
     durationMs: Double
   ) -> RunnerInteractionOutcome {
 #if os(iOS)
+    let orientation = Int(RunnerSynthesizedGesture.interfaceOrientation(forApplication: app))
+    let frame = app.frame
+    let start = nativeSynthesizedPoint(orientedX: x, orientedY: y, in: frame, interfaceOrientation: orientation)
+    let end = nativeSynthesizedPoint(orientedX: x2, orientedY: y2, in: frame, interfaceOrientation: orientation)
     if let message = RunnerSynthesizedGesture.synthesizeSwipe(
       withApplication: app,
-      x: x,
-      y: y,
-      x2: x2,
-      y2: y2,
+      x: Double(start.x),
+      y: Double(start.y),
+      x2: Double(end.x),
+      y2: Double(end.y),
       durationMs: durationMs
     ) {
       return .unsupported(
@@ -672,10 +701,12 @@ extension RunnerTests {
 
   func synthesizedTapAt(app: XCUIApplication, x: Double, y: Double) -> RunnerInteractionOutcome {
 #if os(iOS)
+    let orientation = Int(RunnerSynthesizedGesture.interfaceOrientation(forApplication: app))
+    let point = nativeSynthesizedPoint(orientedX: x, orientedY: y, in: app.frame, interfaceOrientation: orientation)
     if let message = RunnerSynthesizedGesture.synthesizeTap(
       withApplication: app,
-      x: x,
-      y: y
+      x: Double(point.x),
+      y: Double(point.y)
     ) {
       return .unsupported(
         message: message,
@@ -1090,5 +1121,26 @@ extension RunnerTests {
     )
     let element = app.descendants(matching: .any).matching(predicate).firstMatch
     return element.exists ? element : nil
+  }
+
+  // Identity in portrait/unknown, 90° per landscape, 180° upside-down.
+  func testNativeSynthesizedPointRotatesByInterfaceOrientation() {
+    let portrait = CGRect(x: 0, y: 0, width: 834, height: 1210)
+    let landscape = CGRect(x: 0, y: 0, width: 1210, height: 834)
+    // (frame, UIInterfaceOrientation, expected native point) for a tap at (170, 268).
+    let cases: [(CGRect, Int, CGPoint)] = [
+      (portrait, 1, CGPoint(x: 170, y: 268)),   // portrait
+      (landscape, 3, CGPoint(x: 566, y: 170)),  // landscapeRight
+      (landscape, 4, CGPoint(x: 268, y: 1040)), // landscapeLeft
+      (portrait, 2, CGPoint(x: 664, y: 942)),   // portraitUpsideDown
+      (portrait, 0, CGPoint(x: 170, y: 268)),   // unknown -> identity
+    ]
+    for (frame, orientation, expected) in cases {
+      XCTAssertEqual(
+        nativeSynthesizedPoint(orientedX: 170, orientedY: 268, in: frame, interfaceOrientation: orientation),
+        expected,
+        "interfaceOrientation \(orientation)"
+      )
+    }
   }
 }

--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -1,5 +1,13 @@
 import XCTest
 
+private enum RunnerInterfaceOrientation {
+  static let unknown = 0
+  static let portrait = 1
+  static let portraitUpsideDown = 2
+  static let landscapeRight = 3
+  static let landscapeLeft = 4
+}
+
 extension RunnerTests {
   struct TouchVisualizationFrame {
     let x: Double
@@ -648,14 +656,33 @@ extension RunnerTests {
     let width = Double(frame.width)
     let height = Double(frame.height)
     switch interfaceOrientation {
-    case 3:  // landscapeRight
+    case RunnerInterfaceOrientation.landscapeRight:
       return CGPoint(x: height - localY, y: localX)
-    case 4:  // landscapeLeft
+    case RunnerInterfaceOrientation.landscapeLeft:
       return CGPoint(x: localY, y: width - localX)
-    case 2:  // portraitUpsideDown
+    case RunnerInterfaceOrientation.portraitUpsideDown:
       return CGPoint(x: width - localX, y: height - localY)
-    default:  // 1 portrait, 0 unknown
+    default:  // portrait or unknown
       return CGPoint(x: localX, y: localY)
+    }
+  }
+
+  /// Rotates an interface-oriented translation vector into the same native
+  /// coordinate space as `nativeSynthesizedPoint`.
+  func nativeSynthesizedVector(
+    orientedDx dx: Double,
+    orientedDy dy: Double,
+    interfaceOrientation: Int
+  ) -> CGVector {
+    switch interfaceOrientation {
+    case RunnerInterfaceOrientation.landscapeRight:
+      return CGVector(dx: -dy, dy: dx)
+    case RunnerInterfaceOrientation.landscapeLeft:
+      return CGVector(dx: dy, dy: -dx)
+    case RunnerInterfaceOrientation.portraitUpsideDown:
+      return CGVector(dx: -dx, dy: -dy)
+    default:  // portrait or unknown
+      return CGVector(dx: dx, dy: dy)
     }
   }
 
@@ -983,12 +1010,15 @@ extension RunnerTests {
   ) -> RunnerInteractionOutcome {
 #if os(iOS)
     let target = interactionRoot(app: app)
+    let orientation = Int(RunnerSynthesizedGesture.interfaceOrientation(forApplication: app))
+    let point = nativeSynthesizedPoint(orientedX: x, orientedY: y, in: app.frame, interfaceOrientation: orientation)
+    let vector = nativeSynthesizedVector(orientedDx: dx, orientedDy: dy, interfaceOrientation: orientation)
     if let message = RunnerSynthesizedGesture.synthesizeTransform(
       withApplication: app,
-      x: x,
-      y: y,
-      dx: dx,
-      dy: dy,
+      x: Double(point.x),
+      y: Double(point.y),
+      dx: Double(vector.dx),
+      dy: Double(vector.dy),
       scale: scale,
       degrees: degrees,
       radius: transformGestureRadius(frame: target.frame, scale: scale),
@@ -1127,13 +1157,14 @@ extension RunnerTests {
   func testNativeSynthesizedPointRotatesByInterfaceOrientation() {
     let portrait = CGRect(x: 0, y: 0, width: 834, height: 1210)
     let landscape = CGRect(x: 0, y: 0, width: 1210, height: 834)
+    let offsetLandscape = CGRect(x: 10, y: 20, width: 1210, height: 834)
     // (frame, UIInterfaceOrientation, expected native point) for a tap at (170, 268).
     let cases: [(CGRect, Int, CGPoint)] = [
-      (portrait, 1, CGPoint(x: 170, y: 268)),   // portrait
-      (landscape, 3, CGPoint(x: 566, y: 170)),  // landscapeRight
-      (landscape, 4, CGPoint(x: 268, y: 1040)), // landscapeLeft
-      (portrait, 2, CGPoint(x: 664, y: 942)),   // portraitUpsideDown
-      (portrait, 0, CGPoint(x: 170, y: 268)),   // unknown -> identity
+      (portrait, RunnerInterfaceOrientation.portrait, CGPoint(x: 170, y: 268)),
+      (landscape, RunnerInterfaceOrientation.landscapeRight, CGPoint(x: 566, y: 170)),
+      (landscape, RunnerInterfaceOrientation.landscapeLeft, CGPoint(x: 268, y: 1040)),
+      (portrait, RunnerInterfaceOrientation.portraitUpsideDown, CGPoint(x: 664, y: 942)),
+      (portrait, RunnerInterfaceOrientation.unknown, CGPoint(x: 170, y: 268)),
     ]
     for (frame, orientation, expected) in cases {
       XCTAssertEqual(
@@ -1141,6 +1172,31 @@ extension RunnerTests {
         expected,
         "interfaceOrientation \(orientation)"
       )
+    }
+    XCTAssertEqual(
+      nativeSynthesizedPoint(
+        orientedX: 180,
+        orientedY: 288,
+        in: offsetLandscape,
+        interfaceOrientation: RunnerInterfaceOrientation.landscapeLeft
+      ),
+      CGPoint(x: 268, y: 1040),
+      "non-zero frame origin is localized before rotation"
+    )
+  }
+
+  func testNativeSynthesizedVectorRotatesByInterfaceOrientation() {
+    let cases: [(Int, CGVector)] = [
+      (RunnerInterfaceOrientation.portrait, CGVector(dx: 40, dy: -20)),
+      (RunnerInterfaceOrientation.landscapeRight, CGVector(dx: 20, dy: 40)),
+      (RunnerInterfaceOrientation.landscapeLeft, CGVector(dx: -20, dy: -40)),
+      (RunnerInterfaceOrientation.portraitUpsideDown, CGVector(dx: -40, dy: 20)),
+      (RunnerInterfaceOrientation.unknown, CGVector(dx: 40, dy: -20)),
+    ]
+    for (orientation, expected) in cases {
+      let vector = nativeSynthesizedVector(orientedDx: 40, orientedDy: -20, interfaceOrientation: orientation)
+      XCTAssertEqual(vector.dx, expected.dx, "dx interfaceOrientation \(orientation)")
+      XCTAssertEqual(vector.dy, expected.dy, "dy interfaceOrientation \(orientation)")
     }
   }
 }


### PR DESCRIPTION
### Summary

Synthesized iOS taps/drags land in the wrong place once the device is rotated — in landscape, taps on a sidebar row, keyboard key, or any element-by-ref miss their target. `XCUICoordinate` taps are unaffected.

`XCSynthesizedEventRecord` pointer paths are consumed in **device-native (portrait)** screen coordinates, but `synthesizedTapAt`/`synthesizedDragAt` pass the element frame's **interface-oriented** coordinates through unchanged (they coincide in portrait but differ by a 90° rotation in landscape). The synthesized path already passes the app's `interfaceOrientation` to the event record, but the path *points* still need to be in native space. From bisecting it looks like this bug was introduced by #702 and the fix should be in the scope of ADR 0005. The pre-#702 `XCUICoordinate.tap()` was fine because XCTest rotates internally.

Fix: rotate the point into native space using the app's `interfaceOrientation` before synthesizing (identity fallback when the orientation can't be read, so a missing reading is never worse than today). Adds `testNativeSynthesizedPointRotatesByInterfaceOrientation` as a regression test.

### Test plan

See `testNativeSynthesizedPointRotatesByInterfaceOrientation`.

Deterministic unit test (no device) — passes with the fix, fails against the pre-fix pass-through.

To reproduce the original bug and its fix end-to-end on a simulator you can drive a rotation-supported app with a click target through:

```bash
agent-device --udid <SIM> open <your.test.app>
agent-device rotate landscape-left
REF=$(agent-device snapshot | grep '<a tappable row/button>' | grep -oE '@e[0-9]+' | head -1)
agent-device click "$REF"     # this branch or before #702: tap lands on target; current main: misses
```

Integration tests would require adding a rotation aware device test -- I have one locally to prove this out but maybe a bit heavy for this one case. Happy to add as a follow-up if useful.