### PR TITLE
refactor: validate JSON-RPC at the MCP/HTTP boundary

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -239,6 +239,17 @@ function optionalString(
   return value === undefined ? undefined : expectString(value, `${path}.${key}`);
 }
 
+function optionalStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] | undefined {
+  const value = record[key];
+  if (value === undefined) return undefined;
+  const items = expectArray(value, `${path}.${key}`);
+  return items.map((item, index) => expectString(item, `${path}.${key}[${String(index)}]`));
+}
+
 function optionalDeviceKey(
   record: Record<string, unknown>,
   key: string,
@@ -545,5 +556,25 @@ export const jsonRpcRequestSchema = schema<JsonRpcRequestEnvelope>((input, path)
     id: parseJsonRpcId(record, path),
     method: optionalString(record, 'method', path),
     params: record.params,
+  };
+});
+
+export type CommandRpcParams = Partial<DaemonRequest>;
+
+// Validates the `params` object of a command JSON-RPC request at the daemon's HTTP
+// boundary so attacker-controlled wire input is parsed instead of force-cast. The
+// control fields (token/session/command/positionals) are checked here; the richer
+// flags/runtime/meta shapes are only confirmed to be objects and validated in depth
+// by the session open handler downstream.
+export const commandRpcParamsSchema = schema<CommandRpcParams>((input, path) => {
+  const record = expectObject(input, path);
+  return {
+    token: optionalString(record, 'token', path),
+    session: optionalString(record, 'session', path),
+    command: optionalString(record, 'command', path),
+    positionals: optionalStringArray(record, 'positionals', path),
+    flags: optionalObject(record, 'flags', path),
+    runtime: optionalObject(record, 'runtime', path) as SessionRuntimeHints | undefined,
+    meta: optionalObject(record, 'meta', path) as DaemonRequestMeta | undefined,
   };
 });

--- a/src/daemon/__tests__/http-server-rpc-validation.test.ts
+++ b/src/daemon/__tests__/http-server-rpc-validation.test.ts
@@ -1,0 +1,78 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { createDaemonHttpServer } from '../http-server.ts';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  skipWhenLoopbackUnavailable,
+} from '../../__tests__/test-utils/index.ts';
+
+type RpcErrorResponse = {
+  jsonrpc: string;
+  id: unknown;
+  error?: { code: number; message: string; data?: { code?: string } };
+  result?: unknown;
+};
+
+async function withCommandRpcServer(
+  run: (
+    postRpc: (params: unknown) => Promise<{ status: number; body: RpcErrorResponse }>,
+  ) => Promise<void>,
+  t: { skip(reason?: string): void },
+): Promise<void> {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  let handlerCalls = 0;
+  const handleRequest = async (_req: DaemonRequest): Promise<DaemonResponse> => {
+    handlerCalls += 1;
+    return { ok: true, data: { ok: true } };
+  };
+  const server = await createDaemonHttpServer({ handleRequest });
+
+  try {
+    const port = await listenOnLoopback(server);
+    const postRpc = async (params: unknown) => {
+      const response = await fetch(`http://127.0.0.1:${port}/rpc`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'req-1',
+          method: 'agent_device.command',
+          params,
+        }),
+      });
+      return { status: response.status, body: (await response.json()) as RpcErrorResponse };
+    };
+    await run(postRpc);
+    // The malformed-input cases below must be rejected at the boundary, never dispatched.
+    assert.equal(handlerCalls, 0);
+  } finally {
+    await closeLoopbackServer(server);
+  }
+}
+
+test('malformed command params (positionals as string) yield 400 / -32602, not 500 / -32000', async (t) => {
+  await withCommandRpcServer(async (postRpc) => {
+    const { status, body } = await postRpc({ command: 'devices', positionals: 'not-an-array' });
+
+    assert.equal(status, 400);
+    assert.equal(body.error?.code, -32602);
+    assert.notEqual(body.error?.code, -32000);
+    assert.equal(body.error?.data?.code, 'INVALID_ARGS');
+    assert.ok(body.error?.message.startsWith('Invalid params:'), body.error?.message);
+    // The internal schema path sigil must not leak onto the wire.
+    assert.ok(!body.error?.message.includes('$.'), body.error?.message);
+  }, t);
+});
+
+test('malformed command params (command as number) yield 400 / -32602', async (t) => {
+  await withCommandRpcServer(async (postRpc) => {
+    const { status, body } = await postRpc({ command: 42 });
+
+    assert.equal(status, 400);
+    assert.equal(body.error?.code, -32602);
+    assert.equal(body.error?.data?.code, 'INVALID_ARGS');
+  }, t);
+});

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -3,7 +3,13 @@ import fs from 'node:fs';
 import { AppError, normalizeError, toAppErrorCode } from '../utils/errors.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { timingSafeStringEqual } from '../utils/timing-safe-equal.ts';
