### PR TITLE
refactor: extract daemon selector capture runtime

### DIFF
--- a/src/daemon/selector-runtime-backend.ts
+++ b/src/daemon/selector-runtime-backend.ts
@@ -1,0 +1,252 @@
+import type {
+  AgentDeviceBackend,
+  BackendSnapshotOptions,
+  BackendSnapshotResult,
+} from '../backend.ts';
+import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
+import { resolveTargetDevice, type CommandFlags } from '../core/dispatch.ts';
+import { createAgentDevice } from '../runtime.ts';
+import { isApplePlatform } from '../utils/device.ts';
+import { errorResponse } from './handlers/response.ts';
+import type { SnapshotNode } from '../utils/snapshot.ts';
+import { findNodeByLabel } from '../utils/snapshot-processing.ts';
+import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
+import { createDaemonRuntimePolicy } from './runtime-policy.ts';
+import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
+import { contextFromFlags } from './context.ts';
+import { ensureDeviceReady } from './device-ready.ts';
+import { readTextForNode } from './handlers/interaction-read.ts';
+import { setSessionSnapshot } from './session-snapshot.ts';
+import type { ContextFromFlags } from './handlers/interaction-common.ts';
+import { SessionStore } from './session-store.ts';
+import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
+import { createSelectorCaptureRuntime } from './selector-capture-runtime.ts';
+
+export type SelectorRuntimeParams = {
+  req: DaemonRequest;
+  sessionName: string;
+  logPath?: string;
+  sessionStore: SessionStore;
+  contextFromFlags?: ContextFromFlags;
+};
+
+type SelectorRuntimeDeviceParams = SelectorRuntimeParams & {
+  session: SessionState | undefined;
+  device: SessionState['device'];
+};
+
+type AppleRunnerFindTextTarget = {
+  device: SessionState['device'];
+  appBundleId: string;
+  traceLogPath?: string;
+};
+
+type SnapshotFlagOverrides = Partial<
+  Pick<CommandFlags, 'snapshotInteractiveOnly' | 'snapshotScope' | 'snapshotDepth' | 'snapshotRaw'>
+>;
+
+export function createSelectorRuntimeForDevice(params: SelectorRuntimeDeviceParams) {
+  return createAgentDevice({
+    backend: createSelectorBackend(params),
+    ...createDaemonRuntimePolicy('selector commands', { plural: true }),
+    sessions: createDaemonRuntimeSessionStore({
+      sessionName: params.sessionName,
+      getSession: () => params.session,
+      recordOptions: { includeSnapshot: true },
+      setRecord: (record) => {
+        if (!params.session || !record.snapshot) return;
+        setSessionSnapshot(params.session, record.snapshot);
+        params.sessionStore.set(params.sessionName, params.session);
+      },
+    }),
+  });
+}
+
+export async function createSelectorRuntime(
+  params: SelectorRuntimeParams,
+  options: { requireSession: boolean; capability: 'find' | 'get' | 'is' },
+): Promise<
+  | { ok: true; runtime: ReturnType<typeof createSelectorRuntimeForDevice> }
+  | { ok: false; response: DaemonResponse }
+> {
+  const session = params.sessionStore.get(params.sessionName);
+  if (!session && options.requireSession) {
+    return {
+      ok: false,
+      response: errorResponse('SESSION_NOT_FOUND', 'No active session. Run open first.'),
+    };
+  }
+  const device = session?.device ?? (await resolveTargetDevice(params.req.flags ?? {}));
+  if (!session) await ensureDeviceReady(device);
+  if (!isCommandSupportedOnDevice(options.capability, device)) {
+    return {
+      ok: false,
+      response: errorResponse(
+        'UNSUPPORTED_OPERATION',
+        `${options.capability} is not supported on this device`,
+      ),
+    };
+  }
+  return {
+    ok: true,
+    runtime: createSelectorRuntimeForDevice({
+      ...params,
+      session,
+      device,
+    }),
+  };
+}
+
+function createSelectorBackend(params: SelectorRuntimeDeviceParams): AgentDeviceBackend {
+  const { req, session, device, logPath, sessionName, sessionStore } = params;
+  const captureRuntime = createSelectorCaptureRuntime({
+    device,
+    session,
+    sessionStore,
+    sessionName,
+    req,
+    logPath,
+  });
+  return {
+    platform: device.platform,
+    captureSnapshot: async (_context, options): Promise<BackendSnapshotResult> => {
+      const flags = {
+        ...req.flags,
+        ...snapshotFlagOverrides(options),
+      };
+      const includeRects = options?.includeRects === true;
+      const snapshotScope = options?.scope ?? req.flags?.snapshotScope;
+      const needsFreshSnapshot =
+        req.command === 'wait' ||
+        req.command === 'find' ||
+        (includeRects && device.platform === 'web');
+      return await captureRuntime.capture({
+        flags,
+        snapshotScope,
+        includeRects,
+        cache: {
+          forceFresh: needsFreshSnapshot,
+          useSessionSnapshot: true,
+          bypassForPostGestureStabilization: true,
+        },
+      });
+    },
+    readText: async (_context, node: SnapshotNode) => ({
+      text: await readTextForNode({
+        device,
+        node,
+        flags: req.flags,
+        appBundleId: session?.appBundleId,
+        traceOutPath: session?.trace?.outPath,
+        surface: session?.surface,
+        contextFromFlags:
+          params.contextFromFlags ??
+          ((flags, appBundleId, traceLogPath) =>
+            contextFromFlags(logPath ?? '', flags, appBundleId, traceLogPath)),
+      }),
+    }),
+    findText: async (_context, text) => ({
+      found: await findText(params, text),
+    }),
+  };
+}
+
+function snapshotFlagOverrides(options: BackendSnapshotOptions | undefined): SnapshotFlagOverrides {
+  const flags: SnapshotFlagOverrides = {};
+  if (options?.interactiveOnly !== undefined)
+    flags.snapshotInteractiveOnly = options.interactiveOnly;
+  if (options?.scope !== undefined) flags.snapshotScope = options.scope;
+  if (options?.depth !== undefined) flags.snapshotDepth = options.depth;
+  if (options?.raw !== undefined) flags.snapshotRaw = options.raw;
+  return flags;
+}
+
+async function findText(params: SelectorRuntimeDeviceParams, text: string): Promise<boolean> {
+  const macosSurfaceResult = await findTextInMacosNonAppSurface(params, text);
+  if (macosSurfaceResult !== null) return macosSurfaceResult;
+  const appleRunnerResult = await findTextWithAppleRunner(params, text);
+  if (appleRunnerResult !== null) return appleRunnerResult;
+  return await findTextInWaitSnapshot(params, text);
+}
+
+async function findTextInMacosNonAppSurface(
+  params: SelectorRuntimeDeviceParams,
+  text: string,
+): Promise<boolean | null> {
+  if (params.device.platform !== 'macos') return null;
+  if (!params.session?.surface || params.session.surface === 'app') return null;
+  return await findTextInWaitSnapshot(params, text);
+}
+
+async function findTextWithAppleRunner(
+  params: SelectorRuntimeDeviceParams,
+  text: string,
+): Promise<boolean | null> {
+  const target = readAppleRunnerFindTextTarget(params);
+  if (!target) return null;
+  const result = (await runIosRunnerCommand(
+    target.device,
+    { command: 'findText', text, appBundleId: target.appBundleId },
+    buildAppleRunnerFindTextOptions(params, target),
+  )) as { found?: boolean };
+  return result?.found === true;
+}
+
+function readAppleRunnerFindTextTarget(
+  params: SelectorRuntimeDeviceParams,
+): AppleRunnerFindTextTarget | null {
+  if (!isApplePlatform(params.device.platform)) return null;
+  if (!params.session?.appBundleId) return null;
+  return {
+    device: params.device,
+    appBundleId: params.session.appBundleId,
+    traceLogPath: params.session.trace?.outPath,
+  };
+}
+
+function buildAppleRunnerFindTextOptions(
+  params: SelectorRuntimeDeviceParams,
+  target: AppleRunnerFindTextTarget,
+) {
+  const flags = params.req.flags ?? {};
+  const meta = params.req.meta ?? {};
+  return {
+    verbose: flags.verbose,
+    logPath: params.logPath,
+    traceLogPath: target.traceLogPath,
+    requestId: meta.requestId,
+    iosXctestrunFile: flags.iosXctestrunFile,
+    iosXctestDerivedDataPath: flags.iosXctestDerivedDataPath,
+    iosXctestEnvDir: flags.iosXctestEnvDir,
+  };
+}
+
+async function findTextInWaitSnapshot(
+  params: SelectorRuntimeDeviceParams,
+  text: string,
+): Promise<boolean> {
+  const snapshot = await captureWaitSnapshot(params);
+  return Boolean(findNodeByLabel(snapshot.nodes, text));
+}
+
+async function captureWaitSnapshot(params: SelectorRuntimeDeviceParams) {
+  const captureRuntime = createSelectorCaptureRuntime({
+    device: params.device,
+    session: params.session,
+    sessionStore: params.sessionStore,
+    sessionName: params.sessionName,
+    req: params.req,
+    logPath: params.logPath,
+  });
+  const { snapshot } = await captureRuntime.capture({
+    flags: {
+      ...params.req.flags,
+      snapshotInteractiveOnly: false,
+    },
+    cache: {
+      forceFresh: true,
+      bypassForPostGestureStabilization: true,
+    },
+  });
+  return snapshot;
+}

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -1,24 +1,11 @@
-import type {
-  AgentDeviceBackend,
-  BackendSnapshotOptions,
-  BackendSnapshotResult,
-} from '../backend.ts';
-import { createAgentDevice } from '../runtime.ts';
 import { parseWaitPositionals } from '../core/wait-positionals.ts';
 import type { WaitParsed } from '../core/wait-positionals.ts';
 import { isCommandSupportedOnDevice } from '../core/capabilities.ts';
