### PR TITLE
feat: build capability matrix from descriptors, delete the hand table — Phase 1 step 3

### DIFF
--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -1,3 +1,5 @@
+import { deriveCapabilityMatrix } from './command-descriptor/derive.ts';
+import { commandDescriptors } from './command-descriptor/registry.ts';
 import type { DeviceInfo } from '../utils/device.ts';
 
 type KindMatrix = {
@@ -17,29 +19,6 @@ export type CommandCapability = {
   unsupportedHint?: (device: DeviceInfo) => string | undefined;
 };
 
-const isNotMacOs = (device: DeviceInfo): boolean => device.platform !== 'macos';
-const isMacOsOrAppleSimulator = (device: DeviceInfo): boolean =>
-  device.platform === 'macos' || device.kind === 'simulator';
-const isIosMobileSimulator = (device: DeviceInfo): boolean =>
-  device.platform === 'ios' && device.kind === 'simulator' && device.target !== 'tv';
-
-// Two-finger gesture synthesis (RunnerSynthesizedGesture) is iOS-simulator-only (plus Android).
-// When such a gesture is rejected at admission, explain where it IS available so an agent can
-// redirect instead of getting a bare "not supported on this device".
-const synthesisGestureUnsupportedHint = (device: DeviceInfo): string | undefined => {
-  if (device.platform === 'macos')
-    return 'macOS automation has no multi-touch input — this gesture is supported on Android and the iOS simulator only.';
-  if (device.platform === 'ios' && device.target === 'tv')
-    return 'tvOS has no touch input — this gesture is supported on Android and the iOS simulator only.';
-  if (device.platform === 'ios' && device.kind === 'device')
-    return 'Two-finger gesture synthesis is iOS-simulator only — not available on physical iOS devices.';
-  return undefined;
-};
-
-// Linux desktop supports these commands via xdotool/ydotool + AT-SPI2.
-// Linux device kind is always 'device' (local desktop).
-const LINUX_DEVICE: KindMatrix = { device: true };
-const LINUX_NONE: KindMatrix = {};
 const WEB_DEVICE: KindMatrix = { device: true };
 const WEB_RUNTIME_COMMANDS = ['open', 'close'] as const;
 const WEB_RECORDING_COMMANDS = ['record'] as const;
@@ -61,220 +40,13 @@ const WEB_SUPPORTED_COMMANDS = new Set<string>([
   ...WEB_INTERACTION_COMMANDS,
   ...WEB_SETTING_COMMANDS,
 ]);
-const ALL_DEVICE_COMMAND_CAPABILITY = {
-  apple: { simulator: true, device: true },
-  android: { emulator: true, device: true, unknown: true },
-  linux: LINUX_DEVICE,
-} as const satisfies CommandCapability;
-const APP_RUNTIME_CAPABILITY = ALL_DEVICE_COMMAND_CAPABILITY;
-const APP_INVENTORY_CAPABILITY = {
-  apple: { simulator: true, device: true },
-  android: { emulator: true, device: true, unknown: true },
-  linux: LINUX_NONE,
-} as const satisfies CommandCapability;
-const APP_INSTALL_CAPABILITY = {
-  apple: { simulator: true, device: true },
-  android: { emulator: true, device: true, unknown: true },
-  linux: LINUX_NONE,
-  supports: isNotMacOs,
-} as const satisfies CommandCapability;
-
-export const BASE_COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> = {
-  // Apple simulator-only.
-  alert: {
-    // macOS desktop targets report kind=device, so this stays enabled here and the
-    // supports() guard excludes iOS physical devices.
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: (device) => device.platform === 'android' || isMacOsOrAppleSimulator(device),
-  },
-  pinch: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    // iOS-simulator-only (plus Android): pinch is driven by the two-finger XCTest synthesis
-    // path (RunnerSynthesizedGesture), which is iOS-only. macOS has no multi-touch synthesis, so
-    // it is excluded and fails fast at admission rather than round-tripping to an unsupported
-    // runner. Matches rotate-gesture / transform-gesture.
-    supports: (device) => device.platform === 'android' || isIosMobileSimulator(device),
-    unsupportedHint: synthesisGestureUnsupportedHint,
-  },
-  'rotate-gesture': {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: (device) => device.platform === 'android' || isIosMobileSimulator(device),
-    unsupportedHint: synthesisGestureUnsupportedHint,
-  },
-  'transform-gesture': {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: (device) => device.platform === 'android' || isIosMobileSimulator(device),
-    unsupportedHint: synthesisGestureUnsupportedHint,
-  },
-  'app-switcher': {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: isNotMacOs,
-  },
-  open: APP_RUNTIME_CAPABILITY,
-  close: APP_RUNTIME_CAPABILITY,
-  reinstall: APP_INSTALL_CAPABILITY,
-  install: APP_INSTALL_CAPABILITY,
-  'install-from-source': APP_INSTALL_CAPABILITY,
-  apps: APP_INVENTORY_CAPABILITY,
-  back: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  boot: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: isNotMacOs,
-  },
-  shutdown: {
-    apple: { simulator: true },
-    android: { emulator: true },
-    linux: LINUX_NONE,
-  },
-  click: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  clipboard: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-    supports: (device) =>
-      device.platform === 'android' ||
-      device.platform === 'linux' ||
-      device.platform === 'macos' ||
-      device.kind === 'simulator',
-  },
-  keyboard: {
-    // iOS only supports keyboard dismiss/enter; status/get remains Android-only.
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: (device) =>
-      device.platform === 'android' || (device.platform === 'ios' && device.target !== 'tv'),
-  },
-  fill: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  fling: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  snapshot: ALL_DEVICE_COMMAND_CAPABILITY,
-  diff: ALL_DEVICE_COMMAND_CAPABILITY,
-  screenshot: ALL_DEVICE_COMMAND_CAPABILITY,
-  wait: ALL_DEVICE_COMMAND_CAPABILITY,
-  get: ALL_DEVICE_COMMAND_CAPABILITY,
-  find: ALL_DEVICE_COMMAND_CAPABILITY,
-  is: ALL_DEVICE_COMMAND_CAPABILITY,
-  focus: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  home: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-    supports: isNotMacOs,
-  },
-  logs: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  network: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  longpress: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  perf: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  pan: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  press: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  push: {
-    apple: { simulator: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: isNotMacOs,
-  },
-  record: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  'react-native': {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  rotate: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: (device) =>
-      device.platform === 'android' || (device.platform === 'ios' && device.target !== 'tv'),
-  },
-  scroll: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  swipe: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_DEVICE,
-  },
-  settings: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-    supports: (device) =>
-      device.platform === 'android' || device.platform === 'macos' || device.kind === 'simulator',
-  },
-  viewport: {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  'trigger-app-event': {
-    apple: { simulator: true, device: true },
-    android: { emulator: true, device: true, unknown: true },
-    linux: LINUX_NONE,
-  },
-  type: ALL_DEVICE_COMMAND_CAPABILITY,
-};
+// Built from the additive command-descriptor registry (ADR-0008, Phase 1 step 3).
+// The hand-authored literal was deleted after #906 proved deriveCapabilityMatrix is
+// byte-equal to it (platform/kind buckets plus the supports/unsupportedHint closures,
+// across the sample-device matrix). The registry only type-imports CommandCapability
+// from here, so this value-level dependency does not form a runtime cycle.
+export const BASE_COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> =
+  deriveCapabilityMatrix(commandDescriptors);
 
 const COMMAND_CAPABILITY_MATRIX = addWebCommandCapabilities(BASE_COMMAND_CAPABILITY_MATRIX);
 

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -2,18 +2,13 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { STRUCTURED_BATCH_COMMAND_NAMES } from '../../../batch-policy.ts';
 import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
