### PR TITLE
fix: classify external xctest runner flags

### DIFF
--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -242,7 +242,15 @@ function summarizeProviderScenarioFlagExclusions() {
     {
       name: 'Apple launch and perf artifact options',
       owner: 'iOS platform, observability command, and parser tests',
-      keys: ['deviceHub', 'kind', 'launchArgs', 'perfTemplate'],
+      keys: [
+        'deviceHub',
+        'kind',
+        'launchArgs',
+        'perfTemplate',
+        'iosXctestrunFile',
+        'iosXctestDerivedDataPath',
+        'iosXctestEnvDir',
+      ],
     },
     {
       name: 'parser/client-only command flags',

--- a/src/compat/maestro/support-matrix.ts
+++ b/src/compat/maestro/support-matrix.ts
@@ -25,11 +25,9 @@ export const MAESTRO_COMPAT_UNSUPPORTED_CAPABILITIES = [
   'Android app state reset',
 ] as const;
 
-export const MAESTRO_COMPAT_TRACKER_URL =
-  'https://github.com/callstack/agent-device/issues/558';
+export const MAESTRO_COMPAT_TRACKER_URL = 'https://github.com/callstack/agent-device/issues/558';
 
-export const MAESTRO_NEW_ISSUE_URL =
-  'https://github.com/callstack/agent-device/issues/new';
+export const MAESTRO_NEW_ISSUE_URL = 'https://github.com/callstack/agent-device/issues/new';
 
 export function formatMaestroSupportedSubsetForCli(): string {
   return `Supported subset: ${formatMaestroCapabilityList(MAESTRO_COMPAT_SUPPORTED_CAPABILITIES)}.`;


### PR DESCRIPTION
## Summary

Fixes the CI fallout from the external XCTest runner merge by classifying the new iOS XCTest runner flags in the provider integration progress model.

Also carries the formatter result for the Maestro support-matrix URL constants that was failing the merge-ref format check.

## Validation

pnpm test:integration:progress:check
pnpm format:check
pnpm check:quick