### PR TITLE
docs: document minimal web support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,6 @@ The installed CLI help is the source of truth for agents. Start with `agent-devi
 
 Prerequisites depend on the target platform: Node.js 22+, Xcode for iOS/tvOS/macOS targets, Android SDK + ADB for Android, and macOS Accessibility permission for desktop automation. Web automation requires Node 24+. See [Installation](https://oss.callstack.com/agent-device/docs/installation) for platform setup.
 
-For web sessions, set up the managed browser backend before first use:
-
-```bash
-agent-device web setup
-agent-device web doctor
-```
-
 Try the basic loop:
 
 ```bash
@@ -88,32 +81,6 @@ agent-device close
 ```
 
 Snapshots assign refs like `@e1`, `@e2`, and `@e3` to elements on the current screen. Refs from the latest snapshot are immediately actionable; after scrolling or changing screens, take a fresh snapshot.
-
-## Minimal Web Support
-
-`agent-device --platform web` is intentionally narrow. `agent-device` owns the command surface, sessions, replay integration, refs/selectors, and artifact routing; `agent-browser` owns browser launch, page control, screenshots, and browser-specific mechanics.
-
-Use `--platform web` when a browser step belongs inside an `agent-device` session, replay, batch, MCP, or typed-client flow. Use `agent-browser` directly for standalone web automation.
-
-Supported first-slice loop:
-
-```bash
-agent-device web setup
-agent-device open https://example.com --platform web
-agent-device snapshot -i --platform web
-agent-device get text @e2 --platform web
-agent-device is visible 'label="Welcome"' --platform web
-agent-device find text "Welcome" exists --platform web
-agent-device click @e12 --platform web
-agent-device fill @e13 "test@example.com" --platform web
-agent-device wait text "Welcome" 3000 --platform web
-agent-device screenshot ./artifacts/web-home.png --platform web
-agent-device close --platform web
-```
-
-Supported through `agent-device`: URL open, snapshot refs, `get text/attrs`, `is visible/exists/text`, `find text/selector`, click/press, fill/type, wait, screenshot, close, and replay scripts composed from those commands.
-
-Out of scope for `agent-device` web support: tab/window/devtools control, network interception, cookies/storage, downloads/uploads, arbitrary page scripting, and raw browser diagnostics. Use `agent-browser` directly for those browser-specific workflows.
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A device automation CLI for real apps on iOS, Android, TV, and desktop. Agents g
 
 `agent-device` lets coding agents open apps, inspect the current UI, interact with visible elements, and collect debugging evidence through one CLI. Use it when an agent needs to verify what actually happens on a device, not just reason about code.
 
-If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), `agent-device` is the same idea for mobile, TV, and desktop apps.
+If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), `agent-device` is the same idea for mobile, TV, and desktop apps. Minimal `--platform web` support reuses `agent-browser` when a browser session needs to fit into the same command/session/replay loop.
 
 It works with native iOS and Android apps, plus apps built with Expo, Flutter, and React Native, as long as the target can run on a supported device, simulator, emulator, or desktop environment.
 
@@ -56,7 +56,14 @@ agent-device help workflow
 
 The installed CLI help is the source of truth for agents. Start with `agent-device help workflow`, then follow the topic-specific help when a task needs dogfooding, debugging, replay, or React Native profiling.
 
-Prerequisites depend on the target platform: Node.js 22+, Xcode for iOS/tvOS/macOS targets, Android SDK + ADB for Android, and macOS Accessibility permission for desktop automation. See [Installation](https://oss.callstack.com/agent-device/docs/installation) for platform setup.
+Prerequisites depend on the target platform: Node.js 22+, Xcode for iOS/tvOS/macOS targets, Android SDK + ADB for Android, and macOS Accessibility permission for desktop automation. Web automation requires Node 24+. See [Installation](https://oss.callstack.com/agent-device/docs/installation) for platform setup.
+
+For web sessions, set up the managed browser backend before first use:
+
+```bash
+agent-device web setup
+agent-device web doctor
+```
 
 Try the basic loop:
 
@@ -81,6 +88,27 @@ agent-device close
 ```
 
 Snapshots assign refs like `@e1`, `@e2`, and `@e3` to elements on the current screen. Refs from the latest snapshot are immediately actionable; after scrolling or changing screens, take a fresh snapshot.
