### PR TITLE
fix: refine Apple provider pressure reporting

### DIFF
--- a/scripts/integration-progress-model.test.ts
+++ b/scripts/integration-progress-model.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import os from 'node:os';
+import path from 'node:path';
+import { buildIntegrationProgressModel } from './integration-progress-model.ts';
+
+test('integration progress counts explicit generic Apple host-tool usage only', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'agent-device-progress-'));
+  try {
+    const scenarioDir = path.join(root, 'test/integration/provider-scenarios');
+    await mkdir(scenarioDir, { recursive: true });
+    await writeFile(
+      path.join(scenarioDir, 'workflow.test.ts'),
+      [
+        "const steps = [{ command: 'open' }];",
+        "await daemon.callCommand('open', ['settings']);",
+        "assertFlatToolCall(appleTool.calls, ['simctl', 'pbcopy', 'sim-1']);",
+        "assertFlatToolCall(appleTool.calls, ['pkill', '-TERM', '-P', '1234']);",
+        "await provider.runCommand('mdfind', ['kMDItemCFBundleIdentifier == com.example']);",
+      ].join('\n'),
+    );
+
+    const progress = buildIntegrationProgressModel({ root });
+    const appleGeneric = progress.providerPressureRows.find(
+      (row) => row.name === 'Apple generic host-tool provider',
+    );
+
+    assert.equal(appleGeneric?.references, 2);
+    assert.equal(appleGeneric?.files, 1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -372,8 +372,7 @@ function summarizeProviderPressure(files) {
     },
     {
       name: 'Apple generic host-tool provider',
-      pattern:
-        /\bxcrun\b|['"](?:open|pbcopy|pbpaste|plutil|osascript|swift|codesign|mdfind|ps|pkill)['"]/g,
+      pattern: buildAppleGenericHostToolPattern(),
     },
     {
       name: 'Linux semantic desktop provider',
@@ -407,6 +406,31 @@ function summarizeProviderPressure(files) {
   return surfaces
     .map((surface) => ({ name: surface.name, ...countSurfaceReferences(files, surface.pattern) }))
     .filter((surface) => surface.references > 0);
+}
+
+function buildAppleGenericHostToolPattern(): RegExp {
+  const hostTools = [
+    'xcrun',
+    'open',
+    'pbcopy',
+    'pbpaste',
+    'plutil',
+    'osascript',
+    'swift',
+    'codesign',
+    'mdfind',
+    'ps',
+    'pkill',
+  ].join('|');
+  return new RegExp(
+    [
+      String.raw`\brunAppleToolCommand\b`,
+      String.raw`\brunCommand\s*\(\s*['"](?:${hostTools})['"]`,
+      String.raw`\bassertFlatToolCall\([^,\n]+,\s*\[\s*['"](?:${hostTools})['"]`,
+      String.raw`\bcalls\.push\(\[\s*['"](?:${hostTools})['"]`,
+    ].join('|'),
+    'g',
+  );
 }
 
 function countSurfaceReferences(files, pattern) {


### PR DESCRIPTION
## Summary

Refines integration progress reporting so Apple generic host-tool pressure counts explicit generic provider usage only, not workflow command names or semantic simctl/devicectl assertions.

Adds script-level regression coverage for the metric: public `open` workflow strings and `simctl pbcopy` stay out of the generic bucket, while raw host-tool assertions such as `pkill` and `mdfind` still count.

Touched-file count: 2. Scope stayed within integration progress reporting.

## Validation

Verified with the script regression test, integration progress check, targeted iOS provider-backed scenario, formatting, and quick static checks:

- `node --experimental-strip-types --test scripts/integration-progress-model.test.ts`
- `node --experimental-strip-types scripts/integration-progress.ts --check`
- `pnpm exec vitest run --project provider-integration test/integration/provider-scenarios/ios-lifecycle.test.ts`
- `pnpm format`
- `pnpm check:quick`