### PR TITLE
refactor: type-safe recording backends + exhaustive capability gating

### DIFF
--- a/docs/adr/0003-daemon-command-registry.md
+++ b/docs/adr/0003-daemon-command-registry.md
@@ -53,3 +53,37 @@ sets.
 
 `AGENTS.md` should contain only the operating rule and relevant file pointers for agents. This ADR
 owns the rationale so future changes do not need to infer it from agent instructions.
+
+## Update (2026-06): single-declaration / derivation model
+
+A later proposal (the `CommandDescriptor` direction in `plans/perfect-shape.md`) unifies a command's
+declarations so the public catalog, capability matrix, CLI/MCP projections, batch allowlist, and this
+daemon registry are *derived* from one registration site, to remove the cross-table drift that several
+of these surfaces are kept aligned against by convention.
+
+**This ADR's decision stands.** Its boundary is about *ownership* and the *predicate interface*, not
+about the physical file a trait is typed in. "Separate source of truth" means separately owned and
+exposed through named predicates — a property that survives a projected/derived backing table. A
+derived daemon registry is therefore permitted **only if** it preserves all of the following invariants:
+
+1. **Daemon-owned declaration.** Route and request-policy traits are declared in a daemon-owned facet
+   (under `src/daemon/`) and *composed* into the registration — never inlined as fields on the public
+   command contract in `src/commands/**` or `src/command-catalog.ts`. Co-locating a registration *call*
+   is fine; co-locating *ownership* of daemon policy in the public surface is the contamination this ADR
+   rejected (see Alternatives, "Keep daemon groups in `src/command-catalog.ts`").
+2. **Predicate interface unchanged.** Consumers keep asking daemon-policy questions through the named
+   predicates (`getDaemonCommandRoute`, `isLeaseAdmissionExempt`, `shouldLockSessionExecution`, …). The
+   daemon registry remains their sole exposer; derivation changes how the backing table is *built*, not
+   how it is *read*.
+3. **No leakage into public projections.** The catalog/CLI/MCP/help/capability projections must be
+   type-prevented from reading daemon-only traits, and the daemon registry must still not define CLI
+   grammar, Node.js options, MCP schemas, user-facing help, or capability support.
+4. **One declaration per concern, enforced by types.** The single registration site must make a missing
+   or duplicated daemon trait a *compile error* — replacing today's "aligned by convention". This is the
+   structural improvement that justifies derivation over a separately hand-authored table.
+
+A single flat public descriptor whose daemon fields leak into public views is **not** permitted — that is
+the "collapse daemon policy into a public command registry" failure this ADR exists to prevent. Compose
+facets owned by their domains; derive the registry from them. Until that derivation lands and is pinned
+by the registry tests, the hand-authored `src/daemon/daemon-command-registry.ts` remains the source of
+truth and the operating rule in `AGENTS.md` is unchanged.

