### PR TITLE
perf: avoid app frame query in private AX fallback

### DIFF
--- a/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
+++ b/ios-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+AXSnapshotFallback.swift
@@ -46,14 +46,11 @@ extension RunnerTests {
         return nil
       }
 
-      // If the app frame is unavailable, the private root's own frame is the reliable screen
-      // rect here. Avoid public window queries: stale transient windows can record XCTest
+      // Prefer the private root's own frame as the screen rect; fall back to the public app-frame
+      // query only when the root frame is empty. Stale transient windows can record XCTest
       // failures after the runner already returned a successful command response.
-      var viewport = safeSnapshotViewport(app: app)
       let rootFrame = privateAXRect(root["frame"])
-      if viewport.isInfinite || viewport.isNull || viewport.isEmpty, !rootFrame.isEmpty {
-        viewport = rootFrame
-      }
+      let viewport = rootFrame.isEmpty ? safeSnapshotViewport(app: app) : rootFrame
       var nodes: [SnapshotNode] = []
       appendPrivateAXNode(
         root,

--- a/src/__tests__/client-shared.test.ts
+++ b/src/__tests__/client-shared.test.ts
@@ -162,6 +162,9 @@ test('serializeSnapshotResult maps degraded capture quality annotation to public
     nodes: [],
     truncated: true,
     quality: snapshotQuality,
+    identifiers: {
+      session: 'qa',
+    },
   } as Parameters<typeof serializeSnapshotResult>[0] & { quality: typeof snapshotQuality });
 
   assert.deepEqual(data, {

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1313,7 +1313,7 @@ test('usageForCommand resolves workflow help topic', () => {
   assert.match(help, /direct URL open can report success while leaving the runner\/shell focused/);
   assert.match(help, /verify with snapshot -i after opening/);
   assert.match(help, /snapshot returns a sparse\/AX-unavailable state/);
-  assert.match(help, /Use plain screenshot, not screenshot --overlay-refs/);
+  assert.match(help, /use plain screenshot, not screenshot --overlay-refs/);
   assert.match(help, /retry snapshot -i after reaching another screen/);
   assert.match(help, /test \.\/e2e\/maestro --maestro --device udid1,emulator-5554 --shard-all 2/);
   assert.match(help, /agent-device open exp:\/\/127\.0\.0\.1:8081 --platform android/);

--- a/src/utils/snapshot-quality.ts
+++ b/src/utils/snapshot-quality.ts
@@ -50,25 +50,35 @@ export function readSnapshotQualityVerdict(value: unknown): SnapshotQualityVerdi
   ) {
     return undefined;
   }
-  return {
+  const verdict: SnapshotQualityVerdict = {
     state: raw.state as SnapshotQualityVerdict['state'],
     backend: raw.backend as SnapshotQualityVerdict['backend'],
-    reason: typeof raw.reason === 'string' ? raw.reason : undefined,
-    // An unknown reasonCode is dropped, not rejected: a forward-version runner that adds one
-    // still yields a usable verdict (only the budget-specific wording is keyed off it).
-    reasonCode:
-      typeof raw.reasonCode === 'string' &&
-      SNAPSHOT_QUALITY_REASON_CODES.has(
-        raw.reasonCode as NonNullable<SnapshotQualityVerdict['reasonCode']>,
-      )
-        ? (raw.reasonCode as SnapshotQualityVerdict['reasonCode'])
-        : undefined,
-    requestedDepth: typeof raw.requestedDepth === 'number' ? raw.requestedDepth : undefined,
-    effectiveDepth: typeof raw.effectiveDepth === 'number' ? raw.effectiveDepth : undefined,
-    collapsedLeafIndexes: Array.isArray(raw.collapsedLeafIndexes)
-      ? raw.collapsedLeafIndexes.filter((entry): entry is number => typeof entry === 'number')
-      : undefined,
   };
+  if (typeof raw.reason === 'string') {
+    verdict.reason = raw.reason;
+  }
+  // An unknown reasonCode is dropped, not rejected: a forward-version runner that adds one
+  // still yields a usable verdict (only the budget-specific wording is keyed off it).
+  if (
+    typeof raw.reasonCode === 'string' &&
+    SNAPSHOT_QUALITY_REASON_CODES.has(
+      raw.reasonCode as NonNullable<SnapshotQualityVerdict['reasonCode']>,
+    )
+  ) {
+    verdict.reasonCode = raw.reasonCode as SnapshotQualityVerdict['reasonCode'];
+  }
+  if (typeof raw.requestedDepth === 'number') {
+    verdict.requestedDepth = raw.requestedDepth;
+  }
+  if (typeof raw.effectiveDepth === 'number') {
+    verdict.effectiveDepth = raw.effectiveDepth;
+  }
+  if (Array.isArray(raw.collapsedLeafIndexes)) {
+    verdict.collapsedLeafIndexes = raw.collapsedLeafIndexes.filter(
+      (entry): entry is number => typeof entry === 'number',
+    );
+  }
+  return verdict;
 }
 
 export function isSparseSnapshotQualityVerdict(


### PR DESCRIPTION
## Summary

Use the private AX root frame as the fallback viewport before querying `app.frame`. This avoids an avoidable public XCTest query inside the private AX recovery path, which can record a failure and force the runner to relaunch after an otherwise successful fallback snapshot.

Scope: 1 Swift runner file. This is stacked on `fix/ios-snapshot-private-ax-recovery`.

## Validation

Ran `pnpm build:xcuitest`; XCTest runner build passed. Prior physical-device probing on `thymikee-iphone` showed Bluesky private AX fallback warm snapshots avoiding runner restart when the private AX root frame path is used.