-import { BASE_COMMAND_CAPABILITY_MATRIX, type CommandCapability } from '../../capabilities.ts';
+import { BASE_COMMAND_CAPABILITY_MATRIX } from '../../capabilities.ts';
 import {
   DAEMON_COMMAND_DESCRIPTORS,
   type DaemonCommandDescriptor,
 } from '../../../daemon/daemon-command-registry.ts';
 import type { DaemonRequest } from '../../../daemon/types.ts';
-import type { DeviceInfo } from '../../../utils/device.ts';
-import {
-  deriveCapabilityMatrix,
-  deriveDaemonCommandDescriptors,
-  deriveStructuredBatchCommandNames,
-} from '../derive.ts';
+import { deriveDaemonCommandDescriptors, deriveStructuredBatchCommandNames } from '../derive.ts';
 import { commandDescriptors } from '../registry.ts';
 
 // Function-valued traits cannot be deep-equaled across re-authored closures, so
@@ -23,7 +18,6 @@ const DAEMON_FUNCTION_TRAITS = [
   'allowSessionlessDefaultDevice',
   'skipSessionlessProviderDevice',
 ] as const;
-const CAPABILITY_FUNCTION_TRAITS = ['supports', 'unsupportedHint'] as const;
 
 // Public commands that intentionally have no daemon route — they live only in the
 // capability/batch tables, so the daemon registry has never covered them.
