### PR TITLE
refactor: extract shared Android instrumentation-helper

### DIFF
--- a/src/platforms/android/instrumentation-helper.ts
+++ b/src/platforms/android/instrumentation-helper.ts
@@ -1,0 +1,134 @@
+import { AppError } from '../../utils/errors.ts';
+
+// Shared primitives for the Android instrumentation helpers (snapshot + multi-touch).
+// Both helpers drive `am instrument -w` and parse the resulting
+// INSTRUMENTATION_STATUS / INSTRUMENTATION_RESULT key/value records, and both
+// validate a bundled JSON manifest with the same integer/literal field rules.
+
+type AndroidInstrumentationRecordState = {
+  status: Array<Record<string, string>>;
+  results: Array<Record<string, string>>;
+  currentStatus: Record<string, string> | null;
+  currentResult: Record<string, string> | null;
+};
+
+export function parseInstrumentationRecords(output: string): {
+  status: Array<Record<string, string>>;
+  results: Array<Record<string, string>>;
+} {
+  const state: AndroidInstrumentationRecordState = {
+    status: [],
+    results: [],
+    currentStatus: null,
+    currentResult: null,
+  };
+
+  for (const line of output.split(/\r?\n/)) {
+    readInstrumentationRecordLine(line, state);
+  }
+  flushInstrumentationRecords(state);
+  return { status: state.status, results: state.results };
+}
+
+function readInstrumentationRecordLine(
+  line: string,
+  state: AndroidInstrumentationRecordState,
+): void {
+  if (line.startsWith('INSTRUMENTATION_STATUS: ')) {
+    state.currentStatus ??= {};
+    readKeyValue(line.slice('INSTRUMENTATION_STATUS: '.length), state.currentStatus);
+    return;
+  }
+  if (line.startsWith('INSTRUMENTATION_STATUS_CODE: ')) {
+    flushStatusRecord(state);
+    return;
+  }
+  if (line.startsWith('INSTRUMENTATION_RESULT: ')) {
+    state.currentResult ??= {};
+    readKeyValue(line.slice('INSTRUMENTATION_RESULT: '.length), state.currentResult);
+    return;
+  }
+  if (line.startsWith('INSTRUMENTATION_CODE: ')) {
+    flushResultRecord(state);
+  }
+}
+
+function flushInstrumentationRecords(state: AndroidInstrumentationRecordState): void {
+  flushStatusRecord(state);
+  flushResultRecord(state);
+}
+
+function flushStatusRecord(state: {
+  status: Array<Record<string, string>>;
+  currentStatus: Record<string, string> | null;
+}): void {
+  if (state.currentStatus) {
+    state.status.push(state.currentStatus);
+    state.currentStatus = null;
+  }
+}
+
+function flushResultRecord(state: {
+  results: Array<Record<string, string>>;
+  currentResult: Record<string, string> | null;
+}): void {
+  if (state.currentResult) {
+    state.results.push(state.currentResult);
+    state.currentResult = null;
+  }
+}
+
+function readKeyValue(line: string, target: Record<string, string>): void {
+  const separator = line.indexOf('=');
+  if (separator < 0) {
+    return;
+  }
+  target[line.slice(0, separator)] = line.slice(separator + 1);
+}
+
+export function readInstrumentationResultNumber(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function readInstrumentationResultBoolean(value: string | undefined): boolean | undefined {
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return undefined;
+}
+
+export function readAndroidHelperManifestInteger(
+  value: unknown,
+  field: string,
+  helperLabel: string,
+): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Android ${helperLabel} manifest ${field} must be an integer.`,
+    );
+  }
+  return value;
+}
+
+export function readAndroidHelperManifestLiteral<const Value extends string>(
+  value: unknown,
+  field: string,
+  expected: Value,
+  helperLabel: string,
+): Value {
+  if (value !== expected) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Android ${helperLabel} manifest ${field} must be "${expected}".`,
+    );
+  }
+  return expected;
+}

--- a/src/platforms/android/multitouch-helper.ts
+++ b/src/platforms/android/multitouch-helper.ts
@@ -16,6 +16,12 @@ import {
   type AndroidTouchGestureRequest,
 } from './adb-executor.ts';
 import { getAndroidScreenSize, swipeAndroid } from './input-actions.ts';
