### PR TITLE
feat: manage web backend setup

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: 'Node.js version'
     required: false
-    default: '22.19'
+    default: '24.13'
   pnpm-version:
     description: 'pnpm version'
     required: false

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "22"
+          node-version: '24.13'
 
       - name: Resolve release metadata
         id: meta

--- a/.github/workflows/release-android-snapshot-helper.yml
+++ b/.github/workflows/release-android-snapshot-helper.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "22"
+          node-version: '24.13'
 
       - name: Install Android SDK packages
         run: |

--- a/.github/workflows/release-ios-runner.yml
+++ b/.github/workflows/release-ios-runner.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       AGENT_DEVICE_XCUITEST_PLATFORM: ios
       AGENT_DEVICE_XCUITEST_DESTINATION: generic/platform=iOS Simulator
-      AGENT_DEVICE_IOS_CLEAN_DERIVED: "1"
+      AGENT_DEVICE_IOS_CLEAN_DERIVED: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "22"
+          node-version: '24.13'
 
       - name: Resolve release metadata
         id: meta

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -7,5 +7,6 @@ Before architecture, diagnosis, TDD, triage, PRD, or roadmap work, read:
 - `CONTEXT.md` for domain vocabulary, test strategy terms, and architecture language.
 - Relevant ADRs in `docs/adr/` for accepted architecture decisions.
 - This `docs/agents/` directory for issue-tracker and triage-label conventions.
+- `docs/agents/web-backend.md` before changing web automation backend setup or diagnostics.
 
 Use the vocabulary from `CONTEXT.md` in issue titles, refactor proposals, test names, and architecture notes. If a proposed change contradicts an ADR, call that out explicitly and explain why the decision should be reopened.

--- a/docs/agents/web-backend.md
+++ b/docs/agents/web-backend.md
@@ -1,0 +1,23 @@
+# Web Backend
+
+Web automation uses a managed `agent-browser` backend as an implementation detail.
+
+- Runtime web commands resolve the backend only from the state-dir managed install at `tools/agent-browser/<version>`.
+- Normal `--platform web` commands do not install the managed backend on first use. If the backend is missing, they fail with a setup hint.
+- Use `agent-device web setup` before first web automation and in CI/sandbox bootstrap steps.
+- Use `agent-device web doctor` to run the backend health check.
+- The managed install respects `--state-dir` / `AGENT_DEVICE_STATE_DIR`.
+- Web automation requires Node 24+ while the rest of agent-device keeps its Node 22 baseline.
+
+Default first-run flow:
+
+```sh
+agent-device web setup
+agent-device open "https://example.com" --platform web
+agent-device snapshot -i --platform web
+agent-device close --platform web
+```
+
+Do not document direct `agent-browser` commands as agent-device features. Browser-specific network,
+CDP, React web, tabs, downloads, auth vaults, and profiling stay out of the minimal web surface until
+there is an explicit agent-device command design for them.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import {
 import { materializeRemoteConnectionForCommand } from './cli/commands/connection-runtime.ts';
 import { tryRunClientBackedCommand } from './cli/commands/router.ts';
 import { runReactDevtoolsCommand } from './cli/commands/react-devtools.ts';
+import { runWebCommand } from './cli/commands/web.ts';
 import { readCliBatchStepsJson } from './cli/batch-steps.ts';
 import {
   createRequestId,
@@ -201,6 +202,14 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
             session: effectiveFlags.session ?? sessionName,
             cwd: process.cwd(),
             env: process.env,
+          });
+          process.exit(exitCode);
+          return;
+        }
+        if (command === 'web') {
+          const exitCode = await runWebCommand(positionals, {
+            flags: effectiveFlags,
+            stateDir: daemonPaths.baseDir,
           });
           process.exit(exitCode);
           return;

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -1,0 +1,44 @@
+import {
+  doctorManagedAgentBrowser,
+  setupManagedAgentBrowser,
+} from '../../platforms/web/agent-browser-tool.ts';
+import { AppError } from '../../utils/errors.ts';
+import type { CliFlags } from '../../utils/cli-flags.ts';
+import { printJson } from '../../utils/output.ts';
+
+export async function runWebCommand(
+  positionals: string[],
+  options: { flags: CliFlags; stateDir: string },
+): Promise<number> {
+  const action = positionals[0];
+  switch (action) {
+    case 'setup': {
+      const status = await setupManagedAgentBrowser({
+        stateDir: options.stateDir,
+      });
+      printWebResult(options.flags.json, 'Managed web backend installed.', { status });
+      return 0;
+    }
+    case 'doctor': {
+      const result = await doctorManagedAgentBrowser({
+        stateDir: options.stateDir,
+      });
+      printWebResult(
+        options.flags.json,
+        result.exitCode === 0 ? 'Web backend is healthy.' : 'Web backend doctor reported issues.',
+        result,
+      );
+      return result.exitCode;
+    }
+    default:
+      throw new AppError('INVALID_ARGS', 'web requires setup or doctor');
+  }
+}
+
+function printWebResult(json: boolean | undefined, message: string, data: Record<string, unknown>) {
+  if (json) {
+    printJson({ success: true, data });
+    return;
+  }
+  process.stdout.write(`${message}\n`);
+}

--- a/src/command-catalog.ts
+++ b/src/command-catalog.ts
@@ -67,6 +67,7 @@ const LOCAL_CLI_COMMANDS = {
   metro: 'metro',
   reactDevtools: 'react-devtools',
   session: 'session',
+  web: 'web',
 } as const;
 
 export const GESTURE_KINDS = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'transform'] as const;
