### PR TITLE
refactor: unify selector capture runtime

### DIFF
--- a/src/daemon/__tests__/selector-capture-runtime.test.ts
+++ b/src/daemon/__tests__/selector-capture-runtime.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { dispatchCommand } from '../../core/dispatch.ts';
+import { buildSnapshotPresentationKey } from '../../utils/snapshot.ts';
+import { makeIosSession } from '../../__tests__/test-utils/index.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
+
+vi.mock('../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/dispatch.ts')>();
+  return {
+    ...actual,
+    dispatchCommand: vi.fn(async () => ({})),
+  };
+});
+
+const mockDispatch = vi.mocked(dispatchCommand);
+
+beforeEach(() => {
+  mockDispatch.mockReset();
+});
+
+test('selector capture cache is keyed by scoped presentation options', async () => {
+  const sessionName = 'selector-cache-scope';
+  const sessionStore = makeSessionStore('agent-device-selector-capture-');
+  const session = makeIosSession(sessionName, {
+    snapshot: {
+      createdAt: Date.now(),
+      presentationKey: buildSnapshotPresentationKey({ scope: 'A' }),
+      nodes: [{ ref: 'e1', index: 0, type: 'Button', label: 'A' }],
+    },
+  });
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockImplementation(async (_device, _command, _positionals, _outPath, context) => ({
+    backend: 'xctest',
+    nodes: [
+      {
+        index: 0,
+        type: 'Button',
+        label:
+          context && typeof context.snapshotScope === 'string' ? context.snapshotScope : 'broad',
+      },
+    ],
+  }));
+
+  const runtime = createSelectorCaptureRuntime({
+    device: session.device,
+    session,
+    sessionStore,
+    sessionName,
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'get',
+      positionals: [],
+      flags: {},
+    },
+  });
+
+  const first = await runtime.capture({ flags: {}, snapshotScope: 'A' });
+  const second = await runtime.capture({ flags: {}, snapshotScope: 'B' });
+  const cachedSecond = await runtime.capture({ flags: {}, snapshotScope: 'B' });
+
+  expect(first.snapshot.nodes[0]?.label).toBe('A');
+  expect(second.snapshot.nodes[0]?.label).toBe('B');
+  expect(cachedSecond.snapshot.nodes[0]?.label).toBe('B');
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
+});
+
+test('legacy iOS sparse recovery retries a full snapshot', async () => {
+  const { runtime } = makeCaptureRuntime('selector-legacy-sparse-recovery');
+  mockDispatch
+    .mockResolvedValueOnce({
+      backend: 'xctest',
+      nodes: [{ index: 0, type: 'Application' }],
+    })
+    .mockResolvedValueOnce({
+      backend: 'xctest',
+      nodes: [{ index: 0, type: 'Button', label: 'Recovered' }],
+    });
+
+  const result = await runtime.capture({
+    flags: { snapshotInteractiveOnly: true },
+    recovery: {
+      legacyIosSparse: {
+        query: 'Search',
+        scope: undefined,
+        shouldScope: false,
+      },
+    },
+  });
+
+  expect(result.snapshot.nodes[0]?.label).toBe('Recovered');
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
+  expect(mockDispatch.mock.calls[0]?.[4]).toMatchObject({ snapshotInteractiveOnly: true });
+  expect(mockDispatch.mock.calls[1]?.[4]).toMatchObject({ snapshotInteractiveOnly: false });
+});
+
+test('legacy iOS sparse recovery rethrows full snapshot failure when scoping is disabled', async () => {
+  const { runtime } = makeCaptureRuntime('selector-legacy-sparse-rethrow');
+  mockDispatch
+    .mockResolvedValueOnce({
+      backend: 'xctest',
+      nodes: [{ index: 0, type: 'Application' }],
+    })
+    .mockRejectedValueOnce(new Error('full snapshot failed'));
+
+  await expect(
+    runtime.capture({
+      flags: { snapshotInteractiveOnly: true },
+      recovery: {
+        legacyIosSparse: {
+          query: 'Search',
+          scope: undefined,
+          shouldScope: false,
+        },
+      },
+    }),
+  ).rejects.toThrow('full snapshot failed');
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
+});
+
+test('sparse verdict recovery retries with query scope and stores recovered snapshot', async () => {
+  const { runtime, sessionName, sessionStore } = makeCaptureRuntime('selector-sparse-verdict');
+  mockDispatch
+    .mockResolvedValueOnce({
+      backend: 'xctest',
+      quality: {
+        state: 'sparse',
+        backend: 'private-ax',
+        reason: 'sparse tree',
+        reasonCode: 'sparse-tree',
+      },
+      nodes: [{ index: 0, type: 'Application' }],
+    })
+    .mockResolvedValueOnce({
+      backend: 'xctest',
+      nodes: [{ index: 0, type: 'Button', label: 'Search' }],
+    });
+
+  const result = await runtime.capture({
+    flags: { snapshotInteractiveOnly: true },
+    recovery: {
+      sparseVerdictQueryScope: {
+        query: 'Search',
+        shouldScope: true,
+      },
+    },
+  });
+
+  expect(result.snapshot.nodes[0]?.label).toBe('Search');
+  expect(sessionStore.get(sessionName)?.snapshot?.nodes[0]?.label).toBe('Search');
+  expect(mockDispatch).toHaveBeenCalledTimes(2);
+  expect(mockDispatch.mock.calls[1]?.[4]).toMatchObject({
+    snapshotInteractiveOnly: false,
+    snapshotScope: 'Search',
+  });
+});
+
+function makeCaptureRuntime(sessionName: string) {
+  const sessionStore = makeSessionStore('agent-device-selector-capture-');
+  const session = makeIosSession(sessionName);
+  sessionStore.set(sessionName, session);
+  const runtime = createSelectorCaptureRuntime({
+    device: session.device,
+    session,
+    sessionStore,
+    sessionName,
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'find',
+      positionals: [],
+      flags: {},
+    },
+  });
+  return { runtime, sessionName, sessionStore };
+}

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -13,12 +13,10 @@ import {
 } from '../../core/interaction-targeting.ts';
 import { isSnapshotNodeInteractionBlocked } from '../../utils/snapshot-occlusion.ts';
 import { readTextForNode } from './interaction-read.ts';
