### PR TITLE
feat: build batch allowlist from descriptors, delete the hand list — Phase 1 step 4

### DIFF
--- a/src/batch-policy.ts
+++ b/src/batch-policy.ts
@@ -1,53 +1,75 @@
 import { PUBLIC_COMMANDS } from './command-catalog.ts';
+import { deriveStructuredBatchCommandNames } from './core/command-descriptor/derive.ts';
+import { commandDescriptors } from './core/command-descriptor/registry.ts';
 import { AppError } from './utils/errors.ts';
 
-export const STRUCTURED_BATCH_COMMAND_NAMES = [
-  PUBLIC_COMMANDS.devices,
-  PUBLIC_COMMANDS.boot,
-  PUBLIC_COMMANDS.shutdown,
-  PUBLIC_COMMANDS.apps,
-  PUBLIC_COMMANDS.open,
-  PUBLIC_COMMANDS.close,
-  PUBLIC_COMMANDS.install,
-  PUBLIC_COMMANDS.reinstall,
-  PUBLIC_COMMANDS.installFromSource,
-  PUBLIC_COMMANDS.push,
-  PUBLIC_COMMANDS.triggerAppEvent,
-  PUBLIC_COMMANDS.snapshot,
-  PUBLIC_COMMANDS.screenshot,
-  PUBLIC_COMMANDS.diff,
-  PUBLIC_COMMANDS.wait,
-  PUBLIC_COMMANDS.alert,
-  PUBLIC_COMMANDS.settings,
-  PUBLIC_COMMANDS.click,
-  PUBLIC_COMMANDS.press,
-  PUBLIC_COMMANDS.longPress,
-  PUBLIC_COMMANDS.swipe,
-  PUBLIC_COMMANDS.focus,
-  PUBLIC_COMMANDS.type,
-  PUBLIC_COMMANDS.fill,
-  PUBLIC_COMMANDS.scroll,
-  PUBLIC_COMMANDS.get,
-  PUBLIC_COMMANDS.gesture,
-  PUBLIC_COMMANDS.is,
-  PUBLIC_COMMANDS.find,
-  PUBLIC_COMMANDS.perf,
-  PUBLIC_COMMANDS.logs,
-  PUBLIC_COMMANDS.network,
-  PUBLIC_COMMANDS.record,
-  PUBLIC_COMMANDS.trace,
-  PUBLIC_COMMANDS.test,
-  PUBLIC_COMMANDS.appState,
-  PUBLIC_COMMANDS.back,
-  PUBLIC_COMMANDS.home,
-  PUBLIC_COMMANDS.rotate,
-  PUBLIC_COMMANDS.appSwitcher,
-  PUBLIC_COMMANDS.keyboard,
-  PUBLIC_COMMANDS.clipboard,
-  PUBLIC_COMMANDS.reactNative,
-] as const;
+/**
+ * The exact set of command names exposed through `batch`, as a narrow union.
+ *
+ * This type is kept HAND-AUTHORED on purpose (ADR-0008, Phase 1 step 4): the
+ * runtime allowlist below is now derived from the command-descriptor registry,
+ * but the registry types each `name` as `string`, so deriving the value yields
+ * `string[]`. Re-deriving the type from that value would WIDEN this union to
+ * `string` and silently widen its downstream consumers — most notably
+ * `BatchCommandName` (re-exported from `command-surface.ts`) and the
+ * `satisfies readonly DaemonCommandName[]` guard in `commands/batch/projection.ts`.
+ * Keeping the union spelled out preserves those compile-time contracts. The
+ * derived runtime value is proven to match this union, member-for-member, by
+ * `core/command-descriptor/__tests__/parity.test.ts`.
+ */
+export type StructuredBatchCommandName =
+  | (typeof PUBLIC_COMMANDS)['devices']
+  | (typeof PUBLIC_COMMANDS)['boot']
+  | (typeof PUBLIC_COMMANDS)['shutdown']
+  | (typeof PUBLIC_COMMANDS)['apps']
+  | (typeof PUBLIC_COMMANDS)['open']
+  | (typeof PUBLIC_COMMANDS)['close']
+  | (typeof PUBLIC_COMMANDS)['install']
+  | (typeof PUBLIC_COMMANDS)['reinstall']
+  | (typeof PUBLIC_COMMANDS)['installFromSource']
+  | (typeof PUBLIC_COMMANDS)['push']
+  | (typeof PUBLIC_COMMANDS)['triggerAppEvent']
+  | (typeof PUBLIC_COMMANDS)['snapshot']
+  | (typeof PUBLIC_COMMANDS)['screenshot']
+  | (typeof PUBLIC_COMMANDS)['diff']
+  | (typeof PUBLIC_COMMANDS)['wait']
+  | (typeof PUBLIC_COMMANDS)['alert']
+  | (typeof PUBLIC_COMMANDS)['settings']
+  | (typeof PUBLIC_COMMANDS)['click']
+  | (typeof PUBLIC_COMMANDS)['press']
+  | (typeof PUBLIC_COMMANDS)['longPress']
+  | (typeof PUBLIC_COMMANDS)['swipe']
+  | (typeof PUBLIC_COMMANDS)['focus']
+  | (typeof PUBLIC_COMMANDS)['type']
+  | (typeof PUBLIC_COMMANDS)['fill']
+  | (typeof PUBLIC_COMMANDS)['scroll']
+  | (typeof PUBLIC_COMMANDS)['get']
+  | (typeof PUBLIC_COMMANDS)['gesture']
+  | (typeof PUBLIC_COMMANDS)['is']
+  | (typeof PUBLIC_COMMANDS)['find']
+  | (typeof PUBLIC_COMMANDS)['perf']
+  | (typeof PUBLIC_COMMANDS)['logs']
+  | (typeof PUBLIC_COMMANDS)['network']
+  | (typeof PUBLIC_COMMANDS)['record']
+  | (typeof PUBLIC_COMMANDS)['trace']
+  | (typeof PUBLIC_COMMANDS)['test']
+  | (typeof PUBLIC_COMMANDS)['appState']
+  | (typeof PUBLIC_COMMANDS)['back']
+  | (typeof PUBLIC_COMMANDS)['home']
+  | (typeof PUBLIC_COMMANDS)['rotate']
+  | (typeof PUBLIC_COMMANDS)['appSwitcher']
+  | (typeof PUBLIC_COMMANDS)['keyboard']
+  | (typeof PUBLIC_COMMANDS)['clipboard']
+  | (typeof PUBLIC_COMMANDS)['reactNative'];
 
