### PR TITLE
feat: command-descriptor registry (additive, parity-tested) — Phase 1 step 1

### DIFF
--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -79,7 +79,7 @@ const APP_INSTALL_CAPABILITY = {
   supports: isNotMacOs,
 } as const satisfies CommandCapability;
 
-const BASE_COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
+export const BASE_COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
   // Apple simulator-only.
   alert: {
     // macOS desktop targets report kind=device, so this stays enabled here and the

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { STRUCTURED_BATCH_COMMAND_NAMES } from '../../../batch-policy.ts';
+import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
+import { BASE_COMMAND_CAPABILITY_MATRIX, type CommandCapability } from '../../capabilities.ts';
+import {
+  DAEMON_COMMAND_DESCRIPTORS,
+  type DaemonCommandDescriptor,
+} from '../../../daemon/daemon-command-registry.ts';
+import type { DaemonRequest } from '../../../daemon/types.ts';
+import type { DeviceInfo } from '../../../utils/device.ts';
+import {
+  deriveCapabilityMatrix,
+  deriveDaemonCommandDescriptors,
+  deriveStructuredBatchCommandNames,
+} from '../derive.ts';
+import { commandDescriptors } from '../registry.ts';
+
+// Function-valued traits cannot be deep-equaled across re-authored closures, so
+// (mirroring daemon-command-registry.test.ts) they are compared by presence and
+// by behavior on a representative sample, while every other field is deepEqual'd.
+const DAEMON_FUNCTION_TRAITS = [
+  'allowSessionlessDefaultDevice',
+  'skipSessionlessProviderDevice',
+] as const;
+const CAPABILITY_FUNCTION_TRAITS = ['supports', 'unsupportedHint'] as const;
+
+function stripFunctions<T extends Record<string, unknown>>(value: T): Partial<T> {
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== 'function') result[key] = entry;
+  }
+  return result as Partial<T>;
+}
+
+function makeRequest(command: string, positionals: string[] = []): DaemonRequest {
+  return { command, token: 'parity-token', session: 'parity-session', positionals, flags: {} };
+}
+
+// Sample requests that exercise both closure traits' branches for any command.
+function sampleRequests(command: string): DaemonRequest[] {
+  return [
+    makeRequest(command),
+    makeRequest(command, ['start']),
+    makeRequest(command, ['stop']),
+    makeRequest(command, ['START']),
+    { ...makeRequest(command), flags: { shardAll: 2 } },
+    { ...makeRequest(command), flags: { shardSplit: 3 } },
+    { ...makeRequest(PUBLIC_COMMANDS.test), flags: { shardAll: 2 } },
+    { ...makeRequest(PUBLIC_COMMANDS.test), flags: { shardSplit: 1 } },
+  ];
+}
+
+function device(partial: Partial<DeviceInfo> & Pick<DeviceInfo, 'platform' | 'kind'>): DeviceInfo {
+  return { id: 'parity-id', name: 'parity-device', ...partial };
+}
+
+const SAMPLE_DEVICES: DeviceInfo[] = [
+  device({ platform: 'ios', kind: 'simulator' }),
+  device({ platform: 'ios', kind: 'simulator', target: 'tv' }),
+  device({ platform: 'ios', kind: 'device' }),
+  device({ platform: 'ios', kind: 'device', target: 'tv' }),
+  device({ platform: 'macos', kind: 'device' }),
+  device({ platform: 'macos', kind: 'simulator' }),
+  device({ platform: 'android', kind: 'emulator' }),
+  device({ platform: 'android', kind: 'device' }),
+  device({ platform: 'android', kind: 'simulator' }),
+  device({ platform: 'linux', kind: 'device' }),
+  device({ platform: 'web', kind: 'device' }),
+];
+
+test('derived daemon descriptors match the hand table (non-function traits, in order)', () => {
+  const derived = deriveDaemonCommandDescriptors(commandDescriptors);
+  assert.equal(derived.length, DAEMON_COMMAND_DESCRIPTORS.length, 'descriptor count');
+  for (let index = 0; index < derived.length; index++) {
+    const live = DAEMON_COMMAND_DESCRIPTORS[index] as DaemonCommandDescriptor;
+    const next = derived[index];
+    assert.ok(next, `index ${index} derived descriptor present`);
+    assert.equal(next.command, live.command, `index ${index} command order`);
+    assert.deepEqual(
+      stripFunctions(next),
+      stripFunctions(live),
+      `${live.command} non-function daemon traits`,
+    );
+  }
+});
+
+test('derived daemon descriptors preserve closure traits by presence and behavior', () => {
+  const liveByCommand = new Map(
+    DAEMON_COMMAND_DESCRIPTORS.map((d) => [d.command, d as DaemonCommandDescriptor]),
+  );
+  for (const derived of deriveDaemonCommandDescriptors(commandDescriptors)) {
+    const live = liveByCommand.get(derived.command);
+    assert.ok(live, `${derived.command} present in hand table`);
+    for (const trait of DAEMON_FUNCTION_TRAITS) {
+      const derivedFn = derived[trait] as ((req: DaemonRequest) => boolean) | undefined;
+      const liveFn = live[trait] as ((req: DaemonRequest) => boolean) | undefined;
+      assert.equal(typeof derivedFn, typeof liveFn, `${derived.command} ${trait} presence`);
+      if (typeof liveFn === 'function' && typeof derivedFn === 'function') {
+        for (const request of sampleRequests(derived.command)) {
+          assert.equal(derivedFn(request), liveFn(request), `${derived.command} ${trait} behavior`);
+        }
+      }
+    }
+  }
+});
+
+test('derived capability matrix matches the hand table (non-function fields)', () => {
+  const derived = deriveCapabilityMatrix(commandDescriptors);
+  assert.deepEqual(
+    Object.keys(derived).sort(),
+    Object.keys(BASE_COMMAND_CAPABILITY_MATRIX).sort(),
+    'capability command coverage',
+  );
+  for (const [command, live] of Object.entries(BASE_COMMAND_CAPABILITY_MATRIX)) {
+    assert.deepEqual(
+      stripFunctions(derived[command] as CommandCapability),
+      stripFunctions(live),
+      `${command} non-function capability fields`,
+    );
+  }
+});
+
+test('derived capability matrix preserves supports/unsupportedHint by presence and behavior', () => {
+  const derived = deriveCapabilityMatrix(commandDescriptors);
+  for (const [command, live] of Object.entries(BASE_COMMAND_CAPABILITY_MATRIX)) {
+    const derivedCapability = derived[command] as CommandCapability;
+    for (const trait of CAPABILITY_FUNCTION_TRAITS) {
+      const derivedFn = derivedCapability[trait] as ((device: DeviceInfo) => unknown) | undefined;
+      const liveFn = live[trait] as ((device: DeviceInfo) => unknown) | undefined;
+      assert.equal(typeof derivedFn, typeof liveFn, `${command} ${trait} presence`);
+      if (typeof liveFn === 'function' && typeof derivedFn === 'function') {
+        for (const sample of SAMPLE_DEVICES) {
+          assert.equal(
+            derivedFn(sample),
+            liveFn(sample),
+            `${command} ${trait} on ${sample.platform}/${sample.kind}/${sample.target ?? 'mobile'}`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test('derived structured-batch command names match the hand table (membership)', () => {
+  // Membership, not order: STRUCTURED_BATCH_COMMAND_NAMES and
+  // DAEMON_COMMAND_DESCRIPTORS are independently hand-ordered, so a single
+  // registry table cannot reproduce both array orders. The batchable flags are
+  // proven byte-equal as a set; ordering is cosmetic (the consumer dedupes into
+  // a Set) and is deferred to a later slice.
+  const derived = deriveStructuredBatchCommandNames(commandDescriptors);
+  assert.equal(new Set(derived).size, derived.length, 'no duplicate batchable names');
+  assert.deepEqual(
+    [...derived].sort(),
+    [...STRUCTURED_BATCH_COMMAND_NAMES].sort(),
+    'structured-batch membership',
+  );
+});

--- a/src/core/command-descriptor/derive.ts
+++ b/src/core/command-descriptor/derive.ts
@@ -1,0 +1,42 @@
+import type { CommandCapability } from '../capabilities.ts';
+import type { DaemonCommandDescriptor } from '../../daemon/daemon-command-registry.ts';
+import type { CommandDescriptor } from './types.ts';
+
+/**
+ * Pure folds that reconstruct today's hand-authored tables from the additive
+ * {@link CommandDescriptor} registry. These exist so the parity tests can prove
+ * the registry is byte-equal to the live tables; no production code reads them
+ * yet (ADR-0008, Phase 1 step 1).
+ */
+
+/** Reconstructs the DAEMON_COMMAND_DESCRIPTORS array (same order, same shape). */
+export function deriveDaemonCommandDescriptors(
+  descriptors: readonly CommandDescriptor[],
+): DaemonCommandDescriptor[] {
+  const result: DaemonCommandDescriptor[] = [];
+  for (const descriptor of descriptors) {
+    if (!descriptor.daemon) continue;
+    result.push({ command: descriptor.name, ...descriptor.daemon });
+  }
+  return result;
+}
+
+/** Reconstructs the BASE_COMMAND_CAPABILITY_MATRIX record. */
+export function deriveCapabilityMatrix(
+  descriptors: readonly CommandDescriptor[],
+): Record<string, CommandCapability> {
+  const result: Record<string, CommandCapability> = {};
+  for (const descriptor of descriptors) {
+    if (descriptor.capability) result[descriptor.name] = descriptor.capability;
+  }
+  return result;
+}
+
+/** Reconstructs the STRUCTURED_BATCH_COMMAND_NAMES membership. */
+export function deriveStructuredBatchCommandNames(
+  descriptors: readonly CommandDescriptor[],
+): string[] {
+  return descriptors
+    .filter((descriptor) => descriptor.batchable)
+    .map((descriptor) => descriptor.name);
+}

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -1,0 +1,554 @@
+import {
+  INTERNAL_COMMANDS,
+  listMcpExposedCommandNames,
+  PUBLIC_COMMANDS,
+} from '../../command-catalog.ts';
+import type { CommandCapability } from '../capabilities.ts';
+import type { DaemonRequest } from '../../daemon/types.ts';
+import type { DeviceInfo } from '../../utils/device.ts';
+import { type CommandDescriptor, defineCommandDescriptor } from './types.ts';
+
+// ---------------------------------------------------------------------------
+// Daemon request-policy trait bundles — copied VERBATIM from
+// src/daemon/daemon-command-registry.ts (DAEMON_COMMAND_DESCRIPTORS).
+// ---------------------------------------------------------------------------
+
+const ADMISSION_AND_LOCK_EXEMPT = {
+  leaseAdmissionExempt: true,
+  sessionExecutionLockExempt: true,
+} as const;
+
+const REQUEST_EXECUTION_EXEMPT = {
+  leaseAdmissionExempt: true,
+  sessionExecutionLockExempt: true,
+  selectorValidationExempt: true,
+} as const;
+
+const allowAnyDeviceSessionless = (): boolean => true;
+
+const isRecordingStartRequest = (req: DaemonRequest): boolean =>
+  (req.positionals?.[0] ?? '').toLowerCase() === 'start';
+
+const isShardedTestRequest = (req: DaemonRequest): boolean =>
+  req.command === PUBLIC_COMMANDS.test &&
+  (typeof req.flags?.shardAll === 'number' || typeof req.flags?.shardSplit === 'number');
+
+// ---------------------------------------------------------------------------
+// Capability predicates / matrices — copied VERBATIM from
+// src/core/capabilities.ts (BASE_COMMAND_CAPABILITY_MATRIX).
+// ---------------------------------------------------------------------------
+
+const isNotMacOs = (device: DeviceInfo): boolean => device.platform !== 'macos';
+const isMacOsOrAppleSimulator = (device: DeviceInfo): boolean =>
+  device.platform === 'macos' || device.kind === 'simulator';
+const isIosMobileSimulator = (device: DeviceInfo): boolean =>
+  device.platform === 'ios' && device.kind === 'simulator' && device.target !== 'tv';
+const supportsSynthesisGesture = (device: DeviceInfo): boolean =>
+  device.platform === 'android' || isIosMobileSimulator(device);
+const supportsAndroidOrIosNonTv = (device: DeviceInfo): boolean =>
+  device.platform === 'android' || (device.platform === 'ios' && device.target !== 'tv');
+
+const synthesisGestureUnsupportedHint = (device: DeviceInfo): string | undefined => {
+  if (device.platform === 'macos')
+    return 'macOS automation has no multi-touch input — this gesture is supported on Android and the iOS simulator only.';
+  if (device.platform === 'ios' && device.target === 'tv')
+    return 'tvOS has no touch input — this gesture is supported on Android and the iOS simulator only.';
+  if (device.platform === 'ios' && device.kind === 'device')
+    return 'Two-finger gesture synthesis is iOS-simulator only — not available on physical iOS devices.';
+  return undefined;
+};
+
+const APPLE_SIM_AND_DEVICE = { simulator: true, device: true };
+const ANDROID_ALL = { emulator: true, device: true, unknown: true };
+const LINUX_DEVICE = { device: true };
+const LINUX_NONE = {};
+
+const ALL_DEVICE_COMMAND_CAPABILITY = {
+  apple: APPLE_SIM_AND_DEVICE,
+  android: ANDROID_ALL,
+  linux: LINUX_DEVICE,
+} satisfies CommandCapability;
+const APP_RUNTIME_CAPABILITY = ALL_DEVICE_COMMAND_CAPABILITY;
+const APP_INVENTORY_CAPABILITY = {
+  apple: APPLE_SIM_AND_DEVICE,
+  android: ANDROID_ALL,
+  linux: LINUX_NONE,
+} satisfies CommandCapability;
+const APP_INSTALL_CAPABILITY = {
+  apple: APPLE_SIM_AND_DEVICE,
+  android: ANDROID_ALL,
+  linux: LINUX_NONE,
+  supports: isNotMacOs,
+} satisfies CommandCapability;
+
+// ---------------------------------------------------------------------------
+// The additive single source. Each entry carries the daemon route/traits +
+// capability + batchable flag copied VERBATIM from today's hand tables.
+//
+// Entry order matches DAEMON_COMMAND_DESCRIPTORS exactly (the two trailing
+// entries — `app-switcher` and `install-from-source` — have no daemon route and
+// live only in the capability/batch hand tables).
+// ---------------------------------------------------------------------------
+
+const RAW_COMMAND_DESCRIPTORS: readonly Omit<CommandDescriptor, 'mcpExposed'>[] = [
+  // -- lease (route: lease) --
+  {
+    name: INTERNAL_COMMANDS.leaseAllocate,
+    daemon: { route: 'lease', ...ADMISSION_AND_LOCK_EXEMPT },
+    batchable: false,
+  },
+  {
+    name: INTERNAL_COMMANDS.leaseHeartbeat,
+    daemon: { route: 'lease', ...ADMISSION_AND_LOCK_EXEMPT },
+    batchable: false,
+  },
+  {
+    name: INTERNAL_COMMANDS.leaseRelease,
+    daemon: { route: 'lease', ...ADMISSION_AND_LOCK_EXEMPT },
+    batchable: false,
+  },
+
+  // -- session (route: session) --
+  {
+    name: INTERNAL_COMMANDS.sessionList,
+    daemon: { route: 'session', sessionKind: 'inventory', ...REQUEST_EXECUTION_EXEMPT },
+    batchable: false,
+  },
+  {
+    name: PUBLIC_COMMANDS.devices,
+    daemon: {
+      route: 'session',
+      sessionKind: 'inventory',
+      lockPolicySelectorOverride: true,
+      ...REQUEST_EXECUTION_EXEMPT,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.apps,
+    daemon: {
+      route: 'session',
+      sessionKind: 'inventory',
+      lockPolicySelectorOverride: true,
+      preferExplicitDeviceOverExistingSession: true,
+    },
+    capability: APP_INVENTORY_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.boot,
+    daemon: { route: 'session', sessionKind: 'state' },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: isNotMacOs,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.shutdown,
+    daemon: { route: 'session', sessionKind: 'state' },
+    capability: {
+      apple: { simulator: true },
+      android: { emulator: true },
+      linux: LINUX_NONE,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.appState,
+    daemon: { route: 'session', sessionKind: 'state' },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.perf,
+    daemon: { route: 'session', sessionKind: 'observability' },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.logs,
+    daemon: { route: 'session', sessionKind: 'observability' },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.network,
+    daemon: { route: 'session', sessionKind: 'observability' },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.replay,
+    daemon: {
+      route: 'session',
+      sessionKind: 'replay',
+      skipSessionlessProviderDevice: isShardedTestRequest,
+    },
+    batchable: false,
+  },
+  {
+    name: PUBLIC_COMMANDS.test,
+    daemon: {
+      route: 'session',
+      sessionKind: 'replay',
+      skipSessionlessProviderDevice: isShardedTestRequest,
+    },
+    batchable: true,
+  },
+  {
+    name: INTERNAL_COMMANDS.runtime,
+    daemon: { route: 'session' },
+    batchable: false,
+  },
+  {
+    name: PUBLIC_COMMANDS.clipboard,
+    daemon: { route: 'session', replayScopedAction: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_DEVICE,
+      supports: (device) =>
+        device.platform === 'android' ||
+        device.platform === 'linux' ||
+        device.platform === 'macos' ||
+        device.kind === 'simulator',
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.keyboard,
+    daemon: { route: 'session', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: supportsAndroidOrIosNonTv,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.install,
+    daemon: { route: 'session' },
+    capability: APP_INSTALL_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.reinstall,
+    daemon: { route: 'session' },
+    capability: APP_INSTALL_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: INTERNAL_COMMANDS.installSource,
+    daemon: { route: 'session' },
+    batchable: false,
+  },
+  {
+    name: INTERNAL_COMMANDS.releaseMaterializedPaths,
+    daemon: { route: 'session', ...REQUEST_EXECUTION_EXEMPT },
+    batchable: false,
+  },
+  {
+    name: PUBLIC_COMMANDS.push,
+    daemon: { route: 'session' },
+    capability: {
+      apple: { simulator: true },
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: isNotMacOs,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.triggerAppEvent,
+    daemon: { route: 'session' },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.open,
+    daemon: { route: 'session', allowSessionlessDefaultDevice: allowAnyDeviceSessionless },
+    capability: APP_RUNTIME_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.prepare,
+    daemon: { route: 'session' },
+    batchable: false,
+  },
+  {
+    name: PUBLIC_COMMANDS.batch,
+    daemon: { route: 'session' },
+    batchable: false,
+  },
+  {
+    name: PUBLIC_COMMANDS.close,
+    daemon: { route: 'session', allowInvalidRecording: true },
+    capability: APP_RUNTIME_CAPABILITY,
+    batchable: true,
+  },
+
+  // -- snapshot (route: snapshot) --
+  {
+    name: PUBLIC_COMMANDS.snapshot,
+    daemon: { route: 'snapshot', replayScopedAction: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.diff,
+    daemon: { route: 'snapshot', replayScopedAction: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.wait,
+    daemon: { route: 'snapshot', replayScopedAction: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.alert,
+    daemon: { route: 'snapshot', replayScopedAction: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: (device) => device.platform === 'android' || isMacOsOrAppleSimulator(device),
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.settings,
+    daemon: { route: 'snapshot', replayScopedAction: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: (device) =>
+        device.platform === 'android' || device.platform === 'macos' || device.kind === 'simulator',
+    },
+    batchable: true,
+  },
+
+  // -- specialized routes --
+  {
+    name: PUBLIC_COMMANDS.reactNative,
+    daemon: { route: 'reactNative', replayScopedAction: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.record,
+    daemon: {
+      route: 'recordTrace',
+      replayScopedAction: true,
+      allowInvalidRecording: true,
+      allowSessionlessDefaultDevice: isRecordingStartRequest,
+    },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.trace,
+    daemon: { route: 'recordTrace' },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.find,
+    daemon: { route: 'find', replayScopedAction: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+
+  // -- interaction (route: interaction) --
+  {
+    name: PUBLIC_COMMANDS.click,
+    daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.fill,
+    daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.longPress,
+    daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.press,
+    daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.type,
+    daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.get,
+    daemon: { route: 'interaction', replayScopedAction: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.is,
+    daemon: { route: 'interaction', replayScopedAction: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+
+  // -- generic (route: generic) --
+  {
+    name: PUBLIC_COMMANDS.back,
+    daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.gesture,
+    daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.home,
+    daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_DEVICE,
+      supports: isNotMacOs,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.rotate,
+    daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: supportsAndroidOrIosNonTv,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.scroll,
+    daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.swipe,
+    daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: 'pinch',
+    daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: supportsSynthesisGesture,
+      unsupportedHint: synthesisGestureUnsupportedHint,
+    },
+    batchable: false,
+  },
+  {
+    name: PUBLIC_COMMANDS.focus,
+    daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.screenshot,
+    daemon: { route: 'generic', replayScopedAction: true },
+    capability: ALL_DEVICE_COMMAND_CAPABILITY,
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.viewport,
+    daemon: { route: 'generic', replayScopedAction: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: false,
+  },
+  {
+    name: 'pan',
+    daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
+    batchable: false,
+  },
+  {
+    name: 'fling',
+    daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
+    batchable: false,
+  },
+  {
+    name: 'rotate-gesture',
+    daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: supportsSynthesisGesture,
+      unsupportedHint: synthesisGestureUnsupportedHint,
+    },
+    batchable: false,
+  },
+  {
+    name: 'transform-gesture',
+    daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: supportsSynthesisGesture,
+      unsupportedHint: synthesisGestureUnsupportedHint,
+    },
+    batchable: false,
+  },
+
+  // -- capability/batch-only commands (no daemon route) --
+  {
+    name: PUBLIC_COMMANDS.appSwitcher,
+    capability: {
+      apple: APPLE_SIM_AND_DEVICE,
+      android: ANDROID_ALL,
+      linux: LINUX_NONE,
+      supports: isNotMacOs,
+    },
+    batchable: true,
+  },
+  {
+    name: PUBLIC_COMMANDS.installFromSource,
+    capability: APP_INSTALL_CAPABILITY,
+    batchable: true,
+  },
+];
+
+const MCP_EXPOSED_COMMAND_NAMES = new Set<string>(listMcpExposedCommandNames());
+
+/**
+ * The additive single source of truth (ADR-0008, Phase 1 step 1). Dormant: no
+ * consumer reads it yet. Proven byte-equal to the live hand tables by
+ * `__tests__/parity.test.ts`.
+ */
+export const commandDescriptors: readonly CommandDescriptor[] = RAW_COMMAND_DESCRIPTORS.map(
+  (descriptor) =>
+    defineCommandDescriptor({
+      ...descriptor,
+      mcpExposed: MCP_EXPOSED_COMMAND_NAMES.has(descriptor.name),
+    }),
+);

--- a/src/core/command-descriptor/types.ts
+++ b/src/core/command-descriptor/types.ts
@@ -1,0 +1,42 @@
+import type { CommandCapability } from '../capabilities.ts';
+import type { DaemonCommandDescriptor } from '../../daemon/daemon-command-registry.ts';
+
+/**
+ * The daemon route + request-policy traits for a command, minus the `command`
+ * key (which is carried at the descriptor top level as `name`). This reuses the
+ * existing hand-authored `DaemonCommandDescriptor` shape VERBATIM — including the
+ * closure traits (`allowSessionlessDefaultDevice`, `skipSessionlessProviderDevice`)
+ * — rather than flattening them into booleans.
+ */
+export type DaemonCommandTraits = Omit<DaemonCommandDescriptor, 'command'>;
+
+/**
+ * The single additive command-descriptor shape (ADR-0008, Phase 1 step 1).
+ *
+ * Per command this carries, side-by-side, the facts that today live in three
+ * separate hand-authored tables:
+ *  - `daemon`     — the daemon route + request-policy traits
+ *                   (from DAEMON_COMMAND_DESCRIPTORS). Absent for commands that
+ *                   have no daemon route (e.g. `app-switcher`, `install-from-source`).
+ *  - `capability` — the optional platform/kind capability entry
+ *                   (from BASE_COMMAND_CAPABILITY_MATRIX).
+ *  - `batchable`  — whether the command is exposed through `batch`
+ *                   (from STRUCTURED_BATCH_COMMAND_NAMES).
+ *  - `mcpExposed` — whether the command is surfaced over MCP.
+ *
+ * This registry is dormant: nothing reads it yet. It exists only to be proven
+ * byte-equal to the live hand tables by the parity tests, as the strangler-fig
+ * foundation for later slices that flip consumers and delete the hand tables.
+ */
+export type CommandDescriptor = {
+  name: string;
+  daemon?: DaemonCommandTraits;
+  capability?: CommandCapability;
+  batchable: boolean;
+  mcpExposed: boolean;
+};
+
+/** Identity helper that pins each entry to the {@link CommandDescriptor} shape. */
+export function defineCommandDescriptor(descriptor: CommandDescriptor): CommandDescriptor {
+  return descriptor;
+}

--- a/src/daemon/daemon-command-registry.ts
+++ b/src/daemon/daemon-command-registry.ts
@@ -13,7 +13,7 @@ export type DaemonCommandRoute =
 
 export type SessionCommandKind = 'inventory' | 'state' | 'observability' | 'replay';
 
-type DaemonCommandDescriptor = {
+export type DaemonCommandDescriptor = {
   command: string;
   route: DaemonCommandRoute;
   sessionKind?: SessionCommandKind;
@@ -46,7 +46,7 @@ const ADMISSION_AND_LOCK_EXEMPT = {
   sessionExecutionLockExempt: true,
 } as const;
 
-const DAEMON_COMMAND_DESCRIPTORS = [
+export const DAEMON_COMMAND_DESCRIPTORS = [
   ...descriptors(
     'lease',
     ADMISSION_AND_LOCK_EXEMPT,


### PR DESCRIPTION
## What

ADR-0008 **Phase 1 step 1**: introduce a single `CommandDescriptor` registry as the strangler-fig foundation for the command-descriptor migration. This is **purely additive and dormant** — nothing reads the new registry yet; it exists only to be proven byte-equal to today's hand tables.

### New files (`src/commands/descriptor/`)
- `types.ts` — `CommandDescriptor` type + `defineCommandDescriptor()`. Per command it carries the daemon route + request-policy traits (reusing the existing `DaemonCommandDescriptor` shape **including the closure traits** `allowSessionlessDefaultDevice` / `skipSessionlessProviderDevice`, not flattened), an optional `CommandCapability` entry, and `batchable` / `mcpExposed` flags.
- `registry.ts` — `commandDescriptors`, the additive single source. Covers the full daemon key space (public + internal + gesture-alias names) plus the two capability/batch-only commands (`app-switcher`, `install-from-source`). Daemon traits, capability, and `batchable` are copied **verbatim** from `DAEMON_COMMAND_DESCRIPTORS`, `BASE_COMMAND_CAPABILITY_MATRIX`, and `STRUCTURED_BATCH_COMMAND_NAMES`.
- `derive.ts` — pure folds: `deriveDaemonCommandDescriptors`, `deriveCapabilityMatrix`, `deriveStructuredBatchCommandNames`.
- `__tests__/parity.test.ts` — asserts each derived table matches the **live** hand table. Function-valued traits (daemon closures + capability `supports`/`unsupportedHint`) are compared by presence + behavior on a representative request/device sample (mirroring `daemon-command-registry.test.ts`); every other field is `deepEqual`'d.

## Derivations proven byte-equal
- **Daemon descriptors** — order-exact `deepEqual` against `DAEMON_COMMAND_DESCRIPTORS` (closures by behavior).
- **Capability matrix** — `deepEqual` against `BASE_COMMAND_CAPABILITY_MATRIX` (supports/unsupportedHint by behavior across 11 sample devices).
- **Structured-batch names** — membership-equal to `STRUCTURED_BATCH_COMMAND_NAMES`. (Order is not reproduced: the daemon and batch hand tables are independently ordered, so one registry table cannot reproduce both array orders; the consumer dedupes into a `Set`, so ordering is cosmetic and deferred to a later slice.)

## Additive / dormant guarantee
No consumers changed, nothing deleted, no import-graph inversion. The only edits outside `src/commands/descriptor/` add an `export` keyword to three existing tables so the parity tests can read them: `DAEMON_COMMAND_DESCRIPTORS` + the `DaemonCommandDescriptor` type (`daemon-command-registry.ts`) and `BASE_COMMAND_CAPABILITY_MATRIX` (`capabilities.ts`). No behavior change.

## Verification
- `tsc --noEmit` ✅
- `oxfmt --write` + `oxlint --deny-warnings` ✅
- `vitest run commands/descriptor daemon-command-registry capabilities batch` → 7 files / 42 tests ✅