### PR TITLE
test: guard Maestro swipe stabilization flag

### DIFF
--- a/src/compat/maestro/__tests__/runtime-interactions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-interactions.test.ts
@@ -291,11 +291,12 @@ test('invokeMaestroSwipeScreen mirrors Android horizontal directional content la
 test('invokeMaestroSwipeOn resolves visible non-interactive text from a regular snapshot', async () => {
   const snapshotFlags: Array<DaemonRequest['flags']> = [];
   const swipes: string[][] = [];
+  const swipeFlags: Array<DaemonRequest['flags']> = [];
   const response = await invokeMaestroSwipeOn({
     baseReq: {
       token: 'test',
       session: 'android-carousel',
-      flags: { platform: 'android' },
+      flags: { platform: 'android', postGestureStabilization: true },
     },
     positionals: ['label="Gallery" || text="Gallery" || id="Gallery"', 'left', '300'],
     invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
@@ -325,6 +326,7 @@ test('invokeMaestroSwipeOn resolves visible non-interactive text from a regular 
       }
       if (req.command === 'swipe') {
         swipes.push(req.positionals ?? []);
+        swipeFlags.push(req.flags);
         return { ok: true, data: {} };
       }
       return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
@@ -336,6 +338,7 @@ test('invokeMaestroSwipeOn resolves visible non-interactive text from a regular 
   expect(snapshotFlags[0]?.snapshotInteractiveOnly).toBeUndefined();
   expect(snapshotFlags[0]?.snapshotRaw).toBe(true);
   expect(swipes).toEqual([['200', '250', '8', '250', '300']]);
+  expect(swipeFlags[0]?.postGestureStabilization).toBe(true);
 });
 
 test('invokeMaestroSwipeScreen preserves vertical percentage endpoints', async () => {


### PR DESCRIPTION
## Summary

Keeps the Maestro `swipe.label` deletion guard focused by extending the existing raw snapshot/geometry test to assert that `postGestureStabilization` survives on the outgoing `swipe` request.

## Validation

Ran focused Maestro runtime validation and the repo quick static check: `CI=true pnpm exec vitest run src/compat/maestro/__tests__/runtime-interactions.test.ts` and `CI=true pnpm check:quick`. Verified `git diff origin/main...HEAD --stat` is limited to `src/compat/maestro/__tests__/runtime-interactions.test.ts`.

Touched files: 1. Scope stayed limited to tests.