-export type StructuredBatchCommandName = (typeof STRUCTURED_BATCH_COMMAND_NAMES)[number];
+/**
+ * The structured-batch allowlist, BUILT from the command-descriptor registry
+ * (the `batchable` flag) rather than hand-maintained. The derived value is a
+ * `string[]`; the cast re-applies the narrow {@link StructuredBatchCommandName}
+ * union, whose membership equality with this value is asserted by the parity test.
+ */
+export const STRUCTURED_BATCH_COMMAND_NAMES: readonly StructuredBatchCommandName[] =
+  deriveStructuredBatchCommandNames(commandDescriptors) as readonly StructuredBatchCommandName[];
 
 export const BATCH_BLOCKED_COMMANDS: ReadonlySet<string> = new Set(['batch', 'replay']);
 

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
-import { STRUCTURED_BATCH_COMMAND_NAMES } from '../../../batch-policy.ts';
+import {
+  STRUCTURED_BATCH_COMMAND_NAMES,
+  type StructuredBatchCommandName,
+} from '../../../batch-policy.ts';
 import { PUBLIC_COMMANDS } from '../../../command-catalog.ts';
 import { BASE_COMMAND_CAPABILITY_MATRIX } from '../../capabilities.ts';
 import {
@@ -129,17 +132,101 @@ test('capability matrix holds its admission invariants', () => {
   }
 });
 