@@ -32,13 +26,18 @@ const UNROUTED_PUBLIC_COMMANDS = new Set<string>([
   PUBLIC_COMMANDS.installFromSource,
 ]);
 
-function stripFunctions<T extends Record<string, unknown>>(value: T): Partial<T> {
-  const result: Record<string, unknown> = {};
-  for (const [key, entry] of Object.entries(value)) {
-    if (typeof entry !== 'function') result[key] = entry;
-  }
-  return result as Partial<T>;
-}
+// Public commands that intentionally carry no capability entry — pure control-plane
+// or always-admitted commands, so the capability matrix has never covered them.
+const NO_CAPABILITY_PUBLIC_COMMANDS = new Set<string>([
+  PUBLIC_COMMANDS.appState,
+  PUBLIC_COMMANDS.batch,
+  PUBLIC_COMMANDS.devices,
+  PUBLIC_COMMANDS.gesture,
+  PUBLIC_COMMANDS.prepare,
+  PUBLIC_COMMANDS.replay,
+  PUBLIC_COMMANDS.test,
+  PUBLIC_COMMANDS.trace,
+]);
 
 function makeRequest(command: string, positionals: string[] = []): DaemonRequest {
   return { command, token: 'parity-token', session: 'parity-session', positionals, flags: {} };
@@ -57,24 +56,6 @@ function sampleRequests(command: string): DaemonRequest[] {
     { ...makeRequest(PUBLIC_COMMANDS.test), flags: { shardSplit: 1 } },
   ];
 }
-
-function device(partial: Partial<DeviceInfo> & Pick<DeviceInfo, 'platform' | 'kind'>): DeviceInfo {
-  return { id: 'parity-id', name: 'parity-device', ...partial };
-}
-
-const SAMPLE_DEVICES: DeviceInfo[] = [
-  device({ platform: 'ios', kind: 'simulator' }),
-  device({ platform: 'ios', kind: 'simulator', target: 'tv' }),
-  device({ platform: 'ios', kind: 'device' }),
-  device({ platform: 'ios', kind: 'device', target: 'tv' }),
-  device({ platform: 'macos', kind: 'device' }),
-  device({ platform: 'macos', kind: 'simulator' }),
-  device({ platform: 'android', kind: 'emulator' }),
-  device({ platform: 'android', kind: 'device' }),
-  device({ platform: 'android', kind: 'simulator' }),
-  device({ platform: 'linux', kind: 'device' }),
-  device({ platform: 'web', kind: 'device' }),
-];
 
 test('derived daemon registry holds its routing invariants', () => {
   // The daemon registry is now BUILT from these derived descriptors (the
@@ -120,40 +101,31 @@ test('derived daemon descriptors preserve closure traits by presence and behavio
   }
 });
 
