### PR TITLE
docs: clarify agent-device QA mental model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A device automation CLI for real apps on iOS, Android, TV, web, and desktop. Age
 
 `agent-device` lets coding agents open apps, inspect the current UI, interact with visible elements, and collect debugging evidence through one CLI. Use it when an agent needs to verify what actually happens on a device, not just reason about code.
 
+The CLI is the agent's hands, eyes, and evidence collector; it is not the brain. Your coding agent or QA harness reads the task, interprets the current screen, chooses the next command, and decides whether the result satisfies the test. `agent-device` keeps that loop grounded in structured accessibility data, deterministic actions, and files an engineer can inspect.
+
 If you know Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser), `agent-device` is the same idea for mobile, TV, and desktop apps. Minimal `--platform web` support reuses `agent-browser` when a browser session needs to fit into the same command/session/replay loop.
 
 It works with native iOS and Android apps, plus apps built with Expo, Flutter, and React Native, as long as the target can run on a supported device, simulator, emulator, or desktop environment.
@@ -81,6 +83,8 @@ agent-device close
 ```
 
 Snapshots assign refs like `@e1`, `@e2`, and `@e3` to elements on the current screen. Refs from the latest snapshot are immediately actionable; after scrolling or changing screens, take a fresh snapshot.
+
+Snapshots come from the app's accessibility tree, so high-quality labels, roles, and test IDs make agent runs far more reliable. Use screenshots and videos as evidence or visual fallback, but prefer refs and selectors for actions and assertions whenever the UI exposes enough structure.
 
 ## Next Steps
 

--- a/website/docs/docs/introduction.md
+++ b/website/docs/docs/introduction.md
@@ -9,6 +9,8 @@ description: Learn what agent-device is, where it fits in agentic mobile, TV, de
 
 Use it when an agent needs to inspect and operate a real app, not just reason about source code or screenshots.
 
+`agent-device` is the agent's hands, eyes, and evidence collector. It does not contain the test intelligence itself: the coding agent, QA agent, or project harness reads the task, interprets the current screen, chooses commands, and judges whether the result meets the scenario. Keeping that boundary clear makes it easier to combine live exploration, deterministic replay, and human review without hiding decision-making inside the device tool.
+
 ## Where it shines
 
 - **App verification for agents**: run the app, inspect visible UI, act through refs/selectors, and verify expected state.
@@ -38,6 +40,8 @@ agent-device press @e12
 agent-device diff snapshot -i
 agent-device close
 ```
+
+Snapshots are accessibility-first: labels, roles, values, and test IDs are the primary signal for choosing refs and selectors. Screenshots and videos are still important evidence, and they are useful fallbacks when a screen exposes poor accessibility data, but durable agent workflows should prefer structured refs/selectors over pixel or OCR guesses.
 
 Installed CLI help is the version-matched operating guide. Start there before planning device work:
 


### PR DESCRIPTION
## Summary

Clarifies that agent-device provides the agent hands, eyes, and evidence layer while coding agents or QA harnesses own scenario decisions and pass/fail judgment.

Adds accessibility-first guidance so readers understand refs/selectors are preferred for durable actions, with screenshots and videos as evidence or fallback.

Touched-file count: 2. Scope stayed limited to public docs.

## Validation

Docs-only change; no automated checks required by the testing matrix.