+
+## Minimal Web Support
+
+`agent-device --platform web` is intentionally narrow. `agent-device` owns the command surface, sessions, replay integration, refs/selectors, and artifact routing; `agent-browser` owns browser launch, page control, screenshots, and browser-specific mechanics.
+
+Supported first-slice loop:
+
+```bash
+agent-device web setup
+agent-device open https://example.com --platform web
+agent-device snapshot -i --platform web
+agent-device click @e12 --platform web
+agent-device fill @e13 "test@example.com" --platform web
+agent-device wait text "Welcome" 3000 --platform web
+agent-device screenshot ./artifacts/web-home.png --platform web
+agent-device close --platform web
+```
+
+Supported through `agent-device`: URL open, snapshot refs, click/press, fill/type, wait, screenshot, close, and replay scripts composed from those commands.
+
+Out of scope for `agent-device` web support: tab/window/devtools control, network interception, cookies/storage, downloads/uploads, arbitrary page scripting, and raw browser diagnostics. Use `agent-browser` directly for those browser-specific workflows.
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -93,12 +93,17 @@ Snapshots assign refs like `@e1`, `@e2`, and `@e3` to elements on the current sc
 
 `agent-device --platform web` is intentionally narrow. `agent-device` owns the command surface, sessions, replay integration, refs/selectors, and artifact routing; `agent-browser` owns browser launch, page control, screenshots, and browser-specific mechanics.
 
+Use `--platform web` when a browser step belongs inside an `agent-device` session, replay, batch, MCP, or typed-client flow. Use `agent-browser` directly for standalone web automation.
+
 Supported first-slice loop:
 
 ```bash
 agent-device web setup
 agent-device open https://example.com --platform web
 agent-device snapshot -i --platform web
+agent-device get text @e2 --platform web
+agent-device is visible 'label="Welcome"' --platform web
+agent-device find text "Welcome" exists --platform web
 agent-device click @e12 --platform web
 agent-device fill @e13 "test@example.com" --platform web
 agent-device wait text "Welcome" 3000 --platform web
@@ -106,7 +111,7 @@ agent-device screenshot ./artifacts/web-home.png --platform web
 agent-device close --platform web
 ```
 
-Supported through `agent-device`: URL open, snapshot refs, click/press, fill/type, wait, screenshot, close, and replay scripts composed from those commands.
+Supported through `agent-device`: URL open, snapshot refs, `get text/attrs`, `is visible/exists/text`, `find text/selector`, click/press, fill/type, wait, screenshot, close, and replay scripts composed from those commands.
 
 Out of scope for `agent-device` web support: tab/window/devtools control, network interception, cookies/storage, downloads/uploads, arbitrary page scripting, and raw browser diagnostics. Use `agent-browser` directly for those browser-specific workflows.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-device",
   "version": "0.17.6",
-  "description": "Agent-native CLI for AI mobile testing and app automation across iOS, Android, tvOS, Android TV, macOS, and Linux.",
+  "description": "Agent-native CLI for AI app automation across iOS, Android, tvOS, Android TV, macOS, Linux, and web.",
   "mcpName": "io.github.callstackincubator/agent-device",
   "license": "MIT",
   "author": "Callstack",
@@ -178,6 +178,8 @@
     "android",
     "tvos",
     "macos",
+    "web",
+    "browser",
     "react-native",
     "observability",
     "diagnostics",

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1015,7 +1015,7 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /Web browser sessions: read help web/);
   assert.match(
     usageText,
-    /open <url> --platform web -> snapshot -i -> click\/fill\/wait\/screenshot -> close/,
+    /open <url> --platform web -> snapshot -i -> click\/fill\/get\/is\/find\/wait\/screenshot -> close/,
   );
   assert.match(usageText, /Session state contains request diagnostics and runner\.log/);
   assert.match(usageText, /logs clear --restart\/mark\/path/);
@@ -1164,9 +1164,18 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /Manual adb reverse tcp:<port> tcp:<port> is only needed/);
   assert.match(help, /do not split clear\/restart/);
   assert.match(help, /do not write network log headers/);
-  assert.match(help, /Web: agent-device reuses agent-browser/);
-  assert.match(help, /agent-browser doctor --offline --quick/);
+  assert.match(help, /Web: agent-device uses a managed, pinned agent-browser backend/);
+  assert.match(
+    help,
+    /Use --platform web when a browser step belongs inside an agent-device session/,
+  );
+  assert.match(help, /use agent-browser directly for standalone web automation/);
+  assert.match(help, /agent-device web setup/);
+  assert.match(help, /agent-device web doctor/);
   assert.match(help, /agent-device open https:\/\/example\.com --platform web/);
+  assert.match(help, /agent-device get text @e2 --platform web/);
+  assert.match(help, /agent-device is visible 'label="Welcome"' --platform web/);
+  assert.match(help, /agent-device find text "Welcome" exists --platform web/);
   assert.match(help, /agent-device close --platform web/);
   assert.match(help, /Use agent-browser directly for browser-specific features/);
   assert.match(help, /agent-device open exp:\/\/127\.0\.0\.1:8081 --platform ios/);