+import {
+  parseInstrumentationRecords,
+  readAndroidHelperManifestInteger,
+  readAndroidHelperManifestLiteral,
+  readInstrumentationResultNumber,
+} from './instrumentation-helper.ts';
 
 const ANDROID_MULTITOUCH_HELPER_NAME = 'android-multitouch-helper';
 const ANDROID_MULTITOUCH_HELPER_PACKAGE = 'com.callstack.agentdevice.multitouchhelper';
@@ -401,7 +407,7 @@ export async function runAndroidMultiTouchHelperGesture(options: {
 }
 
 export function parseAndroidMultiTouchHelperOutput(output: string): Record<string, unknown> {
-  const finalResult = parseInstrumentationResults(output).find(
+  const finalResult = parseInstrumentationRecords(output).results.find(
     (record) => record.agentDeviceProtocol === ANDROID_MULTITOUCH_HELPER_PROTOCOL,
   );
   if (!finalResult) {
@@ -423,8 +429,8 @@ export function parseAndroidMultiTouchHelperOutput(output: string): Record<strin
   return {
     kind: finalResult.kind,
     helperApiVersion: finalResult.helperApiVersion,
-    injectedEvents: readOptionalNumber(finalResult.injectedEvents),
-    elapsedMs: readOptionalNumber(finalResult.elapsedMs),
+    injectedEvents: readInstrumentationResultNumber(finalResult.injectedEvents),
+    elapsedMs: readInstrumentationResultNumber(finalResult.elapsedMs),
   };
 }
 
@@ -432,33 +438,6 @@ function readHelperErrorMessage(finalResult: Record<string, string>): string {
   return finalResult.message && finalResult.message !== 'null'
     ? finalResult.message
     : finalResult.errorType || 'Android multi-touch helper returned an error';
-}
-
-function parseInstrumentationResults(output: string): Array<Record<string, string>> {
-  const results: Array<Record<string, string>> = [];
-  let current: Record<string, string> | null = null;
-  for (const line of output.split(/\r?\n/)) {
-    if (line.startsWith('INSTRUMENTATION_RESULT: ')) {
-      current ??= {};
-      readKeyValue(line.slice('INSTRUMENTATION_RESULT: '.length), current);
-    } else if (line.startsWith('INSTRUMENTATION_CODE: ') && current) {
-      results.push(current);
-      current = null;
-    }
-  }
-  if (current) results.push(current);
-  return results;
-}
-
-function readKeyValue(line: string, target: Record<string, string>): void {
-  const separator = line.indexOf('=');
-  if (separator >= 0) target[line.slice(0, separator)] = line.slice(separator + 1);
-}
-
-function readOptionalNumber(value: string | undefined): number | undefined {
-  if (value === undefined) return undefined;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 async function resolveAndroidMultiTouchHelperArtifact(): Promise<AndroidMultiTouchHelperArtifact> {
@@ -622,23 +601,15 @@ function readString(value: unknown, field: string): string {
 }
 
 function readNumber(value: unknown, field: string): number {
-  if (!Number.isInteger(value)) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Android multi-touch helper manifest ${field} must be an integer.`,
-    );
-  }
-  return value as number;
+  return readAndroidHelperManifestInteger(value, field, 'multi-touch helper');
 }
 
-function readLiteral<T extends string>(value: unknown, field: string, expected: T): T {
-  if (value !== expected) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Android multi-touch helper manifest ${field} must be "${expected}".`,
-    );
-  }
-  return expected;
+function readLiteral<const Value extends string>(
+  value: unknown,
+  field: string,
+  expected: Value,
+): Value {
+  return readAndroidHelperManifestLiteral(value, field, expected, 'multi-touch helper');
 }
 
 function readSha256(value: unknown): string {

--- a/src/platforms/android/snapshot-helper-artifact.ts
+++ b/src/platforms/android/snapshot-helper-artifact.ts
@@ -5,6 +5,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '../../utils/errors.ts';
 import {
+  readAndroidHelperManifestInteger,
+  readAndroidHelperManifestLiteral,
+} from './instrumentation-helper.ts';
+import {
   ANDROID_SNAPSHOT_HELPER_NAME,
   ANDROID_SNAPSHOT_HELPER_OUTPUT_FORMAT,
   ANDROID_SNAPSHOT_HELPER_PROTOCOL,
@@ -149,6 +153,18 @@ export function parseAndroidSnapshotHelperManifest(value: unknown): AndroidSnaps
   };
 }
 
+function readNumber(value: unknown, field: string): number {
+  return readAndroidHelperManifestInteger(value, field, 'snapshot helper');
+}
+
+function readLiteral<const Value extends string>(
+  value: unknown,
+  field: string,
+  expected: Value,
+): Value {
+  return readAndroidHelperManifestLiteral(value, field, expected, 'snapshot helper');
+}
+
 export function readAndroidSnapshotHelperInstallOptions(
   manifest: AndroidSnapshotHelperManifest,
 ): AndroidSnapshotHelperInstallOptions {
@@ -281,30 +297,6 @@ function readOptionalString(value: unknown): string | undefined {
 function readOptionalNullableString(value: unknown, field: string): string | null {
   if (value === null) return null;
   return readString(value, field);
-}
-
-function readNumber(value: unknown, field: string): number {
-  if (typeof value !== 'number' || !Number.isInteger(value)) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Android snapshot helper manifest ${field} must be an integer.`,
-    );
-  }
-  return value;
-}
-
-function readLiteral<const Value extends string>(
-  value: unknown,
-  field: string,
-  expected: Value,
-): Value {
-  if (value !== expected) {
-    throw new AppError(
-      'INVALID_ARGS',
-      `Android snapshot helper manifest ${field} must be "${expected}".`,
-    );
-  }
-  return expected;
 }
 
 function readStringArray(value: unknown, field: string): string[] {

--- a/src/platforms/android/snapshot-helper-capture.ts
+++ b/src/platforms/android/snapshot-helper-capture.ts
@@ -1,5 +1,10 @@
 import { AppError } from '../../utils/errors.ts';
 import type { SnapshotOptions } from '../../utils/snapshot.ts';
+import {
+  parseInstrumentationRecords,
+  readInstrumentationResultBoolean,
+  readInstrumentationResultNumber,
+} from './instrumentation-helper.ts';
 import { parseUiHierarchy } from './ui-hierarchy.ts';
 import {
   ANDROID_SNAPSHOT_HELPER_COMMAND_OVERHEAD_MS,
@@ -20,13 +25,6 @@ type AndroidSnapshotHelperChunk = {
   index: number | undefined;
   count: number | undefined;
   payloadBase64: string;
-};
-
-type AndroidInstrumentationRecordState = {
-  status: Array<Record<string, string>>;
-  results: Array<Record<string, string>>;
-  currentStatus: Record<string, string> | null;
-  currentResult: Record<string, string> | null;
 };
 
 export type AndroidSnapshotHelperResolvedCaptureOptions = {
@@ -429,101 +427,10 @@ function readOptionalCaptureMode(
   return value === 'interactive-windows' || value === 'active-window' ? value : undefined;
 }
 
-function parseInstrumentationRecords(output: string): {
-  status: Array<Record<string, string>>;
-  results: Array<Record<string, string>>;
-} {
-  const state: AndroidInstrumentationRecordState = {
-    status: [],
-    results: [],
-    currentStatus: null,
-    currentResult: null,
-  };
+export {
+  readInstrumentationResultNumber as readAndroidSnapshotHelperMetadataNumber,
+  readInstrumentationResultBoolean as readAndroidSnapshotHelperMetadataBoolean,
+};
 
-  for (const line of output.split(/\r?\n/)) {
-    readInstrumentationRecordLine(line, state);
-  }
-  flushInstrumentationRecords(state);
-  return { status: state.status, results: state.results };
-}
-
-function readInstrumentationRecordLine(
-  line: string,
-  state: AndroidInstrumentationRecordState,
-): void {
-  if (line.startsWith('INSTRUMENTATION_STATUS: ')) {
-    state.currentStatus ??= {};
-    readKeyValue(line.slice('INSTRUMENTATION_STATUS: '.length), state.currentStatus);
-    return;
-  }
-  if (line.startsWith('INSTRUMENTATION_STATUS_CODE: ')) {
-    flushStatusRecord(state);
-    return;
-  }
-  if (line.startsWith('INSTRUMENTATION_RESULT: ')) {
-    state.currentResult ??= {};
-    readKeyValue(line.slice('INSTRUMENTATION_RESULT: '.length), state.currentResult);
-    return;
-  }
-  if (line.startsWith('INSTRUMENTATION_CODE: ')) {
-    flushResultRecord(state);
-  }
-}
-
-function flushInstrumentationRecords(state: AndroidInstrumentationRecordState): void {
-  flushStatusRecord(state);
-  flushResultRecord(state);
-}
-
-function flushStatusRecord(state: {
-  status: Array<Record<string, string>>;
-  currentStatus: Record<string, string> | null;
-}): void {
-  if (state.currentStatus) {
-    state.status.push(state.currentStatus);
-    state.currentStatus = null;
-  }
-}
-
-function flushResultRecord(state: {
-  results: Array<Record<string, string>>;
-  currentResult: Record<string, string> | null;
-}): void {
-  if (state.currentResult) {
-    state.results.push(state.currentResult);
-    state.currentResult = null;
-  }
-}
-
-function readKeyValue(line: string, target: Record<string, string>): void {
-  const separator = line.indexOf('=');
-  if (separator < 0) {
-    return;
-  }
-  target[line.slice(0, separator)] = line.slice(separator + 1);
-}
-
-export function readAndroidSnapshotHelperMetadataNumber(
-  value: string | undefined,
-): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-export function readAndroidSnapshotHelperMetadataBoolean(
-  value: string | undefined,
-): boolean | undefined {
-  if (value === 'true') {
-    return true;
-  }
-  if (value === 'false') {
-    return false;
-  }
-  return undefined;
-}
-
-const readOptionalNumber = readAndroidSnapshotHelperMetadataNumber;
-const readOptionalBoolean = readAndroidSnapshotHelperMetadataBoolean;
+const readOptionalNumber = readInstrumentationResultNumber;
+const readOptionalBoolean = readInstrumentationResultBoolean;


### PR DESCRIPTION
## What

The Android **snapshot helper** and **multi-touch helper** both drive `am instrument -w` and independently re-implement the same low-level glue:

- parsing `INSTRUMENTATION_STATUS` / `INSTRUMENTATION_RESULT` key/value records
- reading optional numeric/boolean values out of those records
- validating a bundled JSON manifest's integer + string-literal fields

This PR extracts the **genuinely-identical** parts into a new single-source module `src/platforms/android/instrumentation-helper.ts` and has both helpers consume it:

- `parseInstrumentationRecords(output)` — status + result record parsing (+ the shared `=` key/value reader)
- `readInstrumentationResultNumber` / `readInstrumentationResultBoolean`
- `readAndroidHelperManifestInteger` / `readAndroidHelperManifestLiteral` — label-parameterized (`"snapshot helper"` / `"multi-touch helper"`) so each helper's **exact** error message is preserved byte-for-byte

`multitouch-helper.ts` previously carried its own ~25-line copy of the result parser; it now calls `parseInstrumentationRecords(...).results`. `snapshot-helper-capture.ts` re-exports the shared metadata readers under their existing public names (`readAndroidSnapshotHelperMetadataNumber/Boolean`) so `snapshot-helper-session.ts` keeps importing them unchanged.

## LOC

Consumers shed **173** lines of duplicated/relocated parsing+validation logic, now single-sourced in the new **134**-line shared module (`+177 / -173` across 4 files; net ~flat, duplication eliminated). The genuine duplicate that was deleted outright is multi-touch's parallel INSTRUMENTATION parser plus the per-helper manifest integer/literal validators.

## Validation

- `tsc -p tsconfig.json --noEmit` — clean
- `oxfmt --write` + `oxlint --deny-warnings` — clean
- `vitest run android snapshot-helper multitouch` — **284 passed (25 files)**, including the manifest message tests (`... outputFormat must be "uiautomator-xml".`, `... sha256 must be a 64-character hex string.`) and the result-number parsing tests (`injectedEvents`/`elapsedMs`).

## behaviorless

No behavior change for any valid input. The shared manifest validators preserve each helper's exact `INVALID_ARGS` messages via a label parameter; the shared `readInstrumentationResultNumber/Boolean` are byte-identical to the prior local copies; multitouch's `parseInstrumentationResults(output)` is exactly `parseInstrumentationRecords(output).results` (the extra status records are collected but discarded by multitouch, which only reads `.results`).

**Partial by design** — the behavior-bearing differences were intentionally left in each consumer and NOT force-unified:
- install cache: `Set<string>` (multi-touch, no policy) vs `Map<string,number>` (snapshot, with install-policy / forget-on-failure / retry-on-`INSTALL_FAILED_UPDATE_INCOMPATIBLE`)
- installed-versionCode read: single-regex + hardcoded 5s timeout (multi-touch) vs per-line parser + caller-supplied timeout (snapshot)
- `sha256File`: whole-file `readFile` (multi-touch) vs streaming (snapshot)
- `readString`: `value.length === 0` (multi-touch) vs `value.trim().length === 0` (snapshot) — and therefore `readSha256`, which depends on it
- artifact resolution + per-helper manifest schemas differ entirely