### PR TITLE
fix: preserve web backend setup hint

### DIFF
--- a/src/platforms/web/agent-browser-provider.test.ts
+++ b/src/platforms/web/agent-browser-provider.test.ts
@@ -140,6 +140,28 @@ test('agent-browser provider adds doctor guidance for missing binary and invalid
   });
 });
 
+test('agent-browser provider preserves Node version guidance for missing managed backend', async () => {
+  await withNodeRuntimeVersion('22.19.0', async () => {
+    const missingStateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'agent-device-web-provider-node-'),
+    );
+    try {
+      const provider = createAgentBrowserWebProvider({ stateDir: missingStateDir });
+      await assert.rejects(
+        async () => await provider.open('https://example.test'),
+        (error: unknown) =>
+          error instanceof AppError &&
+          error.code === 'TOOL_MISSING' &&
+          error.details?.hint === 'Web automation requires Node 24+; current Node is v22.19.0.' &&
+          error.details?.version === '0.27.1' &&
+          typeof error.details?.installDir === 'string',
+      );
+    } finally {
+      fs.rmSync(missingStateDir, { recursive: true, force: true });
+    }
+  });
+});
+
 async function withManagedAgentBrowserProvider(
   options: { session?: string },
   testFn: (provider: ReturnType<typeof createAgentBrowserWebProvider>) => void | Promise<void>,
@@ -151,6 +173,28 @@ async function withManagedAgentBrowserProvider(
     await testFn(provider);
   } finally {
     fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+async function withNodeRuntimeVersion(
+  version: string,
+  testFn: () => void | Promise<void>,
+): Promise<void> {
+  const originalNodeVersion = process.versions.node;
+  const originalProcessVersion = process.version;
+  Object.defineProperty(process.versions, 'node', { value: version, configurable: true });
+  Object.defineProperty(process, 'version', { value: `v${version}`, configurable: true });
+  try {
+    await testFn();
+  } finally {
+    Object.defineProperty(process.versions, 'node', {
+      value: originalNodeVersion,
+      configurable: true,
+    });
+    Object.defineProperty(process, 'version', {
+      value: originalProcessVersion,
+      configurable: true,
+    });
   }
 }
 

--- a/src/platforms/web/agent-browser-provider.ts
+++ b/src/platforms/web/agent-browser-provider.ts
@@ -207,7 +207,12 @@ function mapAgentBrowserRunError(error: unknown, args: string[]): AppError {
     return new AppError(
       'TOOL_MISSING',
       appError.message,
-      { cmd: AGENT_BROWSER, args, hint: AGENT_BROWSER_DOCTOR_HINT },
+      {
+        ...(appError.details ?? {}),
+        cmd: AGENT_BROWSER,
+        args,
+        hint: webBackendHint(appError),
+      },
       appError,
     );
   }
@@ -219,15 +224,16 @@ function mapAgentBrowserRunError(error: unknown, args: string[]): AppError {
         ...(appError.details ?? {}),
         cmd: AGENT_BROWSER,
         args,
-        hint:
-          typeof appError.details?.hint === 'string'
-            ? appError.details.hint
-            : AGENT_BROWSER_DOCTOR_HINT,
+        hint: webBackendHint(appError),
       },
       appError,
     );
   }
   return appError;
+}
+
+function webBackendHint(error: AppError): string {
+  return typeof error.details?.hint === 'string' ? error.details.hint : AGENT_BROWSER_DOCTOR_HINT;
 }
 
 function readEnvelopeErrorMessage(envelope: JsonObject): string {


### PR DESCRIPTION
## Summary

Preserve managed backend details when the web provider wraps missing agent-browser failures, so Node <24 users keep the actionable Node 24+ hint instead of seeing only the generic setup hint.

Closes #834

Touched files: 2. Scope stays inside the web provider and its regression coverage.

## Validation

pnpm exec vitest run src/platforms/web/agent-browser-provider.test.ts src/platforms/web/agent-browser-tool.test.ts
pnpm check:quick
