### PR TITLE
refactor: remove shallow re-export modules and a dead branch

### DIFF
--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -2,7 +2,6 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { AppError } from '../utils/errors.ts';
 import {
   isApplePlatform,
-  normalizePlatformSelector,
   resolveDevice,
   resolveAppleSimulatorSetPathForSelector,
   type DeviceInfo,
@@ -112,7 +111,7 @@ function hasExplicitAppleDeviceSelector(selector: AppleDeviceSelector): boolean 
 }
 
 export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<DeviceInfo> {
-  const normalizedPlatform = normalizePlatformSelector(flags.platform);
+  const normalizedPlatform = flags.platform;
   const iosSimulatorSetPath = resolveAppleSimulatorSetPathForSelector({
     simulatorSetPath: resolveIosSimulatorDeviceSetPath(flags.iosSimulatorDeviceSet),
     platform: normalizedPlatform,

--- a/src/daemon/handlers/__tests__/snapshot.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { parseWaitPositionals as parseWaitArgs } from '../../../core/wait-positionals.ts';
-import { parseTimeout } from '../parse-utils.ts';
+import { parseTimeout } from '../../../utils/parse-timeout.ts';
 
 // --- parseTimeout ---
 

--- a/src/daemon/handlers/handler-utils.ts
+++ b/src/daemon/handlers/handler-utils.ts
@@ -2,8 +2,6 @@ import type { CommandFlags } from '../../core/dispatch.ts';
 import { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, SessionState } from '../types.ts';
 
-export { mergeParentFlags } from '../../core/batch.ts';
-
 /**
  * Record a session action if a session is active. No-op when session is undefined.
  */

--- a/src/daemon/handlers/parse-utils.ts
+++ b/src/daemon/handlers/parse-utils.ts
@@ -1,6 +1,0 @@
-export {
-  ALERT_ACTION_RETRY_MS,
-  ALERT_POLL_INTERVAL_MS as POLL_INTERVAL_MS,
-  DEFAULT_ALERT_TIMEOUT_MS as DEFAULT_TIMEOUT_MS,
-} from '../../alert-contract.ts';
-export { parseTimeout } from '../../utils/parse-timeout.ts';

--- a/src/daemon/handlers/session-inventory.ts
+++ b/src/daemon/handlers/session-inventory.ts
@@ -4,9 +4,9 @@ import { assertResolvedAppsFilter } from '../../contracts/app-inventory.ts';
 import { asAppError } from '../../utils/errors.ts';
 import {
   isApplePlatform,
-  normalizePlatformSelector,
   resolveAppleSimulatorSetPathForSelector,
   type DeviceInfo,
+  type PlatformSelector,
 } from '../../utils/device.ts';
 import {
   resolveAndroidSerialAllowlist,
@@ -63,7 +63,7 @@ export async function handleSessionInventoryCommands(params: {
       const androidSerialAllowlist = resolveAndroidSerialAllowlist(
         req.flags?.androidDeviceAllowlist,
       );
-      const requestedPlatform = normalizePlatformSelector(req.flags?.platform);
+      const requestedPlatform = req.flags?.platform;
       const iosSimulatorSetPath = resolveAppleSimulatorSetPathForSelector({
         simulatorSetPath: resolveIosSimulatorDeviceSetPath(req.flags?.iosSimulatorDeviceSet),
         platform: requestedPlatform,
@@ -145,7 +145,7 @@ export async function handleSessionInventoryCommands(params: {
 
 function matchesRequestedPlatform(
   device: DeviceInfo,
-  requestedPlatform: ReturnType<typeof normalizePlatformSelector>,
+  requestedPlatform: PlatformSelector | undefined,
 ): boolean {
   if (!requestedPlatform) return true;
   if (requestedPlatform === 'apple') return isApplePlatform(device.platform);

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -6,7 +6,7 @@ import {
   type ReplayVarScope,
 } from '../../replay/vars.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionAction } from '../types.ts';
-import { mergeParentFlags } from './handler-utils.ts';
+import { mergeParentFlags } from '../../core/batch.ts';
 import { invokeMaestroRuntimeCommand } from '../../compat/maestro/runtime.ts';
 import { invokeMaestroRunFlowWhenControl } from '../../compat/maestro/runtime-flow.ts';
 import {

--- a/src/daemon/handlers/session-runtime-command.ts
+++ b/src/daemon/handlers/session-runtime-command.ts
@@ -1,4 +1,3 @@
-import { normalizePlatformSelector } from '../../utils/device.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { clearRuntimeHintsFromApp, hasRuntimeTransportHints } from '../runtime-hints.ts';
@@ -44,7 +43,7 @@ export async function handleRuntimeCommand(params: {
   }
 
   const platform = toRuntimePlatform(
-    normalizePlatformSelector(req.flags?.platform) ?? current?.platform ?? session?.device.platform,
+    req.flags?.platform ?? current?.platform ?? session?.device.platform,
   );
   if (!platform) {
     return errorResponse(

--- a/src/daemon/handlers/session-state.ts
+++ b/src/daemon/handlers/session-state.ts
@@ -1,6 +1,6 @@
 import { isCommandSupportedOnDevice } from '../../core/capabilities.ts';
 import { asAppError } from '../../utils/errors.ts';
-import { isApplePlatform, normalizePlatformSelector, type DeviceInfo } from '../../utils/device.ts';
+import { isApplePlatform, type DeviceInfo } from '../../utils/device.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
@@ -36,7 +36,7 @@ async function handleAppStateCommand(params: {
   const { req, sessionName, sessionStore } = params;
   const session = sessionStore.get(sessionName);
   const flags = req.flags ?? {};
-  const normalizedPlatform = normalizePlatformSelector(flags.platform);
+  const normalizedPlatform = flags.platform;
 
   if (!session && hasExplicitSessionFlag(flags)) {
     const message =
@@ -147,8 +147,7 @@ export async function handleSessionStateCommands(params: {
     const guard = requireSessionOrExplicitSelector(req.command, session, flags);
     if (guard) return guard;
 
-    const normalizedPlatform =
-      normalizePlatformSelector(flags.platform) ?? session?.device.platform;
+    const normalizedPlatform = flags.platform ?? session?.device.platform;
     const targetsAndroid = normalizedPlatform === 'android';
     const wantsAndroidHeadless = flags.headless === true;
     if (wantsAndroidHeadless && !targetsAndroid) {

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -8,7 +8,7 @@ import {
   type PrepareIosRunnerResult,
 } from '../../platforms/ios/runner-client.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
-import { isApplePlatform, normalizePlatformSelector } from '../../utils/device.ts';
+import { isApplePlatform } from '../../utils/device.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { contextFromFlags } from '../context.ts';
@@ -304,7 +304,7 @@ export async function handleSessionCommands(params: {
       keyboardAction === 'dismiss' || keyboardAction === 'enter' || keyboardAction === 'return';
     if (!session && needsForegroundIosApp) {
       const flags = req.flags ?? {};
-      const normalizedPlatform = normalizePlatformSelector(flags.platform);
+      const normalizedPlatform = flags.platform;
       if (normalizedPlatform === 'ios') {
         return errorResponse(
           'SESSION_NOT_FOUND',

--- a/src/daemon/handlers/snapshot-alert.ts
+++ b/src/daemon/handlers/snapshot-alert.ts
@@ -1,5 +1,10 @@
 import { isCommandSupportedOnDevice } from '../../core/capabilities.ts';
-import type { AlertAction } from '../../alert-contract.ts';
+import {
+  ALERT_ACTION_RETRY_MS,
+  ALERT_POLL_INTERVAL_MS as POLL_INTERVAL_MS,
+  DEFAULT_ALERT_TIMEOUT_MS as DEFAULT_TIMEOUT_MS,
+  type AlertAction,
+} from '../../alert-contract.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import { runIosRunnerCommand } from '../../platforms/ios/runner-client.ts';
 import { runMacOsAlertAction } from '../../platforms/ios/macos-helper.ts';
@@ -8,12 +13,7 @@ import { AppError } from '../../utils/errors.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import { recordIfSession } from './snapshot-session.ts';
-import {
-  ALERT_ACTION_RETRY_MS,
-  DEFAULT_TIMEOUT_MS,
-  parseTimeout,
-  POLL_INTERVAL_MS,
-} from './parse-utils.ts';
+import { parseTimeout } from '../../utils/parse-timeout.ts';
 import { errorResponse } from './response.ts';
 
 type HandleAlertCommandParams = {

--- a/src/daemon/request-lock-policy.ts
+++ b/src/daemon/request-lock-policy.ts
@@ -7,14 +7,14 @@ import {
   type SessionSelectorConflict,
   type SessionSelectorConflictKey,
 } from './session-selector.ts';
-import { isApplePlatform, normalizePlatformSelector } from '../utils/device.ts';
+import { isApplePlatform, type PlatformSelector } from '../utils/device.ts';
 import { buildSessionRecoveryHint, describeSessionDevice } from './session-recovery-hints.ts';
 import { shellQuoteIfNeeded } from '../utils/shell-quote.ts';
 import { hasLockableDeviceSelector, hasSelectorValue } from './device-selector-intent.ts';
 import { canOverrideLockPolicySelector } from './daemon-command-registry.ts';
 
 type LockPlatform = NonNullable<DaemonRequest['meta']>['lockPlatform'];
-type NormalizedLockPlatform = NonNullable<ReturnType<typeof normalizePlatformSelector>>;
+type NormalizedLockPlatform = NonNullable<PlatformSelector>;
 
 export function applyRequestLockPolicy(
   req: DaemonRequest,
@@ -141,11 +141,11 @@ function listFreshSessionConflicts(
   // participate in the first binding for the locked platform; concrete device
   // existence and identity remain the target resolver's job.
   const conflicts: SessionSelectorConflict[] = [];
-  const normalizedLockPlatform = normalizePlatformSelector(lockPlatform);
+  const normalizedLockPlatform = lockPlatform;
   if (
     flags.platform !== undefined &&
     normalizedLockPlatform &&
-    platformSelectorsConflict(normalizePlatformSelector(flags.platform), normalizedLockPlatform)
+    platformSelectorsConflict(flags.platform, normalizedLockPlatform)
   ) {
     conflicts.push({ key: 'platform', value: flags.platform });
   }
@@ -158,8 +158,8 @@ function listFreshSessionConflicts(
 }
 
 function platformSelectorsConflict(
-  requested: ReturnType<typeof normalizePlatformSelector>,
-  locked: ReturnType<typeof normalizePlatformSelector>,
+  requested: PlatformSelector | undefined,
+  locked: PlatformSelector | undefined,
 ): boolean {
   if (!requested || !locked) return false;
   if (requested === locked) return false;
@@ -235,7 +235,7 @@ function freshSessionSelectorKeysForPlatform(
 }
 
 function isAppleDesktopSelector(flags: CommandFlags): boolean {
-  return flags.target === 'desktop' || normalizePlatformSelector(flags.platform) === 'macos';
+  return flags.target === 'desktop' || flags.platform === 'macos';
 }
 
 function stripSessionConflicts(flags: CommandFlags, conflicts: SessionSelectorConflict[]): void {

--- a/src/daemon/session-routing.ts
+++ b/src/daemon/session-routing.ts
@@ -16,7 +16,6 @@ export function resolveEffectiveSessionName(
   if (hasExplicitSessionFlag(req)) return requested;
   const scope = resolveImplicitSessionScope(req);
   if (scope) return formatScopedSessionName(scope.id, requested);
-  if (requested !== 'default') return requested;
   return requested;
 }
 

--- a/src/daemon/session-selector.ts
+++ b/src/daemon/session-selector.ts
@@ -1,7 +1,7 @@
 import { AppError } from '../utils/errors.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
 import type { SessionState } from './types.ts';
-import { matchesPlatformSelector, normalizePlatformSelector } from '../utils/device.ts';
+import { matchesPlatformSelector } from '../utils/device.ts';
 import { parseSerialAllowlist } from '../utils/device-isolation.ts';
 import { buildSessionRecoveryHint, describeSessionDevice } from './session-recovery-hints.ts';
 
@@ -43,7 +43,7 @@ export function listSessionSelectorConflicts(
   const mismatches: SessionSelectorConflict[] = [];
   const device = session.device;
 
-  const normalizedPlatform = normalizePlatformSelector(flags.platform);
+  const normalizedPlatform = flags.platform;
   if (normalizedPlatform && !matchesPlatformSelector(device.platform, normalizedPlatform)) {
     mismatches.push({ key: 'platform', value: flags.platform! });
   }

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -39,14 +39,6 @@ type DeviceSelectionContext = {
   simulatorSetPath?: string;
 };
 
-export function normalizePlatformSelector(
-  platform: PlatformSelector | undefined,
-): PlatformSelector | undefined {
-  // Single normalization hook for platform selectors. Current CLI parsing already
-  // yields canonical values, but Apple-family routing still depends on one shared point.
-  return platform;
-}
-
 export function isApplePlatform(
   platform: Platform | PlatformSelector | undefined,
 ): platform is ApplePlatform | 'apple' {


### PR DESCRIPTION
## What

Pure-deletion dedup of shallow/dead modules — no behavior change.

1. **`src/daemon/handlers/parse-utils.ts`** was a 6-line pure re-export alias (alert constants + `parseTimeout`). Inlined at its two importers (`snapshot-alert.ts`, `snapshot.test.ts`) — they now import from the real homes (`alert-contract.ts`, `utils/parse-timeout.ts`) — and deleted the file. Alias names (`POLL_INTERVAL_MS`, `DEFAULT_TIMEOUT_MS`) are preserved via `as` import renames, so bound identifiers are unchanged.
2. **`src/daemon/handlers/handler-utils.ts`** re-exported `mergeParentFlags` from `core/batch.ts`. Repointed the sole importer (`session-replay-action-runtime.ts`) to import it from its real home and dropped the re-export. `recordSessionAction` (the module's real export) is untouched.
3. **`src/daemon/session-routing.ts`** had a dead both-arms branch `if (requested !== 'default') return requested; return requested;` — collapsed to `return requested`.
4. **`src/utils/device.ts` `normalizePlatformSelector`** was a documented identity no-op (`return platform`). Verified against every call site: all inputs (`flags.platform`, `req.flags?.platform`, `lockPlatform`) are typed `PlatformSelector | undefined` — exactly the function's return type — so inlining is type-identical. Deleted the function and inlined all 9 value sites; replaced the 3 type-position usages (`ReturnType<typeof normalizePlatformSelector>` -> `PlatformSelector | undefined`, `NonNullable<...>` -> `NonNullable<PlatformSelector>`).

Net **-20 lines** (28 insertions, 48 deletions across 14 files; one file deleted).

## Validation

- `tsc -p tsconfig.json --noEmit` -> clean
- `oxfmt --write` + `oxlint --deny-warnings` on all changed files -> clean
- `vitest run daemon device session-routing` -> 99 files / 948 tests pass (covers session-routing, request-lock-policy, session-selector, device-ready, and the `parseTimeout` snapshot test)

behaviorless: every change is either a pure import-source repoint (same bound identifiers/values), an unreachable-branch collapse (both arms returned the same value), or inlining an identity function whose return type matched each call-site input type exactly. No error codes, messages, or recorded shapes touched.