### PR TITLE
fix: enable ios runner prepare in sandboxed environments

### DIFF
--- a/scripts/build-xcuitest-apple.sh
+++ b/scripts/build-xcuitest-apple.sh
@@ -102,6 +102,10 @@ xcodebuild build-for-testing \
   AGENT_DEVICE_IOS_RUNNER_TEST_BUNDLE_ID="$RUNNER_TEST_BUNDLE_ID" \
   COMPILER_INDEX_STORE_ENABLE=NO \
   ENABLE_CODE_COVERAGE=NO \
+  -IDEPackageSupportDisableManifestSandbox=1 \
+  -IDEPackageSupportDisablePluginExecutionSandbox=1 \
+  ENABLE_USER_SCRIPT_SANDBOXING=NO \
+  OTHER_SWIFT_FLAGS='$(inherited) -disable-sandbox' \
   $SIGNING_BUILD_SETTINGS
 
 node --experimental-strip-types scripts/patch-xcuitest-runner-icon.ts "$DERIVED_PATH"

--- a/scripts/write-xcuitest-cache-metadata.mjs
+++ b/scripts/write-xcuitest-cache-metadata.mjs
@@ -197,6 +197,15 @@ function resolveSigningBuildSettings() {
   ];
 }
 
+function resolveSandboxBuildArgs() {
+  return [
+    '-IDEPackageSupportDisableManifestSandbox=1',
+    '-IDEPackageSupportDisablePluginExecutionSandbox=1',
+    'ENABLE_USER_SCRIPT_SANDBOXING=NO',
+    'OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox',
+  ];
+}
+
 const appBundleId = resolveRunnerAppBundleId();
 const testBundleId = resolveRunnerTestBundleId();
 const metadata = {
@@ -214,6 +223,7 @@ const metadata = {
   ],
   runnerSigningBuildSettings: resolveSigningBuildSettings(),
   runnerPerformanceBuildSettings: ['COMPILER_INDEX_STORE_ENABLE=NO', 'ENABLE_CODE_COVERAGE=NO'],
+  runnerSandboxBuildArgs: resolveSandboxBuildArgs(),
 };
 
 const artifacts = resolveRunnerCacheArtifacts();

--- a/src/platforms/ios/__tests__/runner-client.test.ts
+++ b/src/platforms/ios/__tests__/runner-client.test.ts
@@ -55,6 +55,7 @@ import {
   resolveRunnerDerivedPath,
   resolveRunnerCacheMetadataPath,
   resolveRunnerPerformanceBuildSettings,
+  resolveRunnerSandboxBuildArgs,
   shouldDeleteRunnerDerivedRootEntry,
   writeRunnerCacheMetadata,
   xctestrunReferencesProjectRoot,
@@ -472,6 +473,15 @@ test('resolveRunnerPerformanceBuildSettings disables indexing and code coverage'
   assert.deepEqual(resolveRunnerPerformanceBuildSettings(), [
     'COMPILER_INDEX_STORE_ENABLE=NO',
     'ENABLE_CODE_COVERAGE=NO',
+  ]);
+});
+
+test('resolveRunnerSandboxBuildArgs disables nested Xcode and Swift sandboxing', () => {
+  assert.deepEqual(resolveRunnerSandboxBuildArgs(), [
+    '-IDEPackageSupportDisableManifestSandbox=1',
+    '-IDEPackageSupportDisablePluginExecutionSandbox=1',
+    'ENABLE_USER_SCRIPT_SANDBOXING=NO',
+    'OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox',
   ]);
 });
 
@@ -1193,6 +1203,37 @@ test('ensureXctestrun rebuilds cached runner when metadata package version misma
     resolveExpectedRunnerCacheMetadata(macOsDevice, repoRoot),
   );
   assert.equal(rebuiltMetadata.artifacts?.xctestrunPath, rebuiltXctestrunPath);
