### PR TITLE
fix: avoid copying pnpm node_modules into worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,8 +1,3 @@
-# JavaScript dependencies
-node_modules/
-.pnpm-store/
-examples/test-app/node_modules/
-
 # Local environment
 .env
 .env.*

--- a/src/platforms/android/__tests__/index.test.ts
+++ b/src/platforms/android/__tests__/index.test.ts
@@ -2109,7 +2109,7 @@ test('fillAndroid tolerates delayed React Native text verification', async () =>
       await fillAndroid(device, 10, 10, 'sent the update');
     },
   );
-});
+}, 10_000);
 
 test('typeAndroid reports clear error when unicode input is unsupported', async () => {
   await withMockedAdb(


### PR DESCRIPTION
## Summary

Avoid copying pnpm-managed dependency trees into Codex worktrees so pnpm can recreate its symlink/hardlink graph locally.

Also give the delayed Android fill verification regression a larger per-test timeout so the shell-backed mock can tolerate production retry delays.

## Validation

Ran `git diff --check`.

Focused Vitest startup is currently blocked in this worktree by the existing malformed copied `node_modules`: `tinyglobby` cannot resolve `fdir`.