@@ -89,6 +90,7 @@ const MCP_UNEXPOSED_CLI_COMMANDS = commandSet(
   LOCAL_CLI_COMMANDS.disconnect,
   LOCAL_CLI_COMMANDS.mcp,
   LOCAL_CLI_COMMANDS.reactDevtools,
+  LOCAL_CLI_COMMANDS.web,
   PUBLIC_COMMANDS.prepare,
 );
 
@@ -102,6 +104,7 @@ const CAPABILITY_EXEMPT_CLI_COMMANDS = commandSet(
   LOCAL_CLI_COMMANDS.metro,
   LOCAL_CLI_COMMANDS.reactDevtools,
   LOCAL_CLI_COMMANDS.session,
+  LOCAL_CLI_COMMANDS.web,
   PUBLIC_COMMANDS.appState,
   PUBLIC_COMMANDS.prepare,
   PUBLIC_COMMANDS.batch,

--- a/src/daemon-runtime.ts
+++ b/src/daemon-runtime.ts
@@ -83,6 +83,7 @@ export async function startDaemonRuntime(
 
   const handleRequest = createRequestHandler({
     logPath,
+    stateDir: baseDir,
     token,
     sessionStore,
     leaseRegistry,

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -41,6 +41,7 @@ import { createAgentBrowserWebProvider } from '../platforms/web/agent-browser-pr
 
 export type RequestRouterDeps = {
   logPath: string;
+  stateDir?: string;
   token: string;
   sessionStore: SessionStore;
   leaseRegistry: LeaseRegistry;
@@ -62,6 +63,7 @@ export type RequestRouterDeps = {
 export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
   const {
     logPath,
+    stateDir,
     token,
     androidAdbProvider,
     appleRunnerProvider,
@@ -138,7 +140,9 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
                 linuxToolProvider,
                 webProvider:
                   webProvider ??
-                  (shouldUseDefaultWebProvider(lockedScope) ? createDefaultWebProvider : undefined),
+                  (shouldUseDefaultWebProvider(lockedScope)
+                    ? createDefaultWebProvider(stateDir)
+                    : undefined),
                 appLogProvider,
                 recordingProvider,
               },
@@ -202,8 +206,10 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
   return handleRequest;
 }
 
-const createDefaultWebProvider: WebProviderResolver = ({ req, session }) =>
-  createAgentBrowserWebProvider({ session: session?.name ?? req.session });
+const createDefaultWebProvider =
+  (stateDir: string | undefined): WebProviderResolver =>
+  ({ req, session }) =>
+    createAgentBrowserWebProvider({ session: session?.name ?? req.session, stateDir });
 
 function shouldUseDefaultWebProvider(scope: LockedRequestScope): boolean {
   return scope.existingSession?.device.platform === 'web' || scope.req.flags?.platform === 'web';

--- a/src/platforms/web/__tests__/test-utils.ts
+++ b/src/platforms/web/__tests__/test-utils.ts
@@ -1,0 +1,41 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const TEST_AGENT_BROWSER_VERSION = '0.27.1';
+
+type FakeManagedAgentBrowserInstall = ReturnType<typeof expectedManagedAgentBrowserInstall>;
+
+export function installFakeManagedAgentBrowser(stateDir: string): FakeManagedAgentBrowserInstall {
+  const install = expectedManagedAgentBrowserInstall(stateDir);
+  fs.mkdirSync(path.dirname(install.binaryPath), { recursive: true });
+  fs.writeFileSync(install.binaryPath, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(install.binaryPath, 0o755);
+  fs.writeFileSync(path.join(install.installDir, 'manifest.json'), '{}');
+  return install;
+}
+
+function expectedManagedAgentBrowserInstall(stateDir: string) {
+  const installDir = path.join(stateDir, 'tools', 'agent-browser', TEST_AGENT_BROWSER_VERSION);
+  return {
+    version: TEST_AGENT_BROWSER_VERSION,
+    installDir,
+    binaryPath: path.join(
+      installDir,
+      'package',
+      'node_modules',
+      '.bin',
+      process.platform === 'win32' ? 'agent-browser.cmd' : 'agent-browser',
+    ),
+    homeDir: path.join(installDir, 'home'),
+    runtimeHomeDir:
+      process.platform === 'win32'
+        ? path.join(installDir, 'home')
+        : path.join(os.tmpdir(), 'agent-device-web', sha1Short(installDir)),
+  };
+}
+
+function sha1Short(value: string): string {
+  return crypto.createHash('sha1').update(value).digest('hex').slice(0, 12);
+}

--- a/src/platforms/web/agent-browser-provider.test.ts
+++ b/src/platforms/web/agent-browser-provider.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { test } from 'vitest';
 import { createAgentBrowserWebProvider } from './agent-browser-provider.ts';
 import type { WebSnapshotResult } from './provider.ts';
@@ -10,6 +13,7 @@ import {
   resolveSelectorChain,
 } from '../../daemon/selectors.ts';
 import { attachRefs } from '../../utils/snapshot.ts';
+import { installFakeManagedAgentBrowser } from './__tests__/test-utils.ts';
 
 type AgentBrowserCall = {
   cmd: string;
@@ -17,122 +21,138 @@ type AgentBrowserCall = {
 };
 
 test('agent-browser provider maps supported operations to session-scoped JSON commands', async () => {
-  const calls: AgentBrowserCall[] = [];
-  const provider = createAgentBrowserWebProvider({ session: 'web-session' });
+  await withManagedAgentBrowserProvider({ session: 'web-session' }, async (provider) => {
+    const calls: AgentBrowserCall[] = [];
 
-  await withCommandExecutorOverride(recordingExecutor(calls), async () => {
-    await provider.open('https://example.test');
-    await provider.screenshot('/tmp/page.png', { fullscreen: true });
-    await provider.click(10.4, 20.6);
-    await provider.fill(11, 22, 'Ada');
-    await provider.typeText('hello');
-    await provider.scroll('down', { pixels: 400 });
-    await provider.close();
+    await withCommandExecutorOverride(recordingExecutor(calls), async () => {
+      await provider.open('https://example.test');
+      await provider.screenshot('/tmp/page.png', { fullscreen: true });
+      await provider.click(10.4, 20.6);
+      await provider.fill(11, 22, 'Ada');
+      await provider.typeText('hello');
+      await provider.scroll('down', { pixels: 400 });
+      await provider.close();
+    });
+
+    assert.deepEqual(
+      calls.map((call) => call.args),
+      [
+        ['open', 'https://example.test', '--json', '--session', 'web-session'],
+        ['screenshot', '--full', '/tmp/page.png', '--json', '--session', 'web-session'],
+        ['mouse', 'move', '10', '21', '--json', '--session', 'web-session'],
+        ['mouse', 'down', '--json', '--session', 'web-session'],
+        ['mouse', 'up', '--json', '--session', 'web-session'],
+        ['mouse', 'move', '11', '22', '--json', '--session', 'web-session'],
+        ['mouse', 'down', '--json', '--session', 'web-session'],
+        ['mouse', 'up', '--json', '--session', 'web-session'],
+        ['press', expectedSelectAllShortcut(), '--json', '--session', 'web-session'],
+        ['keyboard', 'type', 'Ada', '--json', '--session', 'web-session'],
+        ['keyboard', 'type', 'hello', '--json', '--session', 'web-session'],
+        ['scroll', 'down', '400', '--json', '--session', 'web-session'],
+        ['close', '--json', '--session', 'web-session'],
+      ],
+    );
   });
-
-  assert.deepEqual(
-    calls.map((call) => call.args),
-    [
-      ['open', 'https://example.test', '--json', '--session', 'web-session'],
-      ['screenshot', '--full', '/tmp/page.png', '--json', '--session', 'web-session'],
-      ['mouse', 'move', '10', '21', '--json', '--session', 'web-session'],
-      ['mouse', 'down', '--json', '--session', 'web-session'],
-      ['mouse', 'up', '--json', '--session', 'web-session'],
-      ['mouse', 'move', '11', '22', '--json', '--session', 'web-session'],
-      ['mouse', 'down', '--json', '--session', 'web-session'],
-      ['mouse', 'up', '--json', '--session', 'web-session'],
-      ['press', expectedSelectAllShortcut(), '--json', '--session', 'web-session'],
-      ['keyboard', 'type', 'Ada', '--json', '--session', 'web-session'],
-      ['keyboard', 'type', 'hello', '--json', '--session', 'web-session'],
-      ['scroll', 'down', '400', '--json', '--session', 'web-session'],
-      ['close', '--json', '--session', 'web-session'],
-    ],
-  );
 });
 
 test('agent-browser provider normalizes snapshot refs, labels, values, parents, and rects', async () => {
-  const calls: AgentBrowserCall[] = [];
-  const provider = createAgentBrowserWebProvider({ session: 'web-session' });
+  await withManagedAgentBrowserProvider({ session: 'web-session' }, async (provider) => {
+    const calls: AgentBrowserCall[] = [];
+    const snapshot = await withCommandExecutorOverride(
+      snapshotExecutor(calls),
+      async () => await provider.snapshot({ interactiveOnly: true, depth: 4, scope: '#main' }),
+    );
 
-  const snapshot = await withCommandExecutorOverride(
-    snapshotExecutor(calls),
-    async () => await provider.snapshot({ interactiveOnly: true, depth: 4, scope: '#main' }),
-  );
-
-  assert.deepEqual(calls[0]?.args, [
-    'snapshot',
-    '--interactive',
-    '--compact',
-    '--depth',
-    '4',
-    '--selector',
-    '#main',
-    '--json',
-    '--session',
-    'web-session',
-  ]);
-  assertNormalizedSnapshot(snapshot);
-  assertRoleSelectorResolves(snapshot);
+    assert.deepEqual(calls[0]?.args, [
+      'snapshot',
+      '--interactive',
+      '--compact',
+      '--depth',
+      '4',
+      '--selector',
+      '#main',
+      '--json',
+      '--session',
+      'web-session',
+    ]);
+    assertNormalizedSnapshot(snapshot);
+    assertRoleSelectorResolves(snapshot);
+  });
 });
 
 test('agent-browser provider surfaces stale ref failures during snapshot geometry lookup', async () => {
-  const provider = createAgentBrowserWebProvider({ session: 'web-session' });
-
-  await assert.rejects(
-    () =>
-      withCommandExecutorOverride(
-        async (_cmd, args) => {
-          if (args[0] === 'snapshot') {
-            return jsonResult({
-              success: true,
-              data: {
-                refs: { e1: { role: 'button', name: 'Save' } },
-                snapshot: 'button "Save" [ref=e1]',
-              },
-            });
-          }
-          return jsonResult({ success: false, error: 'Stale ref @e1' });
-        },
-        async () => await provider.snapshot(),
-      ),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'COMMAND_FAILED' &&
-      error.message === 'Stale ref @e1',
-  );
+  await withManagedAgentBrowserProvider({ session: 'web-session' }, async (provider) => {
+    await assert.rejects(
+      () =>
+        withCommandExecutorOverride(
+          async (_cmd, args) => {
+            if (args[0] === 'snapshot') {
+              return jsonResult({
+                success: true,
+                data: {
+                  refs: { e1: { role: 'button', name: 'Save' } },
+                  snapshot: 'button "Save" [ref=e1]',
+                },
+              });
+            }
+            return jsonResult({ success: false, error: 'Stale ref @e1' });
+          },
+          async () => await provider.snapshot(),
+        ),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'COMMAND_FAILED' &&
+        error.message === 'Stale ref @e1',
+    );
+  });
 });
 
 test('agent-browser provider adds doctor guidance for missing binary and invalid JSON', async () => {
-  const provider = createAgentBrowserWebProvider();
-
-  await assert.rejects(
-    () =>
-      withCommandExecutorOverride(
-        async () => {
-          throw new AppError('TOOL_MISSING', 'agent-browser not found');
-        },
-        async () => await provider.open('https://example.test'),
-      ),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'TOOL_MISSING' &&
-      error.details?.hint ===
-        'Install agent-browser and run `agent-browser doctor --offline --quick` to verify the local browser setup.',
+  const missingStateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-web-provider-missing-'),
   );
+  try {
+    const provider = createAgentBrowserWebProvider({ stateDir: missingStateDir });
+    await assert.rejects(
+      async () => await provider.open('https://example.test'),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'TOOL_MISSING' &&
+        error.details?.hint === 'Run `agent-device web setup` to install the managed web backend.',
+    );
+  } finally {
+    fs.rmSync(missingStateDir, { recursive: true, force: true });
+  }
 
-  await assert.rejects(
-    () =>
-      withCommandExecutorOverride(
-        async () => ({ stdout: 'not-json', stderr: '', exitCode: 0 }),
-        async () => await provider.open('https://example.test'),
-      ),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'COMMAND_FAILED' &&
-      error.message === 'agent-browser returned invalid JSON' &&
-      typeof error.details?.hint === 'string',
-  );
+  await withManagedAgentBrowserProvider({}, async (installedProvider) => {
+    await assert.rejects(
+      () =>
+        withCommandExecutorOverride(
+          async () => ({ stdout: 'not-json', stderr: '', exitCode: 0 }),
+          async () => await installedProvider.open('https://example.test'),
+        ),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'COMMAND_FAILED' &&
+        error.message === 'agent-browser returned invalid JSON' &&
+        typeof error.details?.hint === 'string',
+    );
+  });
 });
+
+async function withManagedAgentBrowserProvider(
+  options: { session?: string },
+  testFn: (provider: ReturnType<typeof createAgentBrowserWebProvider>) => void | Promise<void>,
+): Promise<void> {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-web-provider-'));
+  try {
+    installFakeManagedAgentBrowser(stateDir);
+    const provider = createAgentBrowserWebProvider({ ...options, stateDir });
+    await testFn(provider);
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}
 
 function recordingExecutor(calls: AgentBrowserCall[]) {
   return async (cmd: string, args: string[]): Promise<ExecResult> => {

--- a/src/platforms/web/agent-browser-provider.ts
+++ b/src/platforms/web/agent-browser-provider.ts
@@ -1,5 +1,5 @@
 import { runCmd } from '../../utils/exec.ts';
-import { AppError, asAppError } from '../../utils/errors.ts';
+import { AppError } from '../../utils/errors.ts';
 import type { Rect } from '../../utils/snapshot.ts';
 import { normalizeAgentBrowserSnapshot } from './agent-browser-snapshot.ts';
 import {
@@ -9,14 +9,16 @@ import {
   type JsonObject,
 } from './json-utils.ts';
 import type { WebProvider, WebSnapshotOptions, WebSnapshotResult } from './provider.ts';
+import { mapManagedAgentBrowserError, resolveAgentBrowserTool } from './agent-browser-tool.ts';
 
 const AGENT_BROWSER = 'agent-browser';
 const AGENT_BROWSER_TIMEOUT_MS = 30_000;
 const AGENT_BROWSER_DOCTOR_HINT =
-  'Install agent-browser and run `agent-browser doctor --offline --quick` to verify the local browser setup.';
+  'Run `agent-device web setup` to install the managed web backend.';
 
 type AgentBrowserProviderOptions = {
   session?: string;
+  stateDir?: string;
 };
 
 export function createAgentBrowserWebProvider(
@@ -24,7 +26,7 @@ export function createAgentBrowserWebProvider(
 ): WebProvider {
   const session = options.session?.trim();
   const runJson = async (args: string[]): Promise<unknown> =>
-    await runAgentBrowserJson(args, session);
+    await runAgentBrowserJson(args, { session, options });
 
   return {
     async open(target) {
@@ -104,14 +106,21 @@ function isIgnorableBoxError(error: unknown): boolean {
   return !/\bstale\b/i.test(message) && /\bbox\b|not visible|not found|no element/i.test(message);
 }
 
-async function runAgentBrowserJson(args: string[], session: string | undefined): Promise<unknown> {
+async function runAgentBrowserJson(
+  args: string[],
+  params: { session: string | undefined; options: AgentBrowserProviderOptions },
+): Promise<unknown> {
+  const { session, options } = params;
   const cliArgs = [...args, '--json', ...(session ? ['--session', session] : [])];
-  const result = await runAgentBrowserCommand(cliArgs);
+  const result = await runAgentBrowserCommand(cliArgs, options);
   const parsed = parseAgentBrowserJson(result.stdout, result.stderr, cliArgs, result.exitCode);
   return unwrapAgentBrowserJson(parsed, result, cliArgs);
 }
 
-async function runAgentBrowserCommand(cliArgs: string[]): Promise<{
+async function runAgentBrowserCommand(
+  cliArgs: string[],
+  options: AgentBrowserProviderOptions,
+): Promise<{
   stdout: string;
   stderr: string;
   exitCode: number;
@@ -120,8 +129,10 @@ async function runAgentBrowserCommand(cliArgs: string[]): Promise<{
   let stderr = '';
   let exitCode = 0;
   try {
-    const result = await runCmd(AGENT_BROWSER, cliArgs, {
+    const tool = await resolveAgentBrowserTool({ stateDir: options.stateDir });
+    const result = await runCmd(tool.command, cliArgs, {
       allowFailure: true,
+      env: tool.env,
       timeoutMs: AGENT_BROWSER_TIMEOUT_MS,
     });
     stdout = result.stdout;
@@ -191,11 +202,11 @@ function parseAgentBrowserJson(
 }
 
 function mapAgentBrowserRunError(error: unknown, args: string[]): AppError {
-  const appError = asAppError(error);
+  const appError = mapManagedAgentBrowserError(error);
   if (appError.code === 'TOOL_MISSING') {
     return new AppError(
       'TOOL_MISSING',
-      'agent-browser not found in PATH',
+      appError.message,
       { cmd: AGENT_BROWSER, args, hint: AGENT_BROWSER_DOCTOR_HINT },
       appError,
     );

--- a/src/platforms/web/agent-browser-tool.test.ts
+++ b/src/platforms/web/agent-browser-tool.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'vitest';
+import { resolveAgentBrowserTool } from './agent-browser-tool.ts';
+import { installFakeManagedAgentBrowser } from './__tests__/test-utils.ts';
+import { AppError } from '../../utils/errors.ts';
+
+test('managed agent-browser tool reports actionable guidance when install is missing', async () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-web-tool-'));
+  try {
+    await assert.rejects(
+      () => resolveAgentBrowserTool({ stateDir }),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'TOOL_MISSING' &&
+        error.details?.installDir === path.join(stateDir, 'tools', 'agent-browser', '0.27.1') &&
+        error.details?.hint === expectedMissingInstallHint(),
+    );
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('managed agent-browser tool uses short runtime home for backend state', async () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-web-tool-'));
+  try {
+    const status = installFakeManagedAgentBrowser(stateDir);
+
+    const tool = await resolveAgentBrowserTool({ stateDir });
+
+    assert.equal(tool.command, status.binaryPath);
+    assert.equal(tool.env?.HOME, status.runtimeHomeDir);
+    assert.notEqual(status.runtimeHomeDir, status.homeDir);
+    assert.ok(fs.existsSync(status.runtimeHomeDir));
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+function expectedMissingInstallHint(): string {
+  const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
+  if (nodeMajor < 24) {
+    return `Web automation requires Node 24+; current Node is ${process.version}.`;
+  }
+  return 'Run `agent-device web setup` to install the managed web backend.';
+}

--- a/src/platforms/web/agent-browser-tool.ts
+++ b/src/platforms/web/agent-browser-tool.ts
@@ -1,0 +1,264 @@
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { runCmd } from '../../utils/exec.ts';
+import { AppError, asAppError } from '../../utils/errors.ts';
+import { acquireProcessLock } from '../../utils/process-lock.ts';
+import { readProcessStartTime } from '../../utils/process-identity.ts';
+
+const MANAGED_AGENT_BROWSER_VERSION = '0.27.1';
+
+const AGENT_BROWSER = 'agent-browser';
+const MINIMUM_WEB_NODE_MAJOR = 24;
+const SETUP_TIMEOUT_MS = 5 * 60_000;
+const DOCTOR_TIMEOUT_MS = 60_000;
+
+export type AgentBrowserTool = {
+  command: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type AgentBrowserToolStatus = {
+  version: string;
+  stateDir: string;
+  installDir: string;
+  binaryPath: string;
+  homeDir: string;
+  runtimeHomeDir: string;
+  installed: boolean;
+  nodeMajor: number;
+  nodeSupported: boolean;
+};
+
+export async function resolveAgentBrowserTool(options: {
+  stateDir?: string;
+}): Promise<AgentBrowserTool> {
+  const status = getManagedAgentBrowserStatus(options);
+  if (status.installed) {
+    return createManagedTool(status);
+  }
+
+  throw missingManagedToolError(status);
+}
+
+export async function setupManagedAgentBrowser(options: {
+  stateDir?: string;
+}): Promise<AgentBrowserToolStatus> {
+  const status = getManagedAgentBrowserStatus(options);
+  assertWebNodeSupported(status.nodeMajor);
+
+  const release = await acquireProcessLock({
+    lockDirPath: path.join(status.installDir, '..', '.agent-browser-install.lock'),
+    owner: {
+      pid: process.pid,
+      startTime: readProcessStartTime(process.pid),
+      acquiredAtMs: Date.now(),
+    },
+    timeoutMs: SETUP_TIMEOUT_MS,
+    description: 'managed agent-browser setup',
+  });
+  try {
+    const freshStatus = getManagedAgentBrowserStatus(options);
+    if (freshStatus.installed) return freshStatus;
+    fs.mkdirSync(freshStatus.installDir, { recursive: true });
+    await installAgentBrowserPackage(freshStatus);
+    await runManagedAgentBrowser(freshStatus, ['install'], { timeoutMs: SETUP_TIMEOUT_MS });
+    await runManagedAgentBrowser(freshStatus, ['doctor', '--offline', '--quick'], {
+      timeoutMs: DOCTOR_TIMEOUT_MS,
+    });
+    writeManifest(freshStatus);
+    return getManagedAgentBrowserStatus(options);
+  } finally {
+    await release();
+  }
+}
+
+export async function doctorManagedAgentBrowser(options: {
+  stateDir?: string;
+}): Promise<{ status: AgentBrowserToolStatus; stdout: string; stderr: string; exitCode: number }> {
+  const status = getManagedAgentBrowserStatus(options);
+  if (!status.installed) {
+    throw missingManagedToolError(status);
+  }
+  const result = await runManagedAgentBrowser(status, ['doctor', '--offline', '--quick'], {
+    timeoutMs: DOCTOR_TIMEOUT_MS,
+    allowFailure: true,
+  });
+  return { status, ...result };
+}
+
+function getManagedAgentBrowserStatus(options: { stateDir?: string }): AgentBrowserToolStatus {
+  const stateDir = options.stateDir ?? process.env.AGENT_DEVICE_STATE_DIR ?? defaultStateDir();
+  const installDir = path.join(stateDir, 'tools', 'agent-browser', MANAGED_AGENT_BROWSER_VERSION);
+  const binaryPath = resolveManagedBinaryPath(installDir);
+  const homeDir = path.join(installDir, 'home');
+  const runtimeHomeDir = resolveManagedRuntimeHomeDir(installDir);
+  const installed = isExecutable(binaryPath) && hasManifest(installDir);
+  const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
+  return {
+    version: MANAGED_AGENT_BROWSER_VERSION,
+    stateDir,
+    installDir,
+    binaryPath,
+    homeDir,
+    runtimeHomeDir,
+    installed,
+    nodeMajor,
+    nodeSupported: nodeMajor >= MINIMUM_WEB_NODE_MAJOR,
+  };
+}
+
+function createManagedTool(status: AgentBrowserToolStatus): AgentBrowserTool {
+  if (!status.installed) throw missingManagedToolError(status);
+  return {
+    command: status.binaryPath,
+    env: managedAgentBrowserEnv(status, process.env),
+  };
+}
+
+async function installAgentBrowserPackage(status: AgentBrowserToolStatus): Promise<void> {
+  const packageRoot = path.join(status.installDir, 'package');
+  fs.mkdirSync(packageRoot, { recursive: true });
+  await runCmd(
+    'npm',
+    [
+      'install',
+      '--prefix',
+      packageRoot,
+      '--no-audit',
+      '--no-fund',
+      '--no-save',
+      `${AGENT_BROWSER}@${MANAGED_AGENT_BROWSER_VERSION}`,
+    ],
+    { env: process.env, timeoutMs: SETUP_TIMEOUT_MS },
+  );
+}
+
+async function runManagedAgentBrowser(
+  status: AgentBrowserToolStatus,
+  args: string[],
+  options: { timeoutMs: number; allowFailure?: boolean },
+) {
+  return await runCmd(status.binaryPath, args, {
+    allowFailure: options.allowFailure,
+    env: managedAgentBrowserEnv(status, process.env),
+    timeoutMs: options.timeoutMs,
+  });
+}
+
+function managedAgentBrowserEnv(
+  status: AgentBrowserToolStatus,
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  fs.mkdirSync(status.homeDir, { recursive: true });
+  ensureRuntimeHomeDir(status);
+  return {
+    ...env,
+    HOME: status.runtimeHomeDir,
+  };
+}
+
+function ensureRuntimeHomeDir(status: AgentBrowserToolStatus): void {
+  if (status.runtimeHomeDir === status.homeDir) return;
+  fs.mkdirSync(path.dirname(status.runtimeHomeDir), { recursive: true });
+  try {
+    const stats = fs.lstatSync(status.runtimeHomeDir);
+    if (stats.isSymbolicLink() && fs.readlinkSync(status.runtimeHomeDir) === status.homeDir) return;
+    if (stats.isDirectory()) return;
+    if (stats.isSymbolicLink()) fs.unlinkSync(status.runtimeHomeDir);
+  } catch (error) {
+    if (!isNoEntryError(error)) throw error;
+  }
+  try {
+    fs.symlinkSync(status.homeDir, status.runtimeHomeDir, 'dir');
+  } catch {
+    fs.mkdirSync(status.runtimeHomeDir, { recursive: true });
+  }
+}
+
+function writeManifest(status: AgentBrowserToolStatus): void {
+  fs.writeFileSync(
+    path.join(status.installDir, 'manifest.json'),
+    JSON.stringify(
+      {
+        package: AGENT_BROWSER,
+        version: MANAGED_AGENT_BROWSER_VERSION,
+        node: process.version,
+        installedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+}
+
+function hasManifest(installDir: string): boolean {
+  return fs.existsSync(path.join(installDir, 'manifest.json'));
+}
+
+function resolveManagedBinaryPath(installDir: string): string {
+  const packageRoot = path.join(installDir, 'package');
+  return path.join(
+    packageRoot,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'agent-browser.cmd' : 'agent-browser',
+  );
+}
+
+function missingManagedToolError(status: AgentBrowserToolStatus): AppError {
+  return new AppError('TOOL_MISSING', 'Managed web browser backend is not installed.', {
+    version: MANAGED_AGENT_BROWSER_VERSION,
+    installDir: status.installDir,
+    hint:
+      status.nodeSupported === false
+        ? `Web automation requires Node ${MINIMUM_WEB_NODE_MAJOR}+; current Node is ${process.version}.`
+        : 'Run `agent-device web setup` to install the managed web backend.',
+  });
+}
+
+function assertWebNodeSupported(nodeMajor: number): void {
+  if (nodeMajor >= MINIMUM_WEB_NODE_MAJOR) return;
+  throw new AppError('UNSUPPORTED_OPERATION', 'Web automation requires Node 24 or newer.', {
+    currentNode: process.version,
+    requiredNodeMajor: MINIMUM_WEB_NODE_MAJOR,
+    hint: 'Run agent-device with Node 24+ for web setup and web automation.',
+  });
+}
+
+function resolveManagedRuntimeHomeDir(installDir: string): string {
+  if (process.platform === 'win32') return path.join(installDir, 'home');
+  const hash = crypto.createHash('sha1').update(installDir).digest('hex').slice(0, 12);
+  return path.join(os.tmpdir(), 'agent-device-web', hash);
+}
+
+function isNoEntryError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function isExecutable(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultStateDir(): string {
+  return path.join(process.env.HOME ?? process.cwd(), '.agent-device');
+}
+
+export function mapManagedAgentBrowserError(error: unknown): AppError {
+  const appError = asAppError(error);
+  if (appError.code !== 'TOOL_MISSING') return appError;
+  return new AppError(appError.code, appError.message, {
+    ...(appError.details ?? {}),
+    hint:
+      typeof appError.details?.hint === 'string'
+        ? appError.details.hint
+        : 'Run `agent-device web setup` to install the managed web backend.',
+  });
+}

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -113,6 +113,16 @@ test('parseArgs recognizes command-specific flag combinations', async () => {
       },
     },
     {
+      label: 'web setup',
+      argv: ['web', 'setup', '--state-dir', './tmp/ad-state'],
+      strictFlags: true,
+      assertParsed: (parsed) => {
+        assert.equal(parsed.command, 'web');
+        assert.deepEqual(parsed.positionals, ['setup']);
+        assert.equal(parsed.flags.stateDir, './tmp/ad-state');
+      },
+    },
+    {
       label: 'open --surface frontmost-app',
       argv: ['open', '--platform', 'macos', '--surface', 'frontmost-app'],
       strictFlags: true,
@@ -1598,6 +1608,20 @@ test('session command help includes daemon state directory discovery', () => {
   if (help === null) throw new Error('Expected command help text');
   assert.match(help, /Usage:\s+agent-device session list \| session state-dir/);
   assert.match(help, /effective daemon state directory/);
+});
+
+test('web command help includes managed backend setup', () => {
+  const help = usageForCommand('web');
+  if (help === null) throw new Error('Expected command help text');
+  assert.match(help, /Usage:\s+agent-device web setup \| web doctor/);
+  assert.match(help, /managed web automation backend/);
+  assert.match(
+    help,
+    /agent-device web setup[\s\S]*agent-device open "https:\/\/example\.com" --platform web/,
+  );
+  assert.match(help, /do not install the backend implicitly/);
+  assert.match(help, /web setup[\s\S]*install or reuse the pinned backend/);
+  assert.doesNotMatch(help, /web status/);
 });
 
 test('command usage describes test suite flags', () => {

--- a/src/utils/cli-command-overrides.ts
+++ b/src/utils/cli-command-overrides.ts
@@ -60,6 +60,23 @@ const SCHEMA_ONLY_CLI_COMMAND_SCHEMAS = {
     positionalArgs: ['args?'],
     allowsExtraPositionals: true,
   },
+  web: {
+    usageOverride: 'web setup | web doctor',
+    listUsageOverride: 'web setup|doctor',
+    helpDescription: `Install and inspect the managed web automation backend used by --platform web.
+
+First-run flow:
+  agent-device web setup
+  agent-device open "https://example.com" --platform web
+  agent-device snapshot -i --platform web
+  agent-device close --platform web
+
+Runtime web commands do not install the backend implicitly. If the managed backend is missing, run agent-device web setup. The backend is resolved only from the managed install in the effective agent-device state dir.
+
+Use web setup to install or reuse the pinned backend. Use web doctor after setup to verify browser backend health.`,
+    summary: 'Manage web automation backend',
+    positionalArgs: ['setup|doctor'],
+  },
 } as const satisfies Record<SchemaOnlyCliCommandName, CommandSchema>;
 
 const CLI_COMMAND_OVERRIDES = {

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -633,6 +633,23 @@ const FIXTURE_SMOKE_CASES: Case[] = [
 
 const SKILL_GUIDANCE_CASES: Case[] = [
   makeCase({
+    id: 'web-first-use-runs-managed-setup',
+    contract: [
+      'Platform: Web',
+      'URL to verify: https://example.com',
+      'No web backend has been set up in this state directory yet',
+      'Web automation uses the managed backend through agent-device, not direct backend commands',
+    ],
+    task: 'Plan the first-run commands to set up web automation, open the URL, inspect interactive refs, and close the session.',
+    outputs: [
+      /(?:^|\n)(?:agent-device\s+)?web\s+setup\b[\s\S]*(?:^|\n)(?:agent-device\s+)?open\s+["']?https:\/\/example\.com["']?\s+--platform\s+web/i,
+      /(?:^|\n)(?:agent-device\s+)?snapshot\s+-i\s+--platform\s+web\b/i,
+      /(?:^|\n)(?:agent-device\s+)?close\s+--platform\s+web\b/i,
+    ],
+    forbiddenOutputs: [/agent-browser/i, /(?:^|\n)\s*(?:npm|pnpm|npx)\b/i],
+    strictFinalOutput: true,
+  }),
+  makeCase({
     id: 'inspect-visible-text-readonly',
     contract: [
       'App name: Agent Device Tester',

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -18,6 +18,7 @@ agent-device help react-native
 agent-device help react-devtools
 agent-device help remote
 agent-device help macos
+agent-device help web
 agent-device help dogfood
 ```
 
@@ -100,6 +101,24 @@ agent-device reinstall MyApp /path/to/app-debug.apk --platform android --serial 
 agent-device open com.example.myapp --platform android --serial emulator-5554 --session my-session --relaunch
 agent-device metro reload
 ```
+
+## Web Automation
+
+```bash
+agent-device web setup
+agent-device web doctor
+agent-device open "https://example.com" --platform web
+agent-device snapshot -i --platform web
+agent-device close --platform web
+```
+
+- Web automation uses a managed, pinned `agent-browser` backend as an implementation detail.
+- Run `web setup` before first use and in CI bootstrap steps. Normal `--platform web` commands do not install the backend implicitly.
+- Runtime web commands resolve the backend only from the managed install in the effective agent-device state dir.
+- `web setup` is idempotent and reuses the pinned backend when it is already installed.
+- `web doctor` verifies the managed backend after setup.
+- The managed install respects `--state-dir` and `AGENT_DEVICE_STATE_DIR`.
+- Web automation requires Node 24+.
 
 ## Device isolation scopes
 


### PR DESCRIPTION
## Summary

Makes agent-browser a managed web backend implementation detail instead of a user-installed global prerequisite.

Details:
- adds agent-device web setup|doctor for explicit setup and health checks
- resolves web runtime only from the pinned managed install under the effective agent-device state dir
- requires explicit setup before first web automation; runtime --platform web commands fail with a setup hint instead of installing implicitly
- scopes managed backend files under the agent-device state dir, with a short runtime HOME symlink so agent-browser socket paths stay below macOS limits
- passes the daemon state dir into the web Provider
- runs GitHub Actions Node jobs on Node 24.13 through the shared setup action and direct release/publish workflows
- keeps browser network/CDP out of this PR; those need separate command-surface design because network already has native app-log semantics and CDP belongs with #823

Touched-file count: 20 files. Scope stayed within web setup/runtime plumbing, web CLI help/docs, CI Node setup, and focused tests.

## Validation

- pnpm exec vitest run src/platforms/web src/utils/__tests__/args.test.ts
- pnpm typecheck
- pnpm lint
- pnpm check:tooling
- pnpm test:unit
- pnpm test:coverage
- pnpm check:fallow --base origin/main
- /Users/thymikee/.nvm/versions/node/v22.22.2/bin/node ./node_modules/vitest/vitest.mjs run src/platforms/web/agent-browser-tool.test.ts --project unit
- SKILLGYM_ALLOW_EXTERNAL_RUNNERS_IN_SANDBOX=1 pnpm test:skillgym:case web-first-use-runs-managed-setup (2/2 runners passed)
- node --experimental-strip-types src/bin.ts help web
- node --experimental-strip-types src/bin.ts web status --state-dir /private/tmp/ad-web-no-status --json returns INVALID_ARGS
- daemon-backed missing-backend smoke with fresh state dir and PATH excluding agent-browser: open --platform web returned TOOL_MISSING and did not create tools/agent-browser
- daemon-backed managed backend smoke: setup reuse, open, snapshot, close, and doctor were verified during the subagent/manual pass