-test('derived capability matrix matches the hand table (non-function fields)', () => {
-  const derived = deriveCapabilityMatrix(commandDescriptors);
-  assert.deepEqual(
-    Object.keys(derived).sort(),
-    Object.keys(BASE_COMMAND_CAPABILITY_MATRIX).sort(),
-    'capability command coverage',
-  );
-  for (const [command, live] of Object.entries(BASE_COMMAND_CAPABILITY_MATRIX)) {
-    assert.deepEqual(
-      stripFunctions(derived[command] as CommandCapability),
-      stripFunctions(live),
-      `${command} non-function capability fields`,
+test('capability matrix holds its admission invariants', () => {
+  // BASE_COMMAND_CAPABILITY_MATRIX is now BUILT from these derived descriptors
+  // (the hand-authored literal was deleted after #906 proved byte-equality,
+  // including the supports/unsupportedHint closures across the sample-device
+  // matrix), so a derived-vs-BASE comparison would be a tautology. Instead assert
+  // the invariants the admission path depends on: every entry is selectable (has a
+  // platform bucket or a supports predicate) and the public-command coverage floor
+  // is unchanged.
+  const entries = Object.entries(BASE_COMMAND_CAPABILITY_MATRIX);
+  assert.ok(entries.length > 0, 'capability matrix present');
+
+  for (const [command, capability] of entries) {
+    const hasPlatformBucket = Boolean(
+      capability.apple || capability.android || capability.linux || capability.web,
+    );
+    assert.ok(
+      hasPlatformBucket || typeof capability.supports === 'function',
+      `${command} has a platform bucket or a supports predicate`,
     );
   }
-});
 
-test('derived capability matrix preserves supports/unsupportedHint by presence and behavior', () => {
-  const derived = deriveCapabilityMatrix(commandDescriptors);
-  for (const [command, live] of Object.entries(BASE_COMMAND_CAPABILITY_MATRIX)) {
-    const derivedCapability = derived[command] as CommandCapability;
-    for (const trait of CAPABILITY_FUNCTION_TRAITS) {
-      const derivedFn = derivedCapability[trait] as ((device: DeviceInfo) => unknown) | undefined;
-      const liveFn = live[trait] as ((device: DeviceInfo) => unknown) | undefined;
-      assert.equal(typeof derivedFn, typeof liveFn, `${command} ${trait} presence`);
-      if (typeof liveFn === 'function' && typeof derivedFn === 'function') {
-        for (const sample of SAMPLE_DEVICES) {
-          assert.equal(
-            derivedFn(sample),
-            liveFn(sample),
-            `${command} ${trait} on ${sample.platform}/${sample.kind}/${sample.target ?? 'mobile'}`,
-          );
-        }
-      }
-    }
+  const covered = new Set(Object.keys(BASE_COMMAND_CAPABILITY_MATRIX));
+  for (const command of Object.values(PUBLIC_COMMANDS)) {
+    if (NO_CAPABILITY_PUBLIC_COMMANDS.has(command)) continue;
+    assert.ok(covered.has(command), `capability matrix covers public command ${command}`);
   }
 });
 


### PR DESCRIPTION
## What

Phase 1 step 3 of the command-descriptor migration (ADR-0008). Stacked on #907.

`BASE_COMMAND_CAPABILITY_MATRIX` is now **built** from the additive descriptor registry:

```ts
export const BASE_COMMAND_CAPABILITY_MATRIX: Record<string, CommandCapability> =
  deriveCapabilityMatrix(commandDescriptors);
```

The entire hand-authored capability literal in `src/core/capabilities.ts` is **deleted** (~200 lines).

## Behaviorless (parity-proven)

#906 proved `deriveCapabilityMatrix(commandDescriptors)` is byte-equal to the old literal — platform/kind buckets **and** the `supports`/`unsupportedHint` closures across the sample-device matrix. `isCommandSupportedOnDevice` / `unsupportedHintForDevice` / `listCapabilityCommands` are unchanged. The matrix still resolves 44 commands; a runtime `import()` confirms the closures fire (e.g. `pinch` rejected on macOS with its actionable hint).

## Dead predicate helpers removed

After deleting the literal these were unused (their copies live in `registry.ts` now) and are deleted to satisfy `oxlint --deny-warnings`:
`isNotMacOs`, `isMacOsOrAppleSimulator`, `isIosMobileSimulator`, `synthesisGestureUnsupportedHint`, `ALL_DEVICE_COMMAND_CAPABILITY`, `APP_RUNTIME_CAPABILITY`, `APP_INVENTORY_CAPABILITY`, `APP_INSTALL_CAPABILITY`, `LINUX_DEVICE`, `LINUX_NONE`.

Kept: `WEB_DEVICE` + the `WEB_*` command sets and `addWebCommandCapabilities` (still consumed), and all consumers.

## Cycle check

`capabilities.ts` (value) → `descriptor/derive.ts` + `descriptor/registry.ts`; those modules only **type-import** `CommandCapability` back from `capabilities.ts` (erased at runtime). No runtime cycle: `tsc -p tsconfig.json --noEmit` clean, and a runtime `import('./src/core/capabilities.ts')` loads with no TDZ/circular-init error.

## Tests

The two capability parity tests became tautologies (BASE *is* the derived value), so they are rewritten into one admission invariant: every matrix entry is selectable (a platform bucket or a `supports` predicate) and the public-command coverage floor is unchanged. The daemon-routing and batch-name parity tests are kept.

## Verification

- `tsc --noEmit`: clean
- `oxfmt --write` + `oxlint --deny-warnings` on changed files: clean
- `vitest run capabilities daemon dispatch commands/descriptor`: **110 files / 1001 tests passed**
- runtime `import()` of capabilities.ts: clean (matrix builds, closures fire)

Stacked on #907.