--- a/plans/apple-platform-consolidation.md
+++ b/plans/apple-platform-consolidation.md
@@ -1,0 +1,177 @@
+# Apple Platform Consolidation — `platforms/apple` with an `AppleOS` leaf axis
+
+> The platform-axis half of the [perfect-shape roadmap](./perfect-shape.md): make the Apple plugin own
+> **iOS / iPadOS / tvOS / macOS** today and **visionOS / watchOS** as honest future leaves — a single
+> `apple` platform with an `AppleOS` discriminant. Grounded in a 4-investigator survey of the real code.
+
+## TL;DR
+
+`src/platforms/ios/` is **~85% an OS-agnostic Apple-XCTest engine that is merely misfiled and misnamed.**
+Of ~14.2k LOC, ~12k is OS-agnostic (the 6,136-LOC runner stack, tool-provider, discovery, snapshot/AX,
+screenshot, perf, debug-symbols), and `apple-runner-platform.ts` already models iOS/tvOS/macOS as
+first-class runner profiles. The XCTest runner **already builds `ios|macos|tvos` from one Xcode project**,
+and one `createAppleInteractor` already serves both `ios` and `macos`. So consolidation is overwhelmingly
+**relocate-and-rename, not rewrite** — for iOS/iPadOS/tvOS/macOS. visionOS is real-but-scoped net-new
+work; watchOS is **externally blocked** by Apple (no XCUITest UI automation).
+
+**The taxonomy decision:** add an **`AppleOS` discriminant under one `apple` Platform** — do **not** promote
+each OS to its own `Platform` literal. Reasons from the code:
+- `DeviceTarget` (`mobile|tv|desktop`) is already **cross-platform** — Android TV uses `target:'tv'`, so a
+  `tvos` Platform literal would collide with the form-factor axis. (tvOS is *currently* hacked onto
+  `target:'tv'`; the fix is a dedicated `AppleOS` leaf, **not** more overloading of `target`.)
+- Promoting to literals explodes the ~15 `isApplePlatform` and ~52 `platform==='macos'` sites to enumerate
+  six literals each, and breaks the single-bucket `apple` capability/selector model that already works.
+
+## Before / after
+
+```
+BEFORE — Apple support is smeared across an "iOS" folder that is really the Apple engine
+─────────────────────────────────────────────────────────────────────────────────────────
+
+DeviceInfo (src/utils/device.ts)
+  platform: ios | macos | android | linux | web     ← macOS is its OWN literal …
+  kind:     simulator | emulator | device
+  target?:  mobile | tv | desktop                   ← … but tvOS = ios + target:'tv'  (asymmetric!)
+                                                       'tv'/'desktop' also used by Android (cross-platform)
+
+  resolveApplePlatformName(target) ──► 'iOS' | 'tvOS' | 'macOS'   ← OS name INFERRED late & lossily
+
+core/interactors.ts:  ios ─┐
+                    macos ─┴─► createAppleInteractor      (one Apple owner already exists!)
+
+┌─ src/platforms/ios/  (~14.2k LOC — the "iOS" name is a lie: ~85% is the Apple engine) ─────────┐
+│  ░ APPLE-SHARED ENGINE (OS-agnostic, ~12k) ░                                                   │
+│     runner/ stack ........ 6,136 LOC / 17 files     (speaks JSON to a Swift host w/ #if os())   │
+│     apple-runner-platform.ts ► RUNNER_PROFILES = { iOS, tvOS, macOS }   (3 rows)                │
+│     discovery · tool-provider · snapshot/xml · screenshot · perf · debug-symbols                │
+│  ▓ iOS leaf ▓   touch synthesis · status-bar override · xctrace perf                            │
+│  ▓ tvOS leaf ▓  XCUIRemote focus / remotePress                                                  │
+│  ▒ macOS leaf — MISLABELED HERE (~797 LOC) ▒  macos-helper · macos-apps · host-provider · scroll │
+└───────────────────────────────▲─────────────────────────────────────────────────────────────────┘
+                                 │ imports (dependency arrow points BACKWARD)
+                  src/platforms/macos/devices.ts = 19-LOC stub
+
+Discovery:  xcrun simctl list ─► filter admits only {ios, tvos} ─► watchOS, visionOS SILENTLY DROPPED
+Capabilities: ONE 'apple' bucket + scattered re-derivation
+   isNotMacOs ×5 · isIosMobileSimulator · synthesisGestureUnsupportedHint · dispatch hard-throws ×3
+   ('macos' string in 52 files · 'tv' in 15)
+```
+
+```
+AFTER — one 'apple' platform, an AppleOS leaf axis, the engine named for what it actually is
+─────────────────────────────────────────────────────────────────────────────────────────────
+
+DeviceInfo
+  platform: apple | android | linux | web           ← ios + macos collapse into 'apple'
+  appleOs:  ios | ipados | tvos | watchos | visionos | macos   ← NEW discriminant, stored at discovery
+  kind:     simulator | device
+  target?:  mobile | tv | desktop                   ← UNCHANGED, stays orthogonal (shared w/ Android)
+
+  resolveAppleOs(device) ──► reads appleOs  (fallback: legacy target inference)   ← single seam
+
+Apple plugin  = one instance of the PlatformPlugin registry (perfect-shape.md §5.1),
+                owning every leaf OS via appleOs
+
+┌─ src/platforms/apple/ ──────────────────────────────────────────────────────────────────────────┐
+│  core/   ░ OS-agnostic Apple engine — MOVED VERBATIM from platforms/ios ░                          │
+│    runner/ (6,136 LOC) · tool-provider · discovery (absorbs the old stub, filter widened)          │
+│    snapshot · screenshot · perf · debug-symbols                                                    │
+│    os-profiles.ts ► RUNNER_PROFILES = { iOS, iPadOS, tvOS, macOS, visionOS, watchOS✗ }  (3 → 6)     │
+│  interactor.ts   (from core/interactors/apple.ts)                                                  │
+│  os/     ← leaf code ONLY (genuinely per-OS)                                                       │
+│    ios/      touch synthesis · status-bar · xctrace                                                │
+│    ipados/   aliases ios  (only if iPad-specific features are modeled)                             │
+│    tvos/     XCUIRemote focus — NO coordinate tap  (contract differs; NOT flattened)               │
+│    macos/    AppKit: helper binary · host-provider · desktop-scroll · menubar/desktop surfaces     │
+│    visionos/ NEW — feasible: profile + build case + #if os(visionOS) + real spatial-input QA       │
+│    watchos/  ⛔ unsupported sentinel — XCUITest can't drive watchOS (declared, gated at admission)  │
+└────────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+Capabilities: per-AppleOS DATA TABLE  (mirrors os-profiles + the Swift #if os() guards 1:1)
+   { inputModel, multiTouch, gestures{pinch,rotate,transform}, surfaces, keyboard, orientation }
+   ⇒ scattered isNotMacOs / target!=='tv' predicates collapse into one lookup
+```
+
+## Per-OS readiness (honest)
+
+| OS | Status | Reality |
+|---|---|---|
+| **iOS** | works | Reference path. |
+| **iPadOS** | works | Rides iOS *identically* (matched by `/ipad/`). Zero runner work; splitting it is a naming/label concern — only worth it if Stage Manager / pointer / Pencil are actually modeled. |
+| **tvOS** | works | Functional but modeled as `ios + target:'tv'`. Promotion = **rename to a leaf**; XCUIRemote focus + no-coordinate-tap behavior already exists. |
+| **macOS** | works | Same XCUITest project (`build:xcuitest:macos`) **plus** a separate `agent-device-macos-helper` Swift binary for AX surfaces. ~797 LOC already (mis)lives in `platforms/ios`. AppKit, not UIKit — kept as a distinct leaf, not folded into the touch model. |
+| **visionOS** | feasible, net-new | XCUITest *does* support visionOS. Needs `xros` in `SUPPORTED_PLATFORMS`, a profile row, a build case, `#if os(visionOS)`, a widened discovery filter, **and real QA** of spatial input (look+pinch, no flat coordinates) + multi-window snapshot. Good first net-new OS to validate the leaf pattern. |
+| **watchOS** | blocked by Apple | **XCUITest cannot drive watchOS UI** (no `XCUIApplication`). Not a code gap. Model as an explicit *unsupported sentinel* — do not promise it from this runner. |
+
+## On macOS (the one to think about)
+
+macOS is **AppKit**, the odd one out at the UI-framework level — so it's reasonable to ask whether it
+belongs. The code says **include it, as a distinct leaf**, for two reasons:
+
+1. It's already the **same XCUITest project** the iOS/tvOS runner uses (`build:xcuitest:macos`) — it is
+   already in the Apple runner, not a separate harness.
+2. **~797 LOC of macOS code already lives *inside* `platforms/ios`** (`macos-helper`, `macos-apps`,
+   `macos-host-provider`, `desktop-scroll`), and `platforms/macos/devices.ts` is a 19-LOC stub the iOS
+   discovery imports — the dependency already points backwards.
+
+So macOS is *already entangled* in the Apple stack; **excluding it would leave the mislabel in place**,
+which is worse. Consolidation **normalizes** macOS (today it's the only Apple OS with its own `Platform`
+literal while tvOS rides `target`) without **homogenizing** it: its AppKit specifics — the macos-helper
+backend, the menubar/desktop/frontmost-app surface model, coordinate-pinch, no multi-touch — stay in the
+`apple/os/macos/` leaf. The leaf boundary is exactly what protects the AppKit difference.
+
+## Target shape
+
+```
+src/platforms/apple/
+  core/         ← the ~12k OS-agnostic engine, moved verbatim from platforms/ios
+    runner/     (6,136 LOC, 17 files — never needed to know which Apple OS it drives)
+    os-profiles.ts   (apple-runner-platform.ts RUNNER_PROFILES, 3 → 6 rows)
+    discovery.ts tool-provider/ snapshot/ screenshot/ perf/ debug-symbols/ apps.ts
+  interactor.ts (from core/interactors/apple.ts)
+  os/
+    ios/ ipados/ tvos/ macos/   ← leaf code only (synthesis / focus / AppKit helper / surfaces)
+    visionos/  (new, when pursued)   watchos/  (unsupported sentinel)
+```
+
+This is the Apple plugin from the roadmap, now owning *N OS leaves* via `AppleOS`. Capabilities become a
+**per-`AppleOS` data table** mirroring `RUNNER_PROFILES` and the Swift `#if os()` guards 1:1, replacing the
+scattered `target!=='tv'` / `platform!=='macos'` predicates.
+
+## Sequencing (strangler-fig, low-risk first)
+
+1. **Additive `appleOs`** (non-breaking): add `appleOs?: AppleOS` to `DeviceInfo`, populate it at discovery
+   (the runtime/productType is already known there), and make `resolveApplePlatformName` /
+   `resolveRunnerPlatformName` prefer it with the existing target inference as fallback. Extend
+   `RUNNER_PROFILES` 3 → 6. Instantly makes iOS/iPadOS/tvOS/macOS first-class and unambiguous without
+   touching the ~50 `macos`/`isApplePlatform` call sites. *(Aligns with AGENTS.md's "Apple-family target
+   changes must keep device.ts, capabilities.ts, dispatch-resolve.ts, ios/devices.ts, ios/runner-xctestrun.ts
+   in sync" rule — this step is what makes that rule a single seam instead of a five-file checklist.)*
+2. **Relocate macOS** out of `platforms/ios` into `apple/os/macos/` and invert the `macos/devices.ts` stub.
+   Self-contained de-scatter; the single biggest mislabel removed.
+3. **Move the OS-agnostic core** (`runner/` stack, tool-provider, discovery, snapshot, screenshot, perf,
+   debug-symbols, `os-profiles.ts`) `platforms/ios` → `platforms/apple/core` — pure move + re-export.
+   Rename `ios-runner/` → `apple-runner/` (cosmetic).
+4. **Promote tvOS** from `ios + target:'tv'` to an `apple/os/tvos/` leaf (rename; behavior already exists).
+5. **visionOS** as the first net-new OS: profile row + `SUPPORTED_PLATFORMS += xros` + build case +
+   `#if os(visionOS)` + widened discovery + **budgeted spatial-input/snapshot QA**.
+6. **watchOS** = explicit unsupported sentinel (declared, gated at admission), no runner work.
+7. **Per-`AppleOS` capability table** replaces the scattered predicates (after the leaves exist).
+
+Steps 1–4 compose with the roadmap's **Phase 3 (platform plugin)** — the Apple plugin is the first real
+`PlatformPlugin`, and it owns the `AppleOS` leaves. Step 1 can land early as additive groundwork.
+
+## Risks / do-not-flatten
+
+- **tvOS has a different interaction contract** (focus-only; `tap(x,y)` returns `UNSUPPORTED` off the
+  focused element). A uniform tap across Apple OSes is wrong by design — keep the per-OS capability gates.
+- **macOS is a hybrid backend** (XCTest runner *and* the macos-helper binary). Don't fold the helper into
+  the runner.
+- **visionOS is feasible but unvalidated** — spatial windowing, ornaments, multi-window viewport inference,
+  and look+pinch synthesis need real device/sim QA. "Just add a profile row" under-counts it.
+- **Snapshot fidelity is uneven** — the deep-RN-tree AX-server fallback is iOS-simulator-only; macOS / tvOS
+  / visionOS rely on public XCTest snapshots, so a unified "apple snapshot" has materially different
+  reliability per OS.
+- **`watchos` must be gated unsupported**, or it surfaces a selectable device with no runner backend.
+- The relocation touches ~52 `macos` + ~15 `tv` references — mechanical (move + re-export) but high diff;
+  stage as create-re-export → move-leaves → flip-the-stub-inversion-last to keep each step shippable.

--- a/plans/perfect-shape.md
+++ b/plans/perfect-shape.md
@@ -1,0 +1,397 @@
+# agent-device — The Perfect Shape
+
+> An architecture review + target design, produced from a 31-agent survey of the codebase
+> (13 subsystem maps, 6 debt hunts, 5 architecture visions, 3 judges, 4 prototypes).
+> Every claim is grounded in real `file:line` evidence. Read-only analysis — nothing here was applied.
+
+---
+
+## 0. TL;DR
+
+agent-device is a healthy ~100k-LOC codebase with **one structural disease expressed on two axes**:
+identity is *smeared across many hand-synced tables* instead of owned in one place.
+
+- **Adding a platform touches ~90 files** because there is **no Platform plugin contract** — `Platform`
+  is a bare string union re-discriminated by **231 open-coded branches** across ~90 files outside `platforms/`
+  (the daemon alone: 57 files).
+- **Adding a command touches ~24 files** because **a command is not a single object** — its identity is
+  restated in **~10 stringly-keyed tables** (dispatch switch, capability matrix, daemon registry, batch
+  allowlist, `client-types.ts`, …), even though a *half-finished declarative spine* (`CommandFamilyFacet`)
+  already auto-derives CLI + MCP + batch from one source and just **stops at the command-surface boundary**.
+
+The cure is **two registries** — a `CommandDescriptor` table and a `PlatformPlugin` registry — from which the
+hand-synced tables *derive*, plus a **typed-result spine** that replaces `Record<string,unknown>` bags. Done in
+the right order (command-first, because its typed-result seam is the safety net the platform unwind needs),
+this is a **strangler-fig migration of pure identity tables** — never a rewrite of the genuinely
+toolchain-specific leaf code (XCTest synthesis, adb, Maestro replay), which stays exactly where it is.
+
+**Honest scope:** the headline "90 files → 3" is *wiring* cost, not *total* cost. Writing a correct
+XCUITest/adb-equivalent interactor for a new platform is thousands of irreducible LOC. The registries make the
+wiring cheap and make *half-wired* platforms a compile error — they do not make platforms cheap. Net code
+reduction is real but modest (~**-1k to -3k LOC**, dominated by deleting the `client-types.ts` mirror); the
+*real* prize is **files-per-change** and **type safety**, not raw line count.
+
+---
+
+## 1. Mind map — the codebase today
+
+```
+                                 ┌──────────── INTERFACES ────────────┐
+                  CLI (bin→cli.ts, cli/, utils/cli-*)   MCP (mcp/)   batch (batch.ts, core/batch.ts)
+                                 └──────────────────┬──────────────────┘
+                                                    │
+                     COMMAND SURFACE  commands/ (90 files, 12k) · command-catalog.ts · contracts.ts
+                       └── commands/family/  ← HALF-FINISHED declarative spine (derives CLI+MCP+batch)
+                                                    │   ...stops here. Everything below is hand-synced.
+                                                    ▼
+                       CORE DISPATCH  core/ (5k)   dispatch.ts (24-arm switch, default:throw)
+                                       capabilities.ts (matrix keyed apple/android/linux/web)
+                                                    │      ↑ leaks: ~16 `await import('../platforms/*')`
+                                                    ▼        + ~15 device.platform branches in dispatch*
+                       DAEMON  daemon/ (29k)   daemon-command-registry · session-store · request-router
+                         └── handlers/ (66 files, 14k)   ← 22 verbatim UNSUPPORTED guards, 13 "No active
+                              │                            session" literals, recordAction inlined ×24
+                              │   'generic' route is DISOWNED → request-generic-dispatch.ts (outside handlers/)
+                              ▼
+                       PLATFORMS  platforms/ (29k)   ios 14k ·· android 11.6k ·· macos 19 LOC(!) ·· web/linux
+                         ▲  Interactor (core) vs AgentDeviceBackend (backend.ts): TWO contracts, same ~30 ops,
+                         │  glued by a stringify→re-parse round-trip. macOS hides 697 LOC inside platforms/ios.
+                         │
+       ┌─────────────────┴────────── CROSS-CUTTING / UNOWNED ──────────────────────────┐
+       │  ~8k LOC client/transport/remote/cloud/tunnel/metro UNFOLDERED at src/ root     │
+       │     (the `daemon-` prefix co-locates client driver + server bootstrap + proxy)  │
+       │  utils/ (97 files, 13.5k) = grab-bag: 3k CLI parser + 1.8k screenshot-diff +    │
+       │     AX-snapshot domain + the CANONICAL device.ts (imported by 92–95 modules)    │
+       │  compat/maestro (5.5k) = the LOAD-BEARING .ad replay engine (KEEP)              │
+       └────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Subsystem ownership scorecard** (what each owns well vs. where ownership leaks):
+
+| Subsystem | Owns well | Leaks / debt |
+|---|---|---|
+| CLI | argv tokenizing, zero-load fast paths, remote-lease lifecycle | `runCli` 340-line god fn; special commands routed by string `if`-ladder; 2 divergent deferred-command sets |
+| MCP | tool generation from the catalog | hand-rolled inbound validation; `jsonRpcRequestSchema` exists but is **dead**; `params as unknown as Partial<DaemonRequest>` |
+| Command surface | the family facet (CLI+MCP+batch derive from it) | spine stops at surface boundary; identity restated downstream ×10 |
+| Core dispatch | capability matrix; interactor selection seam | 24-arm string switch; **leaks platform knowledge** (dynamic imports + branches) |
+| Daemon | routing/registry/session/admission | hand-rolled per-handler boilerplate; 'generic' family disowned; dual finalize |
+| Platforms | genuinely toolchain-specific leaf code | macOS hidden in iOS; two parallel platform contracts; 231 branches *outside* the dir |
+| Client/remote | transport, leases, tunnels, cloud | **unfoldered at src root**; `client-types.ts` (1027 LOC) is a 4th copy of the contract |
+| utils | real cross-cutting helpers | hosts 3 full subsystems + the canonical domain types |
+
+---
+
+## 2. Diagnosis — one root cause, two axes
+
+### Axis A — No `CommandDescriptor` (the command smear)
+
+A command's identity is restated, by hand, in **~10 places that must agree**:
+
+```
+PUBLIC_COMMANDS (command-catalog.ts)         core/dispatch.ts  case 'x':  (switch, default: throw)
+commands/*/metadata.ts  name                 daemon-command-registry.ts  descriptor
+commands/family facet                        batch-policy.ts  STRUCTURED_BATCH_COMMAND_NAMES
+cliReader + daemonWriter                     capabilities.ts  matrix entry
+client-types.ts  Options/Result interface    client.ts  executeCommand wrapper
+```
+
+Adding a command = synchronized edits to all of them, with **zero compile-time agreement** between them.
+The arg shape is serialized/deserialized **4 times** (metadata field map → cliReader → daemonWriter → handler
+re-reads positionals). The gesture set is retyped in **3 files**. The dispatch `default: throw` means a
+missing/renamed command **compiles fine and fails only at runtime**.
+
+> The good news: `commands/family/registry.ts` already proves the cure works — `commandFamilies` derives MCP
+> tools, the CLI schema, and the batch writer from **one array**. The fix is to *extend* this proven seam, not
+> invent one.
+
+### Axis B — No `PlatformPlugin` (the platform smear)
+
+`Platform` is `'ios' | 'macos' | 'android' | 'linux' | 'web'` (a bare union in `utils/device.ts`). **231
+branches** in ~90 files re-discriminate it. Partial seams exist (the `Interactor` interface; the
+`request-platform-providers` descriptors) but each of capabilities, device-discovery, providers, recording,
+app-log, perf, surfaces, the `--platform` enum, and client-normalizer validation **re-branches independently**.
+Three allow-lists (`PLATFORMS`, the CLI `--platform` enum, the client-normalizer validator) must be **hand-synced**.
+
+Concrete tells:
+- `capabilities.ts` `CommandCapability` **hardcodes** `apple/android/linux/web` as keys; the
+  `isCommandSupportedOnDevice` ladder has no exhaustiveness — a new platform with no matrix entry is a *future
+  hazard* (it returns `false`/falls through, not a compile error). *(Note: the survey's first pass called this a
+  "silent web mis-gate"; on closer reading at `capabilities.ts:298` it returns `false` — the real defect is the
+  closed key-set with no exhaustiveness, which is cheaper to fix but still wrong.)*
+- `RecordingProvider` is literally named `startIosSimulatorRecording`.
+- **macOS is a hidden sub-platform**: ~697 LOC of macOS lives inside `platforms/ios/`, while `platforms/macos/`
+  is a 19-LOC stub; the Apple interactor lives in `core/interactors/apple.ts` and reaches into `platforms/ios`.
+
+### Supporting debt (the duplication the missing abstractions *force*)
+
+| Debt | Evidence | Est. LOC |
+|---|---|---|
+| `client-types.ts` hand-mirrors every Options/Result | 1027 LOC, 83 interfaces, imports 25 modules to re-declare contracts | ~550 derivable |
+| Every result is `Promise<Record<string,unknown> \| void>` | `DaemonResponseData`, all Interactor methods, `runIosRunnerCommand` | the weakest seam |
+| `core/dispatch*` leaks platform knowledge | ~16 dynamic `import('../platforms/*')` + ~15 branches | ~120 |
+| Two platform contracts glued by string round-trip | `Interactor` vs `AgentDeviceBackend`, ~30 ops each | ~130 |
+| Batch-step validation reimplemented at 5 layers | `metadata.ts`/`projection.ts` byte-for-byte parallel | ~150 |
+| `RecordingBackend` not generic → 5 `as Extract` casts | `record-trace-recording-backends.ts:54,130,179,211,230` | ~12 |
+| ~8k LOC client/remote unfoldered at src root | 55 files; `daemon-` prefix co-locates client + server + proxy | move |
+| `utils/` hosts 3 subsystems + domain types | CLI parser 3k, screenshot-diff 1.8k, AX-snapshot, `device.ts` | move |
+| Daemon 'generic' family disowned; boilerplate | chain returns `null` for 'generic'; 22 guards; 13 literals; recordAction ×24 | ~190 |
+| MCP dead `jsonRpcRequestSchema`; force-cast at HTTP edge | `contracts.ts:541` unused; `http-server.ts:390` | ~70 |
+
+### Legacy to drop — real but *small* (do at next major)
+
+- Legacy batch step shape `{command,positionals,flags}` in `cli/batch-steps.ts` (~110 LOC, already gated to next major)
+- Deprecated `--maestro`/`replayMaestro` alias (~20), `--session-locked`/`--session-lock-conflicts` aliases (~25)
+- `src/batch.ts` test-only re-export barrel (~19)
+- **`compat/maestro` (5.5k LOC) is NOT legacy** — it is the `.ad` replay engine, invoked on *every* replay
+  action. **Keep it; wrap it as a fixed contract; never change the wire shape under it.**
+- Dead exports ≈ 0 (fallow default mode: 1 known false positive). The 232 "prod-unused" exports are LIVE test
+  seams — **not** a shrink opportunity.
+
+> The big reduction is **not** from deleting legacy (~175 LOC). It is from collapsing the duplication that the
+> two missing abstractions force.
+
+---
+
+## 3. The perfect shape — target architecture
+
+```
+                         ┌──────── INTERFACES (thin adapters) ────────┐
+                         cli/        mcp/        sdk/        (batch is a command, not a layer)
+                         └───────────────────┬────────────────────────┘
+                                             │  derive tools/schema/help
+                  ┌──────────────────────────▼──────────────────────────┐
+                  │   COMMAND REGISTRY  (one CommandDescriptor per cmd)   │  ◄── the spine
+                  │   name · inputSchema · typed Result · capability ·    │
+                  │   daemon{route,traits} · surfaces · invoke · execute  │
+                  └───┬───────────────┬───────────────┬──────────────┬────┘
+            derives ▼      derives ▼        derives ▼       derives ▼
+        capability matrix   daemon registry   batch allowlist   dispatch (TOTAL map)
+                                             │
+                                             ▼  execute(ctx, input): CommandResult<Name>
+                  ┌──────────────────────────▼──────────────────────────┐
+                  │   PLATFORM REGISTRY  (one PlatformPlugin per family)  │  ◄── second seam
+                  │   createInteractor · capability bucket · discover ·   │
+                  │   providers · recording · appLog · perf   (LAZY)      │
+                  └───┬─────────────┬──────────────┬─────────────┬────────┘
+                  apple(ios+macos)  android        linux         web
+                    │ wraps XCTest    │ wraps adb     │ ...          │ ...   ← irreducible leaf code, UNCHANGED
+                    ▼
+        ┌──────────────────────── kernel/ (dependency sink) ────────────────────────┐
+        │  device.ts · contracts.ts · errors.ts · command-result.ts · capabilities  │
+        │              pure domain types + pure logic — no IO, no platform           │
+        └───────────────────────────────────────────────────────────────────────────┘
+
+  Folder DAG (imports point DOWN; siblings never import siblings):
+    kernel ◄ platforms ◄ core ◄ commands ◄ {cli, client, daemon/server}
+    client ◄ daemon/client     remote,metro ◄ daemon/client     sdk = re-export barrels only
+```
+
+The shape is **two registries over a clean DAG with a typed spine**:
+
+1. **`CommandDescriptor` registry** — the single source for a command's identity. The ~10 tables become *pure
+   derivations*. Dispatch becomes a total map keyed by the command-name union (missing handler = compile error).
+2. **`PlatformPlugin` registry** — the single source for a platform's behavior. `getInteractor`, capabilities,
+   discovery, providers, recording, app-log, perf all become `getPlugin(device.platform).x()`. The three
+   allow-lists derive from `registry.keys()`. Plugins load **lazily** (dynamic import inside the factory) so CLI
+   cold-start latency — a north-star metric — never regresses.
+3. **Typed-result spine** — `CommandResult<Name>` replaces `Record<string,unknown>`; `client-types.ts` Options
+   derive from `inputSchema`, Results from `CommandResult`. Generic `RecordingBackend<P>` deletes the 5 casts.
+4. **Clean layering** — a `kernel/` sink owns domain types; the src-root cluster and the utils-buried
+   subsystems move into intent folders behind an import-direction lint.
+5. **Agent-cost as thin grafts, not a subsystem** — leveled payloads (`digest|default|full` where `default` ==
+   today's wire shape), per-command MCP `outputSchema` from `CommandResult`, batch as the primary multi-step
+   primitive (intermediate steps elide to digest), and capability-derived typed errors (`{code, retriable,
+   supportedOn}`) so an agent self-corrects without a wasted round-trip.
+
+---
+
+## 4. Why this shape is perfect — measured against the north star
+
+| North-star goal | How the shape delivers | Honest caveat |
+|---|---|---|
+| **Add a platform cheaply** | One plugin file + one registration line; the union line in `device.ts`. Wiring drops ~90 files → ~3. Half-wired platform = compile error. | The *interactor* (XCUITest/adb-equivalent) is irreducible — thousands of LOC. "Cheap" = the wiring, not the driver. |
+| **Add a command cheaply** | One descriptor file; the ~10 tables derive. ~24 files → ~2. | A genuinely new *platform primitive* still needs the per-platform impl + (for iOS) the Swift runner verb. |
+| **Fast + cheap for AI agents** | Leveled/digest payloads cut snapshot/screenshot tokens; batch collapses N round-trips → 1; typed errors with `supportedOn` kill retry round-trips; per-command MCP `outputSchema` lets agents trust `structuredContent` over re-parsing text; zero-load fast-paths answer `tools/list`/`--help`/`devices` without spinning the platform graph. | Must be **opt-in** with `default` == today's wire shape, or the Maestro `.ad` recompare path breaks. |
+| **Less code** | Delete `client-types.ts` mirror (~550), batch dup (~150), dispatch/registry/capability literals (~250), bag-guards (~120). | Net ~**-1k to -3k LOC**. Don't oversell; capability rows and daemon traits *relocate*, they don't vanish. |
+| **Scoped ownership** | `kernel/` sink + intent folders + import-direction lint; the 'generic' daemon family re-owned; deep modules replace shallow re-export layers. | The folder reorg is high-*diff*, low-*LOC*; sell it as ownership + lint, not shrink. |
+| **Type safety** | Command-name union (exhaustive dispatch), per-command `CommandResult`, generic `RecordingBackend<P>`, parse-at-boundary at the JSON-RPC/HTTP edge. | ~40 result shapes are legitimately heterogeneous — don't block the registry on theoretically-pure Result types day one. |
+
+**Why it's *perfect* and not just *better*:** the two axes of this product's entire future — *more platforms*
+and *more commands* — become the two things you extend by adding **one file each**, while everything that is
+genuinely hard (device-specific gesture synthesis, the replay engine) stays isolated behind a contract and is
+never touched by a wiring change. The codebase's shape finally matches its growth vectors.
+
+---
+
+## 5. Prototypes (concrete, grounded in real signatures)
+
+> Full code sketches are distilled below; each is buildable against the current types.
+
+### 5.1 `PlatformPlugin` (the platform axis)
+
+```ts
+// src/platforms/plugin.ts — type-only imports + LAZY impls (mirrors today's `await import('../platforms/*')`)
+export type PlatformPlugin = {
+  readonly id: string;                               // also the capability-matrix bucket key
+  readonly platforms: readonly Platform[];           // Apple owns BOTH ['ios','macos'] ← folds in the macOS unwind
+  readonly familySelector?: PlatformSelector;        // 'apple' → ios+macos
+  createInteractor(device: DeviceInfo, runner: RunnerContext): Promise<Interactor>;   // replaces getInteractor switch arm
+  discoverDevices(req: DeviceInventoryRequest): Promise<DeviceInfo[]>;                  // replaces inventory if-chain
+  readonly capability: { bucket: 'apple'|'android'|'linux'|'web';
+                         supportsByDefault?(d: DeviceInfo, m: KindMatrix): boolean };  // sub-platform guards live here
+  readonly providers?: () => Partial<PlatformProviderResolvers>;
+  readonly recording?: { start(req: PlatformRecordingRequest): RecordingProcess };     // de-iOS-named
+  readonly appLog?: { start(req): Promise<AppLogResult>; logBackend(d): LogBackend };
+  readonly perf?: { collect(d: DeviceInfo): Promise<Record<string, unknown>> };
+};
+
+const registry = new Map<Platform, PlatformPlugin>();
+export function getPlugin(p: Platform): PlatformPlugin {
+  const x = registry.get(p);
+  if (!x) throw new AppError('UNSUPPORTED_PLATFORM', `Unsupported platform: ${p}`);
+  return x;
+}
+export const registeredPlatforms = () => [...registry.keys()];   // ← the 3 allow-lists derive from this
+
+// register-builtins.ts asserts exhaustiveness vs the hand-authored union:
+//   Object.fromEntries(registeredPlatforms().map(p => [p, true])) satisfies Record<Platform, true>;
+//   → a new Platform literal without a plugin is a COMPILE error.
+
+// Derived call-sites:
+const getInteractor = (d, r) => getPlugin(d.platform).createInteractor(d, r);
+function isCommandSupportedOnDevice(cmd, device) {
+  const cap = COMMAND_CAPABILITY_MATRIX[cmd];               if (!cap) return true;
+  const plugin = tryGetPlugin(device.platform);            if (!plugin) return false;   // ← no more fallthrough
+  const m = cap[plugin.capability.bucket];                 if (!m) return false;
+  if (cap.supports && !cap.supports(device)) return false;
+  return m[device.kind ?? 'unknown'] === true;
+}
+```
+
+**Honest limitation:** the *compile-time* `Platform` union must stay hand-authored (you can't derive a TS type
+from a runtime `Map`). The registry is asserted exhaustive against it, and the three *runtime* lists collapse —
+but "add a platform" still touches the `device.ts` union line.
+
+### 5.2 `CommandDescriptor` (the command axis) — *extends* the existing facet, additively
+
+```ts
+// src/commands/descriptor/types.ts
+export type CommandDescriptor<Name extends string = string> = CommandFacet<Name> & {  // ← reuse the proven spine
+  capability?: CommandCapability;                       // → BASE_COMMAND_CAPABILITY_MATRIX
+  daemon: { route: DaemonCommandRoute } & DaemonCommandTraits;  // → DAEMON_COMMAND_DESCRIPTORS (closures move, not flatten)
+  batchable?: boolean;                                  // → STRUCTURED_BATCH_COMMAND_NAMES
+  mcp?: { expose: boolean; outputSchema?: JsonSchema }; // → MCP tool list + per-command output schema
+  invoke: CommandFacet<Name>['definition']['invoke'];   // cross-process client  (KEEP distinct...
+  execute?: (ctx, input: CommandResult<Name>) => Promise<CommandResult<Name>>; // ...from in-daemon — never collapse the boundary)
+};
+
+// derive.ts — pure folds; each one replaces a hand table:
+const PUBLIC_COMMANDS   = descriptors.map(d => d.name);
+const CAPABILITY_MATRIX = Object.fromEntries(descriptors.flatMap(d => d.capability ? [[d.name, d.capability]] : []));
+const DAEMON_ROUTES     = Object.fromEntries(descriptors.map(d => [d.name, d.daemon]));
+const BATCH_ALLOWLIST   = descriptors.filter(d => d.batchable).map(d => d.name);
+const DISPATCH: { [N in CommandDescriptor['name']]: CommandDescriptor<N>['execute'] } = /* total map: missing = compile error */;
+```
+
+### 5.3 Typed-result spine
+
+```ts
+export interface CommandResultMap {                 // tighten per command; default keeps the union total
+  snapshot: SnapshotResult; screenshot: ScreenshotResult;
+  press: PressCommandResult;                          // ← already exists in contracts/interaction.ts
+}
+export type CommandResult<N extends string> = N extends keyof CommandResultMap ? CommandResultMap[N] : Record<string, unknown>;
+
+// generic RecordingBackend deletes all 5 `as Extract` casts; a missing backend is a compile error:
+export type RecordingBackend<P extends RecordingPlatform = RecordingPlatform> = {
+  stop: (ctx: RecordingStopContext<RecordingFor<P>>) => Promise<DaemonResponse | null>;   // PRE-NARROWED
+  /* ...start/resolveOutputPath... */
+};
+const recordingBackends = { ios: …, android: …, 'ios-device-runner': …, 'macos-runner': …, web: … }
+  satisfies { [P in RecordingPlatform]: RecordingBackend<P> };
+```
+
+### 5.4 Agent-cost grafts (ride on 5.2 + 5.3 — *not* a new subsystem)
+
+```ts
+export type ResponseLevel = 'digest' | 'default' | 'full';   // 'default' == today's wire shape (protects Maestro)
+const snapshotView: ResponseView<SnapshotResult> = { toView(r, lvl) {
+  if (lvl === 'full') return r;
+  if (lvl === 'default') return stripRects(r);                // byte-for-byte today
+  return { nodeCount: r.nodes.length, refs: r.nodes.filter(n => n.hittable).slice(0, 12).map(n => n.ref) };
+}};
+export type TypedError = { code: ErrorCode; message: string; hint?: string;
+                           retriable?: boolean; supportedOn?: string };  // supportedOn DERIVED from descriptor.capability
+
+// Phase-0 parse-at-boundary (independent, ships first): wire the DEAD jsonRpcRequestSchema into the MCP/HTTP edge,
+// killing `parsed as JsonRpcMessage[]` (server.ts:133) and `params as unknown as Partial<DaemonRequest>` (http-server.ts:390).
+```
+
+### 5.5 Target folder DAG (pure `ts-morph .move()` codemods, leaf-first)
+
+```
+src/
+  kernel/         device.ts (←utils, 92 importers) · contracts.ts · errors.ts · command-result.ts · capabilities.ts
+  client/         client*.ts · companion/
+  daemon/client/  daemon-client*.ts          daemon/server/  daemon-runtime.ts · bootstrap
+  remote/         daemon-proxy · daemon-artifacts · upload-client · remote-*
+  metro/          metro* · client-metro*
+  sdk/            re-export barrels only (package.json `exports` ← rewrite in the SAME commit, verify with `npm pack`)
+  cli/parser/     ← absorb utils/{args,cli-flags,cli-help} (~2.5k)
+  screenshot-diff/  ← utils (1.8k, 1 consumer)        snapshot/  ← utils AX-snapshot domain
+  core/ commands/ platforms/ recording/ replay/ compat/ mcp/ contracts/   (KEEP)
+
+Rule (lint-enforced): imports point DOWN toward kernel; siblings never import siblings;
+                      only daemon/server may import platforms/ statically.
+```
+
+---
+
+## 6. How to get there — the roadmap (strangler-fig, leverage-per-risk)
+
+**Discipline:** every step is independently shippable *and* revertable; each derived table is asserted
+**byte-for-byte equivalent** to the hand table by a parity test **before** the hand table is deleted. The moment
+a step can't ship alone, the plan has failed.
+
+| Phase | Step | Risk | Payoff |
+|---|---|---|---|
+| **0 · confidence builders** (behaviorless) | (a) parse-at-boundary on MCP/HTTP edge; (b) make capability lookup exhaustive/throwing for unknown platforms; (c) generic `RecordingBackend<P>` → delete 5 casts; (d) collapse the 3 platform allow-lists + 5-layer batch validation | low | correctness/security; builds muscle memory; touches no identity table |
+| **1 · command spine** | (a) **invert the import graph** — `commandRegistry` becomes root, `command-catalog`/`capabilities`/`daemon-registry`/`batch-policy` derive (parity-tested, no deletion yet); (b) promote each family's facet → `CommandDescriptor` additively; (c) replace the 24-arm switch with the total map, arm-by-arm | **med** (the import-cycle inversion is the real first-week blocker: `command-catalog` has ~95 importers and the facet imports `AgentDeviceClient` today) | finishes a proven seam; add-command → ~2 files; enables everything below |
+| **2 · typed results** (the parity oracle) | (a) `CommandResultMap` with `Record` default, migrate per-command from real runner payloads; (b) graft `TypedError`; fold the disowned 'generic' family into `handlers/` **last**; (c) kill the `client-types.ts` mirror (~550 LOC) | med (must be per-command, never a big-bang retype of 203 files) | the safety net the platform unwind needs; biggest single LOC win |
+| **3 · platform plugin** (now safe) | (a) define `PlatformPlugin`, **lazy** factories (cold-start benchmark guards latency); (b) move capability columns onto plugin grants, **porting every `supports()` closure verbatim**, pinned by the table-equivalence test before deletion; (c) **last & most-gated:** unwind macOS out of iOS (keep an `apple-shared/` runner byte-identical), gated behind the sim-validation request-counting harness | **high** (touches the shared XCTest runner) | add-platform wiring → ~3 files; kills the 231-branch smear |
+| **4 · agent-cost** (opt-in) | (a) `ResponseView.toView` with `default`==today; `responseLevel` knob defaulting to `default`; (b) typed `BatchStepResult` → intermediate steps digest; per-command MCP `outputSchema`; generalize zero-load fast-paths | med (wire-shape risk vs Maestro — strictly opt-in) | the north-star-#2 token/latency wins |
+| **5 · layering + legacy** (quiet windows) | intent-folder moves + utils extraction as pure path codemods; at next major drop the ~175 LOC of legacy aliases/barrels | low-per-step, high-diff | scoped ownership + import lint; merge-pain risk → land fast, small |
+
+**Dependency logic:** command-first (proven seam, lowest blast radius) → typed results (the oracle) → platform
+plugin (bigger prize, riskier, *needs* the oracle) → agent-cost (rides on both) → layering/legacy (orthogonal,
+noisy, last).
+
+---
+
+## 7. What NOT to touch (the dissent, preserved)
+
+- **The Maestro `.ad` replay engine** (`compat/maestro`, 5.5k LOC) — load-bearing; wrap as a fixed contract,
+  never rewrite, and never let leveled payloads change the wire shape its recompare path assumes.
+- **The iOS XCTest synthesis** (`RunnerSynthesizedGesture`, two-finger synthesis) and **adb/idb leaf code** —
+  genuinely toolchain-specific, correctly isolated, the site of hard-won flakiness fixes. The plugin contract's
+  job is to stop core/daemon *branching* on platform, **not** to homogenize these irreducible leaves.
+- **The `supports()` / `unsupportedHint()` device closures** — they encode macOS-coordinate-pinch, tvOS-no-touch,
+  physical-iOS, and two-finger-synthesis nuance. **Relocate them onto descriptors/plugins verbatim; never flatten
+  them to data** that loses the device-shaped logic.
+- **The dynamic-import lazy-loading** that keeps CLI cold-start low — preserve as factory laziness.
+- **The two process seams** (`invoke` cross-process vs `execute` in-daemon) — share *types* across the boundary;
+  do **not** collapse the two interfaces and endanger remote/cloud/tunnel/proxy transport.
+- **By-design behaviors** from repo conventions — ambiguous-device rejection, the iOS get-text fast-path, "batch
+  is stop-only." A "uniform typed result" pass must not flatten these.
+
+**Highest-regret mistakes to avoid:** a big-bang typed-result retype; unifying `Interactor`+`AgentDeviceBackend`
+*and* splitting macOS out of iOS in the same PR; deleting any capability table before a parity test pins the new
+grants; bundling the folder reorg with the registry work (maximizes diff-noise against parallel-session commits).
+
+---
+
+## 8. The one-line version
+
+> Give the two things this product grows by — **platforms** and **commands** — each *one file you extend*, make
+> every other table *derive* from those two, type the results so the derivations are sound, and never touch the
+> irreducible leaf code. Command-first, because its typed-result seam is the safety net the platform unwind needs.

--- a/plans/perfect-shape.md
+++ b/plans/perfect-shape.md
@@ -104,6 +104,14 @@ missing/renamed command **compiles fine and fails only at runtime**.
 > tools, the CLI schema, and the batch writer from **one array**. The fix is to *extend* this proven seam, not
 > invent one.
 
+**Compose, don't collapse (ADR 0003).** "One registration" must **not** become "one flat public object that
+owns everything." Daemon route/policy is a deliberately separate, internally-owned concern
+([ADR 0003](../docs/adr/0003-daemon-command-registry.md)). The descriptor **composes facets owned by their
+domains** — a public `surface` facet (`src/commands/**`), a `capability` facet (`src/core/capabilities`), and a
+`daemon` facet **owned under `src/daemon/`** — and *projects* each into its consumer. The daemon registry stays
+the sole exposer of its predicate interface (`isLeaseAdmissionExempt`, `shouldLockSessionExecution`, …); only how
+its backing table is *built* changes, never how it is *read*. See §5.2 for the binding invariants.
+
 ### Axis B — No `PlatformPlugin` (the platform smear)
 
 `Platform` is `'ios' | 'macos' | 'android' | 'linux' | 'web'` (a bare union in `utils/device.ts`). **231
@@ -272,26 +280,51 @@ function isCommandSupportedOnDevice(cmd, device) {
 from a runtime `Map`). The registry is asserted exhaustive against it, and the three *runtime* lists collapse —
 but "add a platform" still touches the `device.ts` union line.
 
-### 5.2 `CommandDescriptor` (the command axis) — *extends* the existing facet, additively
+**Apple is the first real plugin — and owns an `AppleOS` leaf axis.** The Apple plugin owns `apple` (today's
+`ios`+`macos`) and discriminates `ios | ipados | tvos | watchos | visionos | macos` via an `appleOs` field —
+**not** six `Platform` literals (which would collide with the cross-platform `target` axis). The XCTest runner
+already builds `ios|macos|tvos` and ~85% of `platforms/ios` is already the OS-agnostic Apple engine, so this is
+mostly relocate-and-rename for iOS/iPadOS/tvOS/macOS; visionOS is scoped net-new work and watchOS is an
+explicit unsupported sentinel (XCUITest can't drive it). Full plan:
+[apple-platform-consolidation.md](./apple-platform-consolidation.md).
+
+### 5.2 `CommandDescriptor` (the command axis) — *facet composition*, honoring ADR 0003
+
+One registration **composes facets whose type + ownership stay in their domain module** — this is "compose
+with [ADR 0003](../docs/adr/0003-daemon-command-registry.md)", not "collapse daemon policy into a public
+registry."
 
 ```ts
-// src/commands/descriptor/types.ts
-export type CommandDescriptor<Name extends string = string> = CommandFacet<Name> & {  // ← reuse the proven spine
-  capability?: CommandCapability;                       // → BASE_COMMAND_CAPABILITY_MATRIX
-  daemon: { route: DaemonCommandRoute } & DaemonCommandTraits;  // → DAEMON_COMMAND_DESCRIPTORS (closures move, not flatten)
-  batchable?: boolean;                                  // → STRUCTURED_BATCH_COMMAND_NAMES
-  mcp?: { expose: boolean; outputSchema?: JsonSchema }; // → MCP tool list + per-command output schema
-  invoke: CommandFacet<Name>['definition']['invoke'];   // cross-process client  (KEEP distinct...
-  execute?: (ctx, input: CommandResult<Name>) => Promise<CommandResult<Name>>; // ...from in-daemon — never collapse the boundary)
-};
+// src/commands/<family>/press.ts — the single registration site (kills cross-table drift)
+export const press = defineCommand({
+  surface:    pressSurface,       // owned by src/commands/**       (identity, cliReader, schema, mcp)
+  capability: pressCapability,    // owned by src/core/capabilities
+  daemon:     pressDaemon,        // owned by src/daemon/   ← ADR 0003 ownership PRESERVED
+  result:     {} as PressResult,  // typed CommandResult
+});
 
-// derive.ts — pure folds; each one replaces a hand table:
-const PUBLIC_COMMANDS   = descriptors.map(d => d.name);
-const CAPABILITY_MATRIX = Object.fromEntries(descriptors.flatMap(d => d.capability ? [[d.name, d.capability]] : []));
-const DAEMON_ROUTES     = Object.fromEntries(descriptors.map(d => [d.name, d.daemon]));
-const BATCH_ALLOWLIST   = descriptors.filter(d => d.batchable).map(d => d.name);
-const DISPATCH: { [N in CommandDescriptor['name']]: CommandDescriptor<N>['execute'] } = /* total map: missing = compile error */;
+// src/daemon/command-policy/press.ts — DAEMON-owned facet (lives UNDER src/daemon/, not commands/)
+export const pressDaemon = defineDaemonFacet('press', {
+  route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true,
+  // allowSessionlessDefaultDevice / skipSessionlessProviderDevice closures stay here, verbatim
+});
+
+// Projections BUILD each consumer's table; they never restate identity:
+const DAEMON_REGISTRY   = buildDaemonRegistry(commands.map(c => c.daemon));   // built under src/daemon/
+const CAPABILITY_MATRIX = Object.fromEntries(commands.map(c => [c.name, c.capability]));
+const BATCH_ALLOWLIST   = commands.filter(c => c.surface.batchable).map(c => c.name);
+const DISPATCH: { [N in Command]: Execute<N> } = /* total map: a missing handler is a compile error */;
+// getDaemonCommandRoute / isLeaseAdmissionExempt / shouldLockSessionExecution … UNCHANGED for callers.
 ```
+
+**The four invariants (from the [ADR 0003 amendment](../docs/adr/0003-daemon-command-registry.md)) the design
+must satisfy:**
+1. Daemon traits **owned under `src/daemon/`**, composed in — never inlined as fields on the public contract.
+2. **Predicate interface unchanged** — derivation changes how the table is *built*, not how it is *read*.
+3. **No leakage** — public projections (catalog/CLI/MCP/help/capability) are type-prevented from reading
+   daemon-only traits, and vice versa.
+4. **One declaration per concern, enforced by types** — a missing/duplicate facet is a *compile error*
+   (replacing today's "aligned by convention").
 
 ### 5.3 Typed-result spine
 
@@ -355,10 +388,10 @@ a step can't ship alone, the plan has failed.
 
 | Phase | Step | Risk | Payoff |
 |---|---|---|---|
-| **0 · confidence builders** (behaviorless) | (a) parse-at-boundary on MCP/HTTP edge; (b) make capability lookup exhaustive/throwing for unknown platforms; (c) generic `RecordingBackend<P>` → delete 5 casts; (d) collapse the 3 platform allow-lists + 5-layer batch validation | low | correctness/security; builds muscle memory; touches no identity table |
+| **0 · confidence builders** (behaviorless) | **(b) ✅ shipped** — exhaustive capability platform selection; **(c) ✅ shipped** — generic `RecordingBackend<P>` (5 casts deleted); (a) parse-at-boundary on MCP/HTTP edge; (d) collapse the 3 platform allow-lists + 5-layer batch validation | low | correctness/security; builds muscle memory; touches no identity table |
 | **1 · command spine** | (a) **invert the import graph** — `commandRegistry` becomes root, `command-catalog`/`capabilities`/`daemon-registry`/`batch-policy` derive (parity-tested, no deletion yet); (b) promote each family's facet → `CommandDescriptor` additively; (c) replace the 24-arm switch with the total map, arm-by-arm | **med** (the import-cycle inversion is the real first-week blocker: `command-catalog` has ~95 importers and the facet imports `AgentDeviceClient` today) | finishes a proven seam; add-command → ~2 files; enables everything below |
 | **2 · typed results** (the parity oracle) | (a) `CommandResultMap` with `Record` default, migrate per-command from real runner payloads; (b) graft `TypedError`; fold the disowned 'generic' family into `handlers/` **last**; (c) kill the `client-types.ts` mirror (~550 LOC) | med (must be per-command, never a big-bang retype of 203 files) | the safety net the platform unwind needs; biggest single LOC win |
-| **3 · platform plugin** (now safe) | (a) define `PlatformPlugin`, **lazy** factories (cold-start benchmark guards latency); (b) move capability columns onto plugin grants, **porting every `supports()` closure verbatim**, pinned by the table-equivalence test before deletion; (c) **last & most-gated:** unwind macOS out of iOS (keep an `apple-shared/` runner byte-identical), gated behind the sim-validation request-counting harness | **high** (touches the shared XCTest runner) | add-platform wiring → ~3 files; kills the 231-branch smear |
+| **3 · platform plugin** (now safe) | (a) define `PlatformPlugin`, **lazy** factories (cold-start benchmark guards latency); (b) move capability columns onto plugin grants, **porting every `supports()` closure verbatim**, pinned by the table-equivalence test before deletion; (c) **last & most-gated:** unwind macOS out of iOS (keep an `apple-shared/` runner byte-identical), gated behind the sim-validation request-counting harness. The **Apple plugin is the first instance** and owns the `AppleOS` leaves — see [apple-platform-consolidation.md](./apple-platform-consolidation.md) | **high** (touches the shared XCTest runner) | add-platform wiring → ~3 files; kills the 231-branch smear |
 | **4 · agent-cost** (opt-in) | (a) `ResponseView.toView` with `default`==today; `responseLevel` knob defaulting to `default`; (b) typed `BatchStepResult` → intermediate steps digest; per-command MCP `outputSchema`; generalize zero-load fast-paths | med (wire-shape risk vs Maestro — strictly opt-in) | the north-star-#2 token/latency wins |
 | **5 · layering + legacy** (quiet windows) | intent-folder moves + utils extraction as pure path codemods; at next major drop the ~175 LOC of legacy aliases/barrels | low-per-step, high-diff | scoped ownership + import lint; merge-pain risk → land fast, small |
 
@@ -390,7 +423,75 @@ grants; bundling the folder reorg with the registry work (maximizes diff-noise a
 
 ---
 
-## 8. The one-line version
+## 8. Before / after — the command axis
+
+(The platform-axis before/after diagrams live in
+[apple-platform-consolidation.md](./apple-platform-consolidation.md), since Apple is its first instance.)
+
+```
+BEFORE — a command's identity is RESTATED in ~10 hand-synced tables, aligned "by convention"
+─────────────────────────────────────────────────────────────────────────────────────────────
+
+   command "press" = a bare string shared by every table below (no compile-time link between them)
+
+   PUBLIC surface              DAEMON-INTERNAL              DERIVED-BY-HAND
+   ─────────────────           ──────────────────           ──────────────────
+   • command-catalog.ts        • daemon-command-            • client-types.ts (Options/Result
+     (public identity)           registry.ts                  mirror, ~550 LOC)
+   • commands/** contracts       route + policy traits      • core/dispatch.ts (24-arm switch,
+     (cliReader / daemonWriter)  ✔ ADR 0003: own file,         default: throw)
+   • capabilities.ts             internal-only,             • client.ts wrappers
+     (apple/android matrix)      predicate interface        • batch-policy.ts allowlist
+                                 (isLeaseAdmissionExempt,
+                                  shouldLockSessionExec…)
+                                        ▲
+                                        └── consumed by 8 daemon request modules
+
+   ⇒ add/rename a command = touch ~10 files; a missed table compiles fine and fails at RUNTIME (drift)
+   ✔ ADR 0003 already isolated daemon policy correctly — the problem is everything ELSE is also separate
+```
+
+```
+AFTER — ONE registration composes DOMAIN-OWNED facets; the ~10 tables become DERIVED projections
+─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+   src/commands/<family>/press.ts
+   defineCommand({                          each facet's TYPE + OWNERSHIP stays in its domain module
+      surface:    … ,  ─────────────────►   src/commands/**        (identity, cli, schema, mcp)
+      capability: … ,  ─────────────────►   src/core/capabilities
+      daemon:     … ,  ─────────────────►   src/daemon/    ◄── ADR 0003 ownership PRESERVED
+      result:     … ,  ─────────────────►   typed CommandResult
+   })
+   single registration site · a missing/duplicate facet = COMPILE ERROR (drift killed structurally)
+            │
+            ▼  pure projections — they BUILD each table, they don't restate it
+   ┌──────────────────────────────────────────────────────────────────────────────────────────┐
+   │  catalog · capability matrix · batch allowlist · dispatch map · client types               │ ← PUBLIC views
+   │  daemon-command-registry ── still exposes the SAME predicates; the 8 callers are UNCHANGED  │ ← daemon view
+   └──────────────────────────────────────────────────────────────────────────────────────────┘
+
+   ADR 0003 invariants held:
+     (1) daemon traits OWNED under src/daemon/, never inlined into the public command surface
+     (2) predicate interface unchanged — derivation changes how the table is BUILT, not how it is READ
+     (3) public projections type-prevented from reading daemon-only traits (no leakage)
+     (4) one declaration per concern, enforced by the type system (was "aligned by convention")
+```
+
+**The two axes are the same thesis** — replace *"identity smeared across many tables/branches"* with *"one
+registration → everything else derives or looks up"*:
+
+```
+   PLATFORM axis                                  COMMAND axis
+   ─────────────                                  ─────────────
+   PlatformPlugin registry (§5.1)                 CommandDescriptor registry (§5.2)
+     └─ Apple plugin ──owns──► appleOs              └─ defineCommand(...) ──derives──► catalog,
+        { ios … macos … visionos }                    capability, daemon-registry, batch, dispatch,
+   (apple-platform-consolidation.md)                  client-types   (daemonFacet honors ADR 0003)
+```
+
+---
+
+## 9. The one-line version
 
 > Give the two things this product grows by — **platforms** and **commands** — each *one file you extend*, make
 > every other table *derive* from those two, type the results so the derivations are sound, and never touch the

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -1,4 +1,4 @@
-import { isApplePlatform, type DeviceInfo } from '../utils/device.ts';
+import type { DeviceInfo } from '../utils/device.ts';
 
 type KindMatrix = {
   simulator?: boolean;
@@ -295,16 +295,35 @@ function addWebCommandCapabilities(
   return result;
 }
 
+// Exhaustive platform -> capability-bucket selection. Switching over the full Platform
+// union (instead of an if/else ladder that funnels every unmatched platform into
+// `capability.web`) makes adding a new Platform a compile error here, so a future
+// platform can no longer silently inherit web's capability matrix.
+function selectCapabilityForPlatform(
+  capability: CommandCapability,
+  platform: DeviceInfo['platform'],
+): KindMatrix | undefined {
+  switch (platform) {
+    case 'ios':
+    case 'macos':
+      return capability.apple;
+    case 'android':
+      return capability.android;
+    case 'linux':
+      return capability.linux;
+    case 'web':
+      return capability.web;
+    default: {
+      const exhaustive: never = platform;
+      return exhaustive;
+    }
+  }
+}
+
 export function isCommandSupportedOnDevice(command: string, device: DeviceInfo): boolean {
   const capability = COMMAND_CAPABILITY_MATRIX[command];
   if (!capability) return true;
-  const byPlatform = isApplePlatform(device.platform)
-    ? capability.apple
-    : device.platform === 'android'
-      ? capability.android
-      : device.platform === 'linux'
-        ? capability.linux
-        : capability.web;
+  const byPlatform = selectCapabilityForPlatform(capability, device.platform);
   if (!byPlatform) return false;
   if (capability.supports && !capability.supports(device)) return false;
   const kind = (device.kind ?? 'unknown') as keyof KindMatrix;

--- a/src/daemon/handlers/record-trace-recording-backends.ts
+++ b/src/daemon/handlers/record-trace-recording-backends.ts
@@ -24,6 +24,8 @@ import {
 import type { RecordTraceDeps, RecordingBase } from './record-trace-types.ts';
 
 type ActiveRecording = NonNullable<SessionState['recording']>;
+type RecordingPlatform = ActiveRecording['platform'];
+type RecordingFor<P extends RecordingPlatform> = Extract<ActiveRecording, { platform: P }>;
 
 type RecordingOutputPathContext = {
   req: DaemonRequest;
@@ -41,25 +43,36 @@ type RecordingStartContext = {
   resolvedOut: string;
 };
 
-type RecordingStopContext = {
+type RecordingStopContext<P extends RecordingPlatform = RecordingPlatform> = {
   req: DaemonRequest;
   activeSession: SessionState;
   device: SessionState['device'];
   logPath?: string;
   deps: RecordTraceDeps;
-  recording: ActiveRecording;
+  recording: RecordingFor<P>;
   stopRequestedAt: number;
 };
 
-export type RecordingBackend = {
+// A backend is parameterized by the recording tag it owns, so its `stop` receives an
+// already-narrowed recording — no `recording as Extract<ActiveRecording, ...>` casts.
+// `start` stays wide because the device platform does not map 1:1 to a recording tag
+// (e.g. an iOS device resolves to either the `ios` or `ios-device-runner` recording).
+export type RecordingBackend<P extends RecordingPlatform = RecordingPlatform> = {
   validateStart?: (req: DaemonRequest) => DaemonResponse | null;
   resolveOutputPath: (context: RecordingOutputPathContext) => string;
   start: (context: RecordingStartContext) => Promise<DaemonResponse | ActiveRecording>;
-  stop: (context: RecordingStopContext) => Promise<DaemonResponse | null>;
+  stop: (context: RecordingStopContext<P>) => Promise<DaemonResponse | null>;
   cleanupRecordOnlySession?: (session: SessionState) => Promise<void>;
 };
 
-export function resolveRecordingBackendForDevice(device: SessionState['device']): RecordingBackend {
+// Device-resolution view: a backend selected before any recording exists exposes only the
+// start/output/cleanup surface; stop is dispatched per active recording's tag via
+// stopActiveRecording, which is why omitting it keeps the per-tag backends assignable here.
+type RecordingStartBackend = Omit<RecordingBackend, 'stop'>;
+
+export function resolveRecordingBackendForDevice(
+  device: SessionState['device'],
+): RecordingStartBackend {
   if (device.platform === 'web') return webRecordingBackend;
   if (device.platform === 'android') return androidRecordingBackend;
   if (device.platform === 'macos') return macOsRecordingBackend;
@@ -68,18 +81,19 @@ export function resolveRecordingBackendForDevice(device: SessionState['device'])
   return unsupportedRecordingBackend;
 }
 
-export function resolveRecordingBackendForRecording(recording: ActiveRecording): RecordingBackend {
+export function stopActiveRecording(context: RecordingStopContext): Promise<DaemonResponse | null> {
+  const { recording } = context;
   switch (recording.platform) {
     case 'android':
-      return androidRecordingBackend;
+      return androidRecordingBackend.stop({ ...context, recording });
     case 'ios':
-      return iosSimulatorRecordingBackend;
+      return iosSimulatorRecordingBackend.stop({ ...context, recording });
     case 'ios-device-runner':
-      return iosDeviceRecordingBackend;
+      return iosDeviceRecordingBackend.stop({ ...context, recording });
     case 'macos-runner':
-      return macOsRecordingBackend;
+      return macOsRecordingBackend.stop({ ...context, recording });
     case 'web':
-      return webRecordingBackend;
+      return webRecordingBackend.stop({ ...context, recording });
   }
 
   const exhaustive: never = recording;
@@ -98,7 +112,7 @@ function resolveWebRecordingOutputPath({ req }: RecordingOutputPathContext): str
     : appendRecordingExtensionWhenMissing(requestedPath, WEB_RECORDING_EXTENSION);
 }
 
-const webRecordingBackend: RecordingBackend = {
+const webRecordingBackend: RecordingBackend<'web'> = {
   validateStart: (req) => validateWebRecordingFlags(req),
   resolveOutputPath: resolveWebRecordingOutputPath,
   start: async ({ activeSession, recordingBase, resolvedOut }) => {
@@ -125,10 +139,7 @@ const webRecordingBackend: RecordingBackend = {
       showTouches: false,
     };
   },
-  stop: async ({ recording }) =>
-    await stopWebRecording({
-      recording: recording as Extract<ActiveRecording, { platform: 'web' }>,
-    }),
+  stop: async ({ recording }) => await stopWebRecording({ recording }),
   cleanupRecordOnlySession: async () => {
     try {
       await resolveWebProvider().close();
@@ -138,7 +149,7 @@ const webRecordingBackend: RecordingBackend = {
   },
 };
 
-const iosDeviceRecordingBackend: RecordingBackend = {
+const iosDeviceRecordingBackend: RecordingBackend<'ios-device-runner'> = {
   resolveOutputPath: resolveNativeRecordingOutputPath,
   start: async ({
     req,
@@ -176,11 +187,11 @@ const iosDeviceRecordingBackend: RecordingBackend = {
       device,
       logPath,
       deps,
-      recording: recording as Extract<ActiveRecording, { platform: 'ios-device-runner' }>,
+      recording,
     }),
 };
 
-const macOsRecordingBackend: RecordingBackend = {
+const macOsRecordingBackend: RecordingBackend<'macos-runner'> = {
   resolveOutputPath: resolveNativeRecordingOutputPath,
   start: async ({ req, activeSession, device, logPath, deps, fpsFlag, recordingBase }) => {
     const appBundleId = normalizeAppBundleId(activeSession);
@@ -208,11 +219,11 @@ const macOsRecordingBackend: RecordingBackend = {
       device,
       logPath,
       deps,
-      recording: recording as Extract<ActiveRecording, { platform: 'macos-runner' }>,
+      recording,
     }),
 };
 
-const iosSimulatorRecordingBackend: RecordingBackend = {
+const iosSimulatorRecordingBackend: RecordingBackend<'ios'> = {
   resolveOutputPath: resolveNativeRecordingOutputPath,
   start: async ({ req, activeSession, device, logPath, deps, recordingBase, resolvedOut }) =>
     await startIosSimulatorRecording({
@@ -227,12 +238,12 @@ const iosSimulatorRecordingBackend: RecordingBackend = {
   stop: async ({ deps, recording, stopRequestedAt }) =>
     await stopIosSimulatorRecording({
       deps,
-      recording: recording as Extract<ActiveRecording, { platform: 'ios' }>,
+      recording,
       stopRequestedAt,
     }),
 };
 
-const androidRecordingBackend: RecordingBackend = {
+const androidRecordingBackend: RecordingBackend<'android'> = {
   resolveOutputPath: resolveNativeRecordingOutputPath,
   start: async ({ device, recordingBase }) =>
     await startAndroidRecording({ device, recordingBase }),
@@ -240,7 +251,7 @@ const androidRecordingBackend: RecordingBackend = {
     await stopAndroidRecording({
       deps,
       device,
-      recording: recording as Extract<ActiveRecording, { platform: 'android' }>,
+      recording,
       stopRequestedAt,
     }),
 };

--- a/src/daemon/handlers/record-trace-recording.ts
+++ b/src/daemon/handlers/record-trace-recording.ts
@@ -26,7 +26,7 @@ import { errorResponse } from './response.ts';
 import { deriveAndroidChunkOutPath } from './record-trace-android-chunks.ts';
 import {
   resolveRecordingBackendForDevice,
-  resolveRecordingBackendForRecording,
+  stopActiveRecording,
 } from './record-trace-recording-backends.ts';
 import type { RecordTraceDeps, RecordingBase } from './record-trace-types.ts';
 import { resolveImplicitSessionScope, resolvePublicSessionName } from '../session-routing.ts';
@@ -187,9 +187,7 @@ async function stopRecording(params: {
   const stopRequestedAt = Date.now();
   const invalidatedReason = recording.invalidatedReason;
   activeSession.recording = undefined;
-  const backend = resolveRecordingBackendForRecording(recording);
-
-  const stopError = await backend.stop({
+  const stopError = await stopActiveRecording({
     req,
     activeSession,
     device,


### PR DESCRIPTION
## Summary

Two **behaviorless** type-safety improvements — the first Phase-0 step of the architecture roadmap added in `plans/perfect-shape.md`. Both make an invalid state a *compile error* instead of a latent runtime hazard, with zero runtime behavior change.

### 1. Parametrize `RecordingBackend` by recording tag (drops 5 unsound casts)
`RecordingBackend<P>` is now generic over the recording's `platform` tag, so each backend's `stop()` receives an already-narrowed recording. This deletes all five `recording as Extract<ActiveRecording, { platform: ... }>` casts — the discriminated-union-narrowing-by-cast anti-pattern — and makes a backend/tag mismatch unrepresentable.

- `start()` stays wide (`DaemonResponse | ActiveRecording`) because a device platform doesn't map 1:1 to a recording tag (an iOS device resolves to either the `ios` or `ios-device-runner` recording).
- Device resolution now returns a stop-less view (`RecordingStartBackend`); stop is dispatched per active recording via a new exhaustive `stopActiveRecording()`, replacing `resolveRecordingBackendForRecording()`.

### 2. Make capability platform selection exhaustive
`isCommandSupportedOnDevice` resolved the per-platform capability bucket with an if/else ladder whose final branch funneled *every* unmatched platform into `capability.web`. That silently absorbs a **future** `Platform` with no compile error. Replaced with `selectCapabilityForPlatform()` — an exhaustive `switch` over the `Platform` union with a `never` guard — so adding a platform is a compile error here instead of a silent web mis-gate. Behavior is identical for all five current platforms (`ios`/`macos` → apple, `android`, `linux`, `web`).

## Why now

`plans/perfect-shape.md` (included here) is a target-architecture roadmap. Its **typed-result spine** is a prerequisite for the later registry work, and these two changes are the cheapest, lowest-risk first dominoes: pure type-level wins that delete real unsoundness today.

> **Scope note for reviewers:** this PR intentionally implements only the two behaviorless items above. The larger pieces from the roadmap (parse-at-boundary on the MCP/HTTP edge, the `CommandDescriptor`/`PlatformPlugin` registries, the import-graph inversion) are deliberately deferred to separate, independently shippable PRs — no need to relitigate the whole roadmap here.

## Validation

- `pnpm typecheck` — pass
- `pnpm lint` (`oxlint --deny-warnings`) — pass
- `pnpm format:check` — pass
- Full unit project (`vitest run --project unit`) — **278 files / 2729 tests pass**
- Targeted record-trace + capabilities suites — 58/58 pass

Net: **−10 lines**, 5 unsound casts removed, 2 new compile-time exhaustiveness guards.

## Roadmap / governance docs (also in this PR)

Phase-0 sits under the roadmap in `plans/perfect-shape.md` (already in this PR). This update aligns the docs with maintainer review:

- **`docs/adr/0003-daemon-command-registry.md`** — amended (not reversed) with a "single-declaration / derivation model" clause. Ratifies the review caveat: the future `CommandDescriptor` work must **compose with** the daemon-registry boundary (daemon facet owned under `src/daemon/`, predicate interface unchanged, no leakage, one declaration per concern), never **collapse** daemon policy into a public registry.
- **`plans/perfect-shape.md`** — command axis refined to **facet composition** honoring ADR 0003; the two shipped Phase-0 items marked; before/after diagrams added; Apple linked as the first `PlatformPlugin` instance.
- **`plans/apple-platform-consolidation.md`** — new: consolidate Apple under `platforms/apple` with an **`AppleOS` leaf axis** (one `apple` Platform, not six literals). Per-OS readiness + sequencing.

These are docs-only (no source touched); the code scope of this PR is unchanged. Happy to split the docs into their own PR if preferred.
