### PR TITLE
fix: speed up web snapshots

### DIFF
--- a/.github/actions/boot-ios-test-simulator/action.yml
+++ b/.github/actions/boot-ios-test-simulator/action.yml
@@ -9,14 +9,25 @@ inputs:
     description: "Preferred simulator device name"
     required: false
     default: "iPhone 17 Pro"
+  boot-timeout-seconds:
+    description: "Maximum time to wait for simulator bootstatus"
+    required: false
+    default: "300"
+
+outputs:
+  simulator-udid:
+    description: "UDID of the booted iOS simulator"
+    value: ${{ steps.boot.outputs.simulator-udid }}
 
 runs:
   using: "composite"
   steps:
     - name: Resolve and boot iOS test simulator
+      id: boot
       run: |
         set -euo pipefail
-        RUNTIME_TOKEN="SimRuntime.iOS-${{ inputs.runtime-version }}"
+        RUNTIME_VERSION="${{ inputs.runtime-version }}"
+        RUNTIME_TOKEN="SimRuntime.iOS-${RUNTIME_VERSION//./-}"
         export RUNTIME_TOKEN
         export PREFERRED_DEVICE_NAME="${{ inputs.preferred-device-name }}"
         UDID="$(
@@ -40,10 +51,37 @@ runs:
               available.find((device) => device.state === "Booted") ??
               available[0];
             if (!preferred?.udid) process.exit(1);
+            console.error(`Selected ${preferred.name} (${preferred.udid}) from ${preferred.runtime}`);
             process.stdout.write(preferred.udid);
           '
         )"
+        echo "simulator-udid=$UDID" >> "$GITHUB_OUTPUT"
         xcrun simctl shutdown all || true
         xcrun simctl boot "$UDID" || true
-        xcrun simctl bootstatus "$UDID" -b
+        xcrun simctl bootstatus "$UDID" -b &
+        BOOTSTATUS_PID="$!"
+        TIMEOUT_SECONDS="${{ inputs.boot-timeout-seconds }}"
+        BOOT_TIMEOUT_FILE="$(mktemp)"
+        (
+          sleep "$TIMEOUT_SECONDS"
+          if kill -0 "$BOOTSTATUS_PID" 2>/dev/null; then
+            echo "Timed out waiting ${TIMEOUT_SECONDS}s for simulator $UDID to boot" >&2
+            touch "$BOOT_TIMEOUT_FILE"
+            kill "$BOOTSTATUS_PID" 2>/dev/null || true
+          fi
+        ) &
+        BOOT_WATCHDOG_PID="$!"
+        set +e
+        wait "$BOOTSTATUS_PID"
+        BOOTSTATUS_EXIT="$?"
+        set -e
+        kill "$BOOT_WATCHDOG_PID" 2>/dev/null || true
+        wait "$BOOT_WATCHDOG_PID" 2>/dev/null || true
+        if [ -f "$BOOT_TIMEOUT_FILE" ]; then
+          rm -f "$BOOT_TIMEOUT_FILE"
+          xcrun simctl list devices || true
+          exit 1
+        fi
+        rm -f "$BOOT_TIMEOUT_FILE"
+        exit "$BOOTSTATUS_EXIT"
       shell: bash

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -50,6 +50,7 @@ jobs:
           xcuitest-destination: generic/platform=iOS Simulator
 
       - name: Boot iOS test simulator
+        id: ios-simulator
         uses: ./.github/actions/boot-ios-test-simulator
         with:
           runtime-version: ${{ env.IOS_RUNTIME_VERSION }}
@@ -58,12 +59,12 @@ jobs:
       - name: Prepare iOS runner
         run: |
           pnpm clean:daemon
-          node --experimental-strip-types src/bin.ts prepare ios-runner --platform ios --timeout "$AGENT_DEVICE_IOS_PREPARE_TIMEOUT_MS" --json
+          node --experimental-strip-types src/bin.ts prepare ios-runner --platform ios --udid "${{ steps.ios-simulator.outputs.simulator-udid }}" --timeout "$AGENT_DEVICE_IOS_PREPARE_TIMEOUT_MS" --json
           pnpm clean:daemon
 
       - name: Run iOS simulator smoke replay
         run: |
