### PR TITLE
fix: clean daemon-owned ios runner leases

### DIFF
--- a/scripts/clean-daemon.ts
+++ b/scripts/clean-daemon.ts
@@ -6,6 +6,8 @@ import {
   isAgentDeviceDaemonProcess,
   stopProcessForTakeover,
 } from '../src/utils/process-identity.ts';
+import { cleanupRunnerLeasesForOwner } from '../src/platforms/ios/runner-lease.ts';
+import { runnerLeaseCleanupAdapter } from '../src/platforms/ios/runner-disposal.ts';
 
 const DAEMON_TERM_TIMEOUT_MS = 15_000;
 const DAEMON_KILL_TIMEOUT_MS = 2_000;
@@ -27,6 +29,10 @@ if (daemonPid !== null) {
     killTimeoutMs: DAEMON_KILL_TIMEOUT_MS,
     expectedStartTime: info?.processStartTime,
   });
+  await cleanupRunnerLeasesForOwner(
+    { pid: daemonPid, startTime: info?.processStartTime },
+    runnerLeaseCleanupAdapter,
+  );
 }
 
 removeIfPresent(paths.infoPath);

--- a/src/platforms/ios/__tests__/runner-session.test.ts
+++ b/src/platforms/ios/__tests__/runner-session.test.ts
@@ -108,6 +108,7 @@ import {
   validateRunnerDevice,
 } from '../runner-session.ts';
 import {
+  cleanupRunnerLeasesForOwner,
   RUNNER_OWNER_START_TIME,
   RUNNER_OWNER_TOKEN,
   writeRunnerLease,
@@ -708,6 +709,40 @@ test('runner session startup reclaims dead foreign runner lease before launching
     String(pkillCalls[0]?.[1]?.[2] ?? ''),
     /xcodebuild\.\*test-without-building\.\*AgentDeviceRunner\\\.env\\\.session-runner-session-dead-lease-sim-owner-dead-foreign-/,
   );
+});
+
+test('runner lease cleanup reclaims only leases owned by the stopped daemon', async () => {
+  const ownerPid = 999_999_991;
+  const ownerStartTime = 'Fri Jun 19 12:00:00 2026';
+  const owned = makeRunnerLease({
+    deviceId: 'runner-session-clean-owned-lease',
+    ownerPid,
+    ownerStartTime,
+    ownerToken: 'owner-clean-owned',
+  });
+  const foreign = makeRunnerLease({
+    deviceId: 'runner-session-clean-foreign-lease',
+    ownerPid,
+    ownerStartTime: 'Fri Jun 19 12:01:00 2026',
+    ownerToken: 'owner-clean-foreign',
+  });
+  writeRunnerLease(owned);
+  writeRunnerLease(foreign);
+
+  await cleanupRunnerLeasesForOwner(
+    { pid: ownerPid, startTime: ownerStartTime },
+    {
+      cleanupRunnerProcessTree: async () => {},
+      cleanupRunnerXcodebuildProcesses: async () => {},
+      cleanupTempFile: mockCleanupTempFile,
+    },
+  );
+
+  const leaseDir = process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR;
+  assert.ok(leaseDir);
+  assert.equal(fs.existsSync(path.join(leaseDir, `${owned.deviceId}.json`)), false);
+  assert.equal(fs.existsSync(path.join(leaseDir, `${foreign.deviceId}.json`)), true);
+  assert.deepEqual(mockCleanupTempFile.mock.calls, [[owned.xctestrunPath], [owned.jsonPath]]);
 });
 
 test('runner session restarts alive runner when expected xctestrun artifact changes', async () => {

--- a/src/platforms/ios/runner-lease.ts
+++ b/src/platforms/ios/runner-lease.ts
@@ -141,6 +141,19 @@ export async function cleanupOwnedRunnerLease(
   }
 }
 
+export async function cleanupRunnerLeasesForOwner(
+  owner: { pid: number; startTime?: string | null },
+  cleanup: RunnerLeaseCleanupAdapter,
+): Promise<void> {
+  if (!Number.isInteger(owner.pid) || owner.pid <= 0) return;
+  const leases = listRunnerLeasesForOwner(owner);
+  await Promise.all(
+    leases.map(async (lease) => {
+      await cleanupLeasedRunnerProcesses(lease, 'owned', cleanup);
+    }),
+  );
+}
+
 export function releaseRunnerLease(lease: RunnerLease | undefined): void {
   if (!lease) return;
   removeRunnerLease({
@@ -180,6 +193,39 @@ function resolveRunnerLeaseRoot(): string {
   const override = process.env.AGENT_DEVICE_IOS_RUNNER_LEASE_DIR?.trim();
   if (override) return path.resolve(override);
   return path.join(os.homedir(), '.agent-device', 'ios-runner', 'leases');
+}
+
+function listRunnerLeasesForOwner(owner: {
+  pid: number;
+  startTime?: string | null;
+}): RunnerLease[] {
+  let entries: fs.Dirent[];
+  const root = resolveRunnerLeaseRoot();
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const leases: RunnerLease[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const lease = readRunnerLeaseFile(path.join(root, entry.name));
+    if (!lease) continue;
+    if (lease.ownerPid !== owner.pid) continue;
+    if (owner.startTime !== undefined && lease.ownerStartTime !== owner.startTime) continue;
+    leases.push(lease);
+  }
+  return leases;
+}
+
+function readRunnerLeaseFile(filePath: string): RunnerLease | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Partial<RunnerLease>;
+    const deviceId = readNonEmptyString(parsed.deviceId);
+    return deviceId ? normalizeRunnerLease(parsed, deviceId) : null;
+  } catch {
+    return null;
+  }
 }
 
 function normalizeRunnerLease(value: unknown, deviceId: string): RunnerLease | null {


### PR DESCRIPTION
## Summary

Make `pnpm clean:daemon` reclaim iOS runner leases owned by the daemon PID it just stopped, so a timed-out daemon shutdown cannot leave a live XCTest runner blocking the next replay daemon.
Keep normal cross-daemon protection intact by matching owner PID plus process start time before cleaning a lease.
Add regression coverage that verifies owner-scoped cleanup removes only the stopped daemon lease and preserves foreign ownership.

Root cause: CI run 27822970806 showed prepare daemon PID 26099 left its XCTest runner lease/process alive after `pnpm clean:daemon`; the next replay daemon correctly rejected the busy lease.

Touched files: 3. Scope stayed within iOS runner lease cleanup plus the clean-daemon script.

## Validation

Verified the focused runner-session suite passed, TypeScript passed, oxlint passed, and oxfmt completed on the touched files using direct project binaries because the local pnpm shim intermittently failed package-manager signature verification in the sandbox.