-test('derived structured-batch command names match the hand table (membership)', () => {
-  // Membership, not order: STRUCTURED_BATCH_COMMAND_NAMES and
-  // DAEMON_COMMAND_DESCRIPTORS are independently hand-ordered, so a single
-  // registry table cannot reproduce both array orders. The batchable flags are
-  // proven byte-equal as a set; ordering is cosmetic (the consumer dedupes into
-  // a Set) and is deferred to a later slice.
+// Exhaustive map over the StructuredBatchCommandName union. The compiler errors
+// if a union member is missing a key OR a non-member key is added, so its keys
+// ARE the union at type level — giving us a runtime handle on the (otherwise
+// hand-authored) union to compare against the derived allowlist.
+const STRUCTURED_BATCH_UNION_MEMBERS: Record<StructuredBatchCommandName, true> = {
+  [PUBLIC_COMMANDS.devices]: true,
+  [PUBLIC_COMMANDS.boot]: true,
+  [PUBLIC_COMMANDS.shutdown]: true,
+  [PUBLIC_COMMANDS.apps]: true,
+  [PUBLIC_COMMANDS.open]: true,
+  [PUBLIC_COMMANDS.close]: true,
+  [PUBLIC_COMMANDS.install]: true,
+  [PUBLIC_COMMANDS.reinstall]: true,
+  [PUBLIC_COMMANDS.installFromSource]: true,
+  [PUBLIC_COMMANDS.push]: true,
+  [PUBLIC_COMMANDS.triggerAppEvent]: true,
+  [PUBLIC_COMMANDS.snapshot]: true,
+  [PUBLIC_COMMANDS.screenshot]: true,
+  [PUBLIC_COMMANDS.diff]: true,
+  [PUBLIC_COMMANDS.wait]: true,
+  [PUBLIC_COMMANDS.alert]: true,
+  [PUBLIC_COMMANDS.settings]: true,
+  [PUBLIC_COMMANDS.click]: true,
+  [PUBLIC_COMMANDS.press]: true,
+  [PUBLIC_COMMANDS.longPress]: true,
+  [PUBLIC_COMMANDS.swipe]: true,
+  [PUBLIC_COMMANDS.focus]: true,
+  [PUBLIC_COMMANDS.type]: true,
+  [PUBLIC_COMMANDS.fill]: true,
+  [PUBLIC_COMMANDS.scroll]: true,
+  [PUBLIC_COMMANDS.get]: true,
+  [PUBLIC_COMMANDS.gesture]: true,
+  [PUBLIC_COMMANDS.is]: true,
+  [PUBLIC_COMMANDS.find]: true,
+  [PUBLIC_COMMANDS.perf]: true,
+  [PUBLIC_COMMANDS.logs]: true,
+  [PUBLIC_COMMANDS.network]: true,
+  [PUBLIC_COMMANDS.record]: true,
+  [PUBLIC_COMMANDS.trace]: true,
+  [PUBLIC_COMMANDS.test]: true,
+  [PUBLIC_COMMANDS.appState]: true,
+  [PUBLIC_COMMANDS.back]: true,
+  [PUBLIC_COMMANDS.home]: true,
+  [PUBLIC_COMMANDS.rotate]: true,
+  [PUBLIC_COMMANDS.appSwitcher]: true,
+  [PUBLIC_COMMANDS.keyboard]: true,
+  [PUBLIC_COMMANDS.clipboard]: true,
+  [PUBLIC_COMMANDS.reactNative]: true,
+};
+
+// Control-plane / non-batchable commands that must never enter the allowlist.
+const NON_BATCHABLE_COMMANDS = [
+  PUBLIC_COMMANDS.batch,
+  PUBLIC_COMMANDS.replay,
+  PUBLIC_COMMANDS.prepare,
+  'pinch',
+  'viewport',
+  'pan',
+  'fling',
+  'rotate-gesture',
+  'transform-gesture',
+];
+
+test('structured-batch allowlist is built from descriptors and matches the kept union', () => {
   const derived = deriveStructuredBatchCommandNames(commandDescriptors);
+
+  // No duplicates in the derived allowlist.
   assert.equal(new Set(derived).size, derived.length, 'no duplicate batchable names');
+
+  // The exported allowlist is now BUILT from these derived descriptors, so it is
+  // the derived list (order included) — guards the wiring, not a tautology of
+  // membership.
   assert.deepEqual(
-    [...derived].sort(),
-    [...STRUCTURED_BATCH_COMMAND_NAMES].sort(),
-    'structured-batch membership',
+    [...STRUCTURED_BATCH_COMMAND_NAMES],
+    derived,
+    'exported allowlist is built from the descriptors',
   );
+
+  // Membership equals the kept StructuredBatchCommandName union (proves the
+  // narrow type the consumers rely on did not drift from the runtime value).
+  assert.deepEqual(
+    [...new Set(derived)].sort(),
+    Object.keys(STRUCTURED_BATCH_UNION_MEMBERS).sort(),
+    'derived membership equals the kept union',
+  );
+
+  // Every batchable command is a real public command (no internal/control name leaks in).
+  const publicCommands = new Set<string>(Object.values(PUBLIC_COMMANDS));
+  for (const name of derived) {
+    assert.ok(publicCommands.has(name), `batchable command ${name} is a public command`);
+  }
+
+  // Control-plane commands stay out of the allowlist.
+  const batchable = new Set(derived);
+  for (const excluded of NON_BATCHABLE_COMMANDS) {
+    assert.ok(!batchable.has(excluded), `${excluded} is not batchable`);
+  }
 });


### PR DESCRIPTION
## What

Phase 1 step 4 of the command-descriptor migration (ADR-0008). Builds the structured-batch allowlist (`STRUCTURED_BATCH_COMMAND_NAMES` in `src/batch-policy.ts`) from the command-descriptor registry's `batchable` flag via `deriveStructuredBatchCommandNames(commandDescriptors)`, and **deletes the hand-authored `as const` list**. The registry is now the single runtime source of truth for which commands are batchable.

Behaviorless: #906 already proved derived membership equals the hand list (43 names, both sides). This slice flips the runtime value to the derived one; the parity test now guards the invariant instead of being a tautology.

## How the `StructuredBatchCommandName` type was handled

`StructuredBatchCommandName` is a **narrow union** consumed beyond batch-policy:
- `readStructuredBatchCommandName` returns it,
- `commands/batch/projection.ts` has `STRUCTURED_BATCH_COMMAND_NAMES satisfies readonly DaemonCommandName[]` and derives `BatchCommandName = (typeof batchCommandNames)[number]`, which is **re-exported publicly** via `command-surface.ts`.

The registry types each `name` as `string`, so deriving the value yields `string[]`. Re-deriving the type from that value would widen the union to `string`, break the `satisfies` guard, and widen the public `BatchCommandName`. So the type is **kept hand-authored** as an explicit union of `(typeof PUBLIC_COMMANDS)[...]` members; only the runtime VALUE is derived (cast back to the narrow union). The parity test asserts the derived value's membership equals the kept union via an exhaustive `Record<StructuredBatchCommandName, true>` (compiler-enforced over the union) deep-equaled to the derived set — proving the type did not drift from the runtime value in either direction. `tsc --noEmit` passes (exit 0), confirming no consumer type widened.

## Order check

The derived order follows the daemon table, not the old hand-list order. Confirmed no consumer is order-sensitive: the batch-policy consumer dedupes into a `Set`; `projection.ts:18` uses `satisfies` (order-independent); `metadata.ts` feeds the names into a JSON Schema `enum`, but no snapshot/test asserts that enum's order (verified across `.snap` files and the mcp router / command-tools / command-surface-metadata suites). Cosmetic only — behaviorless.

## Tests

Updated the batch parity test (was a tautology after the flip) to an invariant: allowlist is built from the descriptors, no duplicates, membership equals the kept union, every batchable name is a public command, and control-plane commands (`batch`, `replay`, `prepare`, `pinch`, `viewport`, `pan`, `fling`, `rotate-gesture`, `transform-gesture`) stay out. Kept the daemon-routing parity invariants untouched.

## Verification

- `tsc -p tsconfig.json --noEmit` — exit 0
- `oxfmt --write` + `oxlint --deny-warnings` on changed files — clean
- `vitest run` batch + core/command-descriptor + mcp router/command-tools + command-surface-metadata + core — all pass
- Layering Guard git grep — still empty

Stacked on #908 → #907 → #906.