-import { captureSnapshot } from './snapshot-capture.ts';
-import { setSessionSnapshot } from '../session-snapshot.ts';
 import { errorResponse } from './response.ts';
-import { getActiveAndroidSnapshotFreshness } from '../android-snapshot-freshness.ts';
 import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts';
 import { dispatchFindReadOnlyViaRuntime } from '../selector-runtime.ts';
+import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
 import {
   isSparseSnapshotQualityVerdict,
   type SnapshotQualityVerdict,
@@ -158,12 +156,6 @@ export async function handleFindCommands(params: {
   return handler ? handler() : null;
 }
 
-function isLegacySparseIosInteractiveSnapshot(snapshot: SnapshotState): boolean {
-  if (snapshot.snapshotQuality) return false;
-  if (snapshot.backend !== 'xctest' || snapshot.nodes.length !== 1) return false;
-  return snapshot.nodes[0]?.type === 'Application';
-}
-
 // --- Per-action handlers ---
 
 function isReadOnlyFindAction(action: string): boolean {
@@ -199,91 +191,43 @@ function createFindNodeFetcher(params: {
 }): FindNodeFetcher {
   const { device, session, req, logPath, locator, query, scope, interactiveOnly } = params;
   const { sessionStore, sessionName } = params;
-  let lastSnapshotAt = 0;
-  let lastSnapshotResult: FindSnapshotResult | null = null;
-  const capture = async (snapshotScope: string | undefined, interactive: boolean) => {
-    const { snapshot } = await captureSnapshot({
-      device,
-      session,
+  const captureRuntime = createSelectorCaptureRuntime({
+    device,
+    session,
+    sessionStore,
+    sessionName,
+    req,
+    logPath,
+  });
+  return async () => {
+    const { snapshot } = await captureRuntime.capture({
       flags: {
         ...req.flags,
-        snapshotInteractiveOnly: interactive,
+        snapshotInteractiveOnly: interactiveOnly,
       },
-      outPath: req.flags?.out,
-      logPath,
-      snapshotScope,
+      snapshotScope: scope,
+      recovery: interactiveOnly
+        ? {
+            legacyIosSparse: {
+              query,
+              scope,
+              shouldScope: shouldScopeFind(locator),
+            },
+            sparseVerdictQueryScope: {
+              query,
+              shouldScope: shouldScopeFind(locator),
+            },
+          }
+        : undefined,
     });
-    return snapshot;
-  };
-  return async () => {
-    const now = Date.now();
-    // Re-use a snapshot captured within the last 750 ms to avoid redundant dumps during
-    // rapid find iterations.  Skipped when Android freshness tracking is active, because
-    // the cached tree may already be stale from a recent navigation action.
-    if (
-      lastSnapshotResult &&
-      now - lastSnapshotAt < 750 &&
-      !getActiveAndroidSnapshotFreshness(session)
-    ) {
-      return lastSnapshotResult;
-    }
-    let snapshot = await capture(scope, interactiveOnly);
-    if (interactiveOnly && isLegacySparseIosInteractiveSnapshot(snapshot)) {
-      snapshot = await recoverSparseInteractiveSnapshot({ capture, locator, query, scope });
-    } else if (
-      interactiveOnly &&
-      isSparseSnapshotQualityVerdict(snapshot.snapshotQuality) &&
-      shouldScopeFind(locator)
-    ) {
-      snapshot = await recoverSparseVerdictWithQueryScope({ capture, query, snapshot });
-    }
     const snapshotResult = {
       nodes: snapshot.nodes,
       truncated: snapshot.truncated,
       backend: snapshot.backend,
       snapshotQuality: snapshot.snapshotQuality,
     };
-    lastSnapshotAt = now;
-    lastSnapshotResult = snapshotResult;
-    if (session && !isSparseSnapshotQualityVerdict(snapshot.snapshotQuality)) {
-      setSessionSnapshot(session, snapshot);
-      sessionStore.set(sessionName, session);
-    }
     return snapshotResult;
   };
-}
-
-async function recoverSparseVerdictWithQueryScope(params: {
-  capture: (scope: string | undefined, interactive: boolean) => Promise<SnapshotState>;
-  query: string;
-  snapshot: SnapshotState;
-}): Promise<SnapshotState> {
-  const { capture, query, snapshot } = params;
-  try {
-    return await capture(query, false);
-  } catch {
-    return snapshot;
-  }
-}
-
-/**
- * Legacy iOS runners did not report a structured quality verdict. For those mixed-version
- * sessions, the one-node application shape still means the runner could not enumerate the tree:
- * retry with a full snapshot, then a query-scoped full snapshot if broad serialization fails.
- */
-async function recoverSparseInteractiveSnapshot(params: {
-  capture: (scope: string | undefined, interactive: boolean) => Promise<SnapshotState>;
-  locator: FindLocator;
-  query: string;
-  scope: string | undefined;
-}): Promise<SnapshotState> {
-  const { capture, locator, query, scope } = params;
-  try {
-    return await capture(scope, false);
-  } catch (error) {
-    if (!shouldScopeFind(locator)) throw error;
-    return await capture(query, false);
-  }
 }
 
 function sparseFindSnapshotResponse(verdict: SnapshotQualityVerdict): DaemonResponse {

--- a/src/daemon/selector-capture-runtime.ts
+++ b/src/daemon/selector-capture-runtime.ts
@@ -1,0 +1,285 @@
+import type { BackendSnapshotResult } from '../backend.ts';
+import type { CommandFlags } from '../core/dispatch.ts';
+import {
+  buildSnapshotPresentationKey,
+  snapshotPresentationOptionsFromFlags,
+  type SnapshotState,
+} from '../utils/snapshot.ts';
+import { isSparseSnapshotQualityVerdict } from '../utils/snapshot-quality.ts';
+import type { DaemonRequest, SessionState } from './types.ts';
+import { SessionStore } from './session-store.ts';
+import { captureSnapshot } from './handlers/snapshot-capture.ts';
+import { setSessionSnapshot } from './session-snapshot.ts';
+import { getActiveAndroidSnapshotFreshness } from './android-snapshot-freshness.ts';
+
+const SELECTOR_CAPTURE_CACHE_TTL_MS = 750;
+
+type SelectorCaptureRuntimeParams = {
+  device: SessionState['device'];
+  session: SessionState | undefined;
+  sessionStore: SessionStore;
+  sessionName: string;
+  req: DaemonRequest;
+  logPath?: string;
+};
+
+/**
+ * Callers opt into the cache tiers they already owned before this module:
+ * find leaves session snapshots and post-gesture bypass off, selector reads enable both,
+ * and polling/fresh wait captures set forceFresh.
+ */
+type SelectorCaptureCachePolicy = {
+  forceFresh?: boolean;
+  useSessionSnapshot?: boolean;
+  bypassForPostGestureStabilization?: boolean;
+};
+
+type SelectorCaptureRecoveryPolicy = {
+  legacyIosSparse?: {
+    query: string;
+    scope: string | undefined;
+    shouldScope: boolean;
+  };
+  sparseVerdictQueryScope?: {
+    query: string;
+    shouldScope: boolean;
+  };
+};
+
+type SelectorCaptureRequest = {
+  flags: CommandFlags | undefined;
+  includeRects?: boolean;
+  outPath?: string;
+  snapshotScope?: string;
+  cache?: SelectorCaptureCachePolicy;
+  recovery?: SelectorCaptureRecoveryPolicy;
+};
+
+type SelectorCaptureResult = BackendSnapshotResult & { snapshot: SnapshotState };
+
+export function createSelectorCaptureRuntime(params: SelectorCaptureRuntimeParams) {
+  const { session, sessionStore, sessionName } = params;
+  let lastSnapshotAt = 0;
+  let lastSnapshotResult: SelectorCaptureResult | undefined;
+  let lastSnapshotCacheKey: string | undefined;
+
+  const capture = async (request: SelectorCaptureRequest): Promise<SelectorCaptureResult> => {
+    const timestamp = Date.now();
+    const cacheKey = selectorCaptureCacheKey(request, params.req.flags?.out);
+    const reusableLastSnapshot = readReusableLastSnapshot({
+      timestamp,
+      lastSnapshotAt,
+      lastSnapshotResult,
+      lastSnapshotCacheKey,
+      session,
+      request,
+      cacheKey,
+    });
+    if (reusableLastSnapshot) {
+      return reusableLastSnapshot;
+    }
+
+    const sessionSnapshot = reusableSessionSnapshot({ session, timestamp, request });
+    if (sessionSnapshot) {
+      lastSnapshotAt = sessionSnapshot.createdAt;
+      lastSnapshotResult = { snapshot: sessionSnapshot };
+      lastSnapshotCacheKey = cacheKey;
+      return lastSnapshotResult;
+    }
+
+    const snapshot = await captureSelectorSnapshot({ params, request });
+    const result = { snapshot };
+    updateSessionSnapshot({ session, sessionStore, sessionName, snapshot });
+    lastSnapshotAt = timestamp;
+    lastSnapshotResult = result;
+    lastSnapshotCacheKey = cacheKey;
+    return result;
+  };
+
+  return { capture };
+}
+
+async function captureSelectorSnapshot(params: {
+  params: SelectorCaptureRuntimeParams;
+  request: SelectorCaptureRequest;
+}): Promise<SnapshotState> {
+  const { params: runtimeParams, request } = params;
+  const snapshot = await runCapture(runtimeParams, request, request.snapshotScope);
+  if (request.recovery?.legacyIosSparse && isLegacySparseIosInteractiveSnapshot(snapshot)) {
+    return await recoverLegacySparseIosSnapshot({
+      runtimeParams,
+      request,
+      policy: request.recovery.legacyIosSparse,
+    });
+  }
+  if (
+    request.recovery?.sparseVerdictQueryScope?.shouldScope &&
+    isSparseSnapshotQualityVerdict(snapshot.snapshotQuality)
+  ) {
+    return await recoverSparseVerdictWithQueryScope({
+      runtimeParams,
+      request,
+      policy: request.recovery.sparseVerdictQueryScope,
+      snapshot,
+    });
+  }
+  return snapshot;
+}
+
+async function recoverLegacySparseIosSnapshot(params: {
+  runtimeParams: SelectorCaptureRuntimeParams;
+  request: SelectorCaptureRequest;
+  policy: NonNullable<SelectorCaptureRecoveryPolicy['legacyIosSparse']>;
+}): Promise<SnapshotState> {
+  const { runtimeParams, request, policy } = params;
+  try {
+    return await runCapture(runtimeParams, request, policy.scope, false);
+  } catch (error) {
+    if (!policy.shouldScope) throw error;
+    return await runCapture(runtimeParams, request, policy.query, false);
+  }
+}
+
+async function recoverSparseVerdictWithQueryScope(params: {
+  runtimeParams: SelectorCaptureRuntimeParams;
+  request: SelectorCaptureRequest;
+  policy: NonNullable<SelectorCaptureRecoveryPolicy['sparseVerdictQueryScope']>;
+  snapshot: SnapshotState;
+}): Promise<SnapshotState> {
+  const { runtimeParams, request, policy, snapshot } = params;
+  try {
+    return await runCapture(runtimeParams, request, policy.query, false);
+  } catch {
+    return snapshot;
+  }
+}
+
+async function runCapture(
+  params: SelectorCaptureRuntimeParams,
+  request: SelectorCaptureRequest,
+  snapshotScope: string | undefined,
+  interactiveOnly = request.flags?.snapshotInteractiveOnly,
+): Promise<SnapshotState> {
+  const capture = await captureSnapshot({
+    device: params.device,
+    session: params.session,
+    flags: {
+      ...request.flags,
+      snapshotInteractiveOnly: interactiveOnly,
+    },
+    outPath: request.outPath ?? params.req.flags?.out,
+    logPath: params.logPath ?? '',
+    snapshotScope,
+    includeRects: request.includeRects,
+  });
+  return capture.snapshot;
+}
+
+function readReusableLastSnapshot(params: {
+  timestamp: number;
+  lastSnapshotAt: number;
+  lastSnapshotResult: SelectorCaptureResult | undefined;
+  lastSnapshotCacheKey: string | undefined;
+  session: SessionState | undefined;
+  request: SelectorCaptureRequest;
+  cacheKey: string;
+}): SelectorCaptureResult | undefined {
+  const {
+    timestamp,
+    lastSnapshotAt,
+    lastSnapshotResult,
+    lastSnapshotCacheKey,
+    session,
+    request,
+    cacheKey,
+  } = params;
+  if (request.cache?.forceFresh === true) return undefined;
+  if (!lastSnapshotResult) return undefined;
+  if (lastSnapshotCacheKey !== cacheKey) return undefined;
+  if (timestamp - lastSnapshotAt >= SELECTOR_CAPTURE_CACHE_TTL_MS) return undefined;
+  if (getActiveAndroidSnapshotFreshness(session)) return undefined;
+  if (shouldBypassForPostGestureStabilization(session, request)) return undefined;
+  return lastSnapshotResult;
+}
+
+function reusableSessionSnapshot(params: {
+  session: SessionState | undefined;
+  timestamp: number;
+  request: SelectorCaptureRequest;
+}): SnapshotState | undefined {
+  const { session, timestamp, request } = params;
+  const snapshot = session?.snapshot;
+  if (!snapshot) return undefined;
+  if (!canUseSessionSnapshotCache(session, request)) return undefined;
+  if (!isFreshSelectorSnapshot(snapshot, timestamp)) return undefined;
+  if (snapshot.presentationKey !== presentationKeyFor(request)) return undefined;
+  return snapshot;
+}
+
+function canUseSessionSnapshotCache(
+  session: SessionState,
+  request: SelectorCaptureRequest,
+): boolean {
+  if (request.cache?.forceFresh === true) return false;
+  if (request.cache?.useSessionSnapshot !== true) return false;
+  if (getActiveAndroidSnapshotFreshness(session)) return false;
+  if (shouldBypassForPostGestureStabilization(session, request)) return false;
+  return true;
+}
+
+function isFreshSelectorSnapshot(snapshot: SnapshotState, timestamp: number): boolean {
+  return timestamp - snapshot.createdAt < SELECTOR_CAPTURE_CACHE_TTL_MS;
+}
+
+function shouldBypassForPostGestureStabilization(
+  session: SessionState | undefined,
+  request: SelectorCaptureRequest,
+): boolean {
+  return (
+    request.cache?.bypassForPostGestureStabilization === true &&
+    Boolean(session?.postGestureStabilization)
+  );
+}
+
+function presentationKeyFor(request: SelectorCaptureRequest): string {
+  return buildSnapshotPresentationKey(
+    snapshotPresentationOptionsFromFlags(flagsForPresentation(request)),
+  );
+}
+
+function selectorCaptureCacheKey(
+  request: SelectorCaptureRequest,
+  defaultOutPath: string | undefined,
+): string {
+  return JSON.stringify({
+    presentationKey: presentationKeyFor(request),
+    includeRects: request.includeRects === true,
+    outPath: request.outPath ?? defaultOutPath ?? null,
+  });
+}
+
+function flagsForPresentation(request: SelectorCaptureRequest): CommandFlags | undefined {
+  if (request.snapshotScope === undefined) return request.flags;
+  return {
+    ...request.flags,
+    snapshotScope: request.snapshotScope,
+  };
+}
+
+function updateSessionSnapshot(params: {
+  session: SessionState | undefined;
+  sessionStore: SessionStore;
+  sessionName: string;
+  snapshot: SnapshotState;
+}): void {
+  const { session, sessionStore, sessionName, snapshot } = params;
+  if (!session || isSparseSnapshotQualityVerdict(snapshot.snapshotQuality)) return;
+  setSessionSnapshot(session, snapshot);
+  sessionStore.set(sessionName, session);
+}
+
+function isLegacySparseIosInteractiveSnapshot(snapshot: SnapshotState): boolean {
+  if (snapshot.snapshotQuality) return false;
+  if (snapshot.backend !== 'xctest' || snapshot.nodes.length !== 1) return false;
+  return snapshot.nodes[0]?.type === 'Application';
+}

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -10,17 +10,12 @@ import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
 import { resolveTargetDevice, type CommandFlags } from '../core/dispatch.ts';
 import { isApplePlatform } from '../utils/device.ts';
 import { AppError, asAppError, normalizeError } from '../utils/errors.ts';
-import {
-  buildSnapshotPresentationKey,
-  snapshotPresentationOptionsFromFlags,
-  type SnapshotNode,
-} from '../utils/snapshot.ts';
+import type { SnapshotNode } from '../utils/snapshot.ts';
 import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 import { SessionStore } from './session-store.ts';
 import { contextFromFlags } from './context.ts';
 import { ensureDeviceReady } from './device-ready.ts';
-import { captureSnapshot } from './handlers/snapshot-capture.ts';
 import { readTextForNode } from './handlers/interaction-read.ts';
 import { errorResponse } from './handlers/response.ts';
 import { findNodeByLabel } from '../utils/snapshot-processing.ts';
@@ -35,8 +30,6 @@ import {
 } from '../utils/selector-is-predicates.ts';
 import type { ContextFromFlags } from './handlers/interaction-common.ts';
 import { setSessionSnapshot } from './session-snapshot.ts';
-import { getActiveAndroidSnapshotFreshness } from './android-snapshot-freshness.ts';
-import { isSparseSnapshotQualityVerdict } from '../utils/snapshot-quality.ts';
 import {
   describeAndroidEscapeSurface,
   detectAndroidEscapeSurface,
@@ -58,6 +51,7 @@ import {
   readSimpleIosSelectorTarget,
   type DirectIosSelectorTarget,
 } from './direct-ios-selector.ts';
+import { createSelectorCaptureRuntime } from './selector-capture-runtime.ts';
 
 type SelectorRuntimeParams = {
   req: DaemonRequest;
@@ -542,11 +536,16 @@ function createSelectorBackend(params: {
   device: SessionState['device'];
 }): AgentDeviceBackend {
   const { req, session, device, logPath, sessionName, sessionStore } = params;
-  let lastSnapshotAt = 0;
-  let lastSnapshotResult: BackendSnapshotResult | undefined;
+  const captureRuntime = createSelectorCaptureRuntime({
+    device,
+    session,
+    sessionStore,
+    sessionName,
+    req,
+    logPath,
+  });
   return {
     platform: device.platform,
-    // fallow-ignore-next-line complexity
     captureSnapshot: async (_context, options): Promise<BackendSnapshotResult> => {
       const flags = {
         ...req.flags,
@@ -554,51 +553,20 @@ function createSelectorBackend(params: {
       };
       const includeRects = options?.includeRects === true;
       const snapshotScope = options?.scope ?? req.flags?.snapshotScope;
-      const timestamp = Date.now();
-      const presentationKey = buildSnapshotPresentationKey(
-        snapshotPresentationOptionsFromFlags(flags),
-      );
       const needsFreshSnapshot =
         req.command === 'wait' ||
         req.command === 'find' ||
         (includeRects && device.platform === 'web');
-      if (
-        !needsFreshSnapshot &&
-        lastSnapshotResult &&
-        timestamp - lastSnapshotAt < 750 &&
-        !getActiveAndroidSnapshotFreshness(session) &&
-        !session?.postGestureStabilization
-      ) {
-        return lastSnapshotResult;
-      }
-      if (
-        !needsFreshSnapshot &&
-        session?.snapshot &&
-        timestamp - session.snapshot.createdAt < 750 &&
-        session.snapshot.presentationKey === presentationKey &&
-        !getActiveAndroidSnapshotFreshness(session) &&
-        !session.postGestureStabilization
-      ) {
-        lastSnapshotAt = session.snapshot.createdAt;
-        lastSnapshotResult = { snapshot: session.snapshot };
-        return lastSnapshotResult;
-      }
-      const capture = await captureSnapshot({
-        device,
-        session,
+      return await captureRuntime.capture({
         flags,
-        outPath: req.flags?.out,
-        logPath: logPath ?? '',
         snapshotScope,
         includeRects,
+        cache: {
+          forceFresh: needsFreshSnapshot,
+          useSessionSnapshot: true,
+          bypassForPostGestureStabilization: true,
+        },
       });
-      if (session && !isSparseSnapshotQualityVerdict(capture.snapshot.snapshotQuality)) {
-        setSessionSnapshot(session, capture.snapshot);
-        sessionStore.set(sessionName, session);
-      }
-      lastSnapshotAt = timestamp;
-      lastSnapshotResult = { snapshot: capture.snapshot };
-      return lastSnapshotResult;
     },
     readText: async (_context, node: SnapshotNode) => ({
       text: await readTextForNode({
@@ -676,21 +644,26 @@ async function captureWaitSnapshot(params: {
   session: SessionState | undefined;
   device: SessionState['device'];
 }) {
-  const capture = await captureSnapshot({
+  // Reuse selector capture session-write policy, but keep wait text captures fresh.
+  const captureRuntime = createSelectorCaptureRuntime({
     device: params.device,
     session: params.session,
+    sessionStore: params.sessionStore,
+    sessionName: params.sessionName,
+    req: params.req,
+    logPath: params.logPath,
+  });
+  const { snapshot } = await captureRuntime.capture({
     flags: {
       ...params.req.flags,
       snapshotInteractiveOnly: false,
     },
-    outPath: params.req.flags?.out,
-    logPath: params.logPath ?? '',
+    cache: {
+      forceFresh: true,
+      bypassForPostGestureStabilization: true,
+    },
   });
-  if (params.session && !isSparseSnapshotQualityVerdict(capture.snapshot.snapshotQuality)) {
-    setSessionSnapshot(params.session, capture.snapshot);
-    params.sessionStore.set(params.sessionName, params.session);
-  }
-  return capture.snapshot;
+  return snapshot;
 }
 
 function parseGetTarget(req: DaemonRequest):


### PR DESCRIPTION
## Summary

Before: `find` and selector read paths each carried their own selector snapshot capture policy for short-lived cache reuse, sparse snapshot handling, scoped retries, and session snapshot mutation.

After: selector capture policy lives in one daemon runtime module, while `find` still owns parsing, match ranking, action selection, and dispatch. This keeps sparse verdict handling, Android freshness cache bypass, session snapshot writes, and capture cache keys consistent across `find`, `get`, `is`, and `wait`.

Benefits:
- removes duplicated capture policy from two daemon paths
- preserves command-specific behavior at the call sites
- keeps cache reuse keyed to the same effective presentation inputs as before, including per-call selector scope, rect inclusion, and output path
- adds focused regression coverage for scoped selector capture cache reuse and direct sparse recovery paths

Touched files: 4. Scope stayed within daemon selector capture/runtime behavior.

## Validation

Focused selector/find coverage passed for read-only find sparse behavior, actionable find sparse recovery, scoped ref snapshots, selector reads, scoped capture cache reuse, and direct legacy/sparse recovery branches. Static validation passed with `pnpm check:quick`; full unit coverage passed with `pnpm exec vitest run --project unit`; smoke tests passed with `node --test test/integration/smoke-*.test.ts`; fallow reported no issues in changed files.