### PR TITLE
docs: mention web in README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Mobile app verification for AI agents.
 
-A device automation CLI for real apps on iOS, Android, TV, and desktop. Agents get token-efficient snapshots, semantic refs, and evidence captured only when needed.
+A device automation CLI for real apps on iOS, Android, TV, web, and desktop. Agents get token-efficient snapshots, semantic refs, and evidence captured only when needed.
 
 `agent-device` lets coding agents open apps, inspect the current UI, interact with visible elements, and collect debugging evidence through one CLI. Use it when an agent needs to verify what actually happens on a device, not just reason about code.
 


### PR DESCRIPTION
## Summary

Add web to the README platform tagline now that the web support PR stack has merged.

Touched files: 1. Scope is README-only.

## Validation

Docs-only README wording change; no tests required by the repo matrix.
