### PR TITLE
feat: build daemon command registry from descriptors, delete the hand table — Phase 1 step 2

### DIFF
--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -25,6 +25,13 @@ const DAEMON_FUNCTION_TRAITS = [
 ] as const;
 const CAPABILITY_FUNCTION_TRAITS = ['supports', 'unsupportedHint'] as const;
 
+// Public commands that intentionally have no daemon route — they live only in the
+// capability/batch tables, so the daemon registry has never covered them.
+const UNROUTED_PUBLIC_COMMANDS = new Set<string>([
+  PUBLIC_COMMANDS.appSwitcher,
+  PUBLIC_COMMANDS.installFromSource,
+]);
+
 function stripFunctions<T extends Record<string, unknown>>(value: T): Partial<T> {
   const result: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
@@ -69,19 +76,27 @@ const SAMPLE_DEVICES: DeviceInfo[] = [
   device({ platform: 'web', kind: 'device' }),
 ];
 
-test('derived daemon descriptors match the hand table (non-function traits, in order)', () => {
+test('derived daemon registry holds its routing invariants', () => {
+  // The daemon registry is now BUILT from these derived descriptors (the
+  // hand-authored literal was deleted after #906 proved byte-equality), so a
+  // derived-vs-DAEMON_COMMAND_DESCRIPTORS comparison would be a tautology.
+  // Instead assert the structural invariants the daemon depends on: every
+  // descriptor has a route, command names are unique, and the command set still
+  // covers every public command (the prior coverage floor).
   const derived = deriveDaemonCommandDescriptors(commandDescriptors);
-  assert.equal(derived.length, DAEMON_COMMAND_DESCRIPTORS.length, 'descriptor count');
-  for (let index = 0; index < derived.length; index++) {
-    const live = DAEMON_COMMAND_DESCRIPTORS[index] as DaemonCommandDescriptor;
-    const next = derived[index];
-    assert.ok(next, `index ${index} derived descriptor present`);
-    assert.equal(next.command, live.command, `index ${index} command order`);
-    assert.deepEqual(
-      stripFunctions(next),
-      stripFunctions(live),
-      `${live.command} non-function daemon traits`,
-    );
+  assert.ok(derived.length > 0, 'derived descriptors present');
+
+  const names = derived.map((descriptor) => descriptor.command);
+  assert.equal(new Set(names).size, names.length, 'no duplicate daemon command names');
+
+  for (const descriptor of derived) {
+    assert.ok(descriptor.route, `${descriptor.command} has a route`);
+  }
+
+  const nameSet = new Set(names);
+  for (const command of Object.values(PUBLIC_COMMANDS)) {
+    if (UNROUTED_PUBLIC_COMMANDS.has(command)) continue;
+    assert.ok(nameSet.has(command), `daemon registry covers public command ${command}`);
   }
 });
 

--- a/src/daemon/daemon-command-registry.ts
+++ b/src/daemon/daemon-command-registry.ts
@@ -1,4 +1,5 @@
-import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../command-catalog.ts';
+import { deriveDaemonCommandDescriptors } from '../core/command-descriptor/derive.ts';
+import { commandDescriptors } from '../core/command-descriptor/registry.ts';
 import type { DaemonRequest } from './types.ts';
 
 export type DaemonCommandRoute =
@@ -35,139 +36,15 @@ export type DaemonProviderDeviceResolutionIntent =
   | 'sessionless-default-device'
   | 'skip';
 
-const REQUEST_EXECUTION_EXEMPT = {
-  leaseAdmissionExempt: true,
-  sessionExecutionLockExempt: true,
-  selectorValidationExempt: true,
-} as const;
-
-const ADMISSION_AND_LOCK_EXEMPT = {
-  leaseAdmissionExempt: true,
-  sessionExecutionLockExempt: true,
-} as const;
-
-export const DAEMON_COMMAND_DESCRIPTORS = [
-  ...descriptors(
-    'lease',
-    ADMISSION_AND_LOCK_EXEMPT,
-    INTERNAL_COMMANDS.leaseAllocate,
-    INTERNAL_COMMANDS.leaseHeartbeat,
-    INTERNAL_COMMANDS.leaseRelease,
-  ),
-
-  descriptor(INTERNAL_COMMANDS.sessionList, 'session', {
-    sessionKind: 'inventory',
-    ...REQUEST_EXECUTION_EXEMPT,
-  }),
-  descriptor(PUBLIC_COMMANDS.devices, 'session', {
-    sessionKind: 'inventory',
-    lockPolicySelectorOverride: true,
-    ...REQUEST_EXECUTION_EXEMPT,
-  }),
-  descriptor(PUBLIC_COMMANDS.apps, 'session', {
-    sessionKind: 'inventory',
-    lockPolicySelectorOverride: true,
-    preferExplicitDeviceOverExistingSession: true,
-  }),
-  ...descriptors(
-    'session',
-    { sessionKind: 'state' },
-    PUBLIC_COMMANDS.boot,
-    PUBLIC_COMMANDS.shutdown,
-    PUBLIC_COMMANDS.appState,
-  ),
-  ...descriptors(
-    'session',
-    { sessionKind: 'observability' },
-    PUBLIC_COMMANDS.perf,
-    PUBLIC_COMMANDS.logs,
-    PUBLIC_COMMANDS.network,
-  ),
-  ...descriptors(
-    'session',
-    { sessionKind: 'replay', skipSessionlessProviderDevice: isShardedTestRequest },
-    PUBLIC_COMMANDS.replay,
-    PUBLIC_COMMANDS.test,
-  ),
-  descriptor(INTERNAL_COMMANDS.runtime, 'session'),
-  descriptor(PUBLIC_COMMANDS.clipboard, 'session', { replayScopedAction: true }),
-  descriptor(PUBLIC_COMMANDS.keyboard, 'session', {
-    replayScopedAction: true,
-    androidBlockingDialogGuard: true,
-  }),
-  ...descriptors(
-    'session',
-    {},
-    PUBLIC_COMMANDS.install,
-    PUBLIC_COMMANDS.reinstall,
-    INTERNAL_COMMANDS.installSource,
-  ),
-  descriptor(INTERNAL_COMMANDS.releaseMaterializedPaths, 'session', REQUEST_EXECUTION_EXEMPT),
-  ...descriptors('session', {}, PUBLIC_COMMANDS.push, PUBLIC_COMMANDS.triggerAppEvent),
-  descriptor(PUBLIC_COMMANDS.open, 'session', {
-    allowSessionlessDefaultDevice: () => true,
-  }),
-  ...descriptors('session', {}, PUBLIC_COMMANDS.prepare, PUBLIC_COMMANDS.batch),
-  descriptor(PUBLIC_COMMANDS.close, 'session', { allowInvalidRecording: true }),
-
-  ...descriptors(
-    'snapshot',
-    { replayScopedAction: true },
-    PUBLIC_COMMANDS.snapshot,
-    PUBLIC_COMMANDS.diff,
-    PUBLIC_COMMANDS.wait,
-    PUBLIC_COMMANDS.alert,
-    PUBLIC_COMMANDS.settings,
-  ),
-
-  descriptor(PUBLIC_COMMANDS.reactNative, 'reactNative', { replayScopedAction: true }),
-  descriptor(PUBLIC_COMMANDS.record, 'recordTrace', {
-    replayScopedAction: true,
-    allowInvalidRecording: true,
-    allowSessionlessDefaultDevice: isRecordingStartRequest,
-  }),
-  descriptor(PUBLIC_COMMANDS.trace, 'recordTrace'),
-  descriptor(PUBLIC_COMMANDS.find, 'find', { replayScopedAction: true }),
-
-  ...descriptors(
-    'interaction',
-    { replayScopedAction: true, androidBlockingDialogGuard: true },
-    PUBLIC_COMMANDS.click,
-    PUBLIC_COMMANDS.fill,
-    PUBLIC_COMMANDS.longPress,
-    PUBLIC_COMMANDS.press,
-    PUBLIC_COMMANDS.type,
-  ),
-  ...descriptors(
-    'interaction',
-    { replayScopedAction: true },
-    PUBLIC_COMMANDS.get,
-    PUBLIC_COMMANDS.is,
-  ),
-
-  ...descriptors(
-    'generic',
-    { replayScopedAction: true, androidBlockingDialogGuard: true },
-    PUBLIC_COMMANDS.back,
-    PUBLIC_COMMANDS.gesture,
-    PUBLIC_COMMANDS.home,
-    PUBLIC_COMMANDS.rotate,
-    PUBLIC_COMMANDS.scroll,
-    PUBLIC_COMMANDS.swipe,
-    'pinch',
-  ),
-  descriptor(PUBLIC_COMMANDS.focus, 'generic', { androidBlockingDialogGuard: true }),
-  descriptor(PUBLIC_COMMANDS.screenshot, 'generic', { replayScopedAction: true }),
-  descriptor(PUBLIC_COMMANDS.viewport, 'generic', { replayScopedAction: true }),
-  ...descriptors(
-    'generic',
-    { androidBlockingDialogGuard: true },
-    'pan',
-    'fling',
-    'rotate-gesture',
-    'transform-gesture',
-  ),
-] as const satisfies readonly DaemonCommandDescriptor[];
+// Built from the additive command-descriptor registry (ADR-0008, Phase 1 step 2).
+// The hand-authored literal that previously lived here was proven byte-equal to
+// this derived value by `src/core/command-descriptor/__tests__/parity.test.ts` (#906)
+// and has been deleted; the daemon now derives its routes/traits from the single
+// source. The back-edge from derive.ts/registry.ts to this module's
+// `DaemonCommandDescriptor` is type-only (erased at runtime), so there is no
+// runtime import cycle.
+export const DAEMON_COMMAND_DESCRIPTORS: readonly DaemonCommandDescriptor[] =
+  deriveDaemonCommandDescriptors(commandDescriptors);
 
 const DAEMON_COMMAND_REGISTRY = buildDaemonCommandRegistry(DAEMON_COMMAND_DESCRIPTORS);
 
@@ -230,22 +107,6 @@ export function resolveProviderDeviceResolutionIntent(
   return usesSessionlessDefaultProviderDevice(req) ? 'sessionless-default-device' : 'skip';
 }
 
-function descriptor(
-  command: string,
-  route: DaemonCommandRoute,
-  traits: Omit<DaemonCommandDescriptor, 'command' | 'route'> = {},
-): DaemonCommandDescriptor {
-  return { command, route, ...traits };
-}
-
-function descriptors(
-  route: DaemonCommandRoute,
-  traits: Omit<DaemonCommandDescriptor, 'command' | 'route'>,
-  ...commands: readonly string[]
-): DaemonCommandDescriptor[] {
-  return commands.map((command) => descriptor(command, route, traits));
-}
-
 function getDaemonCommandDescriptor(command: string): DaemonCommandDescriptor | undefined {
   return DAEMON_COMMAND_REGISTRY.descriptorsByCommand.get(command);
 }
@@ -261,18 +122,7 @@ function buildDaemonCommandRegistry(descriptors: readonly DaemonCommandDescripto
   return { descriptorsByCommand };
 }
 
-function isRecordingStartRequest(req: DaemonRequest): boolean {
-  return (req.positionals?.[0] ?? '').toLowerCase() === 'start';
-}
-
 function shouldSkipSessionlessProviderDevice(req: DaemonRequest): boolean {
   const skip = getDaemonCommandDescriptor(req.command)?.skipSessionlessProviderDevice;
   return typeof skip === 'function' ? skip(req) : false;
-}
-
-function isShardedTestRequest(req: DaemonRequest): boolean {
-  return (
-    req.command === PUBLIC_COMMANDS.test &&
-    (typeof req.flags?.shardAll === 'number' || typeof req.flags?.shardSplit === 'number')
-  );
 }


### PR DESCRIPTION
## What

Phase 1 step 2 of the command-descriptor migration (ADR-0008), **stacked on #906** (`feat/command-descriptor-registry`).

The daemon command registry now **builds from the derived descriptors** instead of a hand-authored literal:

- `src/daemon/daemon-command-registry.ts` — replaced the `DAEMON_COMMAND_DESCRIPTORS` array literal (plus its private `descriptor`/`descriptors` builders and the `isRecordingStartRequest`/`isShardedTestRequest` closures, now living in `descriptor/registry.ts`) with:
  ```ts
  export const DAEMON_COMMAND_DESCRIPTORS: readonly DaemonCommandDescriptor[] =
    deriveDaemonCommandDescriptors(commandDescriptors);
  ```
  The hand literal is **deleted**. The `DaemonCommandDescriptor` type, the predicate accessors, and `buildDaemonCommandRegistry` are unchanged and consume `DAEMON_COMMAND_DESCRIPTORS` as before.
- `src/commands/descriptor/__tests__/parity.test.ts` — the slice-1 DAEMON parity assertion would now be a tautology (derived-vs-derived), so it was replaced with an **invariant** assertion: no duplicate command names, every descriptor has a route, and the derived command set still covers every public command (minus the two intentionally unrouted `app-switcher`/`install-from-source`). The capability-matrix and batch-name parity tests are kept as-is (those hand tables still exist for later slices).

## Behaviorless

The daemon registry's routes + request-policy traits are **identical** — #906's parity test proved `deriveDaemonCommandDescriptors(commandDescriptors)` is byte-equal to the deleted literal. No predicate accessor or consumer changed.

## Cycle check

No runtime import cycle: `daemon-command-registry.ts` (value) → `descriptor/derive.ts` + `descriptor/registry.ts` (values); the back-edges from `derive.ts` and `descriptor/types.ts` to this module's `DaemonCommandDescriptor` are **type-only imports, erased at runtime**. `tsc --noEmit` is clean (exit 0) and a runtime `import()` of the module loads cleanly (57 descriptors).

## Verification

- `tsc -p tsconfig.json --noEmit`: exit 0
- `oxfmt --write` + `oxlint --deny-warnings` on changed files: exit 0
- `vitest run daemon`: 94 files, 902 tests passed
- `vitest run commands/descriptor`: 1 file, 5 tests passed

Stacked on #906 — merge that first.