-import { resolveTargetDevice, type CommandFlags } from '../core/dispatch.ts';
-import { isApplePlatform } from '../utils/device.ts';
 import { AppError, asAppError, normalizeError } from '../utils/errors.ts';
 import type { SnapshotNode } from '../utils/snapshot.ts';
 import { runIosRunnerCommand } from '../platforms/ios/runner-client.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
-import { SessionStore } from './session-store.ts';
-import { contextFromFlags } from './context.ts';
-import { ensureDeviceReady } from './device-ready.ts';
-import { readTextForNode } from './handlers/interaction-read.ts';
 import { errorResponse } from './handlers/response.ts';
-import { findNodeByLabel } from '../utils/snapshot-processing.ts';
 import { resolveSessionDevice, withSessionlessRunnerCleanup } from './handlers/snapshot-session.ts';
 import { parseFindArgs, type FindAction } from '../utils/finders.ts';
 import { splitIsSelectorArgs } from './selectors.ts';
@@ -28,8 +15,6 @@ import {
   isSupportedPredicate,
   type IsPredicate,
 } from '../utils/selector-is-predicates.ts';
-import type { ContextFromFlags } from './handlers/interaction-common.ts';
-import { setSessionSnapshot } from './session-snapshot.ts';
 import {
   describeAndroidEscapeSurface,
   detectAndroidEscapeSurface,
@@ -43,27 +28,17 @@ import {
   toDaemonGetData,
   toDaemonWaitData,
 } from './selector-recording.ts';
-import { createDaemonRuntimePolicy } from './runtime-policy.ts';
-import { createDaemonRuntimeSessionStore } from './runtime-session.ts';
 import { maybeWaitTimeoutSurfaceResponse } from './wait-current-surface.ts';
 import {
   isDirectIosSelectorFallbackError,
   readSimpleIosSelectorTarget,
   type DirectIosSelectorTarget,
 } from './direct-ios-selector.ts';
-import { createSelectorCaptureRuntime } from './selector-capture-runtime.ts';
-
-type SelectorRuntimeParams = {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath?: string;
-  sessionStore: SessionStore;
-  contextFromFlags?: ContextFromFlags;
-};
-
-type SnapshotFlagOverrides = Partial<
-  Pick<CommandFlags, 'snapshotInteractiveOnly' | 'snapshotScope' | 'snapshotDepth' | 'snapshotRaw'>
->;
+import {
+  createSelectorRuntime,
+  createSelectorRuntimeForDevice,
+  type SelectorRuntimeParams,
+} from './selector-runtime-backend.ts';
 
 type DirectIosSelectorQueryResult = {
   found: boolean;
@@ -464,206 +439,6 @@ function readDirectIosSelectorNode(data: Record<string, unknown>): SnapshotNode 
   const node = nodes[0];
   if (!node || typeof node !== 'object') return undefined;
   return node as SnapshotNode;
-}
-
-function createSelectorRuntimeForDevice(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath?: string;
-  sessionStore: SessionStore;
-  contextFromFlags?: ContextFromFlags;
-  session: SessionState | undefined;
-  device: SessionState['device'];
-}) {
-  return createAgentDevice({
-    backend: createSelectorBackend(params),
-    ...createDaemonRuntimePolicy('selector commands', { plural: true }),
-    sessions: createDaemonRuntimeSessionStore({
-      sessionName: params.sessionName,
-      getSession: () => params.session,
-      recordOptions: { includeSnapshot: true },
-      setRecord: (record) => {
-        if (!params.session || !record.snapshot) return;
-        setSessionSnapshot(params.session, record.snapshot);
-        params.sessionStore.set(params.sessionName, params.session);
-      },
-    }),
-  });
-}
-
-async function createSelectorRuntime(
-  params: SelectorRuntimeParams,
-  options: { requireSession: boolean; capability: 'find' | 'get' | 'is' },
-): Promise<
-  | { ok: true; runtime: ReturnType<typeof createSelectorRuntimeForDevice> }
-  | { ok: false; response: DaemonResponse }
-> {
-  const session = params.sessionStore.get(params.sessionName);
-  if (!session && options.requireSession) {
-    return {
-      ok: false,
-      response: errorResponse('SESSION_NOT_FOUND', 'No active session. Run open first.'),
-    };
-  }
-  const device = session?.device ?? (await resolveTargetDevice(params.req.flags ?? {}));
-  if (!session) await ensureDeviceReady(device);
-  if (!isCommandSupportedOnDevice(options.capability, device)) {
-    return {
-      ok: false,
-      response: errorResponse(
-        'UNSUPPORTED_OPERATION',
-        `${options.capability} is not supported on this device`,
-      ),
-    };
-  }
-  return {
-    ok: true,
-    runtime: createSelectorRuntimeForDevice({
-      ...params,
-      session,
-      device,
-    }),
-  };
-}
-
-function createSelectorBackend(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath?: string;
-  sessionStore: SessionStore;
-  contextFromFlags?: ContextFromFlags;
-  session: SessionState | undefined;
-  device: SessionState['device'];
-}): AgentDeviceBackend {
-  const { req, session, device, logPath, sessionName, sessionStore } = params;
-  const captureRuntime = createSelectorCaptureRuntime({
-    device,
-    session,
-    sessionStore,
-    sessionName,
-    req,
-    logPath,
-  });
-  return {
-    platform: device.platform,
-    captureSnapshot: async (_context, options): Promise<BackendSnapshotResult> => {
-      const flags = {
-        ...req.flags,
-        ...snapshotFlagOverrides(options),
-      };
-      const includeRects = options?.includeRects === true;
-      const snapshotScope = options?.scope ?? req.flags?.snapshotScope;
-      const needsFreshSnapshot =
-        req.command === 'wait' ||
-        req.command === 'find' ||
-        (includeRects && device.platform === 'web');
-      return await captureRuntime.capture({
-        flags,
-        snapshotScope,
-        includeRects,
-        cache: {
-          forceFresh: needsFreshSnapshot,
-          useSessionSnapshot: true,
-          bypassForPostGestureStabilization: true,
-        },
-      });
-    },
-    readText: async (_context, node: SnapshotNode) => ({
-      text: await readTextForNode({
-        device,
-        node,
-        flags: req.flags,
-        appBundleId: session?.appBundleId,
-        traceOutPath: session?.trace?.outPath,
-        surface: session?.surface,
-        contextFromFlags:
-          params.contextFromFlags ??
-          ((flags, appBundleId, traceLogPath) =>
-            contextFromFlags(logPath ?? '', flags, appBundleId, traceLogPath)),
-      }),
-    }),
-    findText: async (_context, text) => ({
-      found: await findText(params, text),
-    }),
-  };
-}
-
-function snapshotFlagOverrides(options: BackendSnapshotOptions | undefined): SnapshotFlagOverrides {
-  const flags: SnapshotFlagOverrides = {};
-  if (options?.interactiveOnly !== undefined)
-    flags.snapshotInteractiveOnly = options.interactiveOnly;
-  if (options?.scope !== undefined) flags.snapshotScope = options.scope;
-  if (options?.depth !== undefined) flags.snapshotDepth = options.depth;
-  if (options?.raw !== undefined) flags.snapshotRaw = options.raw;
-  return flags;
-}
-
-async function findText(
-  params: {
-    req: DaemonRequest;
-    sessionName: string;
-    logPath?: string;
-    sessionStore: SessionStore;
-    contextFromFlags?: ContextFromFlags;
-    session: SessionState | undefined;
-    device: SessionState['device'];
-  },
-  text: string,
-): Promise<boolean> {
-  const { device, session, req, logPath } = params;
-  if (device.platform === 'macos' && session?.surface && session.surface !== 'app') {
-    const snapshot = await captureWaitSnapshot(params);
-    return Boolean(findNodeByLabel(snapshot.nodes, text));
-  }
-  if (isApplePlatform(device.platform) && session?.appBundleId) {
-    const result = (await runIosRunnerCommand(
-      device,
-      { command: 'findText', text, appBundleId: session?.appBundleId },
-      {
-        verbose: req.flags?.verbose,
-        logPath,
-        traceLogPath: session?.trace?.outPath,
-        requestId: req.meta?.requestId,
-        iosXctestrunFile: req.flags?.iosXctestrunFile,
-        iosXctestDerivedDataPath: req.flags?.iosXctestDerivedDataPath,
-        iosXctestEnvDir: req.flags?.iosXctestEnvDir,
-      },
-    )) as { found?: boolean };
-    return result?.found === true;
-  }
-  const snapshot = await captureWaitSnapshot(params);
-  return Boolean(findNodeByLabel(snapshot.nodes, text));
-}
-
-async function captureWaitSnapshot(params: {
-  req: DaemonRequest;
-  sessionName: string;
-  logPath?: string;
-  sessionStore: SessionStore;
-  contextFromFlags?: ContextFromFlags;
-  session: SessionState | undefined;
-  device: SessionState['device'];
-}) {
-  // Reuse selector capture session-write policy, but keep wait text captures fresh.
-  const captureRuntime = createSelectorCaptureRuntime({
-    device: params.device,
-    session: params.session,
-    sessionStore: params.sessionStore,
-    sessionName: params.sessionName,
-    req: params.req,
-    logPath: params.logPath,
-  });
-  const { snapshot } = await captureRuntime.capture({
-    flags: {
-      ...params.req.flags,
-      snapshotInteractiveOnly: false,
-    },
-    cache: {
-      forceFresh: true,
-      bypassForPostGestureStabilization: true,
-    },
-  });
-  return snapshot;
 }
 
 function parseGetTarget(req: DaemonRequest):