-          node --experimental-strip-types src/bin.ts test test/integration/replays/ios/simulator/01-settings.ad --retries 2 --artifacts-dir test/artifacts/replays-ios-simulator-smoke --report-junit test/artifacts/replays-ios-simulator-smoke.junit.xml
+          node --experimental-strip-types src/bin.ts test test/integration/replays/ios/simulator/01-settings.ad --udid "${{ steps.ios-simulator.outputs.simulator-udid }}" --retries 2 --artifacts-dir test/artifacts/replays-ios-simulator-smoke --report-junit test/artifacts/replays-ios-simulator-smoke.junit.xml
 
       - name: Run iOS physical device smoke replay
         if: env.IOS_UDID != ''

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -55,6 +55,7 @@ export type BackendSnapshotResult = {
 } & SnapshotCaptureAnnotations;
 
 export type BackendSnapshotOptions = SnapshotOptions & {
+  includeRects?: boolean;
   outPath?: string;
 };
 

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -13,10 +13,11 @@ export async function runWebCommand(
   const action = positionals[0];
   switch (action) {
     case 'setup': {
+      printWebSetupStart(options.flags.json);
       const status = await setupManagedAgentBrowser({
         stateDir: options.stateDir,
       });
-      printWebResult(options.flags.json, 'Managed web backend installed.', { status });
+      printWebSetupResult(options.flags.json, status);
       return 0;
     }
     case 'doctor': {
@@ -33,6 +34,24 @@ export async function runWebCommand(
     default:
       throw new AppError('INVALID_ARGS', 'web requires setup or doctor');
   }
+}
+
+function printWebSetupStart(json: boolean | undefined): void {
+  if (json) return;
+  process.stdout.write('Setting up managed agent-browser backend (downloads if needed)...\n');
+}
+
+function printWebSetupResult(
+  json: boolean | undefined,
+  status: Awaited<ReturnType<typeof setupManagedAgentBrowser>>,
+): void {
+  if (json) {
+    printJson({ success: true, data: { status } });
+    return;
+  }
+  process.stdout.write(
+    `Managed web backend installed.\nagent-browser available at: ${status.binaryPath}\n`,
+  );
 }
 
 function printWebResult(json: boolean | undefined, message: string, data: Record<string, unknown>) {

--- a/src/commands/interaction/runtime/interactions.test.ts
+++ b/src/commands/interaction/runtime/interactions.test.ts
@@ -106,7 +106,10 @@ test('runtime selector interactions fall back to a full snapshot when interactiv
   assert.equal(result.kind, 'selector');
   assert.equal(result.node?.label, 'General');
   assert.deepEqual(calls, [{ x: 160, y: 122 }]);
-  assert.deepEqual(captureOptions, [{ interactiveOnly: true }, { interactiveOnly: false }]);
+  assert.deepEqual(captureOptions, [
+    { interactiveOnly: true, includeRects: true },
+    { interactiveOnly: false, includeRects: true },
+  ]);
 });
 
 test('runtime click keeps distinct tab button centers when iOS reports the tab bar as hittable', async () => {

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -238,6 +238,7 @@ export async function captureInteractionSnapshot(
   if (!session) throw new AppError('SESSION_NOT_FOUND', 'No active session. Run open first.');
   const result = await runtime.backend.captureSnapshot(toBackendContext(runtime, options), {
     interactiveOnly,
+    includeRects: true,
   });
   const snapshot =
     result.snapshot ??

--- a/src/commands/interaction/runtime/selector-read-shared.ts
+++ b/src/commands/interaction/runtime/selector-read-shared.ts
@@ -36,7 +36,9 @@ export async function requireSnapshotSession(
 export async function captureSelectorSnapshot(
   runtime: AgentDeviceRuntime,
   options: CommandContext & SelectorSnapshotOptions,
-  captureOptions: { updateSession: boolean; scope?: string } = { updateSession: true },
+  captureOptions: { updateSession: boolean; scope?: string; includeRects?: boolean } = {
+    updateSession: true,
+  },
 ): Promise<CapturedSnapshot> {
   const captureSnapshot = runtime.backend.captureSnapshot;
   if (!captureSnapshot) {
@@ -49,6 +51,7 @@ export async function captureSelectorSnapshot(
     depth: options.depth,
     scope: captureOptions.scope ?? options.scope,
     raw: options.raw,
+    includeRects: captureOptions.includeRects,
   });
   const snapshot =
     result.snapshot ??

--- a/src/commands/interaction/runtime/selector-read.test.ts
+++ b/src/commands/interaction/runtime/selector-read.test.ts
@@ -145,7 +145,31 @@ test('runtime selectors forward public snapshot options to backend capture', asy
     depth: 2,
     scope: 'Login',
     raw: true,
+    includeRects: false,
   });
+});
+
+test('runtime visibility predicates request snapshot rects', async () => {
+  const snapshot = selectorSnapshot();
+  let captureOptions: BackendSnapshotOptions | undefined;
+  const device = createAgentDevice({
+    backend: {
+      platform: 'web',
+      captureSnapshot: async (_context, options) => {
+        captureOptions = options;
+        return { snapshot };
+      },
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot }]),
+    policy: localCommandPolicy(),
+  });
+
+  await device.selectors.isVisible(selector('label=Continue'), {
+    session: 'default',
+  });
+
+  assert.equal(captureOptions?.includeRects, true);
 });
 
 test('runtime is validates selector predicates', async () => {

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -18,6 +18,7 @@ import { buildSelectorChainForNode } from '../../../utils/selector-build.ts';
 import {
   evaluateIsPredicate,
   isSupportedPredicate,
+  type IsPredicate,
 } from '../../../utils/selector-is-predicates.ts';
 import type {
   ElementTarget,
@@ -256,7 +257,11 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
   if (options.predicate === 'text' && !options.expectedText) {
     throw new AppError('INVALID_ARGS', 'is text requires expected text value');
   }
-  const capture = await captureSelectorSnapshot(runtime, options, { updateSession: true });
+  const includeRects = predicateNeedsRects(options.predicate);
+  const capture = await captureSelectorSnapshot(runtime, options, {
+    updateSession: true,
+    includeRects,
+  });
   const chain = parseSelectorChain(options.selector);
 
   if (options.predicate === 'exists') {
@@ -421,6 +426,10 @@ function sparseSelectorSnapshotError(verdict: SnapshotQualityVerdict): AppError 
     reason: verdict.reason,
     hint: 'The snapshot quality verdict is sparse. Use screenshot as visual truth, navigate with coordinates if needed, then retry find after reaching a readable screen.',
   });
+}
+
+function predicateNeedsRects(predicate: IsPredicate): boolean {
+  return predicate === 'visible' || predicate === 'hidden';
 }
 
 async function waitForSelector(

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -47,6 +47,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   snapshotDepth?: number;
   snapshotScope?: string;
   snapshotRaw?: boolean;
+  snapshotIncludeRects?: boolean;
   count?: number;
   intervalMs?: number;
   delayMs?: number;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -539,6 +539,7 @@ async function handleSnapshotCommand(
     depth: context?.snapshotDepth,
     scope: context?.snapshotScope,
     raw: context?.snapshotRaw,
+    includeRects: context?.snapshotIncludeRects,
     surface: context?.surface,
   });
 }

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -52,6 +52,7 @@ export type ElementSelectorTapOptions = {
 
 export type SnapshotOptions = BaseSnapshotOptions & {
   appBundleId?: string;
+  includeRects?: boolean;
   surface?: SessionSurface;
 };
 

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -12,6 +12,7 @@ import {
   makeAndroidSession as makeBaseAndroidSession,
   makeMacOsSession as makeBaseMacOsSession,
 } from '../../../__tests__/test-utils/session-factories.ts';
+import { WEB_DESKTOP_DEVICE } from '../../../__tests__/test-utils/device-fixtures.ts';
 
 const { mockRunIosRunnerCommand } = vi.hoisted(() => ({
   mockRunIosRunnerCommand: vi.fn(),
@@ -86,7 +87,11 @@ async function emulateCaptureSnapshotForSession(
     appBundleId?: string,
     traceLogPath?: string,
   ) => Record<string, unknown>,
-  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
+  options: {
+    interactiveOnly: boolean;
+    androidFreshnessMode?: 'ref-refresh';
+    includeRects?: boolean;
+  },
 ) {
   const effectiveFlags = {
     ...(flags ?? {}),
@@ -119,6 +124,26 @@ function makeMacOsDesktopSession(name: string): SessionState {
 
 function makeMacOsMenubarSession(name: string): SessionState {
   return makeBaseMacOsSession(name, { surface: 'menubar' });
+}
+
+function makeVisibleButtonSnapshot(label: string, backend: SnapshotBackend) {
+  return buildSnapshotState(
+    {
+      nodes: [
+        { index: 0, type: 'Application', rect: { x: 0, y: 0, width: 390, height: 844 } },
+        {
+          index: 1,
+          parentIndex: 0,
+          type: 'Button',
+          label,
+          rect: { x: 10, y: 20, width: 120, height: 44 },
+          hittable: true,
+        },
+      ],
+      backend,
+    },
+    { snapshotInteractiveOnly: false },
+  );
 }
 
 const contextFromFlags = (flags: CommandFlags | undefined) => ({
@@ -2408,6 +2433,66 @@ test('is visible preserves CLI snapshot flags during runtime snapshot capture', 
     snapshotScope: 'Login',
     snapshotRaw: true,
     snapshotInteractiveOnly: false,
+    snapshotIncludeRects: true,
+  });
+});
+
+test('is visible reuses fresh cached iOS snapshots with rects', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-visible-cached';
+  const session = makeSession(sessionName);
+  session.snapshot = makeVisibleButtonSnapshot('Cached action', 'xctest');
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockRejectedValue(new Error('unexpected fresh snapshot'));
+
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'is',
+      positionals: ['visible', 'label="Cached action"'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(mockDispatch).not.toHaveBeenCalled();
+});
+
+test('is visible recaptures web snapshots when cached nodes may lack rects', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'web-visible-refreshes-rects';
+  const session = makeSession(sessionName);
+  session.device = WEB_DESKTOP_DEVICE;
+  session.snapshot = buildSnapshotState(
+    {
+      nodes: [{ index: 0, type: 'button', label: 'Submit order' }],
+      backend: 'web',
+    },
+    { snapshotInteractiveOnly: false },
+  );
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockResolvedValue(makeVisibleButtonSnapshot('Submit order', 'web'));
+
+  const response = await handleInteractionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'is',
+      positionals: ['visible', 'label="Submit order"'],
+      flags: {},
+    },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(mockDispatch.mock.calls[0]?.[4]).toMatchObject({
+    snapshotIncludeRects: true,
   });
 });
 

--- a/src/daemon/handlers/interaction-runtime.ts
+++ b/src/daemon/handlers/interaction-runtime.ts
@@ -50,7 +50,10 @@ function createInteractionBackend(
         req.flags,
         params.sessionStore,
         params.contextFromFlags,
-        { interactiveOnly: options?.interactiveOnly === true },
+        {
+          interactiveOnly: options?.interactiveOnly === true,
+          includeRects: options?.includeRects === true,
+        },
       ),
     }),
     tap: async (_context, point): Promise<BackendActionResult> =>

--- a/src/daemon/handlers/interaction-snapshot.ts
+++ b/src/daemon/handlers/interaction-snapshot.ts
@@ -12,7 +12,11 @@ export type CaptureSnapshotForSession = (
   flags: CommandFlags | undefined,
   sessionStore: SessionStore,
   contextFromFlags: ContextFromFlags,
-  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
+  options: {
+    interactiveOnly: boolean;
+    androidFreshnessMode?: 'ref-refresh';
+    includeRects?: boolean;
+  },
 ) => Promise<SnapshotState>;
 
 export async function captureSnapshotForSession(
@@ -20,7 +24,11 @@ export async function captureSnapshotForSession(
   flags: CommandFlags | undefined,
   sessionStore: SessionStore,
   contextFromFlags: ContextFromFlags,
-  options: { interactiveOnly: boolean; androidFreshnessMode?: 'ref-refresh' },
+  options: {
+    interactiveOnly: boolean;
+    androidFreshnessMode?: 'ref-refresh';
+    includeRects?: boolean;
+  },
 ): Promise<SnapshotState> {
   const effectiveFlags = {
     ...(flags ?? {}),
@@ -37,6 +45,7 @@ export async function captureSnapshotForSession(
     flags: effectiveFlags,
     outPath: effectiveFlags.out,
     logPath: dispatchContext.logPath ?? '',
+    includeRects: options.includeRects,
     androidFreshnessMode: options.androidFreshnessMode,
   });
   if (!isSparseSnapshotQualityVerdict(snapshot.snapshotQuality)) {

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -53,6 +53,7 @@ type CaptureSnapshotParams = {
   device: SessionState['device'];
   session: SessionState | undefined;
   flags: CommandFlags | undefined;
+  includeRects?: boolean;
   outPath?: string;
   logPath: string;
   snapshotScope?: string;
@@ -227,6 +228,7 @@ export async function captureSnapshotData(params: CaptureSnapshotParams): Promis
       session?.appBundleId,
       session?.trace?.outPath,
     ),
+    snapshotIncludeRects: params.includeRects,
   })) as SnapshotData;
 }
 

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -552,12 +552,16 @@ function createSelectorBackend(params: {
         ...req.flags,
         ...snapshotFlagOverrides(options),
       };
+      const includeRects = options?.includeRects === true;
       const snapshotScope = options?.scope ?? req.flags?.snapshotScope;
       const timestamp = Date.now();
       const presentationKey = buildSnapshotPresentationKey(
         snapshotPresentationOptionsFromFlags(flags),
       );
-      const needsFreshSnapshot = req.command === 'wait' || req.command === 'find';
+      const needsFreshSnapshot =
+        req.command === 'wait' ||
+        req.command === 'find' ||
+        (includeRects && device.platform === 'web');
       if (
         !needsFreshSnapshot &&
         lastSnapshotResult &&
@@ -586,6 +590,7 @@ function createSelectorBackend(params: {
         outPath: req.flags?.out,
         logPath: logPath ?? '',
         snapshotScope,
+        includeRects,
       });
       if (session && !isSparseSnapshotQualityVerdict(capture.snapshot.snapshotQuality)) {
         setSessionSnapshot(session, capture.snapshot);

--- a/src/platforms/web/__tests__/test-utils.ts
+++ b/src/platforms/web/__tests__/test-utils.ts
@@ -33,6 +33,7 @@ function expectedManagedAgentBrowserInstall(stateDir: string) {
       process.platform === 'win32'
         ? path.join(installDir, 'home')
         : path.join(os.tmpdir(), 'agent-device-web', sha1Short(installDir)),
+    socketDir: path.join(os.tmpdir(), 'adw', sha1Short(installDir)),
   };
 }
 

--- a/src/platforms/web/agent-browser-provider.test.ts
+++ b/src/platforms/web/agent-browser-provider.test.ts
@@ -55,7 +55,7 @@ test('agent-browser provider maps supported operations to session-scoped JSON co
   });
 });
 
-test('agent-browser provider normalizes snapshot refs, labels, values, parents, and rects', async () => {
+test('agent-browser provider normalizes snapshot refs, labels, values, and parents', async () => {
   await withManagedAgentBrowserProvider({ session: 'web-session' }, async (provider) => {
     const calls: AgentBrowserCall[] = [];
     const snapshot = await withCommandExecutorOverride(
@@ -75,7 +75,32 @@ test('agent-browser provider normalizes snapshot refs, labels, values, parents, 
       '--session',
       'web-session',
     ]);
+    assert.equal(calls.length, 1);
     assertNormalizedSnapshot(snapshot);
+    assertRoleSelectorResolves(snapshot);
+  });
+});
+
+test('agent-browser provider fetches snapshot rects only when requested', async () => {
+  await withManagedAgentBrowserProvider({ session: 'web-session' }, async (provider) => {
+    const calls: AgentBrowserCall[] = [];
+    const snapshot = await withCommandExecutorOverride(
+      snapshotExecutor(calls),
+      async () => await provider.snapshot({ includeRects: true }),
+    );
+
+    assert.deepEqual(
+      calls.map((call) => call.args.slice(0, 3)),
+      [
+        ['snapshot', '--compact', '--json'],
+        ['get', 'box', '@e1'],
+        ['get', 'box', '@e2'],
+        ['get', 'box', '@e3'],
+        ['get', 'box', '@e4'],
+      ],
+    );
+    assertNormalizedSnapshot(snapshot);
+    assertSnapshotRects(snapshot);
     assertRoleSelectorResolves(snapshot);
   });
 });
@@ -145,7 +170,7 @@ test('agent-browser provider dumps session network requests', async () => {
   });
 });
 
-test('agent-browser provider surfaces stale ref failures during snapshot geometry lookup', async () => {
+test('agent-browser provider surfaces stale ref failures during requested snapshot geometry lookup', async () => {
   await withManagedAgentBrowserProvider({ session: 'web-session' }, async (provider) => {
     await assert.rejects(
       () =>
@@ -162,7 +187,7 @@ test('agent-browser provider surfaces stale ref failures during snapshot geometr
             }
             return jsonResult({ success: false, error: 'Stale ref @e1' });
           },
-          async () => await provider.snapshot(),
+          async () => await provider.snapshot({ includeRects: true }),
         ),
       (error: unknown) =>
         error instanceof AppError &&
@@ -284,12 +309,25 @@ function snapshotExecutor(calls: AgentBrowserCall[]) {
 }
 
 function assertNormalizedSnapshot(snapshot: WebSnapshotResult): void {
-  assert.deepEqual(snapshot.nodes, [
-    expectedNode(0, 'heading', 'Welcome', undefined, 0, { x: 1, y: 2, width: 100, height: 20 }),
-    expectedNode(1, 'textbox', 'Name', 'Ada', 1, { x: 11, y: 12, width: 100, height: 20 }, 0),
+  const nodesWithoutRects = snapshot.nodes.map(({ rect: _rect, ...node }) => node);
+  assert.deepEqual(nodesWithoutRects, [
+    expectedNode(0, 'heading', 'Welcome', undefined, 0, undefined),
+    expectedNode(1, 'textbox', 'Name', 'Ada', 1, undefined, 0),
     expectedNode(2, 'button', 'Save', undefined, 1, undefined, 0),
-    expectedNode(3, 'link', 'Docs', undefined, 1, { x: 31, y: 32, width: 100, height: 20 }, 0),
+    expectedNode(3, 'link', 'Docs', undefined, 1, undefined, 0),
   ]);
+}
+
+function assertSnapshotRects(snapshot: WebSnapshotResult): void {
+  assert.deepEqual(
+    snapshot.nodes.map((node) => node.rect),
+    [
+      { x: 1, y: 2, width: 100, height: 20 },
+      { x: 11, y: 12, width: 100, height: 20 },
+      undefined,
+      { x: 31, y: 32, width: 100, height: 20 },
+    ],
+  );
 }
 
 function assertRoleSelectorResolves(snapshot: WebSnapshotResult): void {

--- a/src/platforms/web/agent-browser-provider.ts
+++ b/src/platforms/web/agent-browser-provider.ts
@@ -80,7 +80,10 @@ async function captureAgentBrowserSnapshot(
   options: WebSnapshotOptions | undefined,
 ): Promise<WebSnapshotResult> {
   const data = await runJson(buildSnapshotArgs(options));
-  return await normalizeAgentBrowserSnapshot(data, async (ref) => await fetchRefRect(runJson, ref));
+  return await normalizeAgentBrowserSnapshot(
+    data,
+    options?.includeRects ? async (ref) => await fetchRefRect(runJson, ref) : undefined,
+  );
 }
 
 function buildSnapshotArgs(options: WebSnapshotOptions | undefined): string[] {

--- a/src/platforms/web/agent-browser-snapshot.ts
+++ b/src/platforms/web/agent-browser-snapshot.ts
@@ -22,13 +22,13 @@ const MAX_CONCURRENT_BOX_FETCHES = 8;
 
 export async function normalizeAgentBrowserSnapshot(
   data: unknown,
-  fetchBox: (ref: string) => Promise<Rect | undefined>,
+  fetchBox?: (ref: string) => Promise<Rect | undefined>,
 ): Promise<WebSnapshotResult> {
   const snapshotText = readStringProperty(data, 'snapshot') ?? '';
   const refs = collectSnapshotRefs(readProperty(data, 'refs'));
   const drafts = parseSnapshotDraftNodes(snapshotText, refs);
 
-  await attachDraftRects(drafts, fetchBox);
+  if (fetchBox) await attachDraftRects(drafts, fetchBox);
 
   return {
     nodes: drafts.map((draft, index) => ({ ...draft.node, index })),

--- a/src/platforms/web/agent-browser-tool.test.ts
+++ b/src/platforms/web/agent-browser-tool.test.ts
@@ -32,8 +32,10 @@ test('managed agent-browser tool uses short runtime home for backend state', asy
 
     assert.equal(tool.command, status.binaryPath);
     assert.equal(tool.env?.HOME, status.runtimeHomeDir);
+    assert.equal(tool.env?.AGENT_BROWSER_SOCKET_DIR, status.socketDir);
     assert.notEqual(status.runtimeHomeDir, status.homeDir);
     assert.ok(fs.existsSync(status.runtimeHomeDir));
+    assert.ok(fs.existsSync(status.socketDir));
   } finally {
     fs.rmSync(stateDir, { recursive: true, force: true });
   }

--- a/src/platforms/web/agent-browser-tool.ts
+++ b/src/platforms/web/agent-browser-tool.ts
@@ -26,6 +26,7 @@ export type AgentBrowserToolStatus = {
   binaryPath: string;
   homeDir: string;
   runtimeHomeDir: string;
+  socketDir: string;
   installed: boolean;
   nodeMajor: number;
   nodeSupported: boolean;
@@ -94,6 +95,7 @@ function getManagedAgentBrowserStatus(options: { stateDir?: string }): AgentBrow
   const binaryPath = resolveManagedBinaryPath(installDir);
   const homeDir = path.join(installDir, 'home');
   const runtimeHomeDir = resolveManagedRuntimeHomeDir(installDir);
+  const socketDir = resolveManagedSocketDir(installDir);
   const installed = isExecutable(binaryPath) && hasManifest(installDir);
   const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
   return {
@@ -103,6 +105,7 @@ function getManagedAgentBrowserStatus(options: { stateDir?: string }): AgentBrow
     binaryPath,
     homeDir,
     runtimeHomeDir,
+    socketDir,
     installed,
     nodeMajor,
     nodeSupported: nodeMajor >= MINIMUM_WEB_NODE_MAJOR,
@@ -153,9 +156,11 @@ function managedAgentBrowserEnv(
 ): NodeJS.ProcessEnv {
   fs.mkdirSync(status.homeDir, { recursive: true });
   ensureRuntimeHomeDir(status);
+  fs.mkdirSync(status.socketDir, { recursive: true });
   return {
     ...env,
     HOME: status.runtimeHomeDir,
+    AGENT_BROWSER_SOCKET_DIR: status.socketDir,
   };
 }
 
@@ -232,6 +237,11 @@ function resolveManagedRuntimeHomeDir(installDir: string): string {
   if (process.platform === 'win32') return path.join(installDir, 'home');
   const hash = crypto.createHash('sha1').update(installDir).digest('hex').slice(0, 12);
   return path.join(os.tmpdir(), 'agent-device-web', hash);
+}
+
+function resolveManagedSocketDir(installDir: string): string {
+  const hash = crypto.createHash('sha1').update(installDir).digest('hex').slice(0, 12);
+  return path.join(os.tmpdir(), 'adw', hash);
 }
 
 function isNoEntryError(error: unknown): boolean {

--- a/src/platforms/web/provider.ts
+++ b/src/platforms/web/provider.ts
@@ -20,6 +20,7 @@ export type WebSnapshotOptions = {
   depth?: number;
   scope?: string;
   raw?: boolean;
+  includeRects?: boolean;
   surface?: SessionSurface;
 };
 


### PR DESCRIPTION
## Summary

Keep regular web snapshots on the single agent-browser snapshot call instead of fetching every element box up front. Selector visibility checks and interaction targeting still opt into rect capture when they need coordinates.

Set a short managed AGENT_BROWSER_SOCKET_DIR so default web sessions do not fail on long socket paths.

Touched files: 21, scoped to web snapshot/provider plumbing, selector snapshot options, and tests.

## Validation

- pnpm --pm-on-fail=ignore check:quick
- pnpm --pm-on-fail=ignore exec vitest run src/commands/interaction/runtime/selector-read.test.ts src/daemon/handlers/__tests__/interaction.test.ts src/platforms/web/agent-browser-provider.test.ts src/platforms/web/agent-browser-tool.test.ts src/commands/interaction/runtime/interactions.test.ts
- AGENT_DEVICE_WEB_E2E=1 pnpm --pm-on-fail=ignore test:smoke:web
- pnpm --pm-on-fail=ignore check:fallow --base origin/main
- Manual isolated web run: default-session open succeeded; first snapshot -i was about 1.0s, warm snapshot was about 0.35s.

Note: pnpm --pm-on-fail=ignore check:unit ran all 2,588 unit tests successfully, then the aggregate smoke failed locally in smoke-daemon-clean because this temporary worktree path is /private/tmp/ad-web-perf and the daemon cleanup safety matcher only recognizes paths containing agent-device. This appears environment/path-related, not from this change.