### PR TITLE
fix(ios): add no-op XCTest runner startup mode

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -91,6 +91,11 @@ final class RunnerTests: XCTestCase {
 
   @MainActor
   func testCommand() throws {
+    if RunnerEnv.isTruthy("AGENT_DEVICE_RUNNER_NOOP_STARTUP") {
+      NSLog("AGENT_DEVICE_RUNNER_NOOP_STARTUP=1")
+      return
+    }
+
     doneExpectation = expectation(description: "agent-device command handled")
     NSLog("AGENT_DEVICE_RUNNER_HEADLESS_STARTUP=1")
     let desiredPort = RunnerEnv.resolvePort()


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Add `AGENT_DEVICE_RUNNER_NOOP_STARTUP=1` as an explicit opt-in for direct/manual XCTest invocations that should exit immediately instead of starting the runner listener.

This keeps the default agent-device runner behavior unchanged.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- `pnpm build:xcuitest`