-import type { JsonRpcId, JsonRpcRequestEnvelope, LeaseBackend } from '../contracts.ts';
+import type {
+  CommandRpcParams,
+  JsonRpcId,
+  JsonRpcRequestEnvelope,
+  LeaseBackend,
+} from '../contracts.ts';
+import { commandRpcParamsSchema } from '../contracts.ts';
 import type { DaemonInstallSource, DaemonInvokeFn, DaemonRequest } from './types.ts';
 import { normalizeTenantId } from './config.ts';
 import {
@@ -165,20 +171,17 @@ function resolveToken(params: Record<string, unknown>, headers: IncomingHttpHead
   return paramToken ?? headerToken ?? bearerToken ?? '';
 }
 
-function toDaemonRequest(
-  params: Partial<DaemonRequest>,
-  headers: IncomingHttpHeaders,
-): DaemonRequest {
-  const raw = params as Record<string, unknown>;
+function toDaemonRequest(params: CommandRpcParams, headers: IncomingHttpHeaders): DaemonRequest {
   return {
-    token: resolveToken(raw, headers),
+    token: resolveToken(params as Record<string, unknown>, headers),
     session: params.session ?? 'default',
     command: params.command ?? '',
-    positionals: Array.isArray(params.positionals) ? params.positionals : [],
-    flags: params.flags,
-    // JSON-RPC params are untyped here; runtime shape is validated in the session open handler.
+    positionals: params.positionals ?? [],
+    // flags/runtime/meta are validated as objects at the boundary; their full shape is
+    // validated in the session open handler downstream.
+    flags: params.flags as DaemonRequest['flags'],
     runtime: params.runtime,
-    meta: params.meta,
+    meta: params.meta as DaemonRequest['meta'],
   };
 }
 
@@ -387,7 +390,7 @@ function methodToDaemonRequest(
   headers: IncomingHttpHeaders,
 ): DaemonRequest {
   if (COMMAND_RPC_METHODS.has(method)) {
-    return toDaemonRequest(params as unknown as Partial<DaemonRequest>, headers);
+    return toDaemonRequest(commandRpcParamsSchema.parse(params), headers);
   }
   if (INSTALL_FROM_SOURCE_RPC_METHODS.has(method)) {
     return toInstallFromSourceDaemonRequest(params, headers);

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -158,6 +158,14 @@ function statusCodeForNormalizedError(code: string): number {
   }
 }
 
+// Map a thrown boundary error to its JSON-RPC error code. Invalid params (malformed
+// wire input rejected before the request reaches the handler) is JSON-RPC -32602, to
+// match the explicit `Invalid params` sibling checks below; everything else is the
+// generic application error -32000.
+function jsonRpcCodeForNormalizedError(code: string): number {
+  return code === 'INVALID_ARGS' ? -32602 : -32000;
+}
+
 function resolveToken(params: Record<string, unknown>, headers: IncomingHttpHeaders): string {
   const authHeader = typeof headers.authorization === 'string' ? headers.authorization : '';
   const bearerToken = authHeader.toLowerCase().startsWith('bearer ')
@@ -384,13 +392,36 @@ function toReleaseMaterializedPathsDaemonRequest(
   };
 }
 
+// The runtime schema reports failures with an internal JSON-path prefix
+// (e.g. `$.positionals: Expected an array`). Strip the `$` sigil so the wire message
+// stays user-facing without leaking the schema's internal path representation.
+function cleanSchemaParseMessage(message: string): string {
+  const separator = message.indexOf(': ');
+  if (separator === -1 || !message.startsWith('$')) return message;
+  const field = message.slice(0, separator).replace(/^\$\.?/, '');
+  const detail = message.slice(separator + 2);
+  return field ? `${field}: ${detail}` : detail;
+}
+
+// Validate the command params at the boundary so malformed client input is rejected as
+// INVALID_ARGS (-> JSON-RPC -32602 / HTTP 400) instead of leaking as an internal 500.
+function parseCommandRpcParams(params: Record<string, unknown>): CommandRpcParams {
+  try {
+    return commandRpcParamsSchema.parse(params);
+  } catch (error) {
+    const detail =
+      error instanceof Error ? cleanSchemaParseMessage(error.message) : 'invalid command params';
+    throw new AppError('INVALID_ARGS', `Invalid params: ${detail}`);
+  }
+}
+
 function methodToDaemonRequest(
   method: string,
   params: Record<string, unknown>,
   headers: IncomingHttpHeaders,
 ): DaemonRequest {
   if (COMMAND_RPC_METHODS.has(method)) {
-    return toDaemonRequest(commandRpcParamsSchema.parse(params), headers);
+    return toDaemonRequest(parseCommandRpcParams(params), headers);
   }
   if (INSTALL_FROM_SOURCE_RPC_METHODS.has(method)) {
     return toInstallFromSourceDaemonRequest(params, headers);
@@ -684,16 +715,17 @@ export async function createDaemonHttpServer(options: {
       } catch (error) {
         handlerCompleted = true;
         const normalized = normalizeError(error);
+        const rpcErrorCode = jsonRpcCodeForNormalizedError(normalized.code);
         if (res.headersSent) {
           writeRpcResponseEnvelope(
             res,
-            createRpcError(rpcRequest.id ?? null, -32000, normalized.message, normalized),
+            createRpcError(rpcRequest.id ?? null, rpcErrorCode, normalized.message, normalized),
           );
           return;
         }
         sendJson(
           res,
-          createRpcError(rpcRequest.id ?? null, -32000, normalized.message, normalized),
+          createRpcError(rpcRequest.id ?? null, rpcErrorCode, normalized.message, normalized),
           statusCodeForNormalizedError(normalized.code),
         );
       } finally {

--- a/src/mcp/__tests__/router.test.ts
+++ b/src/mcp/__tests__/router.test.ts
@@ -66,7 +66,7 @@ test('MCP stdio payload queue serializes separate messages', async () => {
   const completions = new Map<JsonRpcId, (response: unknown) => void>();
   const queue = createMcpPayloadQueue({
     handlePayload: async (message) => {
-      const id = Array.isArray(message) ? null : (message.id ?? null);
+      const id = Array.isArray(message) ? null : ((message as { id?: JsonRpcId }).id ?? null);
       started.push(id);
       return await new Promise((resolve) => completions.set(id, resolve));
     },

--- a/src/mcp/__tests__/server-validation.test.ts
+++ b/src/mcp/__tests__/server-validation.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { createMcpPayloadQueue, handleMcpPayload } from '../server.ts';
+
+type JsonRpcResponse = {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+};
+
+test('boundary parse accepts a valid request and routes it as before', async () => {
+  const response = (await handleMcpPayload({
+    jsonrpc: '2.0',
+    id: 7,
+    method: 'ping',
+  })) as JsonRpcResponse;
+
+  assert.deepEqual(response, { jsonrpc: '2.0', id: 7, result: {} });
+});
+
+test('boundary parse accepts a notification (no id) and produces no response', async () => {
+  const response = await handleMcpPayload({
+    jsonrpc: '2.0',
+    method: 'notifications/initialized',
+  });
+
+  assert.equal(response, null);
+});
+
+test('boundary parse accepts a batch, preserving request order and skipping notifications', async () => {
+  const response = (await handleMcpPayload([
+    { jsonrpc: '2.0', id: 'first', method: 'ping' },
+    { jsonrpc: '2.0', method: 'notifications/initialized' },
+    { jsonrpc: '2.0', id: 'second', method: 'ping' },
+  ])) as JsonRpcResponse[];
+
+  assert.deepEqual(
+    response.map((entry) => entry.id),
+    ['first', 'second'],
+  );
+  for (const entry of response) {
+    assert.deepEqual(entry.result, {});
+  }
+});
+
+test('boundary parse keeps a request with an explicit null id', async () => {
+  const response = (await handleMcpPayload({
+    jsonrpc: '2.0',
+    id: null,
+    method: 'ping',
+  })) as JsonRpcResponse;
+
+  assert.deepEqual(response, { jsonrpc: '2.0', id: null, result: {} });
+});
+
+test('malformed message with a wrong-typed method is rejected with -32600, preserving id', async () => {
+  const response = (await handleMcpPayload({
+    jsonrpc: '2.0',
+    id: 42,
+    method: 123,
+  })) as JsonRpcResponse;
+
+  assert.equal(response.jsonrpc, '2.0');
+  assert.equal(response.id, 42);
+  assert.equal(response.error?.code, -32600);
+  assert.equal(response.error?.message, 'Invalid JSON-RPC request.');
+});
+
+test('a non-object payload is rejected with -32600 and a null id instead of crashing', async () => {
+  const response = (await handleMcpPayload('not-an-object')) as JsonRpcResponse;
+
+  assert.equal(response.id, null);
+  assert.equal(response.error?.code, -32600);
+});
+
+test('a batch rejects only its malformed element while routing the valid ones', async () => {
+  const response = (await handleMcpPayload([
+    { jsonrpc: '2.0', id: 'ok', method: 'ping' },
+    { jsonrpc: '2.0', id: 'bad', method: 999 },
+  ])) as JsonRpcResponse[];
+
+  assert.equal(response.length, 2);
+  assert.deepEqual(response[0]?.result, {});
+  assert.equal(response[1]?.id, 'bad');
+  assert.equal(response[1]?.error?.code, -32600);
+});
+
+test('a malformed payload pushed through the queue is written as a -32600 error response', async () => {
+  const writes: JsonRpcResponse[] = [];
+  const queue = createMcpPayloadQueue({
+    write: (message) => {
+      writes.push(message as JsonRpcResponse);
+    },
+  });
+
+  queue.push({ jsonrpc: '2.0', id: 5, method: { not: 'a string' } });
+  await queue.idle();
+
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.id, 5);
+  assert.equal(writes[0]?.error?.code, -32600);
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,17 +1,15 @@
 import { handleMcpMessage, type JsonRpcMessage } from './router.ts';
-import type { JsonRpcId } from '../contracts.ts';
+import { jsonRpcRequestSchema, type JsonRpcId } from '../contracts.ts';
 
 type JsonRpcResponse = Awaited<NonNullable<ReturnType<typeof handleMcpMessage>>>;
-type MessageSink = (message: JsonRpcMessage | JsonRpcMessage[]) => void;
-type PayloadHandler = (
-  messageOrBatch: JsonRpcMessage | JsonRpcMessage[],
-) => Promise<unknown | null>;
+type MessageSink = (payload: unknown) => void;
+type PayloadHandler = (payload: unknown) => Promise<unknown | null>;
 type MessageWriter = (message: unknown) => void;
 
 export async function runAgentDeviceMcpServer(): Promise<void> {
   const payloadQueue = createMcpPayloadQueue();
-  const decoder = new McpMessageDecoder((messageOrBatch) => {
-    payloadQueue.push(messageOrBatch);
+  const decoder = new McpMessageDecoder((payload) => {
+    payloadQueue.push(payload);
   });
 
   process.stdin.setEncoding('utf8');
@@ -44,18 +42,18 @@ export function createMcpPayloadQueue(
     write?: MessageWriter;
   } = {},
 ): {
-  push: (messageOrBatch: JsonRpcMessage | JsonRpcMessage[]) => void;
+  push: (payload: unknown) => void;
   idle: () => Promise<void>;
 } {
   const handlePayload = options.handlePayload ?? handleMcpPayload;
   const write = options.write ?? writeMessage;
   let pending = Promise.resolve();
   return {
-    push: (messageOrBatch) => {
-      const fallbackId = fallbackErrorId(messageOrBatch);
+    push: (payload) => {
+      const fallbackId = fallbackErrorId(payload);
       pending = pending
         .then(async () => {
-          const response = await handlePayload(messageOrBatch);
+          const response = await handlePayload(payload);
           if (response) write(response);
         })
         .catch((error: unknown) => {
@@ -75,28 +73,55 @@ export function createMcpPayloadQueue(
   };
 }
 
-export function handleMcpPayload(
-  messageOrBatch: JsonRpcMessage | JsonRpcMessage[],
-): Promise<unknown | null> {
-  if (Array.isArray(messageOrBatch)) {
-    return handleMcpBatch(messageOrBatch);
+export function handleMcpPayload(payload: unknown): Promise<unknown | null> {
+  if (Array.isArray(payload)) {
+    return handleMcpBatch(payload);
   }
-  return handleMcpMessage(messageOrBatch);
+  return handleInboundMessage(payload);
 }
 
-async function handleMcpBatch(messages: JsonRpcMessage[]): Promise<JsonRpcResponse[] | null> {
+async function handleMcpBatch(messages: unknown[]): Promise<JsonRpcResponse[] | null> {
   const responses: JsonRpcResponse[] = [];
   for (const message of messages) {
-    responses.push(...responseArray(await handleMcpMessage(message)));
+    responses.push(...responseArray(await handleInboundMessage(message)));
   }
   return responses.length > 0 ? responses : null;
 }
 
-function fallbackErrorId(messageOrBatch: JsonRpcMessage | JsonRpcMessage[]): JsonRpcId {
-  if (Array.isArray(messageOrBatch)) {
-    return messageOrBatch.length === 1 ? (messageOrBatch[0]?.id ?? null) : null;
+// Parse-at-the-boundary: validate each inbound payload against the shared JSON-RPC
+// envelope schema instead of force-casting attacker-controlled wire input. Requests
+// (with an id), notifications (no id), and batch elements all stay valid; only
+// genuinely malformed payloads (non-object, or wrong-typed jsonrpc/method/id) are
+// rejected with the standard -32600 Invalid Request error.
+async function handleInboundMessage(raw: unknown): Promise<JsonRpcResponse | null> {
+  let message: JsonRpcMessage;
+  try {
+    message = jsonRpcRequestSchema.parse(raw);
+  } catch {
+    return invalidRequestResponse(bestEffortId(raw));
   }
-  return messageOrBatch.id ?? null;
+  return handleMcpMessage(message);
+}
+
+function invalidRequestResponse(id: JsonRpcId): JsonRpcResponse {
+  return { jsonrpc: '2.0', id, error: { code: -32600, message: 'Invalid JSON-RPC request.' } };
+}
+
+function fallbackErrorId(payload: unknown): JsonRpcId {
+  if (Array.isArray(payload)) {
+    return payload.length === 1 ? bestEffortId(payload[0]) : null;
+  }
+  return bestEffortId(payload);
+}
+
+function bestEffortId(value: unknown): JsonRpcId {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const id = (value as Record<string, unknown>).id;
+    if (typeof id === 'string' || typeof id === 'number' || id === null) {
+      return id;
+    }
+  }
+  return null;
 }
 
 class McpMessageDecoder {
@@ -128,12 +153,9 @@ class McpMessageDecoder {
   }
 
   private emit(raw: string): void {
-    const parsed = JSON.parse(raw) as unknown;
-    if (Array.isArray(parsed)) {
-      this.sink(parsed as JsonRpcMessage[]);
-      return;
-    }
-    this.sink(parsed as JsonRpcMessage);
+    // JSON.parse failures propagate to the stdin handler as a -32700 parse error.
+    // The decoded value stays untyped here; handleMcpPayload validates it at the boundary.
+    this.sink(JSON.parse(raw) as unknown);
   }
 }
 


### PR DESCRIPTION
## What

Replace unchecked casts of attacker-controllable JSON-RPC wire input with real boundary validation, wiring in the `jsonRpcRequestSchema` that already existed in `contracts.ts` but was dead code.

- **`src/mcp/server.ts`** — the stdio decode path no longer force-casts `JSON.parse(raw)` to `JsonRpcMessage[]` / `JsonRpcMessage`. Each inbound payload (and each batch element) is parsed through `jsonRpcRequestSchema` before routing. The decoder now forwards the untyped parsed value and `handleMcpPayload` validates at the boundary.
- **`src/contracts.ts`** — add `commandRpcParamsSchema` (and an `optionalStringArray` helper) next to `jsonRpcRequestSchema` to validate the `params` of a command JSON-RPC request.
- **`src/daemon/http-server.ts`** — replace the `params as unknown as Partial<DaemonRequest>` double-cast in `methodToDaemonRequest` with `commandRpcParamsSchema.parse(params)`.

## Why

These were the spots where untrusted wire input was force-cast straight into typed objects. Parsing at the boundary turns a silently-mistyped object into a proper validated envelope (or a clean JSON-RPC error), and revives a schema that was otherwise unused.

## Preserves all valid requests / notifications / batches

`jsonRpcRequestSchema` does **not** mandate an `id`, so:
- **Requests** (with `id`) route exactly as before.
- **Notifications** (no `id`) are accepted and still produce no response (`id === undefined` is preserved distinctly from `id: null`).
- **Batches** are validated per-element, so a valid batch is routed in order and notifications are skipped, identical to today; a malformed element in a batch is rejected individually while valid siblings still respond.

Only genuinely malformed input is rejected:
- A wrong-typed `method`/`jsonrpc`/`id` or a non-object payload yields the standard `-32600` Invalid Request error (best-effort `id` preserved), matching today's router error path, instead of crashing.
- `JSON.parse` failures still surface as `-32700`.

The HTTP command path stays behaviorless for every valid command request; only malformed params (e.g. non-string `command`, non-array `positionals`) are now rejected at the boundary instead of being passed through untyped.

## Validation

All run from the worktree:

- `node_modules/.bin/tsc -p tsconfig.json --noEmit` — clean
- `oxfmt --write` on the changed files
- `oxlint <changed> --deny-warnings` — clean
- `vitest run src/mcp` — 16 passed (adds `src/mcp/__tests__/server-validation.test.ts` proving valid request/notification/batch routing and `-32600` rejection of malformed input)
- `vitest run contracts` and `src/__tests__/contracts-schema-public.test.ts` — passed
- `vitest run` on `http-contract`, `runtime-hints`, `request-router-open` daemon suites — passed
- `node scripts/sync-mcp-metadata.mjs --check` — passed unchanged