### PR TITLE
refactor: collapse duplicated batch-step validation to one schema

### DIFF
--- a/src/batch-contract.ts
+++ b/src/batch-contract.ts
@@ -1,1 +1,65 @@
+import { daemonRuntimeSchema, type SessionRuntimeHints } from './contracts.ts';
+import { AppError } from './utils/errors.ts';
+import { isRecord } from './utils/parsing.ts';
+
 export const DEFAULT_BATCH_MAX_STEPS = 100;
+
+// Builds the error thrown by a batch-step validator, so each consumer keeps its
+// own thrown type (plain `Error` for metadata, `AppError` for the daemon/CLI)
+// while sharing the validation logic and messages.
+export type BatchStepErrorFactory = (message: string) => Error;
+
+const batchInvalidArgsError: BatchStepErrorFactory = (message) =>
+  new AppError('INVALID_ARGS', message);
+
+export function isValidBatchMaxSteps(maxSteps: number): boolean {
+  return Number.isInteger(maxSteps) && maxSteps >= 1 && maxSteps <= 1000;
+}
+
+export function assertBatchStepCount(
+  stepCount: number,
+  maxSteps: number,
+  makeError: BatchStepErrorFactory = batchInvalidArgsError,
+): void {
+  if (stepCount > maxSteps) {
+    throw makeError(`batch has ${stepCount} steps; max allowed is ${maxSteps}.`);
+  }
+}
+
+export function readBatchStepRecord(
+  step: unknown,
+  stepNumber: number,
+  makeError: BatchStepErrorFactory = batchInvalidArgsError,
+): Record<string, unknown> {
+  if (!isRecord(step)) {
+    throw makeError(`Invalid batch step ${stepNumber}.`);
+  }
+  return step;
+}
+
+export function readBatchStepInputObject(
+  record: Record<string, unknown>,
+  stepNumber: number,
+  makeError: BatchStepErrorFactory = batchInvalidArgsError,
+): Record<string, unknown> {
+  const input = record.input;
+  if (!isRecord(input)) {
+    throw makeError(`Batch step ${stepNumber} input must be an object.`);
+  }
+  return input;
+}
+
+export function parseBatchStepRuntime(
+  value: unknown,
+  stepNumber: number,
+  makeError: BatchStepErrorFactory = batchInvalidArgsError,
+): SessionRuntimeHints | undefined {
+  if (value === undefined) return undefined;
+  try {
+    return daemonRuntimeSchema.parse(value);
+  } catch (error) {
+    throw makeError(
+      `Batch step ${stepNumber} runtime is invalid: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -1,5 +1,6 @@
 import type { BatchStep } from '../client-types.ts';
-import { daemonRuntimeSchema, type SessionRuntimeHints } from '../contracts.ts';
+import { type SessionRuntimeHints } from '../contracts.ts';
+import { parseBatchStepRuntime } from '../batch-contract.ts';
 import { readInputFromCli } from '../commands/cli-grammar.ts';
 import { isCommandName, type CommandName } from '../commands/command-metadata.ts';
 import type { CliFlags } from '../utils/cli-flags.ts';
@@ -63,7 +64,7 @@ function readStructuredBatchStep(
   step: Record<string, unknown> & BatchStep,
   stepNumber: number,
 ): BatchStep {
-  const runtime = readRuntimeHints(step.runtime, stepNumber);
+  const runtime = parseBatchStepRuntime(step.runtime, stepNumber);
   const { runtime: _runtime, ...rest } = step;
   return {
     ...rest,
@@ -79,7 +80,7 @@ function readLegacyCliBatchStep(step: unknown, stepNumber: number): LegacyCliBat
   const command = readLegacyCommand(step.command, stepNumber);
   const positionals = readLegacyPositionals(step.positionals, stepNumber);
   const flags = readLegacyFlags(step.flags, stepNumber);
-  const runtime = readRuntimeHints(step.runtime, stepNumber);
+  const runtime = parseBatchStepRuntime(step.runtime, stepNumber);
   return {
     command,
     ...(positionals === undefined ? {} : { positionals }),
@@ -127,18 +128,6 @@ function readLegacyFlags(value: unknown, stepNumber: number): Record<string, unk
     throw new AppError('INVALID_ARGS', `Batch step ${stepNumber} flags must be an object.`);
   }
   return value;
-}
-
-function readRuntimeHints(value: unknown, stepNumber: number): SessionRuntimeHints | undefined {
-  if (value === undefined) return undefined;
-  try {
-    return daemonRuntimeSchema.parse(value);
-  } catch (error) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Batch step ${stepNumber} runtime is invalid: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
 }
 
 function cliFlagsFromBatchStep(flags: Record<string, unknown> | undefined): CliFlags {

--- a/src/commands/batch/metadata.ts
+++ b/src/commands/batch/metadata.ts
@@ -1,5 +1,13 @@
-import { DEFAULT_BATCH_MAX_STEPS } from '../../batch-contract.ts';
-import { daemonRuntimeSchema, type SessionRuntimeHints } from '../../contracts.ts';
+import {
+  DEFAULT_BATCH_MAX_STEPS,
+  assertBatchStepCount,
+  isValidBatchMaxSteps,
+  parseBatchStepRuntime,
+  readBatchStepInputObject,
+  readBatchStepRecord,
+  type BatchStepErrorFactory,
+} from '../../batch-contract.ts';
+import { type SessionRuntimeHints } from '../../contracts.ts';
 import {
   STRUCTURED_BATCH_COMMAND_NAMES,
   readStructuredBatchCommandName,
@@ -21,7 +29,8 @@ import {
   type CommandFieldMap,
   type InferCommandInput,
 } from '../command-input.ts';
-import { isRecord } from '../../utils/parsing.ts';
+
+const batchPlainError: BatchStepErrorFactory = (message) => new Error(message);
 
 export type BatchCommandStep = {
   command: string;
@@ -99,12 +108,10 @@ function batchStepSchema(nestedCommands: readonly string[]): JsonSchema {
 function readBatchInput(input: unknown, fields: ReturnType<typeof batchFields>): BatchInput {
   const parsed = readFieldInput(input, fields);
   const maxSteps = parsed.maxSteps ?? DEFAULT_BATCH_MAX_STEPS;
-  if (!Number.isInteger(maxSteps) || maxSteps < 1 || maxSteps > 1000) {
+  if (!isValidBatchMaxSteps(maxSteps)) {
     throw new Error(`Invalid batch maxSteps: ${String(parsed.maxSteps)}`);
   }
-  if (parsed.steps.length > maxSteps) {
-    throw new Error(`batch has ${parsed.steps.length} steps; max allowed is ${maxSteps}.`);
-  }
+  assertBatchStepCount(parsed.steps.length, maxSteps, batchPlainError);
   return {
     ...parsed,
   };
@@ -122,11 +129,11 @@ function readBatchStep(
   stepNumber: number,
   nestedCommands: readonly string[],
 ): BatchCommandStep {
-  const record = readBatchStepRecord(step, stepNumber);
+  const record = readBatchStepRecord(step, stepNumber, batchPlainError);
   assertAllowedKeys(record, ['command', 'input', 'runtime'], `Batch step ${stepNumber}`);
   return {
     command: readBatchStepCommand(record, stepNumber, nestedCommands),
-    input: readBatchStepInput(record, stepNumber),
+    input: readBatchStepInputObject(record, stepNumber, batchPlainError),
     ...readBatchStepRuntimeProperty(record, stepNumber),
   };
 }
@@ -146,32 +153,10 @@ function readBatchStepCommand(
   return command;
 }
 
-function readBatchStepRecord(step: unknown, stepNumber: number): Record<string, unknown> {
-  if (!isRecord(step)) {
-    throw new Error(`Invalid batch step ${stepNumber}.`);
-  }
-  return step;
-}
-
-function readBatchStepInput(record: Record<string, unknown>, stepNumber: number) {
-  const input = record.input;
-  if (!isRecord(input)) {
-    throw new Error(`Batch step ${stepNumber} input must be an object.`);
-  }
-  return input;
-}
-
 function readBatchStepRuntimeProperty(
   record: Record<string, unknown>,
   stepNumber: number,
 ): Pick<BatchCommandStep, 'runtime'> {
-  const runtime = record.runtime;
-  if (runtime === undefined) return {};
-  try {
-    return { runtime: daemonRuntimeSchema.parse(runtime) };
-  } catch (error) {
-    throw new Error(
-      `Batch step ${stepNumber} runtime is invalid: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+  const runtime = parseBatchStepRuntime(record.runtime, stepNumber, batchPlainError);
+  return runtime === undefined ? {} : { runtime };
 }

--- a/src/commands/batch/projection.ts
+++ b/src/commands/batch/projection.ts
@@ -1,12 +1,15 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
-import { daemonRuntimeSchema, type DaemonRequest } from '../../contracts.ts';
 import {
   STRUCTURED_BATCH_COMMAND_NAMES,
   readStructuredBatchCommandName,
 } from '../../batch-policy.ts';
+import {
+  parseBatchStepRuntime,
+  readBatchStepInputObject,
+  readBatchStepRecord,
+} from '../../batch-contract.ts';
 import type { DaemonBatchStep } from '../../core/batch.ts';
 import { AppError } from '../../utils/errors.ts';
-import { isRecord } from '../../utils/parsing.ts';
 import { request } from '../cli-grammar/common.ts';
 import type { CommandInput, DaemonCommandRequest, DaemonWriter } from '../cli-grammar/types.ts';
 import { buildRequestFlags } from '../command-flags.ts';
@@ -53,8 +56,8 @@ function readBatchDaemonStep(
 ): DaemonBatchStep {
   const record = readBatchStepRecord(step, stepNumber);
   const command = readBatchStepCommand(record, stepNumber);
-  const input = readBatchStepInput(record, stepNumber);
-  const runtime = readBatchStepRuntime(record, stepNumber);
+  const input = readBatchStepInputObject(record, stepNumber) as CommandInput;
+  const runtime = parseBatchStepRuntime(record.runtime, stepNumber);
   const prepared = prepareDaemonCommandRequest(command, input, stepNumber);
   return {
     command: prepared.command,
@@ -64,40 +67,9 @@ function readBatchDaemonStep(
   };
 }
 
-function readBatchStepRecord(step: unknown, stepNumber: number): Record<string, unknown> {
-  if (!isRecord(step)) {
-    throw new AppError('INVALID_ARGS', `Invalid batch step ${stepNumber}.`);
-  }
-  return step;
-}
-
 function readBatchStepCommand(
   record: Record<string, unknown>,
   stepNumber: number,
 ): BatchCommandName {
   return readStructuredBatchCommandName(record.command, stepNumber);
-}
-
-function readBatchStepInput(record: Record<string, unknown>, stepNumber: number): CommandInput {
-  const input = record.input;
-  if (!isRecord(input)) {
-    throw new AppError('INVALID_ARGS', `Batch step ${stepNumber} input must be an object.`);
-  }
-  return input as CommandInput;
-}
-
-function readBatchStepRuntime(
-  record: Record<string, unknown>,
-  stepNumber: number,
-): DaemonRequest['runtime'] {
-  const runtime = record.runtime;
-  if (runtime === undefined) return undefined;
-  try {
-    return daemonRuntimeSchema.parse(runtime);
-  } catch (error) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Batch step ${stepNumber} runtime is invalid: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
 }

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -1,7 +1,12 @@
-import { daemonRuntimeSchema, type DaemonRequest, type DaemonResponse } from '../contracts.ts';
+import { type DaemonRequest, type DaemonResponse } from '../contracts.ts';
 import { AppError, asAppError } from '../utils/errors.ts';
 import { isRecord } from '../utils/parsing.ts';
-import { DEFAULT_BATCH_MAX_STEPS } from '../batch-contract.ts';
+import {
+  DEFAULT_BATCH_MAX_STEPS,
+  assertBatchStepCount,
+  isValidBatchMaxSteps,
+  parseBatchStepRuntime,
+} from '../batch-contract.ts';
 import {
   BATCH_BLOCKED_COMMANDS,
   BATCH_DAEMON_STEP_KEYS,
@@ -74,7 +79,7 @@ export async function runBatch(
     return batchErrorResponse('INVALID_ARGS', `Unsupported batch on-error mode: ${batchOnError}.`);
   }
   const batchMaxSteps = flags?.batchMaxSteps ?? DEFAULT_BATCH_MAX_STEPS;
-  if (!Number.isInteger(batchMaxSteps) || batchMaxSteps < 1 || batchMaxSteps > 1000) {
+  if (!isValidBatchMaxSteps(batchMaxSteps)) {
     return batchErrorResponse(
       'INVALID_ARGS',
       `Invalid batch max-steps: ${String(flags?.batchMaxSteps)}`,
@@ -132,12 +137,7 @@ export function validateAndNormalizeBatchSteps(
   if (!Array.isArray(steps) || steps.length === 0) {
     throw new AppError('INVALID_ARGS', 'batch requires a non-empty batchSteps array.');
   }
-  if (steps.length > maxSteps) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `batch has ${steps.length} steps; max allowed is ${maxSteps}.`,
-    );
-  }
+  assertBatchStepCount(steps.length, maxSteps);
 
   const normalized: NormalizedBatchStep[] = [];
   for (let index = 0; index < steps.length; index += 1) {
@@ -175,22 +175,10 @@ export function validateAndNormalizeBatchSteps(
       command,
       positionals: positionals as string[],
       flags: (step.flags ?? {}) as Record<string, unknown>,
-      runtime: readBatchStepRuntime(step.runtime, index + 1),
+      runtime: parseBatchStepRuntime(step.runtime, index + 1),
     });
   }
   return normalized;
-}
-
-function readBatchStepRuntime(value: unknown, stepNumber: number): DaemonRequest['runtime'] {
-  if (value === undefined) return undefined;
-  try {
-    return daemonRuntimeSchema.parse(value);
-  } catch (error) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Batch step ${stepNumber} runtime is invalid: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
 }
 
 export function buildBatchStepFlags(


### PR DESCRIPTION
## What

Collapses the duplicated batch-step validation that was copy-pasted across the
metadata (public/MCP), projection (daemon writer), legacy CLI, and `core/batch`
(daemon) paths into one shared module (`src/batch-contract.ts`).

Extracted single-source helpers, each parameterized by a `BatchStepErrorFactory`
so every consumer keeps its exact thrown error type while sharing the logic and
messages:

- `readBatchStepRecord` — the `Invalid batch step N.` guard (was duplicated in
  metadata + projection).
- `readBatchStepInputObject` — the `Batch step N input must be an object.` guard
  (was duplicated in metadata + projection).
- `parseBatchStepRuntime` — the `daemonRuntimeSchema.parse` + `Batch step N
  runtime is invalid: ...` guard (was duplicated in core/batch, metadata,
  projection, and cli/batch-steps — 4 copies).
- `assertBatchStepCount` — the `batch has N steps; max allowed is M.` check (was
  duplicated in metadata + core/batch).
- `isValidBatchMaxSteps` — the `1..1000` max-steps bound (was inlined in
  metadata + core/batch).

The error factory defaults to `AppError('INVALID_ARGS', ...)` (the daemon/CLI
behavior); the public metadata path passes a `new Error(message)` factory so it
keeps throwing plain `Error` exactly as before.

## LOC

Net **-2** lines, but the real win is removing ~5 duplicated validators (up to 4
copies each) so messages/bounds now live in one place.

## Validation

- `tsc -p tsconfig.json --noEmit` — clean
- `oxfmt --write` + `oxlint --deny-warnings` — clean
- `vitest run batch` — 4 files, 22 tests pass

## behaviorless: validation outcomes and messages are byte-identical.

`isValidBatchMaxSteps(x)` negates to the original
`!Number.isInteger(x) || x < 1 || x > 1000`. Each shared helper preserves the
exact message string, and the parameterized error factory preserves the exact
thrown type per consumer (plain `Error` for metadata, `AppError('INVALID_ARGS')`
for the daemon/projection/CLI). No public API, error code, or recorded shape
changes.
