### PR TITLE
fix: resolve web find locators

### DIFF
--- a/src/commands/interaction/runtime/selector-read.test.ts
+++ b/src/commands/interaction/runtime/selector-read.test.ts
@@ -208,6 +208,45 @@ test('runtime find get_text reads the matched node', async () => {
   assert.equal(result.node.label, 'Continue');
 });
 
+test('runtime find accepts selector expression queries', async () => {
+  const device = createSelectorDevice(selectorSnapshot());
+
+  const result = await device.selectors.find({
+    session: 'default',
+    query: 'label="Continue"',
+    action: 'exists',
+  });
+
+  assert.deepEqual(result, { kind: 'found', found: true });
+});
+
+test('runtime web find text does not pass locator text as browser selector scope', async () => {
+  const snapshot = selectorSnapshot();
+  let captureOptions: BackendSnapshotOptions | undefined;
+  const device = createAgentDevice({
+    backend: {
+      platform: 'web',
+      captureSnapshot: async (_context, options) => {
+        captureOptions = options;
+        return { snapshot };
+      },
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot }]),
+    policy: localCommandPolicy(),
+  });
+
+  const result = await device.selectors.find({
+    session: 'default',
+    locator: 'text',
+    query: 'Continue',
+    action: 'exists',
+  });
+
+  assert.deepEqual(result, { kind: 'found', found: true });
+  assert.equal(captureOptions?.scope, undefined);
+});
+
 test('runtime find wait reports sparse snapshot verdicts on the selector-read route', async () => {
   const initialSnapshot = selectorSnapshot();
   const session = { name: 'default', snapshot: initialSnapshot };

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -1,5 +1,9 @@
-import type { FindAction, FindLocator } from '../../../utils/finders.ts';
-import { findBestMatchesByLocator } from '../../../utils/finders.ts';
+import {
+  findBestMatchesByLocator,
+  parseFindSelectorExpression,
+  type FindAction,
+  type FindLocator,
+} from '../../../utils/finders.ts';
 import type { SnapshotNode } from '../../../utils/snapshot.ts';
 import { findNodeByRef, normalizeRef } from '../../../utils/snapshot.ts';
 import {
@@ -13,6 +17,7 @@ import {
   formatSelectorFailure,
   parseSelectorChain,
   resolveSelectorChain,
+  type SelectorChain,
 } from '../../../selectors.ts';
 import { buildSelectorChainForNode } from '../../../utils/selector-build.ts';
 import {
@@ -408,17 +413,37 @@ async function findFirstLocatorMatch(
   options: FindReadCommandOptions,
   locator: FindLocator,
 ): Promise<{ capture: CapturedSnapshot; match: SnapshotNode | undefined }> {
+  const selectorChain = parseFindSelectorExpression(locator, options.query);
   const capture = await captureSelectorSnapshot(runtime, options, {
     updateSession: true,
-    scope: shouldScopeFind(locator) ? options.query : undefined,
+    scope: findSnapshotScope(runtime, locator, options.query, selectorChain),
   });
   if (isSparseSnapshotQualityVerdict(capture.snapshot.snapshotQuality)) {
     throw sparseSelectorSnapshotError(capture.snapshot.snapshotQuality);
+  }
+  if (selectorChain) {
+    const resolved = resolveSelectorChain(capture.snapshot.nodes, selectorChain, {
+      platform: runtime.backend.platform,
+      requireRect: false,
+      requireUnique: false,
+    });
+    return { capture, match: resolved?.node };
   }
   const match = findBestMatchesByLocator(capture.snapshot.nodes, locator, options.query, {
     requireRect: false,
   }).matches[0];
   return { capture, match };
+}
+
+function findSnapshotScope(
+  runtime: AgentDeviceRuntime,
+  locator: FindLocator,
+  query: string,
+  selectorChain: SelectorChain | null,
+): string | undefined {
+  if (selectorChain) return undefined;
+  if (runtime.backend.platform === 'web') return undefined;
+  return shouldScopeFind(locator) ? query : undefined;
 }
 
 function sparseSelectorSnapshotError(verdict: SnapshotQualityVerdict): AppError {

--- a/src/daemon/handlers/__tests__/find-args.test.ts
+++ b/src/daemon/handlers/__tests__/find-args.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import { parseFindArgs } from '../find.ts';
+import { parseFindSelectorExpression } from '../../../utils/finders.ts';
 
 test('parseFindArgs defaults to click with any locator', () => {
   const parsed = parseFindArgs(['Login']);
@@ -43,4 +44,12 @@ test('parseFindArgs with bare locator yields empty query', () => {
   expect(parsed.locator).toBe('text');
   expect(parsed.query).toBe('');
   expect(parsed.action).toBe('click');
+});
+
+test('parseFindSelectorExpression only treats bare selector-shaped queries as selectors', () => {
+  const parsed = parseFindSelectorExpression('any', 'label="Continue"');
+  expect(parsed?.raw).toBe('label="Continue"');
+
+  expect(parseFindSelectorExpression('text', 'label="Continue"')).toBeNull();
+  expect(parseFindSelectorExpression('any', 'a=b')).toBeNull();
 });

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -1,6 +1,11 @@
 import { dispatchCommand, resolveTargetDevice } from '../../core/dispatch.ts';
 import { sleep } from '../../utils/timeouts.ts';
-import { findBestMatchesByLocator, parseFindArgs, type FindLocator } from '../../utils/finders.ts';
+import {
+  findBestMatchesByLocator,
+  parseFindArgs,
+  parseFindSelectorExpression,
+  type FindLocator,
+} from '../../utils/finders.ts';
 import { centerOfRect, type SnapshotState } from '../../utils/snapshot.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
@@ -21,6 +26,7 @@ import {
   isSparseSnapshotQualityVerdict,
   type SnapshotQualityVerdict,
 } from '../../utils/snapshot-quality.ts';
+import { resolveSelectorChain, type SelectorChain } from '../../selectors.ts';
 
 export { parseFindArgs } from '../../utils/finders.ts';
 
@@ -91,7 +97,11 @@ export async function handleFindCommands(params: {
   const requiresRect = findActionRequiresRect(action);
   // Interaction targets need the full interactive tree so duplicate labels can be
   // resolved against viewport visibility before an off-screen subtree wins.
-  const scope = shouldScopeFind(locator) && !requiresRect ? query : undefined;
+  const selectorChain = parseFindSelectorExpression(locator, query);
+  const scope =
+    device.platform !== 'web' && !selectorChain && shouldScopeFind(locator) && !requiresRect
+      ? query
+      : undefined;
   const fetchNodes = createFindNodeFetcher({
     device,
     session,
@@ -132,8 +142,10 @@ export async function handleFindCommands(params: {
     nodes,
     locator,
     query,
+    selectorChain,
     requiresRect,
     flags: req.flags,
+    platform: device.platform,
   });
   if (!matchResult.ok) return matchResult.response;
   const node = matchResult.node;
@@ -241,13 +253,29 @@ function resolveFindMatch(params: {
   nodes: SnapshotState['nodes'];
   locator: FindLocator;
   query: string;
+  selectorChain: SelectorChain | null;
   requiresRect: boolean;
   flags: DaemonRequest['flags'];
+  platform: SessionState['device']['platform'];
 }): FindMatchResult {
-  const { nodes, locator, query, requiresRect, flags } = params;
+  const { nodes, locator, query, selectorChain, requiresRect, flags, platform } = params;
   const searchableNodes = requiresRect
     ? nodes.filter((node) => !isRootInteractionContainer(node, nodes[0]))
     : nodes;
+  if (selectorChain) {
+    const resolved = resolveSelectorChain(searchableNodes, selectorChain, {
+      platform,
+      requireRect: requiresRect,
+      requireUnique: false,
+    });
+    if (!resolved) {
+      return {
+        ok: false,
+        response: errorResponse('COMMAND_FAILED', 'find did not match any element'),
+      };
+    }
+    return { ok: true, node: resolved.node };
+  }
   const bestMatches = findBestMatchesByLocator(searchableNodes, locator, query, {
     requireRect: requiresRect,
   });

--- a/src/utils/finders.ts
+++ b/src/utils/finders.ts
@@ -1,5 +1,6 @@
 import type { SnapshotNode } from './snapshot.ts';
 import { AppError } from './errors.ts';
+import { tryParseSelectorChain, type SelectorChain } from './selectors-parse.ts';
 
 export const FIND_LOCATORS = ['any', 'text', 'label', 'value', 'role', 'id'] as const;
 export type FindLocator = (typeof FIND_LOCATORS)[number];
@@ -147,6 +148,15 @@ export function parseFindArgs(args: string[]): {
     return { locator, query, action: 'type', value };
   }
   throw new AppError('INVALID_ARGS', `Unsupported find action: ${actionTokens[0]}`);
+}
+
+export function parseFindSelectorExpression(
+  locator: FindLocator,
+  query: string,
+): SelectorChain | null {
+  if (locator !== 'any') return null;
+  if (!query.includes('=') && !query.includes('||')) return null;
+  return tryParseSelectorChain(query);
 }
 
 function parseTimeout(value: string | undefined): number | null {

--- a/test/integration/smoke-web-platform.test.ts
+++ b/test/integration/smoke-web-platform.test.ts
@@ -120,6 +120,18 @@ async function assertReadAndVisibility(context: WebSmokeContext): Promise<void> 
     ['is', 'visible', 'label="Submit order"'],
     { pass: true },
   );
+  await assertCommandData(
+    context,
+    'find ready text by locator',
+    ['find', 'text', 'Ready marker', 'exists'],
+    { found: true },
+  );
+  await assertCommandData(
+    context,
+    'find ready text by selector expression',
+    ['find', 'text="Ready marker"', 'exists'],
+    { found: true },
+  );
 }
 
 async function assertWebNetwork(context: WebSmokeContext): Promise<void> {


### PR DESCRIPTION
## Summary

Fix web `find` so text and selector-style queries resolve from snapshot data instead of being sent to the browser backend as CSS snapshot scopes.

Closes #867

## Validation

`pnpm check:quick` passed.
`pnpm check:unit` passed.
`pnpm build` passed.
`AGENT_DEVICE_WEB_E2E=1 node --test test/integration/smoke-web-platform.test.ts` passed, including `find text "Ready marker" exists` and `find "text=\"Ready marker\"" exists` on the local web fixture.