### PR TITLE
test: add live web platform smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,32 @@ jobs:
 
       - name: Check Provider-backed integration architecture progress
         run: pnpm test:integration:progress:check
+
+  web-smoke:
+    name: Web Platform Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      AGENT_DEVICE_WEB_E2E: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: "24.13"
+
+      - name: Run live web smoke
+        run: |
+          pnpm clean:daemon
+          pnpm test:smoke:web
+
+      - name: Upload web smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: web-smoke-artifacts
+          if-no-files-found: ignore
+          path: |
+            test/artifacts/web/**

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -8,5 +8,6 @@ Before architecture, diagnosis, TDD, triage, PRD, or roadmap work, read:
 - Relevant ADRs in `docs/adr/` for accepted architecture decisions.
 - This `docs/agents/` directory for issue-tracker and triage-label conventions.
 - `docs/agents/web-backend.md` before changing web automation backend setup or diagnostics.
+- `docs/agents/testing.md` for maintainer-only test lane notes such as the live web smoke.
 
 Use the vocabulary from `CONTEXT.md` in issue titles, refactor proposals, test names, and architecture notes. If a proposed change contradicts an ADR, call that out explicitly and explain why the decision should be reopened.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,11 @@
+# Testing Notes
+
+## Live web smoke
+
+The live web platform smoke runs the public built CLI against a local fixture page through the managed web backend:
+
+```bash
+AGENT_DEVICE_WEB_E2E=1 pnpm test:smoke:web
+```
+
+The test is skipped unless `AGENT_DEVICE_WEB_E2E=1` is set. The test runs `agent-device web setup` and `agent-device web doctor` with an isolated state directory before opening the fixture URL, so it verifies the public managed-backend setup path instead of relying on a global `agent-browser`. CI runs the lane on Node 24 because the managed backend requires Node >= 24. Failure artifacts, daemon state, and browser config are written under `test/artifacts/web/`.

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "test:integration:provider": "vitest run --project provider-integration",
     "test:integration:progress": "node --experimental-strip-types scripts/integration-progress.ts",
     "test:integration:progress:check": "node --experimental-strip-types scripts/integration-progress.ts --check",
+    "test:smoke:web": "pnpm build && node --test test/integration/smoke-web-platform.test.ts",
     "test:skillgym": "node test/skillgym/runner-environment.ts && pnpm build && skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts",
     "test:skillgym:case": "node test/skillgym/runner-environment.ts && pnpm build && skillgym run ./test/skillgym/suites/agent-device-smoke-suite.ts --config ./test/skillgym/skillgym.config.ts --case",
     "test:smoke": "node --test test/integration/smoke-*.test.ts",

--- a/test/integration/cli-json.ts
+++ b/test/integration/cli-json.ts
@@ -1,0 +1,69 @@
+import { runCmd, runCmdSync, type ExecResult } from '../../src/utils/exec.ts';
+
+const CLI_TIMEOUT_MS = 120_000;
+
+export type CliJsonResult = {
+  status: number;
+  json?: any;
+  stdout: string;
+  stderr: string;
+};
+
+export function runSourceCliJsonSync(
+  args: string[],
+  options?: { env?: NodeJS.ProcessEnv },
+): CliJsonResult {
+  const result = runCmdSync(
+    process.execPath,
+    ['--experimental-strip-types', 'src/bin.ts', ...args],
+    {
+      allowFailure: true,
+      env: options?.env,
+      timeoutMs: CLI_TIMEOUT_MS,
+    },
+  );
+  return cliJsonResult(result);
+}
+
+export async function runBuiltCliJson(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<CliJsonResult> {
+  const result = await runCmd(process.execPath, ['bin/agent-device.mjs', ...args], {
+    allowFailure: true,
+    env,
+    timeoutMs: CLI_TIMEOUT_MS,
+  });
+  return cliJsonResult(result);
+}
+
+export function formatResultDebug(step: string, args: string[], result: CliJsonResult): string {
+  const jsonText =
+    result.json === undefined ? '(unparseable)' : JSON.stringify(result.json, null, 2);
+  return [
+    `step: ${step}`,
+    `command: agent-device ${args.join(' ')}`,
+    `status: ${result.status}`,
+    `stderr:`,
+    result.stderr || '(empty)',
+    `stdout:`,
+    result.stdout || '(empty)',
+    `json:`,
+    jsonText,
+  ].join('\n');
+}
+
+function cliJsonResult(result: ExecResult): CliJsonResult {
+  let json: any;
+  try {
+    json = JSON.parse(result.stdout ?? '');
+  } catch {
+    json = undefined;
+  }
+  return {
+    status: result.exitCode,
+    json,
+    stdout: json ? '<JSON output>' : (result.stdout ?? ''),
+    stderr: result.stderr ?? '',
+  };
+}

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -1,0 +1,407 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import path from 'node:path';
+import test from 'node:test';
+import { type CliJsonResult, formatResultDebug, runBuiltCliJson } from './cli-json.ts';
+import { assertPngFile } from './provider-scenarios/assertions.ts';
+
+const TEST_NAME = 'live web platform e2e smoke';
+const WEB_E2E_ENABLED = process.env.AGENT_DEVICE_WEB_E2E === '1';
+
+type StepRecord = {
+  step: string;
+  command: string;
+  status: number;
+  timestamp: string;
+  errorCode?: string;
+  errorMessage?: string;
+};
+
+type WebSmokeContext = {
+  artifactDir: string;
+  common: string[];
+  env: NodeJS.ProcessEnv;
+  lastSnapshot?: any;
+  screenshotPath: string;
+  server: Server;
+  socketDir: string;
+  stepHistory: StepRecord[];
+  url: string;
+};
+
+test(
+  TEST_NAME,
+  {
+    skip: WEB_E2E_ENABLED
+      ? false
+      : 'Set AGENT_DEVICE_WEB_E2E=1 to run the managed web backend smoke.',
+  },
+  async () => {
+    await runWebSmoke(await createWebSmokeContext());
+  },
+);
+
+async function runWebSmoke(context: WebSmokeContext): Promise<void> {
+  let opened = false;
+
+  try {
+    await runStep(context, 'set up managed web backend', ['web', 'setup', '--json']);
+    await runStep(context, 'verify managed web backend', ['web', 'doctor', '--json']);
+    await runStep(context, 'open local fixture', ['open', context.url, ...context.common]);
+    opened = true;
+    await assertInitialWebSurface(context);
+    await assertReadAndVisibility(context);
+    await assertWebInteractions(context);
+    await assertWebScreenshot(context);
+  } finally {
+    await cleanupWebSmoke(context, opened);
+  }
+}
+
+async function createWebSmokeContext(): Promise<WebSmokeContext> {
+  const artifactDir = createArtifactDir();
+  const stateDir = path.join(artifactDir, 'agent-device-state');
+  const agentBrowserConfigPath = path.join(artifactDir, 'agent-browser.json');
+  const session = `ws-${process.pid.toString(36)}-${(Date.now() % 1_679_616).toString(36)}`;
+  const socketDir = path.join('/tmp', `adw-${process.pid.toString(36)}`);
+  const fixture = await startFixtureServer();
+  const env = {
+    ...process.env,
+    AGENT_DEVICE_STATE_DIR: stateDir,
+    AGENT_BROWSER_CONFIG: agentBrowserConfigPath,
+    AGENT_BROWSER_HEADED: 'false',
+    AGENT_BROWSER_IDLE_TIMEOUT_MS: '30000',
+    AGENT_BROWSER_SOCKET_DIR: socketDir,
+  };
+
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(socketDir, { recursive: true });
+  writeFileSync(agentBrowserConfigPath, JSON.stringify({ headed: false }, null, 2));
+
+  return {
+    artifactDir,
+    common: ['--platform', 'web', '--session', session, '--json'],
+    env,
+    screenshotPath: path.join(artifactDir, 'web-smoke.png'),
+    server: fixture.server,
+    socketDir,
+    stepHistory: [],
+    url: fixture.url,
+  };
+}
+
+async function assertInitialWebSurface(context: WebSmokeContext): Promise<void> {
+  const snapshot = await runStep(context, 'capture interactive snapshot', [
+    'snapshot',
+    '-i',
+    ...context.common,
+  ]);
+  const labels = readSnapshotLabels(snapshot.json);
+  assert.ok(labels.includes('Ready marker'), `snapshot labels: ${labels.join(', ')}`);
+  assert.ok(labels.includes('Email'), `snapshot labels: ${labels.join(', ')}`);
+  assert.ok(labels.includes('Submit order'), `snapshot labels: ${labels.join(', ')}`);
+}
+
+async function assertReadAndVisibility(context: WebSmokeContext): Promise<void> {
+  await assertCommandData(
+    context,
+    'wait for ready text',
+    ['wait', 'text', 'Ready marker', '5000'],
+    {
+      text: 'Ready marker',
+    },
+  );
+  await assertCommandData(
+    context,
+    'read ready text through selector',
+    ['get', 'text', 'label="Ready marker"'],
+    { text: 'Ready marker' },
+  );
+  await assertCommandData(
+    context,
+    'assert submit visible',
+    ['is', 'visible', 'label="Submit order"'],
+    { pass: true },
+  );
+}
+
+async function assertWebInteractions(context: WebSmokeContext): Promise<void> {
+  await runStep(context, 'click submit', ['click', 'label="Submit order"', ...context.common]);
+  await runStep(context, 'wait for click result', [
+    'wait',
+    'text',
+    'Submitted',
+    '5000',
+    ...context.common,
+  ]);
+  await runStep(context, 'fill email field', [
+    'fill',
+    'label="Email"',
+    'qa@example.test',
+    ...context.common,
+  ]);
+  await runStep(context, 'wait for fill result', [
+    'wait',
+    'text',
+    'Email qa@example.test',
+    '5000',
+    ...context.common,
+  ]);
+}
+
+async function assertWebScreenshot(context: WebSmokeContext): Promise<void> {
+  await assertCommandData(
+    context,
+    'capture screenshot artifact',
+    ['screenshot', context.screenshotPath, '--fullscreen', '--no-stabilize'],
+    { path: context.screenshotPath },
+  );
+  assertPngFile(context.screenshotPath);
+}
+
+async function assertCommandData(
+  context: WebSmokeContext,
+  step: string,
+  args: string[],
+  expected: Record<string, unknown>,
+): Promise<void> {
+  const fullArgs = [...args, ...context.common];
+  const result = await runStep(context, step, fullArgs);
+  for (const [key, value] of Object.entries(expected)) {
+    if (result.json?.data?.[key] === value) continue;
+    failWithContext(context, step, fullArgs, result, `${key} !== ${JSON.stringify(value)}`);
+  }
+}
+
+async function runStep(
+  context: WebSmokeContext,
+  step: string,
+  args: string[],
+  expectedStatus = 0,
+): Promise<CliJsonResult> {
+  const result = await runBuiltCliJson(args, context.env);
+  recordStep(context, step, args, result);
+  maybeCaptureSnapshot(context, args, result);
+  if (result.status !== expectedStatus) failWithContext(context, step, args, result);
+  return result;
+}
+
+async function cleanupWebSmoke(context: WebSmokeContext, opened: boolean): Promise<void> {
+  if (opened) {
+    await runStep(context, 'close web session', ['close', ...context.common], 0);
+  }
+  await closeServer(context.server);
+  rmSync(context.socketDir, { recursive: true, force: true });
+}
+
+function recordStep(
+  context: WebSmokeContext,
+  step: string,
+  args: string[],
+  result: CliJsonResult,
+): void {
+  const errorCode =
+    typeof result.json?.error?.code === 'string' ? result.json.error.code : undefined;
+  const errorMessage =
+    typeof result.json?.error?.message === 'string' ? result.json.error.message : undefined;
+  context.stepHistory.push({
+    step,
+    command: `agent-device ${args.join(' ')}`,
+    status: result.status,
+    timestamp: new Date().toISOString(),
+    errorCode,
+    errorMessage,
+  });
+}
+
+function maybeCaptureSnapshot(
+  context: WebSmokeContext,
+  args: string[],
+  result: CliJsonResult,
+): void {
+  if (args[0] !== 'snapshot' || result.status !== 0) return;
+  if (!Array.isArray(result.json?.data?.nodes)) return;
+  context.lastSnapshot = result.json;
+}
+
+function failWithContext(
+  context: WebSmokeContext,
+  step: string,
+  args: string[],
+  result: CliJsonResult,
+  assertionDetail?: string,
+): never {
+  const message = buildFailureDebug(context, step, args, result, assertionDetail);
+  writeFailureArtifacts(context, step, args, result, message, assertionDetail);
+  assert.fail(message);
+}
+
+function buildFailureDebug(
+  context: WebSmokeContext,
+  step: string,
+  args: string[],
+  result: CliJsonResult,
+  assertionDetail?: string,
+): string {
+  const lines = [formatResultDebug(step, args, result)];
+  if (assertionDetail) lines.push('assertion:', assertionDetail);
+  lines.push('last snapshot context:', formatLastSnapshotContext(context));
+  lines.push('recent step history:', formatStepHistory(context));
+  lines.push('artifacts:', context.artifactDir);
+  return lines.join('\n');
+}
+
+function writeFailureArtifacts(
+  context: WebSmokeContext,
+  step: string,
+  args: string[],
+  result: CliJsonResult,
+  message: string,
+  assertionDetail?: string,
+): void {
+  writeFileSync(path.join(context.artifactDir, 'failed-step.txt'), message);
+  writeFileSync(
+    path.join(context.artifactDir, 'failed-step.json'),
+    JSON.stringify(
+      { step, command: `agent-device ${args.join(' ')}`, assertionDetail, result },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    path.join(context.artifactDir, 'step-history.json'),
+    JSON.stringify(context.stepHistory, null, 2),
+  );
+  if (context.lastSnapshot) {
+    writeFileSync(
+      path.join(context.artifactDir, 'last-snapshot.json'),
+      JSON.stringify(context.lastSnapshot, null, 2),
+    );
+  }
+}
+
+function formatLastSnapshotContext(context: WebSmokeContext): string {
+  const nodes = context.lastSnapshot?.data?.nodes;
+  if (!Array.isArray(nodes)) return '(none)';
+  const preview = nodes
+    .slice(0, 12)
+    .map((node: { ref?: unknown; type?: unknown; label?: unknown; rect?: unknown }, i: number) => {
+      const rect = node.rect ? JSON.stringify(node.rect) : '(no-bounds)';
+      return `${i + 1}. ${String(node.ref ?? '(no-ref)')} type=${String(node.type ?? '(no-type)')} label=${JSON.stringify(node.label ?? '')} rect=${rect}`;
+    });
+  return [`nodes: ${nodes.length}`, 'nodePreview:', preview.join('\n')].join('\n');
+}
+
+function formatStepHistory(context: WebSmokeContext): string {
+  return context.stepHistory
+    .slice(-8)
+    .map((stepRecord) => {
+      const error =
+        stepRecord.errorCode || stepRecord.errorMessage
+          ? ` error=${stepRecord.errorCode ?? ''}${stepRecord.errorMessage ? `:${stepRecord.errorMessage}` : ''}`
+          : '';
+      return `${stepRecord.timestamp} status=${stepRecord.status}${error} ${stepRecord.step} :: ${stepRecord.command}`;
+    })
+    .join('\n');
+}
+
+async function startFixtureServer(): Promise<{ server: Server; url: string }> {
+  const server = createServer((request, response) => {
+    if (request.url !== '/') {
+      response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+      response.end('not found');
+      return;
+    }
+
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(fixtureHtml());
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  assert.ok(address && typeof address === 'object', 'fixture server did not bind to a port');
+  return { server, url: `http://127.0.0.1:${address.port}/` };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function readSnapshotLabels(json: any): string[] {
+  const nodes = Array.isArray(json?.data?.nodes) ? json.data.nodes : [];
+  return nodes.flatMap((node: { label?: unknown }) =>
+    typeof node.label === 'string' && node.label.length > 0 ? [node.label] : [],
+  );
+}
+
+function createArtifactDir(): string {
+  const runId = new Date().toISOString().replaceAll(':', '-');
+  const artifactDir = path.resolve('test/artifacts/web/live-web-platform-e2e-smoke', runId);
+  mkdirSync(artifactDir, { recursive: true });
+  return artifactDir;
+}
+
+function fixtureHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Agent Device Web Smoke</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 32px;
+      }
+      main {
+        max-width: 420px;
+      }
+      label,
+      button,
+      input {
+        display: block;
+        font: inherit;
+        margin-block: 12px;
+      }
+      input,
+      button {
+        min-height: 40px;
+        min-width: 220px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Agent Device Web Smoke</h1>
+      <button id="ready" type="button">Ready marker</button>
+      <label for="email">Email</label>
+      <input id="email" name="email" aria-label="Email" autocomplete="off" />
+      <button id="submit" type="button">Submit order</button>
+      <p id="status" role="status" aria-live="polite">Idle</p>
+    </main>
+    <script>
+      const email = document.querySelector('#email');
+      const status = document.querySelector('#status');
+      const submit = document.querySelector('#submit');
+      submit.addEventListener('click', () => {
+        submit.textContent = 'Submitted';
+        status.textContent = 'Clicked submit';
+      });
+      email.addEventListener('input', () => {
+        email.setAttribute('aria-label', 'Email ' + email.value);
+        status.textContent = 'Email: ' + email.value;
+      });
+    </script>
+  </body>
+</html>`;
+}

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -188,11 +188,30 @@ async function runStep(
 }
 
 async function cleanupWebSmoke(context: WebSmokeContext, opened: boolean): Promise<void> {
+  const errors: unknown[] = [];
   if (opened) {
-    await runStep(context, 'close web session', ['close', ...context.common], 0);
+    try {
+      await runStep(context, 'close web session', ['close', ...context.common], 0);
+    } catch (error) {
+      errors.push(error);
+    }
   }
-  await closeServer(context.server);
-  rmSync(context.socketDir, { recursive: true, force: true });
+  try {
+    await closeServer(context.server);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    rmSync(context.socketDir, { recursive: true, force: true });
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'web smoke cleanup failed');
+  }
 }
 
 function recordStep(

--- a/test/integration/test-helpers.ts
+++ b/test/integration/test-helpers.ts
@@ -3,16 +3,11 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { PNG } from '../../src/utils/png.ts';
 import { runCmdSync } from '../../src/utils/exec.ts';
+import { type CliJsonResult, formatResultDebug, runSourceCliJsonSync } from './cli-json.ts';
 
-const CLI_TIMEOUT_MS = 120_000;
 const RECORDING_INSPECT_TIMEOUT_MS = 60_000;
 
-export type CliJsonResult = {
-  status: number;
-  json?: any;
-  stdout: string;
-  stderr: string;
-};
+export type { CliJsonResult } from './cli-json.ts';
 
 type IntegrationPlatform = 'ios' | 'android' | 'macos';
 
@@ -66,43 +61,7 @@ export type OverlayCropAnalysis = {
 };
 
 export function runCliJson(args: string[], options?: { env?: NodeJS.ProcessEnv }): CliJsonResult {
-  const result = runCmdSync(
-    process.execPath,
-    ['--experimental-strip-types', 'src/bin.ts', ...args],
-    {
-      allowFailure: true,
-      env: options?.env,
-      timeoutMs: CLI_TIMEOUT_MS,
-    },
-  );
-  let json: any;
-  try {
-    json = JSON.parse(result.stdout ?? '');
-  } catch {
-    json = undefined;
-  }
-  return {
-    status: result.exitCode,
-    json,
-    stdout: json ? '<JSON output>' : (result.stdout ?? ''),
-    stderr: result.stderr ?? '',
-  };
-}
-
-function formatResultDebug(step: string, args: string[], result: CliJsonResult): string {
-  const jsonText =
-    result.json === undefined ? '(unparseable)' : JSON.stringify(result.json, null, 2);
-  return [
-    `step: ${step}`,
-    `command: agent-device ${args.join(' ')}`,
-    `status: ${result.status}`,
-    `stderr:`,
-    result.stderr || '(empty)',
-    `stdout:`,
-    result.stdout || '(empty)',
-    `json:`,
-    jsonText,
-  ].join('\n');
+  return runSourceCliJsonSync(args, options);
 }
 
 export function createIntegrationTestContext(options: IntegrationTestContextOptions) {


### PR DESCRIPTION
## Summary

Add a gated live web platform smoke that runs on Node 24.13 in CI and exercises the public managed-backend path: web setup, web doctor, open, snapshot, get, is, wait, click, fill, screenshot, and close against a local fixture.

Closes #830

Touched files: 7. Scope stays in CI, maintainer testing docs, and integration-test utilities.

## Validation

pnpm check:tooling
AGENT_DEVICE_WEB_E2E=1 pnpm test:smoke:web
pnpm check:quick
