### PR TITLE
docs: configure agent skill conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,11 @@ Minimal operating guide for AI coding agents in this repo.
 
 ### Issue tracker
 
-Issues and PRDs live in GitHub Issues for `callstack/agent-device`. See `docs/agents/issue-tracker.md`.
+Issues and PRDs live in GitHub Issues for `callstack/agent-device`; external PRs are not a triage request surface. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
-Follow the issue label workflow in `docs/agents/triage-labels.md`.
+Follow the issue label workflow in `docs/agents/triage-labels.md`, including `ready-for-agent` and `ready-for-human`.
 
 ### Domain docs
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -2,7 +2,21 @@
 
 Issues and PRDs for this repo live as GitHub issues in `callstack/agent-device`. Use the `gh` CLI for issue operations.
 
+## Pull requests as a triage surface
+
+PRs as a request surface: no.
+
+External PRs are not part of the triage request queue. Use `gh pr` commands only when a task explicitly asks for PR review, CI, or PR maintenance.
+
 ## Conventions
+
+`gh` authentication may only be available through the user's login shell. In sandboxed agent environments, run GitHub operations through the login shell and request escalation for network/auth access, for example:
+
+```sh
+/bin/zsh -lc 'gh issue view <number> --comments'
+```
+
+If `gh` still reports that it is not authenticated, do not attempt to reconfigure credentials. Report the exact command that needs to be run from the user's authenticated shell.
 
 - Create an issue with `gh issue create --title "..." --body "..."`.
 - Read an issue with `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,20 +1,20 @@
 # Issue Label Workflow
 
-This repo uses labels for issue state, not executor type.
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual GitHub labels used in this repo.
 
-| GitHub label | Meaning |
-| --- | --- |
-| `needs-triage` | New or unreviewed issue; maintainer needs to evaluate it |
-| `in-progress` | Someone has started work on the issue |
-| `needs-info` | Waiting on reporter or external input |
-| `wontfix` | Will not be actioned after an explicit maintainer decision |
+| Skill role | GitHub label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | New or unreviewed issue; maintainer needs to evaluate it |
+| `needs-info` | `needs-info` | Waiting on reporter or external input |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, AFK-ready for an agent to pick up |
+| `ready-for-human` | `ready-for-human` | Valid work, but needs human implementation or judgment |
+| `wontfix` | `wontfix` | Will not be actioned after an explicit maintainer decision |
 
 Default flow:
 
 1. New issues get `needs-triage`.
 2. Remove `needs-triage` once the issue is understood and valid.
-3. Add `in-progress` and assign the active owner when work starts.
-4. Leave a triaged, unassigned issue without a state label when it is available work.
-5. Remove `in-progress` when the issue closes or the work is abandoned.
-
-Do not use `ready-for-agent`, `ready-for-human`, or other executor-specific labels.
+3. Add `needs-info` when reporter or external input is required.
+4. Add `ready-for-agent` when the issue is fully specified and can be picked up by an AFK agent with no extra human context.
+5. Add `ready-for-human` when the issue is valid but needs human implementation, product judgment, or maintainer ownership.
+6. Add `wontfix` only after an explicit maintainer decision.


### PR DESCRIPTION
## Summary

Configure the repo-level agent skill guidance for GitHub Issues, triage labels, and domain docs.

Details:
- records GitHub Issues as the tracker and external PRs as outside the triage request surface
- adds sandbox/login-shell guidance for authenticated gh operations
- switches triage guidance to the five canonical roles, including ready-for-agent and ready-for-human

Touched files: 3. Scope stayed within agent guidance docs.

## Validation

Docs-only change. Verified the staged diff before committing; no tests required by the repo testing matrix.