### PR TITLE
refactor: derive replay metadata platforms from the canonical selectors

### DIFF
--- a/src/replay/__tests__/script.test.ts
+++ b/src/replay/__tests__/script.test.ts
@@ -7,6 +7,7 @@ import { AppError } from '../../utils/errors.ts';
 import {
   parseReplayScriptDetailed,
   readReplayScriptMetadata,
+  REPLAY_METADATA_PLATFORMS,
   writeReplayScript,
 } from '../script.ts';
 import type { SessionAction, SessionState } from '../../daemon/types.ts';
@@ -278,6 +279,24 @@ test('readReplayScriptMetadata ignores non-concrete platform aliases', () => {
   const metadata = readReplayScriptMetadata(
     'context platform=apple device="Host Mac"\nopen "Demo"\n',
   );
+
+  assert.equal(metadata.platform, undefined);
+});
+
+test('REPLAY_METADATA_PLATFORMS is exactly the non-web leaf platforms', () => {
+  assert.deepEqual([...REPLAY_METADATA_PLATFORMS].sort(), ['android', 'ios', 'linux', 'macos']);
+});
+
+test('readReplayScriptMetadata accepts every concrete leaf platform', () => {
+  for (const platform of ['ios', 'android', 'macos', 'linux'] as const) {
+    const metadata = readReplayScriptMetadata(`context platform=${platform}\nopen "Demo"\n`);
+
+    assert.equal(metadata.platform, platform);
+  }
+});
+
+test('readReplayScriptMetadata drops unsupported web platform', () => {
+  const metadata = readReplayScriptMetadata('context platform=web device="Browser"\nopen "Demo"\n');
 
   assert.equal(metadata.platform, undefined);
 });

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -3,6 +3,7 @@ import { AppError } from '../utils/errors.ts';
 import { recordingQualityInputToExportQuality } from '../core/recording-export-quality.ts';
 import { readScreenshotScriptFlag } from '../contracts/screenshot.ts';
 import type { DeviceTarget, PlatformSelector } from '../utils/device.ts';
+import { PLATFORM_SELECTORS } from '../utils/device.ts';
 import { parseReplayOpenFlags } from './open-script.ts';
 import { formatPortableActionLine } from './script-formatting.ts';
 import type { SessionAction, SessionState } from '../daemon/types.ts';
@@ -14,14 +15,15 @@ import {
 } from './script-utils.ts';
 import { REPLAY_VAR_KEY_RE } from './vars.ts';
 
-type ReplayScriptPlatform = Exclude<PlatformSelector, 'apple'>;
+// Replay metadata `context platform=` lines only support concrete leaf
+// platforms. 'apple' is an alias (resolved to a leaf), and 'web' is not yet a
+// supported replay target, so both are excluded — keep the type and the runtime
+// allow-list derived from the same canonical PLATFORM_SELECTORS source.
+type ReplayScriptPlatform = Exclude<PlatformSelector, 'apple' | 'web'>;
 
-const REPLAY_METADATA_PLATFORMS = new Set<ReplayScriptPlatform>([
-  'ios',
-  'android',
-  'macos',
-  'linux',
-]);
+export const REPLAY_METADATA_PLATFORMS = new Set<ReplayScriptPlatform>(
+  PLATFORM_SELECTORS.filter((p): p is ReplayScriptPlatform => p !== 'apple' && p !== 'web'),
+);
 const REPLAY_METADATA_TARGETS = new Set<DeviceTarget>(['mobile', 'tv', 'desktop']);
 
 export type ReplayScriptMetadata = {


### PR DESCRIPTION
Follow-up to thymikee's review on #895: the replay parser hand-restated the leaf-platform allow-list a 4th time, and the type/runtime didn't agree.

## Problem
`src/replay/script.ts` defined `type ReplayScriptPlatform = Exclude<PlatformSelector, 'apple'>` (which still INCLUDES `'web'`) while `REPLAY_METADATA_PLATFORMS` was a hardcoded `Set(['ios','android','macos','linux'])` (omits `'web'`). So `context platform=web` lines were silently dropped even though the type permitted `web` — a type/runtime mismatch and a copy of the allow-list that can drift.

## Fix (behaviorless)
- Narrow the type so web's exclusion is explicit: `Exclude<PlatformSelector, 'apple' | 'web'>`.
- Derive the runtime set from the already-exported canonical `PLATFORM_SELECTORS` (`src/utils/device.ts`) instead of hardcoding. This yields exactly `['ios','macos','android','linux']` today and auto-includes any future leaf platform except web.
- Comment that replay metadata `context platform=` lines do not support web.

Web stays dropped exactly as before — now intentionally, type-safe, and derived from a single source. Adding web support remains a separate feature decision and is out of scope here. This branch does not depend on #895 (it derives from `PLATFORM_SELECTORS`, already exported on main).

## Tests
Extended `src/replay/__tests__/script.test.ts`:
- `REPLAY_METADATA_PLATFORMS` equals exactly the non-web leaf platforms.
- every concrete leaf platform (`ios`/`android`/`macos`/`linux`) is accepted in a context line.
- a `context platform=web` line is dropped (behaviorless).

Verified: `tsc --noEmit`, oxfmt, `oxlint --deny-warnings`, and `vitest run replay` (153 passed) all green.