### PR DESCRIPTION
## Summary

Rebased onto latest main after selector capture policy landed there. This PR now extracts daemon selector runtime backend construction into src/daemon/selector-runtime-backend.ts while leaving dispatch, direct iOS selector fast paths, response shaping, and recording/result handling in selector-runtime.ts.

Before/after LOC: selector-runtime.ts 788 -> 536; selector-runtime-backend.ts 0 -> 252. Files touched: 2.

Scope checks: PR diff is only src/daemon/selector-runtime.ts and src/daemon/selector-runtime-backend.ts; no src/commands/interaction/runtime/* changes; no src/compat/maestro/* changes; Maestro target/ranking/visibility logic untouched. The latest main src/daemon/selector-capture-runtime.ts is preserved and reused by the backend.

## Validation

Focused guard suite passed: ./node_modules/.bin/vitest run src/daemon/handlers/__tests__/find.test.ts src/daemon/handlers/__tests__/snapshot-handler.test.ts src/daemon/handlers/__tests__/snapshot-scoped-refs.test.ts src/daemon/handlers/__tests__/interaction.test.ts src/compat/maestro/__tests__/runtime-interactions.test.ts src/compat/maestro/__tests__/runtime-targets.test.ts (6 files, 167 tests).

Fallow passed locally after rebasing: ./node_modules/.bin/fallow audit --base origin/main.

Static checks passed directly: ./node_modules/.bin/oxlint . --deny-warnings and ./node_modules/.bin/tsc -p tsconfig.json.

Format passed via the repo formatter binary: ./node_modules/.bin/oxfmt --write src/daemon/selector-runtime.ts src/daemon/selector-runtime-backend.ts.