@@ -1192,19 +1201,30 @@ test('usageForCommand resolves web help topic', () => {
   const help = usageForCommand('web');
   if (help === null) throw new Error('Expected web help text');
   assert.match(help, /agent-device help web/);
-  assert.match(help, /agent-device reuses agent-browser for browser mechanics/);
+  assert.match(help, /agent-device uses a managed, pinned agent-browser backend/);
   assert.match(help, /agent-device owns command\/session\/replay integration/);
   assert.match(help, /agent-browser owns browser launch, page control, screenshots/);
-  assert.match(help, /agent-browser doctor --offline --quick/);
+  assert.match(
+    help,
+    /Use --platform web when a browser step belongs inside an agent-device session/,
+  );
+  assert.match(help, /Use agent-browser directly for standalone web automation/);
+  assert.match(help, /agent-device web setup/);
+  assert.match(help, /agent-device web doctor/);
   assert.match(help, /agent-device open https:\/\/example\.com --platform web/);
   assert.match(help, /agent-device snapshot -i --platform web/);
+  assert.match(help, /agent-device get text @e2 --platform web/);
+  assert.match(help, /agent-device is visible 'label="Welcome"' --platform web/);
+  assert.match(help, /agent-device find text "Welcome" exists --platform web/);
   assert.match(help, /agent-device click @e12 --platform web/);
   assert.match(help, /agent-device fill @e13 "qa@example\.com" --platform web/);
   assert.match(help, /agent-device wait text "Welcome" 3000 --platform web/);
   assert.match(help, /agent-device screenshot \.\/artifacts\/web-home\.png --platform web/);
   assert.match(help, /agent-device close --platform web/);
-  assert.match(help, /open <url>, snapshot -i, click\/press @ref or selector/);
-  assert.match(help, /Use agent-browser directly for those workflows/);
+  assert.match(help, /open <url>, snapshot -i, get text\/attrs/);
+  assert.match(help, /is visible\/exists\/text, find text\/selector/);
+  assert.match(help, /click\/press @ref or selector/);
+  assert.match(help, /Use agent-browser directly for those browser-specific workflows/);
   assert.match(help, /Do not claim web e2e CI exists/);
   assert.match(help, /Do not use native mobile or desktop setup commands/);
 });
@@ -1634,14 +1654,14 @@ test('session command help includes daemon state directory discovery', () => {
 test('web command help includes managed backend setup', () => {
   const help = usageForCommand('web');
   if (help === null) throw new Error('Expected command help text');
-  assert.match(help, /Usage:\s+agent-device web setup \| web doctor/);
-  assert.match(help, /managed web automation backend/);
+  assert.match(help, /agent-device help web/);
+  assert.match(help, /managed, pinned agent-browser backend/);
   assert.match(
     help,
-    /agent-device web setup[\s\S]*agent-device open "https:\/\/example\.com" --platform web/,
+    /agent-device web setup[\s\S]*agent-device open https:\/\/example\.com --platform web/,
   );
-  assert.match(help, /do not install the backend implicitly/);
-  assert.match(help, /web setup[\s\S]*install or reuse the pinned backend/);
+  assert.match(help, /Before first use, set up and verify the managed backend/);
+  assert.doesNotMatch(help, /do not install the backend implicitly/);
   assert.doesNotMatch(help, /web status/);
 });
 

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1012,6 +1012,11 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /After mutation: refs are stale/);
   assert.match(usageText, /use its selector directly; otherwise refresh with snapshot -i/);
   assert.match(usageText, /app-owned back uses back/);
+  assert.match(usageText, /Web browser sessions: read help web/);
+  assert.match(
+    usageText,
+    /open <url> --platform web -> snapshot -i -> click\/fill\/wait\/screenshot -> close/,
+  );
   assert.match(usageText, /Session state contains request diagnostics and runner\.log/);
   assert.match(usageText, /logs clear --restart\/mark\/path/);
   assert.match(usageText, /network dump --include headers/);
@@ -1032,6 +1037,7 @@ test('usage includes agent workflows, config, environment, and examples footers'
     usageText,
     /help react-native\s+React Native app automation hazards, overlays, Metro, and routing/,
   );
+  assert.match(usageText, /help web\s+Minimal browser sessions through agent-browser/);
   assert.match(usageText, /Configuration:/);
   assert.match(
     usageText,
@@ -1048,6 +1054,7 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /AGENT_DEVICE_DAEMON_BASE_URL\s+Connect to remote daemon/);
   assert.match(usageText, /Examples:/);
   assert.match(usageText, /agent-device open Settings --platform ios/);
+  assert.match(usageText, /agent-device open https:\/\/example\.com --platform web/);
   assert.match(usageText, /agent-device snapshot -i/);
   assert.match(usageText, /agent-device fill @e3 "test@example\.com"/);
   assert.match(usageText, /agent-device replay \.\/session\.ad/);
@@ -1157,6 +1164,11 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /Manual adb reverse tcp:<port> tcp:<port> is only needed/);
   assert.match(help, /do not split clear\/restart/);
   assert.match(help, /do not write network log headers/);
+  assert.match(help, /Web: agent-device reuses agent-browser/);
+  assert.match(help, /agent-browser doctor --offline --quick/);
+  assert.match(help, /agent-device open https:\/\/example\.com --platform web/);
+  assert.match(help, /agent-device close --platform web/);
+  assert.match(help, /Use agent-browser directly for browser-specific features/);
   assert.match(help, /agent-device open exp:\/\/127\.0\.0\.1:8081 --platform ios/);
   assert.match(help, /agent-device open "Expo Go" exp:\/\/127\.0\.0\.1:8081 --platform ios/);
   assert.match(help, /There is no open-url command/);
