### PR TITLE
fix: stabilize Android Maestro replay interactions

### DIFF
--- a/src/compat/maestro/__tests__/runtime-assertions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-assertions.test.ts
@@ -7,6 +7,8 @@ import {
   invokeMaestroAssertNotVisible,
   invokeMaestroAssertVisible,
 } from '../runtime-assertions.ts';
+import { invokeMaestroSwipeScreen } from '../runtime-interactions.ts';
+import { rememberMaestroRecentTap } from '../runtime-support.ts';
 import type { DaemonRequest, DaemonResponse } from '../../../daemon/types.ts';
 import type { SnapshotState } from '../../../utils/snapshot.ts';
 
@@ -140,6 +142,44 @@ test('invokeMaestroAssertVisible uses the Maestro default timeout when omitted',
   assert.deepEqual(calls, [['wait', ['Ready', '17000']]]);
 });
 
+test('invokeMaestroAssertVisible verifies Android native wait success with exact snapshot matching', async () => {
+  const calls: Array<[string, string[] | undefined]> = [];
+  let snapshots = 0;
+  const response = await invokeMaestroAssertVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    positionals: ['label="Albums" || text="Albums" || id="Albums"', '1000'],
+    invoke: async (req): Promise<DaemonResponse> => {
+      calls.push([req.command, req.positionals]);
+      if (req.command === 'wait') {
+        return { ok: true, data: { matches: 1 } };
+      }
+      if (req.command === 'snapshot') {
+        snapshots += 1;
+        return {
+          ok: true,
+          data: snapshot([snapshots === 1 ? node('Push albums') : node('Albums')], snapshots),
+        };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(calls, [
+    ['wait', ['Albums', '1000']],
+    ['snapshot', []],
+    ['snapshot', []],
+  ]);
+  if (response.ok) {
+    assert.ok(response.data);
+    assert.equal(response.data.nodeLabel, 'Albums');
+  }
+});
+
 test('invokeMaestroAssertVisible falls back to one snapshot after native wait misses', async () => {
   const calls: Array<[string, string[] | undefined]> = [];
   const response = await invokeMaestroAssertVisible({
@@ -170,6 +210,202 @@ test('invokeMaestroAssertVisible falls back to one snapshot after native wait mi
   assert.equal(response.ok, true);
   assert.deepEqual(calls, [
     ['wait', ['Ready', '1000']],
+    ['snapshot', []],
+  ]);
+});
+
+test('invokeMaestroAssertVisible re-resolves the previous Android tap when its target remains visible', async () => {
+  const scope = { values: {} };
+  const calls: Array<[string, string[] | undefined]> = [];
+  rememberMaestroRecentTap(scope, {
+    selector: 'label="Go to Contacts" || text="Go to Contacts" || id="Go to Contacts"',
+    point: { x: 999, y: 999 },
+  });
+
+  const response = await invokeMaestroAssertVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    scope,
+    positionals: ['label="Marissa Castillo" || text="Marissa Castillo" || id="Marissa Castillo"'],
+    invoke: async (req): Promise<DaemonResponse> => {
+      calls.push([req.command, req.positionals]);
+      if (req.command === 'wait') {
+        const waitCalls = calls.filter(([command]) => command === 'wait').length;
+        if (waitCalls === 2) return { ok: true, data: { matches: 1 } };
+        return {
+          ok: false,
+          error: { code: 'COMMAND_FAILED', message: 'wait timed out for text: Marissa Castillo' },
+        };
+      }
+      if (req.command === 'snapshot') {
+        return {
+          ok: true,
+          data: snapshot([
+            node('Go to Contacts', {
+              type: 'android.widget.Button',
+              identifier: 'go-to-contacts',
+            }),
+          ]),
+        };
+      }
+      if (req.command === 'click') return { ok: true, data: {} };
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(calls, [
+    ['wait', ['Marissa Castillo', '17000']],
+    ['snapshot', []],
+    ['click', ['80', '100']],
+    ['wait', ['Marissa Castillo', '5000']],
+  ]);
+  if (response.ok) {
+    assert.ok(response.data);
+    assert.equal(response.data.retryTap, true);
+  }
+});
+
+test('invokeMaestroAssertVisible retries previous Android text tap when point resolution misses', async () => {
+  const scope = { values: {} };
+  const calls: Array<[string, string[] | undefined]> = [];
+  rememberMaestroRecentTap(scope, {
+    selector: 'label="Push article" || text="Push article" || id="Push article"',
+    point: { x: 999, y: 999 },
+  });
+
+  const response = await invokeMaestroAssertVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    scope,
+    positionals: [
+      'label="Article by The Doctor" || text="Article by The Doctor" || id="Article by The Doctor"',
+    ],
+    invoke: async (req): Promise<DaemonResponse> => {
+      calls.push([req.command, req.positionals]);
+      if (req.command === 'wait') {
+        const waitCalls = calls.filter(([command]) => command === 'wait').length;
+        if (waitCalls === 2) return { ok: true, data: { matches: 1 } };
+        return {
+          ok: false,
+          error: {
+            code: 'COMMAND_FAILED',
+            message: 'wait timed out for text: Article by The Doctor',
+          },
+        };
+      }
+      if (req.command === 'snapshot') {
+        return {
+          ok: true,
+          data: snapshot([
+            node('Push article', {
+              type: 'android.widget.Button',
+              identifier: undefined,
+              rect: undefined,
+            }),
+          ]),
+        };
+      }
+      if (req.command === 'find') return { ok: true, data: {} };
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(calls, [
+    ['wait', ['Article by The Doctor', '17000']],
+    ['snapshot', []],
+    ['find', ['Push article', 'click']],
+    ['wait', ['Article by The Doctor', '5000']],
+  ]);
+  if (response.ok) {
+    assert.ok(response.data);
+    assert.equal(response.data.retryTap, true);
+  }
+});
+
+test('invokeMaestroAssertVisible does not retry stale Android taps after swipes', async () => {
+  const scope = { values: {} };
+  const calls: Array<[string, string[] | undefined]> = [];
+  rememberMaestroRecentTap(scope, {
+    selector: 'label="Contacts" || text="Contacts" || id="Contacts"',
+    point: { x: 120, y: 720 },
+  });
+
+  const swipeResponse = await invokeMaestroSwipeScreen({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    scope,
+    positionals: ['direction', 'left', '300'],
+    invoke: async (req): Promise<DaemonResponse> => {
+      calls.push([req.command, req.positionals]);
+      if (req.command === 'snapshot') {
+        return {
+          ok: true,
+          data: snapshot([
+            node('Root', {
+              type: 'android.widget.FrameLayout',
+              rect: { x: 0, y: 0, width: 390, height: 844 },
+            }),
+          ]),
+        };
+      }
+      if (req.command === 'swipe') return { ok: true, data: {} };
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+  assert.equal(swipeResponse.ok, true);
+
+  const response = await invokeMaestroAssertVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    scope,
+    positionals: [
+      'label="What is Lorem Ipsum?" || text="What is Lorem Ipsum?" || id="What is Lorem Ipsum?"',
+      '2000',
+    ],
+    invoke: async (req): Promise<DaemonResponse> => {
+      calls.push([req.command, req.positionals]);
+      if (req.command === 'wait') {
+        return {
+          ok: false,
+          error: {
+            code: 'COMMAND_FAILED',
+            message: 'wait timed out for text: What is Lorem Ipsum?',
+          },
+        };
+      }
+      if (req.command === 'snapshot') {
+        return {
+          ok: true,
+          data: snapshot([node('Contacts'), node('Albums')]),
+        };
+      }
+      if (req.command === 'swipe') return { ok: true, data: {} };
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(response.ok, false);
+  assert.deepEqual(calls, [
+    ['snapshot', []],
+    ['swipe', ['332', '549', '59', '549', '300']],
+    ['wait', ['What is Lorem Ipsum?', '2000']],
+    ['snapshot', []],
+    ['swipe', ['332', '549', '59', '549', '300']],
+    ['wait', ['What is Lorem Ipsum?', '2000']],
     ['snapshot', []],
   ]);
 });

--- a/src/compat/maestro/__tests__/runtime-assertions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-assertions.test.ts
@@ -7,8 +7,8 @@ import {
   invokeMaestroAssertNotVisible,
   invokeMaestroAssertVisible,
 } from '../runtime-assertions.ts';
-import { invokeMaestroSwipeScreen } from '../runtime-interactions.ts';
-import { rememberMaestroRecentTap } from '../runtime-support.ts';
+import { invokeMaestroSwipeScreen, invokeMaestroTapOn } from '../runtime-interactions.ts';
+import { rememberMaestroRecoverableInteraction } from '../runtime-support.ts';
 import type { DaemonRequest, DaemonResponse } from '../../../daemon/types.ts';
 import type { SnapshotState } from '../../../utils/snapshot.ts';
 
@@ -217,7 +217,8 @@ test('invokeMaestroAssertVisible falls back to one snapshot after native wait mi
 test('invokeMaestroAssertVisible re-resolves the previous Android tap when its target remains visible', async () => {
   const scope = { values: {} };
   const calls: Array<[string, string[] | undefined]> = [];
-  rememberMaestroRecentTap(scope, {
+  rememberMaestroRecoverableInteraction(scope, {
+    kind: 'tap',
     selector: 'label="Go to Contacts" || text="Go to Contacts" || id="Go to Contacts"',
     point: { x: 999, y: 999 },
   });
@@ -272,7 +273,8 @@ test('invokeMaestroAssertVisible re-resolves the previous Android tap when its t
 test('invokeMaestroAssertVisible retries previous Android text tap when point resolution misses', async () => {
   const scope = { values: {} };
   const calls: Array<[string, string[] | undefined]> = [];
-  rememberMaestroRecentTap(scope, {
+  rememberMaestroRecoverableInteraction(scope, {
+    kind: 'tap',
     selector: 'label="Push article" || text="Push article" || id="Push article"',
     point: { x: 999, y: 999 },
   });
@@ -333,7 +335,8 @@ test('invokeMaestroAssertVisible retries previous Android text tap when point re
 test('invokeMaestroAssertVisible does not retry stale Android taps after swipes', async () => {
   const scope = { values: {} };
   const calls: Array<[string, string[] | undefined]> = [];
-  rememberMaestroRecentTap(scope, {
+  rememberMaestroRecoverableInteraction(scope, {
+    kind: 'tap',
     selector: 'label="Contacts" || text="Contacts" || id="Contacts"',
     point: { x: 120, y: 720 },
   });
@@ -406,6 +409,71 @@ test('invokeMaestroAssertVisible does not retry stale Android taps after swipes'
     ['snapshot', []],
     ['swipe', ['332', '549', '59', '549', '300']],
     ['wait', ['What is Lorem Ipsum?', '2000']],
+    ['snapshot', []],
+  ]);
+});
+
+test('invokeMaestroAssertVisible does not retry stale Android taps after fuzzy taps', async () => {
+  const scope = { values: {} };
+  const calls: Array<[string, string[] | undefined]> = [];
+  rememberMaestroRecoverableInteraction(scope, {
+    kind: 'tap',
+    selector: 'label="Contacts" || text="Contacts" || id="Contacts"',
+    point: { x: 120, y: 720 },
+  });
+
+  const tapResponse = await invokeMaestroTapOn({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    scope,
+    positionals: ['label="Search" || text="Search" || id="Search"'],
+    invoke: async (req): Promise<DaemonResponse> => {
+      calls.push([req.command, req.positionals]);
+      if (req.command === 'snapshot') return { ok: true, data: snapshot([node('Search')]) };
+      if (req.command === 'click') {
+        return { ok: false, error: { code: 'COMMAND_FAILED', message: 'coordinate miss' } };
+      }
+      if (req.command === 'find') return { ok: true, data: {} };
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(tapResponse.ok, true);
+
+  const response = await invokeMaestroAssertVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    scope,
+    positionals: [
+      'label="Marissa Castillo" || text="Marissa Castillo" || id="Marissa Castillo"',
+      '0',
+    ],
+    invoke: async (req): Promise<DaemonResponse> => {
+      calls.push([req.command, req.positionals]);
+      if (req.command === 'wait') {
+        return {
+          ok: false,
+          error: { code: 'COMMAND_FAILED', message: 'wait timed out for text: Marissa Castillo' },
+        };
+      }
+      if (req.command === 'snapshot') return { ok: true, data: snapshot([node('Settings')]) };
+      if (req.command === 'click') return { ok: true, data: {} };
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(response.ok, false);
+  assert.deepEqual(calls, [
+    ['snapshot', []],
+    ['click', ['80', '100']],
+    ['find', ['Search', 'click']],
+    ['wait', ['Marissa Castillo', '0']],
     ['snapshot', []],
   ]);
 });

--- a/src/compat/maestro/__tests__/runtime-interactions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-interactions.test.ts
@@ -242,9 +242,8 @@ test('invokeMaestroTapOn clicks explicit React Native overlay controls directly'
   expect(clicks).toEqual([['355', '30']]);
 });
 
-test('invokeMaestroSwipeScreen maps horizontal directional swipes to native gesture presets', async () => {
-  const gestures: string[][] = [];
-  const gestureFlags: Array<DaemonRequest['flags']> = [];
+test('invokeMaestroSwipeScreen maps Android horizontal directional swipes to content lane', async () => {
+  const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
       token: 'test',
@@ -253,9 +252,9 @@ test('invokeMaestroSwipeScreen maps horizontal directional swipes to native gest
     },
     positionals: ['direction', 'left', '300'],
     invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
-      if (req.command === 'gesture') {
-        gestures.push(req.positionals ?? []);
-        gestureFlags.push(req.flags);
+      if (req.command === 'snapshot') return { ok: true, data: fullScreenSnapshot(400, 800) };
+      if (req.command === 'swipe') {
+        swipes.push(req.positionals ?? []);
         return { ok: true, data: {} };
       }
       return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
@@ -263,12 +262,11 @@ test('invokeMaestroSwipeScreen maps horizontal directional swipes to native gest
   });
 
   expect(response.ok).toBe(true);
-  expect(gestures).toEqual([['swipe', 'left', '300']]);
-  expect(gestureFlags[0]?.postGestureStabilization).toBeUndefined();
+  expect(swipes).toEqual([['340', '520', '60', '520', '300']]);
 });
 
-test('invokeMaestroSwipeScreen mirrors horizontal directional swipe presets', async () => {
-  const gestures: string[][] = [];
+test('invokeMaestroSwipeScreen mirrors Android horizontal directional content lane swipes', async () => {
+  const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
       token: 'test',
@@ -277,8 +275,9 @@ test('invokeMaestroSwipeScreen mirrors horizontal directional swipe presets', as
     },
     positionals: ['direction', 'right', '300'],
     invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
-      if (req.command === 'gesture') {
-        gestures.push(req.positionals ?? []);
+      if (req.command === 'snapshot') return { ok: true, data: fullScreenSnapshot(400, 800) };
+      if (req.command === 'swipe') {
+        swipes.push(req.positionals ?? []);
         return { ok: true, data: {} };
       }
       return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
@@ -286,7 +285,7 @@ test('invokeMaestroSwipeScreen mirrors horizontal directional swipe presets', as
   });
 
   expect(response.ok).toBe(true);
-  expect(gestures).toEqual([['swipe', 'right', '300']]);
+  expect(swipes).toEqual([['60', '520', '340', '520', '300']]);
 });
 
 test('invokeMaestroSwipeOn resolves visible non-interactive text from a regular snapshot', async () => {

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -4,20 +4,27 @@ import { getSnapshotReferenceFrame } from '../../daemon/touch-reference-frame.ts
 import type { DaemonResponse } from '../../daemon/types.ts';
 import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import type { SnapshotState } from '../../utils/snapshot.ts';
 import { buildSnapshotDisplayLines } from '../../utils/snapshot-lines.ts';
 import { sleep } from '../../utils/timeouts.ts';
+import { pointForMaestroTapOnTarget } from './runtime-geometry.ts';
 import {
   captureMaestroSnapshot,
+  consumeMaestroRecentSwipe,
+  consumeMaestroRecentTap,
   errorResponse,
   rememberMaestroVisibleContext,
   readSnapshotState,
+  type MaestroRecentSwipe,
+  type MaestroRecentTap,
   type MaestroRuntimeInvoke,
   type ReplayBaseRequest,
 } from './runtime-support.ts';
 import {
   extractMaestroVisibleTextQuery,
   readMaestroSelectorPlatform,
+  resolveMaestroNodeFromSnapshot,
   resolveVisibleMaestroNodeFromSnapshot,
 } from './runtime-targets.ts';
 
@@ -25,6 +32,7 @@ const MAESTRO_ASSERTION_POLICY = {
   animationPollMs: 250,
   assertVisibleGraceMs: 1000,
   assertVisiblePollMs: 250,
+  assertVisibleRetryTapTimeoutMs: 5000,
   assertNotVisiblePollMs: 250,
   defaultAssertNotVisibleTimeoutMs: 3000,
 } as const;
@@ -42,6 +50,10 @@ type MaestroVisibilityAssertionArgs = {
   selector: string;
   timeoutMs: number;
 };
+
+type MaestroRetryTapTarget =
+  | { kind: 'point'; point: { x: number; y: number } }
+  | { kind: 'text'; query: string };
 
 type MaestroAssertionRuntimeParams = {
   baseReq: ReplayBaseRequest;
@@ -78,6 +90,19 @@ async function invokeNativeMaestroVisibleWaitWithSnapshotFallback(
   const nativeStartedAt = Date.now();
   const nativeResponse = await runNativeVisibleWait(params, args, nativeWaitQuery);
   if (nativeResponse.ok) {
+    if (shouldVerifyNativeVisibleWait(params.baseReq)) {
+      const sample = await readMaestroVisibilitySample(params, args.selector, 'assertVisible');
+      if (!sample.visible) {
+        const failedSample = handleFailedVisibleSample(
+          params.baseReq,
+          args,
+          sample,
+          nativeStartedAt,
+        );
+        if (failedSample.kind === 'return') return failedSample.response;
+        return await invokeSnapshotMaestroAssertVisible(params, args);
+      }
+    }
     rememberMaestroVisibleContext(params.scope, args.selector);
     return visibleAssertionResponse(
       {
@@ -100,6 +125,10 @@ async function invokeNativeMaestroVisibleWaitWithSnapshotFallback(
     nativeResponse,
     nativeStartedAt,
   );
+}
+
+function shouldVerifyNativeVisibleWait(baseReq: ReplayBaseRequest): boolean {
+  return baseReq.flags?.platform === 'android';
 }
 
 async function runNativeVisibleWait(
@@ -154,6 +183,10 @@ async function invokeSnapshotMaestroAssertVisible(
       selector: args.selector,
       timeoutMs: args.timeoutMs,
     });
+  const retryResponse = await retryRecentAndroidTapAfterVisibleMiss(params, args, lastSnapshot);
+  if (retryResponse) return retryResponse;
+  const swipeRetryResponse = await retryRecentAndroidSwipeAfterVisibleMiss(params, args);
+  if (swipeRetryResponse) return swipeRetryResponse;
   return withMaestroFailureSnapshotArtifacts(response, lastSnapshot, params.baseReq);
 }
 
@@ -167,7 +200,203 @@ async function invokeSingleSnapshotMaestroAssertVisible(
   if (sample.visible) return visibleAssertionResponse(sample.response, args.selector, startedAt);
   const failedSample = handleFailedVisibleSample(params.baseReq, args, sample, startedAt);
   if (failedSample.kind === 'return') return failedSample.response;
+  const retryResponse = await retryRecentAndroidTapAfterVisibleMiss(params, args, sample.snapshot);
+  if (retryResponse) return retryResponse;
+  const swipeRetryResponse = await retryRecentAndroidSwipeAfterVisibleMiss(params, args);
+  if (swipeRetryResponse) return swipeRetryResponse;
   return withMaestroFailureSnapshotArtifacts(fallbackResponse, sample.snapshot, params.baseReq);
+}
+
+async function retryRecentAndroidTapAfterVisibleMiss(
+  params: MaestroAssertionRuntimeParams,
+  args: MaestroVisibilityAssertionArgs,
+  snapshot: SnapshotState | undefined,
+): Promise<DaemonResponse | null> {
+  if (params.baseReq.flags?.platform !== 'android' || !snapshot) return null;
+
+  const recentTap = consumeMaestroRecentTap(params.scope);
+  if (!recentTap) return null;
+  const retryTarget = resolveRecentTapTarget(params, snapshot, recentTap);
+  if (!retryTarget.ok) return null;
+
+  emitDiagnostic({
+    level: 'info',
+    phase: 'maestro_assert_visible_retry_tap',
+    data: {
+      selector: args.selector,
+      tapSelector: recentTap.selector,
+      originalPoint: recentTap.point,
+      retryTarget: retryTarget.target,
+      timeoutMs: MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs,
+    },
+  });
+
+  const clickResponse = await invokeRecentTapRetry(params, retryTarget.target);
+  if (!clickResponse.ok) return null;
+
+  const retryArgs = {
+    ...args,
+    timeoutMs: Math.min(args.timeoutMs, MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs),
+  };
+  const nativeWaitQuery = readNativeVisibleWaitQuery(params.baseReq, retryArgs.selector);
+  if (!nativeWaitQuery) return await invokeSnapshotMaestroAssertVisible(params, retryArgs);
+
+  const retryStartedAt = Date.now();
+  const nativeResponse = await runNativeVisibleWait(params, retryArgs, nativeWaitQuery);
+  if (nativeResponse.ok) {
+    rememberMaestroVisibleContext(params.scope, retryArgs.selector);
+    return visibleAssertionResponse(
+      {
+        ok: true,
+        data: {
+          selector: retryArgs.selector,
+          nativeWait: true,
+          retryTap: true,
+          query: nativeWaitQuery,
+          response: nativeResponse.data,
+        },
+      },
+      retryArgs.selector,
+      retryStartedAt,
+    );
+  }
+
+  return await invokeSingleSnapshotMaestroAssertVisible(
+    params,
+    retryArgs,
+    nativeResponse,
+    retryStartedAt,
+  );
+}
+
+async function retryRecentAndroidSwipeAfterVisibleMiss(
+  params: MaestroAssertionRuntimeParams,
+  args: MaestroVisibilityAssertionArgs,
+): Promise<DaemonResponse | null> {
+  if (params.baseReq.flags?.platform !== 'android') return null;
+
+  const recentSwipe = consumeMaestroRecentSwipe(params.scope);
+  if (!recentSwipe) return null;
+
+  emitDiagnostic({
+    level: 'info',
+    phase: 'maestro_assert_visible_retry_swipe',
+    data: {
+      selector: args.selector,
+      swipePositionals: recentSwipe.positionals,
+      timeoutMs: MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs,
+    },
+  });
+
+  const swipeResponse = await invokeRecentSwipeRetry(params, recentSwipe);
+  if (!swipeResponse.ok) return null;
+
+  const retryArgs = {
+    ...args,
+    timeoutMs: Math.min(args.timeoutMs, MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs),
+  };
+  const nativeWaitQuery = readNativeVisibleWaitQuery(params.baseReq, retryArgs.selector);
+  if (!nativeWaitQuery) return await invokeSnapshotMaestroAssertVisible(params, retryArgs);
+
+  const retryStartedAt = Date.now();
+  const nativeResponse = await runNativeVisibleWait(params, retryArgs, nativeWaitQuery);
+  if (nativeResponse.ok) {
+    rememberMaestroVisibleContext(params.scope, retryArgs.selector);
+    return visibleAssertionResponse(
+      {
+        ok: true,
+        data: {
+          selector: retryArgs.selector,
+          nativeWait: true,
+          retrySwipe: true,
+          query: nativeWaitQuery,
+          response: nativeResponse.data,
+        },
+      },
+      retryArgs.selector,
+      retryStartedAt,
+    );
+  }
+
+  return await invokeSingleSnapshotMaestroAssertVisible(
+    params,
+    retryArgs,
+    nativeResponse,
+    retryStartedAt,
+  );
+}
+
+function resolveRecentTapTarget(
+  params: MaestroAssertionRuntimeParams,
+  snapshot: SnapshotState,
+  tap: MaestroRecentTap,
+): { ok: true; target: MaestroRetryTapTarget } | { ok: false } {
+  const platform = readMaestroSelectorPlatform(params.baseReq.flags);
+  const frame = getSnapshotReferenceFrame(snapshot);
+  const tapTarget = resolveMaestroNodeFromSnapshot(
+    snapshot,
+    tap.selector,
+    tap.options ?? {},
+    platform,
+    frame,
+    { promoteTapTarget: true },
+  );
+  if (tapTarget.ok) {
+    return { ok: true, target: { kind: 'point', point: pointForMaestroTapOnTarget(tapTarget) } };
+  }
+
+  const query = extractMaestroVisibleTextQuery(tap.selector);
+  if (!query || !snapshotContainsTextQuery(snapshot, query)) return { ok: false };
+  return { ok: true, target: { kind: 'text', query } };
+}
+
+async function invokeRecentTapRetry(
+  params: MaestroAssertionRuntimeParams,
+  target: MaestroRetryTapTarget,
+): Promise<DaemonResponse> {
+  if (target.kind === 'text') {
+    return await params.invoke({
+      ...params.baseReq,
+      command: 'find',
+      positionals: [target.query, 'click'],
+      flags: {
+        ...params.baseReq.flags,
+        findFirst: true,
+        postGestureStabilization: true,
+      },
+    });
+  }
+
+  return await params.invoke({
+    ...params.baseReq,
+    command: 'click',
+    positionals: [String(target.point.x), String(target.point.y)],
+    flags: {
+      ...params.baseReq.flags,
+      postGestureStabilization: true,
+    },
+  });
+}
+
+async function invokeRecentSwipeRetry(
+  params: MaestroAssertionRuntimeParams,
+  swipe: MaestroRecentSwipe,
+): Promise<DaemonResponse> {
+  return await params.invoke({
+    ...params.baseReq,
+    command: 'swipe',
+    positionals: swipe.positionals,
+  });
+}
+
+function snapshotContainsTextQuery(snapshot: SnapshotState, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return false;
+  return snapshot.nodes.some((node) =>
+    [node.label, node.value, node.identifier].some((value) =>
+      value?.trim().toLowerCase().includes(needle),
+    ),
+  );
 }
 
 function handleFailedVisibleSample(

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -5,7 +5,7 @@ import type { DaemonResponse } from '../../daemon/types.ts';
 import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
-import type { SnapshotState } from '../../utils/snapshot.ts';
+import type { Point, SnapshotState } from '../../utils/snapshot.ts';
 import { buildSnapshotDisplayLines } from '../../utils/snapshot-lines.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import { pointForMaestroTapOnTarget } from './runtime-geometry.ts';
@@ -32,7 +32,7 @@ const MAESTRO_ASSERTION_POLICY = {
   animationPollMs: 250,
   assertVisibleGraceMs: 1000,
   assertVisiblePollMs: 250,
-  assertVisibleRetryTapTimeoutMs: 5000,
+  assertVisibleRetryTimeoutMs: 5000,
   assertNotVisiblePollMs: 250,
   defaultAssertNotVisibleTimeoutMs: 3000,
 } as const;
@@ -51,9 +51,9 @@ type MaestroVisibilityAssertionArgs = {
   timeoutMs: number;
 };
 
-type MaestroRetryTapTarget =
-  | { kind: 'point'; point: { x: number; y: number } }
-  | { kind: 'text'; query: string };
+type MaestroRetryTapTarget = { kind: 'point'; point: Point } | { kind: 'text'; query: string };
+
+type MaestroVisibleRecoveryFlag = 'retryTap' | 'retrySwipe';
 
 type MaestroAssertionRuntimeParams = {
   baseReq: ReplayBaseRequest;
@@ -183,10 +183,8 @@ async function invokeSnapshotMaestroAssertVisible(
       selector: args.selector,
       timeoutMs: args.timeoutMs,
     });
-  const retryResponse = await retryRecentAndroidTapAfterVisibleMiss(params, args, lastSnapshot);
-  if (retryResponse) return retryResponse;
-  const swipeRetryResponse = await retryRecentAndroidSwipeAfterVisibleMiss(params, args);
-  if (swipeRetryResponse) return swipeRetryResponse;
+  const recoveryResponse = await recoverFromAndroidVisibleMiss(params, args, lastSnapshot);
+  if (recoveryResponse) return recoveryResponse;
   return withMaestroFailureSnapshotArtifacts(response, lastSnapshot, params.baseReq);
 }
 
@@ -200,11 +198,21 @@ async function invokeSingleSnapshotMaestroAssertVisible(
   if (sample.visible) return visibleAssertionResponse(sample.response, args.selector, startedAt);
   const failedSample = handleFailedVisibleSample(params.baseReq, args, sample, startedAt);
   if (failedSample.kind === 'return') return failedSample.response;
-  const retryResponse = await retryRecentAndroidTapAfterVisibleMiss(params, args, sample.snapshot);
-  if (retryResponse) return retryResponse;
-  const swipeRetryResponse = await retryRecentAndroidSwipeAfterVisibleMiss(params, args);
-  if (swipeRetryResponse) return swipeRetryResponse;
+  const recoveryResponse = await recoverFromAndroidVisibleMiss(params, args, sample.snapshot);
+  if (recoveryResponse) return recoveryResponse;
   return withMaestroFailureSnapshotArtifacts(fallbackResponse, sample.snapshot, params.baseReq);
+}
+
+async function recoverFromAndroidVisibleMiss(
+  params: MaestroAssertionRuntimeParams,
+  args: MaestroVisibilityAssertionArgs,
+  snapshot: SnapshotState | undefined,
+): Promise<DaemonResponse | null> {
+  if (params.baseReq.flags?.platform !== 'android') return null;
+
+  const tapRetryResponse = await retryRecentAndroidTapAfterVisibleMiss(params, args, snapshot);
+  if (tapRetryResponse) return tapRetryResponse;
+  return await retryRecentAndroidSwipeAfterVisibleMiss(params, args);
 }
 
 async function retryRecentAndroidTapAfterVisibleMiss(
@@ -212,7 +220,7 @@ async function retryRecentAndroidTapAfterVisibleMiss(
   args: MaestroVisibilityAssertionArgs,
   snapshot: SnapshotState | undefined,
 ): Promise<DaemonResponse | null> {
-  if (params.baseReq.flags?.platform !== 'android' || !snapshot) return null;
+  if (!snapshot) return null;
 
   const recentTap = consumeMaestroRecentTap(params.scope);
   if (!recentTap) return null;
@@ -227,54 +235,19 @@ async function retryRecentAndroidTapAfterVisibleMiss(
       tapSelector: recentTap.selector,
       originalPoint: recentTap.point,
       retryTarget: retryTarget.target,
-      timeoutMs: MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs,
+      timeoutMs: MAESTRO_ASSERTION_POLICY.assertVisibleRetryTimeoutMs,
     },
   });
 
   const clickResponse = await invokeRecentTapRetry(params, retryTarget.target);
   if (!clickResponse.ok) return null;
-
-  const retryArgs = {
-    ...args,
-    timeoutMs: Math.min(args.timeoutMs, MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs),
-  };
-  const nativeWaitQuery = readNativeVisibleWaitQuery(params.baseReq, retryArgs.selector);
-  if (!nativeWaitQuery) return await invokeSnapshotMaestroAssertVisible(params, retryArgs);
-
-  const retryStartedAt = Date.now();
-  const nativeResponse = await runNativeVisibleWait(params, retryArgs, nativeWaitQuery);
-  if (nativeResponse.ok) {
-    rememberMaestroVisibleContext(params.scope, retryArgs.selector);
-    return visibleAssertionResponse(
-      {
-        ok: true,
-        data: {
-          selector: retryArgs.selector,
-          nativeWait: true,
-          retryTap: true,
-          query: nativeWaitQuery,
-          response: nativeResponse.data,
-        },
-      },
-      retryArgs.selector,
-      retryStartedAt,
-    );
-  }
-
-  return await invokeSingleSnapshotMaestroAssertVisible(
-    params,
-    retryArgs,
-    nativeResponse,
-    retryStartedAt,
-  );
+  return await confirmVisibleAfterAndroidRecovery(params, args, 'retryTap');
 }
 
 async function retryRecentAndroidSwipeAfterVisibleMiss(
   params: MaestroAssertionRuntimeParams,
   args: MaestroVisibilityAssertionArgs,
 ): Promise<DaemonResponse | null> {
-  if (params.baseReq.flags?.platform !== 'android') return null;
-
   const recentSwipe = consumeMaestroRecentSwipe(params.scope);
   if (!recentSwipe) return null;
 
@@ -284,16 +257,23 @@ async function retryRecentAndroidSwipeAfterVisibleMiss(
     data: {
       selector: args.selector,
       swipePositionals: recentSwipe.positionals,
-      timeoutMs: MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs,
+      timeoutMs: MAESTRO_ASSERTION_POLICY.assertVisibleRetryTimeoutMs,
     },
   });
 
   const swipeResponse = await invokeRecentSwipeRetry(params, recentSwipe);
   if (!swipeResponse.ok) return null;
+  return await confirmVisibleAfterAndroidRecovery(params, args, 'retrySwipe');
+}
 
+async function confirmVisibleAfterAndroidRecovery(
+  params: MaestroAssertionRuntimeParams,
+  args: MaestroVisibilityAssertionArgs,
+  recoveryFlag: MaestroVisibleRecoveryFlag,
+): Promise<DaemonResponse> {
   const retryArgs = {
     ...args,
-    timeoutMs: Math.min(args.timeoutMs, MAESTRO_ASSERTION_POLICY.assertVisibleRetryTapTimeoutMs),
+    timeoutMs: Math.min(args.timeoutMs, MAESTRO_ASSERTION_POLICY.assertVisibleRetryTimeoutMs),
   };
   const nativeWaitQuery = readNativeVisibleWaitQuery(params.baseReq, retryArgs.selector);
   if (!nativeWaitQuery) return await invokeSnapshotMaestroAssertVisible(params, retryArgs);
@@ -308,7 +288,7 @@ async function retryRecentAndroidSwipeAfterVisibleMiss(
         data: {
           selector: retryArgs.selector,
           nativeWait: true,
-          retrySwipe: true,
+          [recoveryFlag]: true,
           query: nativeWaitQuery,
           response: nativeResponse.data,
         },

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -11,13 +11,12 @@ import { sleep } from '../../utils/timeouts.ts';
 import { pointForMaestroTapOnTarget } from './runtime-geometry.ts';
 import {
   captureMaestroSnapshot,
-  consumeMaestroRecentSwipe,
-  consumeMaestroRecentTap,
+  consumeMaestroRecoverableInteraction,
   errorResponse,
   rememberMaestroVisibleContext,
   readSnapshotState,
-  type MaestroRecentSwipe,
-  type MaestroRecentTap,
+  type MaestroRecoverableSwipe,
+  type MaestroRecoverableTap,
   type MaestroRuntimeInvoke,
   type ReplayBaseRequest,
 } from './runtime-support.ts';
@@ -210,20 +209,27 @@ async function recoverFromAndroidVisibleMiss(
 ): Promise<DaemonResponse | null> {
   if (params.baseReq.flags?.platform !== 'android') return null;
 
-  const tapRetryResponse = await retryRecentAndroidTapAfterVisibleMiss(params, args, snapshot);
-  if (tapRetryResponse) return tapRetryResponse;
-  return await retryRecentAndroidSwipeAfterVisibleMiss(params, args);
+  const recoverableInteraction = consumeMaestroRecoverableInteraction(params.scope);
+  if (!recoverableInteraction) return null;
+  if (recoverableInteraction.kind === 'tap') {
+    return await retryRecentAndroidTapAfterVisibleMiss(
+      params,
+      args,
+      snapshot,
+      recoverableInteraction,
+    );
+  }
+  return await retryRecentAndroidSwipeAfterVisibleMiss(params, args, recoverableInteraction);
 }
 
 async function retryRecentAndroidTapAfterVisibleMiss(
   params: MaestroAssertionRuntimeParams,
   args: MaestroVisibilityAssertionArgs,
   snapshot: SnapshotState | undefined,
+  recentTap: MaestroRecoverableTap,
 ): Promise<DaemonResponse | null> {
   if (!snapshot) return null;
 
-  const recentTap = consumeMaestroRecentTap(params.scope);
-  if (!recentTap) return null;
   const retryTarget = resolveRecentTapTarget(params, snapshot, recentTap);
   if (!retryTarget.ok) return null;
 
@@ -247,10 +253,8 @@ async function retryRecentAndroidTapAfterVisibleMiss(
 async function retryRecentAndroidSwipeAfterVisibleMiss(
   params: MaestroAssertionRuntimeParams,
   args: MaestroVisibilityAssertionArgs,
+  recentSwipe: MaestroRecoverableSwipe,
 ): Promise<DaemonResponse | null> {
-  const recentSwipe = consumeMaestroRecentSwipe(params.scope);
-  if (!recentSwipe) return null;
-
   emitDiagnostic({
     level: 'info',
     phase: 'maestro_assert_visible_retry_swipe',
@@ -309,7 +313,7 @@ async function confirmVisibleAfterAndroidRecovery(
 function resolveRecentTapTarget(
   params: MaestroAssertionRuntimeParams,
   snapshot: SnapshotState,
-  tap: MaestroRecentTap,
+  tap: MaestroRecoverableTap,
 ): { ok: true; target: MaestroRetryTapTarget } | { ok: false } {
   const platform = readMaestroSelectorPlatform(params.baseReq.flags);
   const frame = getSnapshotReferenceFrame(snapshot);
@@ -360,7 +364,7 @@ async function invokeRecentTapRetry(
 
 async function invokeRecentSwipeRetry(
   params: MaestroAssertionRuntimeParams,
-  swipe: MaestroRecentSwipe,
+  swipe: MaestroRecoverableSwipe,
 ): Promise<DaemonResponse> {
   return await params.invoke({
     ...params.baseReq,

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -13,15 +13,13 @@ import { sleep } from '../../utils/timeouts.ts';
 import { pointForMaestroTapOnTarget, swipeCoordinatesFromTarget } from './runtime-geometry.ts';
 import {
   captureMaestroSnapshot,
-  clearMaestroRecentTap,
-  clearMaestroRecentSwipe,
+  clearMaestroRecoverableInteraction,
   clearMaestroVisibleContext,
   errorResponse,
   readCachedMaestroReferenceFrame,
   readMaestroVisibleContext,
   readSnapshotState,
-  rememberMaestroRecentSwipe,
-  rememberMaestroRecentTap,
+  rememberMaestroRecoverableInteraction,
   type FailedDaemonResponse,
   type MaestroRuntimeInvoke,
   type ReplayBaseRequest,
@@ -113,6 +111,7 @@ export async function invokeMaestroTapPointPercent(params: {
   baseReq: ReplayBaseRequest;
   positionals: string[];
   invoke: DaemonInvokeFn;
+  scope?: ReplayVarScope;
 }): Promise<DaemonResponse> {
   const [xValue, yValue] = params.positionals;
   const xPercent = Number(xValue);
@@ -141,7 +140,7 @@ export async function invokeMaestroTapPointPercent(params: {
   }
 
   const point = pointFromPercent(frame, xPercent, yPercent);
-  return await params.invoke({
+  const response = await params.invoke({
     ...params.baseReq,
     command: 'click',
     positionals: [String(point.x), String(point.y)],
@@ -150,6 +149,8 @@ export async function invokeMaestroTapPointPercent(params: {
       postGestureStabilization: true,
     },
   });
+  if (response.ok) clearMaestroRecoverableInteraction(params.scope);
+  return response;
 }
 
 export async function invokeMaestroSwipeScreen(params: {
@@ -243,8 +244,10 @@ async function invokeSwipeGesture(
     positionals: responsePositionals,
   });
   if (response.ok) {
-    clearMaestroRecentTap(params.scope);
-    rememberMaestroRecentSwipe(params.scope, { positionals: responsePositionals });
+    rememberMaestroRecoverableInteraction(params.scope, {
+      kind: 'swipe',
+      positionals: responsePositionals,
+    });
   }
   return response;
 }
@@ -527,9 +530,13 @@ async function clickMaestroResolvedTarget(
     },
   });
   if (response.ok) {
-    clearMaestroRecentSwipe(params.scope);
     clearMaestroVisibleContext(params.scope);
-    rememberMaestroRecentTap(params.scope, { selector, point, options: { ...options } });
+    rememberMaestroRecoverableInteraction(params.scope, {
+      kind: 'tap',
+      selector,
+      point,
+      options: { ...options },
+    });
   }
   return {
     response,
@@ -562,7 +569,7 @@ async function invokeMaestroFuzzyTapOn(
     },
   });
   if (findResponse.ok) {
-    clearMaestroRecentSwipe(params.scope);
+    clearMaestroRecoverableInteraction(params.scope);
     return { retry: false, response: findResponse };
   }
   return { retry: true, response: findResponse };

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -13,11 +13,15 @@ import { sleep } from '../../utils/timeouts.ts';
 import { pointForMaestroTapOnTarget, swipeCoordinatesFromTarget } from './runtime-geometry.ts';
 import {
   captureMaestroSnapshot,
+  clearMaestroRecentTap,
+  clearMaestroRecentSwipe,
   clearMaestroVisibleContext,
   errorResponse,
   readCachedMaestroReferenceFrame,
   readMaestroVisibleContext,
   readSnapshotState,
+  rememberMaestroRecentSwipe,
+  rememberMaestroRecentTap,
   type FailedDaemonResponse,
   type MaestroRuntimeInvoke,
   type ReplayBaseRequest,
@@ -169,6 +173,7 @@ async function maybeInvokeMaestroDirectionalSwipePreset(params: {
 }): Promise<DaemonResponse | undefined> {
   const [mode, direction, durationMs] = params.positionals;
   if (mode !== 'direction' || (direction !== 'left' && direction !== 'right')) return undefined;
+  if (readMaestroSelectorPlatform(params.baseReq.flags) === 'android') return undefined;
   return await params.invoke({
     ...params.baseReq,
     command: 'gesture',
@@ -200,6 +205,7 @@ export async function invokeMaestroSwipeOn(params: {
   baseReq: ReplayBaseRequest;
   positionals: string[];
   invoke: MaestroRuntimeInvoke;
+  scope?: ReplayVarScope;
 }): Promise<DaemonResponse> {
   const [selector, direction = 'up', durationMs] = params.positionals;
   if (!selector) return errorResponse('INVALID_ARGS', 'swipe.label requires a label selector.');
@@ -216,6 +222,7 @@ async function invokeSwipeGesture(
   params: {
     baseReq: ReplayBaseRequest;
     invoke: MaestroRuntimeInvoke;
+    scope?: ReplayVarScope;
   },
   swipe: {
     start: { x: number; y: number };
@@ -223,17 +230,23 @@ async function invokeSwipeGesture(
   },
   durationMs: string | undefined,
 ): Promise<DaemonResponse> {
-  return await params.invoke({
+  const responsePositionals = [
+    String(swipe.start.x),
+    String(swipe.start.y),
+    String(swipe.end.x),
+    String(swipe.end.y),
+    ...(durationMs ? [durationMs] : []),
+  ];
+  const response = await params.invoke({
     ...params.baseReq,
     command: 'swipe',
-    positionals: [
-      String(swipe.start.x),
-      String(swipe.start.y),
-      String(swipe.end.x),
-      String(swipe.end.y),
-      ...(durationMs ? [durationMs] : []),
-    ],
+    positionals: responsePositionals,
   });
+  if (response.ok) {
+    clearMaestroRecentTap(params.scope);
+    rememberMaestroRecentSwipe(params.scope, { positionals: responsePositionals });
+  }
+  return response;
 }
 
 async function resolveMaestroScreenSwipe(params: {
@@ -253,7 +266,11 @@ async function resolveMaestroScreenSwipe(params: {
 
   const [mode, ...args] = params.positionals;
   if (mode === 'direction') {
-    return resolveDirectionalScreenSwipe(args, frame);
+    return resolveDirectionalScreenSwipe(
+      args,
+      frame,
+      readMaestroSelectorPlatform(params.baseReq.flags),
+    );
   }
   if (mode === 'percent') {
     return resolvePercentScreenSwipe(
@@ -282,6 +299,7 @@ async function captureFrameForMaestroScreenSwipe(params: {
 function resolveDirectionalScreenSwipe(
   args: string[],
   frame: GestureReferenceFrame,
+  platform: string,
 ): MaestroScreenSwipeResolution {
   const [direction, durationMs] = args;
   if (!direction) {
@@ -294,6 +312,9 @@ function resolveDirectionalScreenSwipe(
     case 'up':
     case 'down':
       return buildMaestroDirectionalScreenSwipe(direction, frame, durationMs);
+    case 'left':
+    case 'right':
+      return buildMaestroHorizontalDirectionalScreenSwipe(direction, frame, platform, durationMs);
     default:
       return {
         ok: false,
@@ -303,6 +324,23 @@ function resolveDirectionalScreenSwipe(
         ),
       };
   }
+}
+
+function buildMaestroHorizontalDirectionalScreenSwipe(
+  direction: 'left' | 'right',
+  frame: GestureReferenceFrame,
+  platform: string,
+  durationMs: string | undefined,
+): MaestroScreenSwipeResolution {
+  const lane = maestroHorizontalContentSwipeLanePercent(platform, 85, 50, 15, 50);
+  const [startX, endX] = direction === 'left' ? [85, 15] : [15, 85];
+  const marginPx = maestroPercentSwipeMarginPx(platform, frame, startX, 50, endX, 50);
+  return {
+    ok: true,
+    start: pointFromPercent(frame, startX, lane.startY, { marginPx }),
+    end: pointFromPercent(frame, endX, lane.endY, { marginPx }),
+    durationMs,
+  };
 }
 
 function buildMaestroDirectionalScreenSwipe(
@@ -452,13 +490,14 @@ async function invokeMaestroResolvedTapOn(
     promoteTapTarget: true,
   });
   if (!target.ok) return { response: target.response, targetResolved: false };
-  return await clickMaestroResolvedTarget(params, selector, target.target);
+  return await clickMaestroResolvedTarget(params, selector, target.target, options);
 }
 
 async function clickMaestroResolvedTarget(
   params: MaestroTapOnParams,
   selector: string,
   target: ResolvedMaestroInteractionTarget,
+  options: MaestroTapOnOptions,
 ): Promise<{ response: DaemonResponse; targetResolved: true }> {
   const point = pointForMaestroTapOnTarget(target);
   emitDiagnostic({
@@ -487,7 +526,11 @@ async function clickMaestroResolvedTarget(
       postGestureStabilization: true,
     },
   });
-  if (response.ok) clearMaestroVisibleContext(params.scope);
+  if (response.ok) {
+    clearMaestroRecentSwipe(params.scope);
+    clearMaestroVisibleContext(params.scope);
+    rememberMaestroRecentTap(params.scope, { selector, point, options: { ...options } });
+  }
   return {
     response,
     targetResolved: true,
@@ -518,7 +561,10 @@ async function invokeMaestroFuzzyTapOn(
       ok: findResponse.ok,
     },
   });
-  if (findResponse.ok) return { retry: false, response: findResponse };
+  if (findResponse.ok) {
+    clearMaestroRecentSwipe(params.scope);
+    return { retry: false, response: findResponse };
+  }
   return { retry: true, response: findResponse };
 }
 

--- a/src/compat/maestro/runtime-support.ts
+++ b/src/compat/maestro/runtime-support.ts
@@ -11,7 +11,7 @@ import type {
 import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayActionBlockInvoker } from '../../replay/control-flow-runtime.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
-import type { SnapshotState } from '../../utils/snapshot.ts';
+import type { Point, SnapshotState } from '../../utils/snapshot.ts';
 
 export type ReplayBaseRequest = Omit<DaemonRequest, 'command' | 'positionals'>;
 
@@ -23,6 +23,21 @@ export type FailedDaemonResponse = DaemonFailureResponse;
 
 const maestroReferenceFrameCache = new WeakMap<ReplayVarScope, TouchReferenceFrame>();
 const maestroVisibleContextCache = new WeakMap<ReplayVarScope, { selector: string }>();
+const maestroRecentTapCache = new WeakMap<ReplayVarScope, MaestroRecentTap>();
+const maestroRecentSwipeCache = new WeakMap<ReplayVarScope, MaestroRecentSwipe>();
+
+export type MaestroRecentTap = {
+  selector: string;
+  point: Point;
+  options?: {
+    childOf?: string;
+    index?: number;
+  };
+};
+
+export type MaestroRecentSwipe = {
+  positionals: string[];
+};
 
 export function errorResponse(
   code: string,
@@ -82,6 +97,46 @@ export function readMaestroVisibleContext(
 
 export function clearMaestroVisibleContext(scope: ReplayVarScope | undefined): void {
   if (scope) maestroVisibleContextCache.delete(scope);
+}
+
+export function rememberMaestroRecentTap(
+  scope: ReplayVarScope | undefined,
+  tap: MaestroRecentTap,
+): void {
+  if (scope) maestroRecentTapCache.set(scope, tap);
+}
+
+export function consumeMaestroRecentTap(
+  scope: ReplayVarScope | undefined,
+): MaestroRecentTap | undefined {
+  if (!scope) return undefined;
+  const tap = maestroRecentTapCache.get(scope);
+  maestroRecentTapCache.delete(scope);
+  return tap;
+}
+
+export function clearMaestroRecentTap(scope: ReplayVarScope | undefined): void {
+  if (scope) maestroRecentTapCache.delete(scope);
+}
+
+export function rememberMaestroRecentSwipe(
+  scope: ReplayVarScope | undefined,
+  swipe: MaestroRecentSwipe,
+): void {
+  if (scope) maestroRecentSwipeCache.set(scope, swipe);
+}
+
+export function consumeMaestroRecentSwipe(
+  scope: ReplayVarScope | undefined,
+): MaestroRecentSwipe | undefined {
+  if (!scope) return undefined;
+  const swipe = maestroRecentSwipeCache.get(scope);
+  maestroRecentSwipeCache.delete(scope);
+  return swipe;
+}
+
+export function clearMaestroRecentSwipe(scope: ReplayVarScope | undefined): void {
+  if (scope) maestroRecentSwipeCache.delete(scope);
 }
 
 function rememberMaestroReferenceFrame(

--- a/src/compat/maestro/runtime-support.ts
+++ b/src/compat/maestro/runtime-support.ts
@@ -23,10 +23,20 @@ export type FailedDaemonResponse = DaemonFailureResponse;
 
 const maestroReferenceFrameCache = new WeakMap<ReplayVarScope, TouchReferenceFrame>();
 const maestroVisibleContextCache = new WeakMap<ReplayVarScope, { selector: string }>();
-const maestroRecentTapCache = new WeakMap<ReplayVarScope, MaestroRecentTap>();
-const maestroRecentSwipeCache = new WeakMap<ReplayVarScope, MaestroRecentSwipe>();
+const maestroRecoverableInteractionCache = new WeakMap<
+  ReplayVarScope,
+  MaestroRecoverableInteraction
+>();
 
-export type MaestroRecentTap = {
+export type MaestroRecoverableInteraction =
+  | ({
+      kind: 'tap';
+    } & MaestroRecoverableTap)
+  | ({
+      kind: 'swipe';
+    } & MaestroRecoverableSwipe);
+
+export type MaestroRecoverableTap = {
   selector: string;
   point: Point;
   options?: {
@@ -35,7 +45,7 @@ export type MaestroRecentTap = {
   };
 };
 
-export type MaestroRecentSwipe = {
+export type MaestroRecoverableSwipe = {
   positionals: string[];
 };
 
@@ -99,44 +109,24 @@ export function clearMaestroVisibleContext(scope: ReplayVarScope | undefined): v
   if (scope) maestroVisibleContextCache.delete(scope);
 }
 
-export function rememberMaestroRecentTap(
+export function rememberMaestroRecoverableInteraction(
   scope: ReplayVarScope | undefined,
-  tap: MaestroRecentTap,
+  interaction: MaestroRecoverableInteraction,
 ): void {
-  if (scope) maestroRecentTapCache.set(scope, tap);
+  if (scope) maestroRecoverableInteractionCache.set(scope, interaction);
 }
 
-export function consumeMaestroRecentTap(
+export function consumeMaestroRecoverableInteraction(
   scope: ReplayVarScope | undefined,
-): MaestroRecentTap | undefined {
+): MaestroRecoverableInteraction | undefined {
   if (!scope) return undefined;
-  const tap = maestroRecentTapCache.get(scope);
-  maestroRecentTapCache.delete(scope);
-  return tap;
+  const interaction = maestroRecoverableInteractionCache.get(scope);
+  maestroRecoverableInteractionCache.delete(scope);
+  return interaction;
 }
 
-export function clearMaestroRecentTap(scope: ReplayVarScope | undefined): void {
-  if (scope) maestroRecentTapCache.delete(scope);
-}
-
-export function rememberMaestroRecentSwipe(
-  scope: ReplayVarScope | undefined,
-  swipe: MaestroRecentSwipe,
-): void {
-  if (scope) maestroRecentSwipeCache.set(scope, swipe);
-}
-
-export function consumeMaestroRecentSwipe(
-  scope: ReplayVarScope | undefined,
-): MaestroRecentSwipe | undefined {
-  if (!scope) return undefined;
-  const swipe = maestroRecentSwipeCache.get(scope);
-  maestroRecentSwipeCache.delete(scope);
-  return swipe;
-}
-
-export function clearMaestroRecentSwipe(scope: ReplayVarScope | undefined): void {
-  if (scope) maestroRecentSwipeCache.delete(scope);
+export function clearMaestroRecoverableInteraction(scope: ReplayVarScope | undefined): void {
+  if (scope) maestroRecoverableInteractionCache.delete(scope);
 }
 
 function rememberMaestroReferenceFrame(

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1116,6 +1116,7 @@ test('runReplayScriptFile scopes duplicate tap targets after native Maestro asse
     [
       ['wait', ['Albums', '17000']],
       ['snapshot', []],
+      ['snapshot', []],
       ['click', ['112', '242']],
     ],
   );
@@ -1782,8 +1783,8 @@ test('runReplayScriptFile uses Android content lane for Maestro horizontal scree
   assert.deepEqual(
     calls.map((call) => [call.command, call.positionals]),
     [
-      ['gesture', ['swipe', 'left', '300']],
       ['snapshot', []],
+      ['swipe', ['340', '520', '60', '520', '300']],
       ['swipe', ['360', '520', '40', '520', '300']],
     ],
   );

--- a/test/integration/provider-scenarios/android-test-suite.test.ts
+++ b/test/integration/provider-scenarios/android-test-suite.test.ts
@@ -122,7 +122,7 @@ test('Provider-backed integration Android Maestro replay uses fresh selector sna
         world.adbCalls.find((call) => call.slice(0, 3).join(' ') === 'shell input swipe'),
         ['shell', 'input', 'swipe', '351', '390', '39', '390', '300'],
       );
-      assert.ok(snapshots >= 2 && snapshots <= 3, `expected 2-3 snapshots, got ${snapshots}`);
+      assertSnapshotCountInRange(snapshots, 2, 3);
     },
   );
 });
@@ -168,7 +168,7 @@ test('Provider-backed integration Android Maestro replay test suite discovers YA
         world.adbCalls.find((call) => call.slice(0, 3).join(' ') === 'shell input tap'),
         ['shell', 'input', 'tap', '180', '330'],
       );
-      assert.equal(snapshots, 2);
+      assertSnapshotCountInRange(snapshots, 2, 3);
     },
   );
 });
@@ -337,7 +337,7 @@ test('Provider-backed integration Android Maestro executes runFlow conditions an
         world.adbCalls.filter((call) => call.slice(0, 3).join(' ') === 'shell input tap'),
         [['shell', 'input', 'tap', '180', '330']],
       );
-      assert.equal(snapshots, 4);
+      assertSnapshotCountInRange(snapshots, 4, 5);
     },
   );
 });
@@ -391,4 +391,8 @@ function androidMaestroReplayXml(searchBounds: string): string {
     '  </node>',
     '</hierarchy>',
   ].join('\n');
+}
+
+function assertSnapshotCountInRange(actual: number, min: number, max: number): void {
+  assert.ok(actual >= min && actual <= max, `expected ${min}-${max} snapshots, got ${actual}`);
 }


### PR DESCRIPTION
## Summary

Improve Android Maestro replay stability for React Navigation CI flakes around tap-triggered transitions and horizontal tab swipes.

- Route Android horizontal `swipeScreen: direction left/right` through content-lane coordinates instead of the native gesture preset.
- Confirm Android native `assertVisible` wait successes with exact Maestro snapshot matching so `Albums` does not pass on `Push albums`.
- Add failure-only Android recovery for immediate tap->assert and swipe->assert misses: retry the last relevant interaction once, cap the follow-up wait at 5s, and clear stale tap/swipe recovery state when another interaction supersedes it.
- Dedupe the Android assertVisible recovery confirmation path, model recoverable tap/swipe state as one discriminated union slot, and relax provider-scenario snapshot-count assertions so tests cover behavior instead of exact internal capture counts.
- Scope: 7 files, Maestro runtime/tests plus one Android provider scenario test; non-Maestro commands do not enter this runtime path.

## Validation

Local checks:
- `./node_modules/.bin/vitest run --project provider-integration` passed: 19 files, 48 tests.
- `./node_modules/.bin/vitest run src/compat/maestro/__tests__/runtime-interactions.test.ts src/compat/maestro/__tests__/runtime-assertions.test.ts src/daemon/handlers/__tests__/session-replay-vars.test.ts` passed outside the sandbox: 3 files, 111 tests.
- `./node_modules/.bin/oxfmt --check test/integration/provider-scenarios/android-test-suite.test.ts` passed.
- `./node_modules/.bin/oxlint . --deny-warnings` passed.
- `./node_modules/.bin/tsc -p tsconfig.json` passed.
- Earlier on this branch: `pnpm build:all` passed.
- Local React Navigation Android full suite under CI-like Pixel 5 dimensions passed: 38/38, 0 retries, 420.1s.

Device/CI evidence:
- Packed this branch and installed it into React Navigation PR 13126 probe branch.
- Focused React Navigation Android CI probe passed all 3 targeted flaky flows first attempt: Native Stack - Card + Modal, Stack - Card + Modal, Tab View - Custom Tab Bar: https://github.com/react-navigation/react-navigation/actions/runs/27496272320
- Full React Navigation Android CI suite passed: 38 passed, 0 failed, 1 flaky in 1335.5s: https://github.com/react-navigation/react-navigation/actions/runs/27496812112/job/81272293307
- The one flaky case was Drawer - Master Detail, which passed on attempt 3. The same flow passed locally 10/10 in isolation and 5/5 after the preceding CI test; the remaining evidence points to a low-frequency Android accessibility hierarchy refresh/state issue in that app screen, not this targeted replay change.

Performance/scope note:
- Normal passing Android Maestro assertions pay one extra exact snapshot confirmation after native wait success. Tap/swipe recovery only runs after assertion failure. Non-Maestro runs are performance-neutral because the changed runtime code is under `src/compat/maestro/*` and is only used by `test --maestro` replay.