+});
+
+test('ensureXctestrunArtifact passes sandbox-disabling settings to xcodebuild', async () => {
+  const projectRoot = repoRoot;
+  const tmpDir = await makeProjectTmpDir();
+  const derivedPath = path.join(tmpDir, 'custom-derived');
+  const rebuiltXctestrunPath = path.join(derivedPath, 'Build', 'Products', 'rebuilt.xctestrun');
+
+  withRunnerDerivedPathEnv(derivedPath);
+
+  mockRunCmdStreaming.mockImplementationOnce(async () => {
+    await fs.promises.mkdir(path.join(derivedPath, 'Build', 'Products', 'Runner.app'), {
+      recursive: true,
+    });
+    writeXctestrunFixture(rebuiltXctestrunPath, {
+      projectRoot,
+      productRelativePaths: ['Runner.app'],
+    });
+  });
+
+  const result = await ensureXctestrunArtifact(iosSimulator, {
+    forceRunnerXctestrunRebuild: true,
+  });
+
+  assert.equal(result.xctestrunPath, rebuiltXctestrunPath);
+  assert.equal(mockRunCmdStreaming.mock.calls.length, 1);
+  const args = mockRunCmdStreaming.mock.calls[0]?.[1] ?? [];
+  assert.equal(args.includes('-IDEPackageSupportDisableManifestSandbox=1'), true);
+  assert.equal(args.includes('-IDEPackageSupportDisablePluginExecutionSandbox=1'), true);
+  assert.equal(args.includes('ENABLE_USER_SCRIPT_SANDBOXING=NO'), true);
+  assert.equal(args.includes('OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox'), true);
 });
 
 test('ensureXctestrunArtifact stress-recovers after a bad restored artifact', async () => {

--- a/src/platforms/ios/runner-xctestrun.ts
+++ b/src/platforms/ios/runner-xctestrun.ts
@@ -52,6 +52,12 @@ const RUNNER_XCTESTRUN_CAPTURE_OPTIONS = {
   SystemAttachmentLifetime: 'keepNever',
   UserAttachmentLifetime: 'keepNever',
 } as const;
+const RUNNER_SANDBOX_BUILD_ARGS = [
+  '-IDEPackageSupportDisableManifestSandbox=1',
+  '-IDEPackageSupportDisablePluginExecutionSandbox=1',
+  'ENABLE_USER_SCRIPT_SANDBOXING=NO',
+  'OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox',
+] as const;
 
 const runnerXctestrunBuildLocks = new Map<string, Promise<unknown>>();
 const badRunnerArtifactsForRun = new Set<string>();
@@ -107,6 +113,7 @@ export type RunnerXctestrunCacheMetadata = {
   runnerBundleBuildSettings: string[];
   runnerSigningBuildSettings: string[];
   runnerPerformanceBuildSettings: string[];
+  runnerSandboxBuildArgs: string[];
   artifacts?: RunnerXctestrunCacheArtifacts;
 };
 
@@ -758,6 +765,7 @@ export function resolveExpectedRunnerCacheMetadata(
       device.platform,
     ),
     runnerPerformanceBuildSettings: resolveRunnerPerformanceBuildSettings(),
+    runnerSandboxBuildArgs: resolveRunnerSandboxBuildArgs(),
   };
 }
 
@@ -1363,6 +1371,7 @@ async function buildRunnerXctestrun(
   );
   const provisioningArgs = device.kind === 'device' ? ['-allowProvisioningUpdates'] : [];
   const performanceBuildSettings = resolveRunnerPerformanceBuildSettings();
+  const sandboxBuildArgs = resolveRunnerSandboxBuildArgs();
   const simulatorSetRedirect = await acquireXcodebuildSimulatorSetRedirect(device);
   try {
     await runCmdStreaming(
@@ -1382,6 +1391,7 @@ async function buildRunnerXctestrun(
         '-derivedDataPath',
         derived,
         ...performanceBuildSettings,
+        ...sandboxBuildArgs,
         ...runnerBundleBuildSettings,
         ...provisioningArgs,
         ...signingBuildSettings,
@@ -1484,6 +1494,10 @@ export function resolveRunnerBundleBuildSettings(env: NodeJS.ProcessEnv = proces
 
 export function resolveRunnerPerformanceBuildSettings(): string[] {
   return ['COMPILER_INDEX_STORE_ENABLE=NO', 'ENABLE_CODE_COVERAGE=NO'];
+}
+
+export function resolveRunnerSandboxBuildArgs(): string[] {
+  return [...RUNNER_SANDBOX_BUILD_ARGS];
 }
 
 function shouldCleanDerived(): boolean {


### PR DESCRIPTION
## Summary

Adds sandbox-disabling Xcode/SPM build args to Apple runner build-for-testing paths so `prepare ios-runner` can build under outer sandbox tools such as `sandbox-exec`/ai-jail.

Keeps the runtime prepare path and standalone XCTest build script aligned, and records the sandbox build args in both runtime and script-written runner cache metadata so script-built caches remain reusable.

Closes #868

## Validation

Focused runner unit coverage passes and asserts the sandbox args are forwarded to xcodebuild. The xctestrun metadata test also verifies the standalone metadata script matches runtime metadata. Static checks and package build pass. Verified locally with `sandbox-exec -p "(version 1)(allow default)" pnpm ad prepare ios-runner --platform ios --session issue-868-prepare-review --timeout 240000 --debug`; the command built with the new args and reported `Prepared Apple runner: iPhone 17 Pro`. Also ran the standalone `pnpm build:xcuitest` script path for iOS and macOS.

Touched files: 4. Scope stayed within the Apple runner build/cache path.