@@ -1174,6 +1186,27 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /help react-devtools/);
   assert.match(help, /help react-native/);
   assert.doesNotMatch(help, /agent-device react-devtools profile/);
+});
+
+test('usageForCommand resolves web help topic', () => {
+  const help = usageForCommand('web');
+  if (help === null) throw new Error('Expected web help text');
+  assert.match(help, /agent-device help web/);
+  assert.match(help, /agent-device reuses agent-browser for browser mechanics/);
+  assert.match(help, /agent-device owns command\/session\/replay integration/);
+  assert.match(help, /agent-browser owns browser launch, page control, screenshots/);
+  assert.match(help, /agent-browser doctor --offline --quick/);
+  assert.match(help, /agent-device open https:\/\/example\.com --platform web/);
+  assert.match(help, /agent-device snapshot -i --platform web/);
+  assert.match(help, /agent-device click @e12 --platform web/);
+  assert.match(help, /agent-device fill @e13 "qa@example\.com" --platform web/);
+  assert.match(help, /agent-device wait text "Welcome" 3000 --platform web/);
+  assert.match(help, /agent-device screenshot \.\/artifacts\/web-home\.png --platform web/);
+  assert.match(help, /agent-device close --platform web/);
+  assert.match(help, /open <url>, snapshot -i, click\/press @ref or selector/);
+  assert.match(help, /Use agent-browser directly for those workflows/);
+  assert.match(help, /Do not claim web e2e CI exists/);
+  assert.match(help, /Do not use native mobile or desktop setup commands/);
 });
 
 test('workflow help keeps common copyable command forms', () => {

--- a/src/utils/cli-help.ts
+++ b/src/utils/cli-help.ts
@@ -55,7 +55,7 @@ const AGENT_QUICKSTART_LINES = [
   'Raw coordinates are fallback-only: use snapshot -i --json rects when iOS refs no-op or child refs are missing.',
   'Batch JSON steps use "command" and structured "input"; legacy "positionals"/"flags" steps still run in CLI but are deprecated until the next major version.',
   'Navigation: app-owned back uses back; system back uses back --system.',
-  'Web browser sessions: read help web; first slice is open <url> --platform web -> snapshot -i -> click/fill/wait/screenshot -> close.',
+  'Web browser sessions: read help web; first slice is open <url> --platform web -> snapshot -i -> click/fill/get/is/find/wait/screenshot -> close.',
   'Verification commands must name the expected text/selector; bare screenshots/snapshots are not enough.',
   'Debug evidence: Session state contains request diagnostics and runner.log; use logs clear --restart/mark/path, trace, and network dump --include headers for app evidence.',
   'Use agent-device commands in final plans; raw platform tools, pseudo commands, and helper prose are wrong.',
@@ -223,17 +223,20 @@ Validation and evidence:
   Debug logs: logs clear --restart, logs mark, reproduce, then logs path; do not split clear/restart into separate stop/start commands.
   Network headers: network dump --include headers; do not write network log headers.
   Remote/cloud: connect to discover a cloud profile, or connect --remote-config ./remote-config.json for a local profile; then open, snapshot, disconnect.
-  Web: agent-device uses a managed, pinned agent-browser backend as an implementation detail. Run agent-device web setup before first use, then agent-device web doctor for backend health checks. Web automation requires Node 24+.
+  Web: agent-device uses a managed, pinned agent-browser backend as an implementation detail. Use --platform web when a browser step belongs inside an agent-device session, replay, batch, MCP, or typed-client flow; use agent-browser directly for standalone web automation. Run agent-device web setup before first use, then agent-device web doctor for backend health checks. Web automation requires Node 24+.
     agent-device web setup
     agent-device web doctor
     agent-device open https://example.com --platform web
     agent-device snapshot -i --platform web
+    agent-device get text @e2 --platform web
+    agent-device is visible 'label="Welcome"' --platform web
+    agent-device find text "Welcome" exists --platform web
     agent-device click @e12 --platform web
     agent-device fill @e13 "qa@example.com" --platform web
     agent-device wait text "Welcome" 3000 --platform web
     agent-device screenshot ./artifacts/web-home.png --platform web
     agent-device close --platform web
-  Minimal web support is for browser sessions with open, snapshot, click/press, fill/type, wait, screenshot, close, and replay over those commands. Use agent-browser directly for browser-specific features that agent-device does not surface, such as tab/devtools management, advanced page scripting, or raw browser debugging.
+  Minimal web support is for browser sessions with open, snapshot, find, get, is, click/press, fill/type, wait, screenshot, close, and replay over those commands. Use agent-browser directly for browser-specific features that agent-device does not surface, such as tab/devtools management, advanced page scripting, or raw browser debugging.
   macOS menu bar: open ... --platform macos --surface menubar; snapshot -i --platform macos --surface menubar.
 
 React Native dev loop:
@@ -574,6 +577,7 @@ Use --platform web only for the minimal browser command loop exposed through age
 
 Dependency:
   agent-device uses a managed, pinned agent-browser backend for browser mechanics. agent-device owns command/session/replay integration, selectors/refs at the command surface, and artifact routing; agent-browser owns browser launch, page control, screenshots, and browser-specific behavior.
+  Use --platform web when a browser step belongs inside an agent-device session, replay, batch, MCP, or typed-client flow. Use agent-browser directly for standalone web automation.
   Before first use, set up and verify the managed backend:
     agent-device web setup
     agent-device web doctor
@@ -582,6 +586,9 @@ Dependency:
 First-slice loop:
   agent-device open https://example.com --platform web
   agent-device snapshot -i --platform web
+  agent-device get text @e2 --platform web
+  agent-device is visible 'label="Welcome"' --platform web
+  agent-device find text "Welcome" exists --platform web
   agent-device click @e12 --platform web
   agent-device fill @e13 "qa@example.com" --platform web
   agent-device wait text "Welcome" 3000 --platform web
@@ -589,7 +596,7 @@ First-slice loop:
   agent-device close --platform web
 
 Supported in agent-device web sessions:
-  open <url>, snapshot -i, click/press @ref or selector, fill/type @ref or selector, wait text/selector, screenshot, close, and replay scripts made from those commands.
+  open <url>, snapshot -i, get text/attrs, is visible/exists/text, find text/selector, click/press @ref or selector, fill/type @ref or selector, wait text/selector, screenshot, close, and replay scripts made from those commands.
 
 Out of scope for agent-device web support:
   Browser runtime debugging, tabs/windows/devtools control, network interception, storage/cookie management, arbitrary page scripting, downloads/uploads, multi-page orchestration, and agent-browser-specific diagnostics. Use agent-browser directly for those browser-specific workflows.

--- a/src/utils/cli-help.ts
+++ b/src/utils/cli-help.ts
@@ -28,6 +28,7 @@ const AGENT_WORKFLOWS = [
     label: 'help remote',
     description: 'Remote/cloud config, tenants, leases, and local service tunnels',
   },
+  { label: 'help web', description: 'Minimal browser sessions through agent-browser' },
   { label: 'help macos', description: 'Desktop, frontmost-app, and menu bar surfaces' },
   { label: 'help dogfood', description: 'Exploratory QA report workflow' },
 ] as const;
@@ -54,6 +55,7 @@ const AGENT_QUICKSTART_LINES = [
   'Raw coordinates are fallback-only: use snapshot -i --json rects when iOS refs no-op or child refs are missing.',
   'Batch JSON steps use "command" and structured "input"; legacy "positionals"/"flags" steps still run in CLI but are deprecated until the next major version.',
   'Navigation: app-owned back uses back; system back uses back --system.',
+  'Web browser sessions: read help web; first slice is open <url> --platform web -> snapshot -i -> click/fill/wait/screenshot -> close.',
   'Verification commands must name the expected text/selector; bare screenshots/snapshots are not enough.',
   'Debug evidence: Session state contains request diagnostics and runner.log; use logs clear --restart/mark/path, trace, and network dump --include headers for app evidence.',
   'Use agent-device commands in final plans; raw platform tools, pseudo commands, and helper prose are wrong.',
@@ -82,6 +84,7 @@ const ENVIRONMENT_LINES = [
 
 const EXAMPLE_LINES = [
   'agent-device open Settings --platform ios',
+  'agent-device open https://example.com --platform web',
   'agent-device open TextEdit --platform macos',
   'agent-device snapshot -i',
   'agent-device react-devtools get tree --depth 3',
@@ -220,6 +223,17 @@ Validation and evidence:
   Debug logs: logs clear --restart, logs mark, reproduce, then logs path; do not split clear/restart into separate stop/start commands.
   Network headers: network dump --include headers; do not write network log headers.
   Remote/cloud: connect to discover a cloud profile, or connect --remote-config ./remote-config.json for a local profile; then open, snapshot, disconnect.
+  Web: agent-device uses a managed, pinned agent-browser backend as an implementation detail. Run agent-device web setup before first use, then agent-device web doctor for backend health checks. Web automation requires Node 24+.
+    agent-device web setup
+    agent-device web doctor
+    agent-device open https://example.com --platform web
+    agent-device snapshot -i --platform web
+    agent-device click @e12 --platform web
+    agent-device fill @e13 "qa@example.com" --platform web
+    agent-device wait text "Welcome" 3000 --platform web
+    agent-device screenshot ./artifacts/web-home.png --platform web
+    agent-device close --platform web
+  Minimal web support is for browser sessions with open, snapshot, click/press, fill/type, wait, screenshot, close, and replay over those commands. Use agent-browser directly for browser-specific features that agent-device does not surface, such as tab/devtools management, advanced page scripting, or raw browser debugging.
   macOS menu bar: open ... --platform macos --surface menubar; snapshot -i --platform macos --surface menubar.
 
 React Native dev loop:
@@ -551,6 +565,39 @@ Rules:
   Do not let iOS simulator-set scoping hide macOS desktop targets.
   Prefer refs/selectors over raw coordinates.
   macOS snapshot rects are window-space; use current refs or overlay refs instead of guessing coordinates.`,
+  },
+  web: {
+    summary: 'Minimal browser workflow with the managed web backend',
+    body: `agent-device help web
+
+Use --platform web only for the minimal browser command loop exposed through agent-device.
+
+Dependency:
+  agent-device uses a managed, pinned agent-browser backend for browser mechanics. agent-device owns command/session/replay integration, selectors/refs at the command surface, and artifact routing; agent-browser owns browser launch, page control, screenshots, and browser-specific behavior.
+  Before first use, set up and verify the managed backend:
+    agent-device web setup
+    agent-device web doctor
+  Web automation requires Node 24+.
+
+First-slice loop:
+  agent-device open https://example.com --platform web
+  agent-device snapshot -i --platform web
+  agent-device click @e12 --platform web
+  agent-device fill @e13 "qa@example.com" --platform web
+  agent-device wait text "Welcome" 3000 --platform web
+  agent-device screenshot ./artifacts/web-home.png --platform web
+  agent-device close --platform web
+
+Supported in agent-device web sessions:
+  open <url>, snapshot -i, click/press @ref or selector, fill/type @ref or selector, wait text/selector, screenshot, close, and replay scripts made from those commands.
+
+Out of scope for agent-device web support:
+  Browser runtime debugging, tabs/windows/devtools control, network interception, storage/cookie management, arbitrary page scripting, downloads/uploads, multi-page orchestration, and agent-browser-specific diagnostics. Use agent-browser directly for those browser-specific workflows.
+
+Rules:
+  Do not claim web e2e CI exists unless a project workflow explicitly provides it.
+  Do not use native mobile or desktop setup commands such as boot, apps, install, settings, alert, keyboard, perf, logs, or react-devtools for --platform web.
+  Keep browser plans session-scoped: open a URL, inspect refs, act on refs/selectors, verify with wait/get/is/snapshot, capture screenshot only when visual evidence is needed, then close.`,
   },
   dogfood: {
     summary: 'Exploratory QA workflow with reproducible evidence',

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -650,6 +650,38 @@ const SKILL_GUIDANCE_CASES: Case[] = [
     strictFinalOutput: true,
   }),
   makeCase({
+    id: 'web-minimal-browser-loop',
+    contract: [
+      'Platform: web',
+      'Target URL: https://example.com/login',
+      'agent-device web setup already passed',
+      'Fresh interactive snapshot will expose @e12 as the email field and @e13 as the Continue button',
+      'Expected success text after submit: Welcome',
+      'Visual evidence path: ./artifacts/web-login.png',
+    ],
+    task: 'Plan the minimal agent-device web commands to open the page, inspect interactive refs, fill the email field, click Continue, wait for the success text, capture a screenshot, and close.',
+    outputs: [
+      /(?:^|\n)(?:agent-device\s+)?open\s+https:\/\/example\.com\/login\b[^\n]*--platform\s+web/i,
+      /(?:^|\n)(?:agent-device\s+)?snapshot\b[^\n]*-i\b[^\n]*--platform\s+web/i,
+      /(?:^|\n)(?:agent-device\s+)?fill\s+@e12\s+["']?[^"'\n]+@[^"'\n]+["']?[^\n]*--platform\s+web/i,
+      /(?:^|\n)(?:agent-device\s+)?(?:click|press)\s+@e13\b[^\n]*--platform\s+web/i,
+      /(?:^|\n)(?:agent-device\s+)?wait\s+text\s+["']Welcome["'][^\n]*--platform\s+web/i,
+      /(?:^|\n)(?:agent-device\s+)?screenshot\s+\.\/artifacts\/web-login\.png\b[^\n]*--platform\s+web/i,
+      /(?:^|\n)(?:agent-device\s+)?close\b[^\n]*--platform\s+web/i,
+    ],
+    forbiddenOutputs: [
+      /agent-browser/i,
+      plannedCommand('boot'),
+      plannedCommand('apps'),
+      plannedCommand('install'),
+      plannedCommand('alert'),
+      plannedCommand('keyboard'),
+      plannedCommand('react-devtools'),
+    ],
+    strictFinalOutput: true,
+    allowOnlyLocalCliHelpCommands: true,
+  }),
+  makeCase({
     id: 'inspect-visible-text-readonly',
     contract: [
       'App name: Agent Device Tester',

--- a/website/docs/docs/agent-setup.md
+++ b/website/docs/docs/agent-setup.md
@@ -1,13 +1,13 @@
 ---
 title: AI Agent Setup
-description: Configure Cursor, Codex, Claude Code, Windsurf, Cline, Goose, skills, and MCP for agent-device mobile, TV, and desktop app verification.
+description: Configure Cursor, Codex, Claude Code, Windsurf, Cline, Goose, skills, and MCP for agent-device mobile, TV, desktop, and web app verification.
 ---
 
 # AI Agent Setup
 
 `agent-device` is built for AI agents, but humans usually install it, grant device permissions, and decide which agent client should use it.
 
-Use this page to wire Cursor, Codex, Claude Code, Windsurf, Cline, Goose, or another coding agent into mobile, TV, and desktop app verification. It covers skills, project rules, and MCP setup for React Native QA, Expo app verification, iOS Simulator automation, Android Emulator automation, tvOS checks, Android TV checks, debugging, profiling, and exploratory QA.
+Use this page to wire Cursor, Codex, Claude Code, Windsurf, Cline, Goose, or another coding agent into mobile, TV, desktop, and web app verification. It covers skills, project rules, and MCP setup for React Native QA, Expo app verification, iOS Simulator automation, Android Emulator automation, tvOS checks, Android TV checks, web browser sessions, debugging, profiling, and exploratory QA.
 
 The short version: install the CLI, make the agent read version-matched help, and let the agent use either MCP tools or CLI commands. MCP tools use command contracts backed by the same `AgentDeviceClient` execution path as the CLI adapters.
 
@@ -55,6 +55,8 @@ Use MCP tools or the CLI in the integrated terminal. If `agent-device` is not on
 ## MCP server
 
 `agent-device mcp` starts the official stdio MCP server. It exposes direct structured tools for installed CLI commands. Tools run through command contracts and `AgentDeviceClient`; local-only workflows stay CLI-only rather than subprocess fallbacks.
+
+For web automation, MCP tools can target `platform: "web"` after the managed backend is available, but `agent-device web setup` and `agent-device web doctor` are CLI-only. Run setup from a terminal in the same effective state directory before asking an MCP client to drive a browser session.
 
 Tool execution failures are returned as MCP tool results with `isError: true`; clients and agents should inspect the tool result, not only the successful JSON-RPC envelope.
 

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -126,6 +126,24 @@ standalone Simulator app.
 `client.sessions.stateDir()` mirrors `session state-dir` and returns the resolved daemon state directory as a pure local resolution — it never starts
 or contacts the daemon. Pass `{ stateDir }` to resolve an explicit override the same way the CLI resolves `--state-dir`.
 
+## Web sessions
+
+Typed client commands can target browser sessions with the same command methods by passing
+`platform: 'web'`. The managed web backend is set up through the CLI, not through a typed client
+method, so run `agent-device web setup` before first use in the same effective state directory. Use
+`agent-device web doctor` when you need to verify backend health.
+
+```ts
+await client.apps.open({ url: 'https://example.com', platform: 'web' });
+await client.capture.snapshot({ platform: 'web', interactiveOnly: true });
+await client.interactions.fill({ platform: 'web', ref: '@e12', text: 'test@example.com' });
+await client.command.wait({ platform: 'web', text: 'Welcome' });
+await client.sessions.close();
+```
+
+Web automation requires Node 24+. MCP tools use the same command contracts, so they can target
+`platform: 'web'` after setup, but local setup/doctor remains a CLI-only workflow.
+
 ## Android snapshot helper providers
 
 Remote Android providers should import `agent-device/android-snapshot-helper` and inject their own

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -105,11 +105,20 @@ agent-device metro reload
 
 ## Web Automation
 
+Minimal `--platform web` support reuses [agent-browser](https://github.com/vercel-labs/agent-browser). `agent-device` owns command/session/replay integration, refs/selectors, and artifact routing; `agent-browser` owns browser launch, page control, screenshots, and browser-specific mechanics.
+
+Use `--platform web` when a browser step belongs inside an `agent-device` session, replay, batch, MCP, or typed-client flow. Use `agent-browser` directly for standalone web automation.
+
+Set up and verify the managed web backend before relying on web sessions:
+
 ```bash
 agent-device web setup
 agent-device web doctor
 agent-device open "https://example.com" --platform web
 agent-device snapshot -i --platform web
+agent-device get text @e2 --platform web
+agent-device is visible 'label="Welcome"' --platform web
+agent-device find text "Welcome" exists --platform web
 agent-device click @e12 --platform web
 agent-device fill @e13 "test@example.com" --platform web
 agent-device wait text "Welcome" --platform web
@@ -124,7 +133,7 @@ agent-device close --platform web
 - `web doctor` verifies the managed backend after setup.
 - The managed install respects `--state-dir` and `AGENT_DEVICE_STATE_DIR`.
 - Web automation requires Node 24+.
-- Supported through `agent-device`: URL open, snapshot refs, click/press, fill/type, wait, screenshot, close, and replay scripts composed from those commands.
+- Supported through `agent-device`: URL open, snapshot refs, `get text/attrs`, `is visible/exists/text`, `find text/selector`, click/press, fill/type, wait, screenshot, close, and replay scripts composed from those commands.
 - Out of scope for `agent-device` web support: tab/window/devtools control, network interception, cookies/storage, downloads/uploads, arbitrary page scripting, multi-page orchestration, and raw browser diagnostics. Use `agent-browser` directly for those browser-specific workflows.
 
 ## Device isolation scopes

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -19,7 +19,6 @@ agent-device help react-devtools
 agent-device help remote
 agent-device help web
 agent-device help macos
-agent-device help web
 agent-device help dogfood
 ```
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -17,6 +17,7 @@ agent-device help debugging
 agent-device help react-native
 agent-device help react-devtools
 agent-device help remote
+agent-device help web
 agent-device help macos
 agent-device help web
 agent-device help dogfood
@@ -30,7 +31,7 @@ For MCP-aware clients that support direct tools, run:
 agent-device mcp
 ```
 
-The MCP server exposes direct structured tools for installed commands. Tools use structured input contracts through `AgentDeviceClient`; local-only workflows stay CLI-only rather than subprocess fallbacks. It does not expose generic shell execution over MCP.
+The MCP server exposes direct structured tools for installed commands. Tools use structured input contracts through `AgentDeviceClient`; local-only workflows stay CLI-only rather than subprocess fallbacks. It does not expose generic shell execution over MCP. MCP tools can target `platform: "web"` after `agent-device web setup`, but setup and doctor stay CLI-only.
 
 ## Navigation
 
@@ -109,6 +110,10 @@ agent-device web setup
 agent-device web doctor
 agent-device open "https://example.com" --platform web
 agent-device snapshot -i --platform web
+agent-device click @e12 --platform web
+agent-device fill @e13 "test@example.com" --platform web
+agent-device wait text "Welcome" --platform web
+agent-device screenshot ./artifacts/web-home.png --platform web
 agent-device close --platform web
 ```
 
@@ -119,6 +124,8 @@ agent-device close --platform web
 - `web doctor` verifies the managed backend after setup.
 - The managed install respects `--state-dir` and `AGENT_DEVICE_STATE_DIR`.
 - Web automation requires Node 24+.
+- Supported through `agent-device`: URL open, snapshot refs, click/press, fill/type, wait, screenshot, close, and replay scripts composed from those commands.
+- Out of scope for `agent-device` web support: tab/window/devtools control, network interception, cookies/storage, downloads/uploads, arbitrary page scripting, multi-page orchestration, and raw browser diagnostics. Use `agent-browser` directly for those browser-specific workflows.
 
 ## Device isolation scopes
 

--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -1,11 +1,11 @@
 ---
 title: Introduction
-description: Learn what agent-device is, where it fits in agentic mobile, TV, and desktop development, and how agents use it for app verification, debugging, profiling, QA, and replay.
+description: Learn what agent-device is, where it fits in agentic mobile, TV, desktop, and web development, and how agents use it for app verification, debugging, profiling, QA, and replay.
 ---
 
 # Introduction
 
-`agent-device` is an agent-native CLI for app verification and QA from coding agents. It gives agents structured UI access, deterministic interactions, debugging evidence, performance signals, and replayable flows across iOS, Android, tvOS, Android TV, macOS, and Linux desktop targets.
+`agent-device` is an agent-native CLI for app verification and QA from coding agents. It gives agents structured UI access, deterministic interactions, debugging evidence, performance signals, and replayable flows across iOS, Android, tvOS, Android TV, macOS, Linux desktop targets, and a minimal managed web browser surface.
 
 Use it when an agent needs to inspect and operate a real app, not just reason about source code or screenshots.
 
@@ -16,9 +16,9 @@ Use it when an agent needs to inspect and operate a real app, not just reason ab
 - **Runtime evidence**: capture screenshots, recordings, logs, network traffic, traces, CPU/memory/perf snapshots, and crash-related logs when the happy path breaks.
 - **Replayable checks**: turn stable exploratory sessions into `.ad` replay scripts that can run again without AI.
 - **React Native and Expo workflows**: pair device automation with optional React DevTools profiling for component trees, props/state/hooks, slow renders, and rerenders.
-- **Local devices and app surfaces**: drive simulators, emulators, physical devices, TV targets, and desktop apps through one CLI.
+- **Local devices and app surfaces**: drive simulators, emulators, physical devices, TV targets, desktop apps, and browser sessions through one CLI.
 
-If you know `agent-browser`, `agent-device` is the app/device counterpart for mobile, TV, and desktop targets.
+If you know `agent-browser`, `agent-device` brings the same agent-oriented workflow to mobile, TV, desktop, and a narrow managed web browser slice.
 
 ## Development loop
 


### PR DESCRIPTION
## Summary

Document the managed web backend as the supported browser path across README, CLI help, website command/client/MCP docs, package metadata, and SkillGym guidance.

Closes #822

Touched files: 9. Scope stays in docs, help, package metadata, and command-planning guidance.

## Validation

pnpm exec vitest run src/utils/__tests__/args.test.ts
pnpm check:tooling

SkillGym focused validation was blocked in this Codex sandbox because external runners would receive branch-local workspace content; run pnpm test:skillgym:case web-first-use-runs-managed-setup from a normal authenticated local shell if needed.
