### PR TITLE
perf: speed up iOS simulator screenshots

### DIFF
--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -50,6 +50,7 @@ export type DispatchContext = ScreenshotDispatchFlags & {
   snapshotScope?: string;
   snapshotRaw?: boolean;
   snapshotIncludeRects?: boolean;
+  skipIosSimulatorBootCheck?: boolean;
   count?: number;
   intervalMs?: number;
   delayMs?: number;

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -340,6 +340,7 @@ async function handleScreenshotCommand(
     fullscreen: screenshotOptions.fullscreen,
     stabilize: screenshotOptions.stabilize,
     surface: context?.surface,
+    skipIosSimulatorBootCheck: context?.skipIosSimulatorBootCheck,
   });
   return { path: screenshotPath, ...successText(`Saved screenshot: ${screenshotPath}`) };
 }

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -43,6 +43,7 @@ export type ScreenshotOptions = {
   fullscreen?: boolean;
   stabilize?: boolean;
   surface?: SessionSurface;
+  skipIosSimulatorBootCheck?: boolean;
 };
 
 export type ElementSelectorKey = 'id' | 'label' | 'text' | 'value';

--- a/src/core/interactors/apple.ts
+++ b/src/core/interactors/apple.ts
@@ -47,8 +47,11 @@ export function createAppleInteractor(
         });
         return;
       }
-      await screenshotIos(device, outPath, options?.appBundleId, options?.fullscreen, runnerOpts, {
-        skipSimulatorBootCheck: options?.skipIosSimulatorBootCheck,
+      await screenshotIos(device, outPath, {
+        appBundleId: options?.appBundleId,
+        fullscreen: options?.fullscreen,
+        runnerOptions: runnerOpts,
+        skipBootCheck: options?.skipIosSimulatorBootCheck,
       });
     },
     snapshot: async (options) => {

--- a/src/core/interactors/apple.ts
+++ b/src/core/interactors/apple.ts
@@ -47,7 +47,9 @@ export function createAppleInteractor(
         });
         return;
       }
-      await screenshotIos(device, outPath, options?.appBundleId, options?.fullscreen, runnerOpts);
+      await screenshotIos(device, outPath, options?.appBundleId, options?.fullscreen, runnerOpts, {
+        skipSimulatorBootCheck: options?.skipIosSimulatorBootCheck,
+      });
     },
     snapshot: async (options) => {
       const result = readAppleSnapshotResult(

--- a/src/daemon/__tests__/request-router-screenshot.test.ts
+++ b/src/daemon/__tests__/request-router-screenshot.test.ts
@@ -129,6 +129,27 @@ test('default screenshot temp directory is cleaned when capture fails', async ()
   expect(fs.existsSync(path.dirname(capturedPath!))).toBe(false);
 });
 
+test('session-backed iOS simulator screenshots skip redundant boot probe', async () => {
+  const session = makeIosSession('ios');
+  const outPath = path.join(os.tmpdir(), 'agent-device-ios-session-screenshot.png');
+  let capturedContext: Parameters<typeof dispatchCommand>[4];
+
+  mockDispatch.mockImplementation(async (_device, _command, _positionals, _outPath, context) => {
+    capturedContext = context;
+    return { path: outPath };
+  });
+
+  await dispatchScreenshotViaRuntime({
+    session,
+    sessionName: session.name,
+    outPath,
+    outputPlacement: 'positional',
+    dispatchContext: {},
+  });
+
+  expect(capturedContext?.skipIosSimulatorBootCheck).toBe(true);
+});
+
 test('router serializes concurrent commands for the same device across sessions', async () => {
   const sessionStore = makeSessionStore('agent-device-router-screenshot-');
   sessionStore.set('session-a', makeSession('session-a'));

--- a/src/daemon/screenshot-runtime.ts
+++ b/src/daemon/screenshot-runtime.ts
@@ -57,6 +57,9 @@ function createDispatchScreenshotBackend(params: {
         ...dispatchContext,
         ...screenshotFlagsFromOptions(options),
         surface: options?.surface,
+        skipIosSimulatorBootCheck:
+          dispatchContext.skipIosSimulatorBootCheck ??
+          (session.device.platform === 'ios' && session.device.kind === 'simulator'),
       };
       if (outputPlacement === 'out') {
         return readScreenshotResultData(

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -713,12 +713,15 @@ test('captureSimulatorScreenshotWithFallback falls back to runner after retry ex
 
   try {
     const outPath = path.join(tmpDir, 'out.png');
-    await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, outPath, 'com.example.app', {
-      ensureBooted: ensureBootedSimulator,
-      prepareStatusBarForScreenshot: prepareStatusBarForScreenshot,
-      captureWithRetry: captureSimulatorScreenshotWithRetry,
-      captureWithRunner: captureScreenshotViaRunner,
-      shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
+    await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, outPath, {
+      appBundleId: 'com.example.app',
+      deps: {
+        ensureBooted: ensureBootedSimulator,
+        prepareStatusBarForScreenshot: prepareStatusBarForScreenshot,
+        captureWithRetry: captureSimulatorScreenshotWithRetry,
+        captureWithRunner: captureScreenshotViaRunner,
+        shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
+      },
     });
     assert.equal(ensureBootedCalls, 1);
     assert.equal(mockRetryWithPolicy.mock.calls.length, 1);
@@ -754,12 +757,15 @@ test('captureSimulatorScreenshotWithFallback falls back to runner after simctl s
 
   try {
     const outPath = path.join(tmpDir, 'out.png');
-    await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, outPath, 'com.example.app', {
-      ensureBooted: ensureBootedSimulator,
-      prepareStatusBarForScreenshot: prepareStatusBarForScreenshot,
-      captureWithRetry: captureSimulatorScreenshotWithRetry,
-      captureWithRunner: captureScreenshotViaRunner,
-      shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
+    await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, outPath, {
+      appBundleId: 'com.example.app',
+      deps: {
+        ensureBooted: ensureBootedSimulator,
+        prepareStatusBarForScreenshot: prepareStatusBarForScreenshot,
+        captureWithRetry: captureSimulatorScreenshotWithRetry,
+        captureWithRunner: captureScreenshotViaRunner,
+        shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
+      },
     });
     assert.equal(mockRunIosRunnerCommand.mock.calls.length, 1);
     assert.equal(await fs.readFile(outPath, 'utf8'), 'runner-timeout');
@@ -775,11 +781,9 @@ test('captureSimulatorScreenshotWithFallback continues when status bar preparati
   mockEnsureBootedSimulator.mockResolvedValue(undefined);
   mockOpenIosSimulatorApp.mockResolvedValue(undefined);
   mockRetryWithPolicy.mockResolvedValue(undefined);
-  await captureSimulatorScreenshotWithFallback(
-    IOS_TEST_SIMULATOR,
-    '/tmp/out.png',
-    'com.example.app',
-  );
+  await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
+    appBundleId: 'com.example.app',
+  });
   assert.equal(mockRetryWithPolicy.mock.calls.length > 0, true);
   assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
 });
@@ -789,15 +793,10 @@ test('captureSimulatorScreenshotWithFallback can skip session-backed simulator b
   mockPrepareStatusBarForScreenshot.mockResolvedValue(async () => {});
   mockRetryWithPolicy.mockResolvedValue(undefined);
 
-  await captureSimulatorScreenshotWithFallback(
-    IOS_TEST_SIMULATOR,
-    '/tmp/out.png',
-    'com.example.app',
-    undefined,
-    undefined,
-    undefined,
-    { skipBootCheck: true },
-  );
+  await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
+    appBundleId: 'com.example.app',
+    skipBootCheck: true,
+  });
 
   assert.equal(mockEnsureBootedSimulator.mock.calls.length, 0);
   assert.equal(mockRetryWithPolicy.mock.calls.length, 1);
@@ -819,21 +818,17 @@ test('captureSimulatorScreenshotWithFallback boots skipped-check simulator after
   });
   const captureWithRunner = vi.fn(async () => {});
 
-  await captureSimulatorScreenshotWithFallback(
-    IOS_TEST_SIMULATOR,
-    '/tmp/out.png',
-    'com.example.app',
-    undefined,
-    {
+  await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
+    appBundleId: 'com.example.app',
+    skipBootCheck: true,
+    deps: {
       ensureBooted,
       prepareStatusBarForScreenshot,
       captureWithRetry,
       captureWithRunner,
       shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
     },
-    undefined,
-    { skipBootCheck: true },
-  );
+  });
 
   assert.equal(ensureBooted.mock.calls.length, 1);
   assert.equal(captureWithRetry.mock.calls.length, 2);
@@ -859,21 +854,17 @@ test('captureSimulatorScreenshotWithFallback keeps runner fallback after skipped
   });
   const captureWithRunner = vi.fn(async () => {});
 
-  await captureSimulatorScreenshotWithFallback(
-    IOS_TEST_SIMULATOR,
-    '/tmp/out.png',
-    'com.example.app',
-    undefined,
-    {
+  await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
+    appBundleId: 'com.example.app',
+    skipBootCheck: true,
+    deps: {
       ensureBooted,
       prepareStatusBarForScreenshot,
       captureWithRetry,
       captureWithRunner,
       shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
     },
-    undefined,
-    { skipBootCheck: true },
-  );
+  });
 
   assert.equal(ensureBooted.mock.calls.length, 1);
   assert.equal(captureWithRetry.mock.calls.length, 2);
@@ -887,11 +878,9 @@ test('captureSimulatorScreenshotWithFallback ignores status bar restore failures
   mockEnsureBootedSimulator.mockResolvedValue(undefined);
   mockOpenIosSimulatorApp.mockResolvedValue(undefined);
   mockRetryWithPolicy.mockResolvedValue(undefined);
-  await captureSimulatorScreenshotWithFallback(
-    IOS_TEST_SIMULATOR,
-    '/tmp/out.png',
-    'com.example.app',
-  );
+  await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
+    appBundleId: 'com.example.app',
+  });
   assert.equal(mockRetryWithPolicy.mock.calls.length > 0, true);
   assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
 });
@@ -929,18 +918,16 @@ test('captureSimulatorScreenshotWithFallback emits fallback diagnostic before us
           }
           throw new Error(`Unexpected xcrun args: ${args.join(' ')}`);
         });
-        await captureSimulatorScreenshotWithFallback(
-          IOS_TEST_SIMULATOR,
-          '/tmp/out.png',
-          'com.example.app',
-          {
+        await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
+          appBundleId: 'com.example.app',
+          deps: {
             ensureBooted: ensureBootedSimulator,
             prepareStatusBarForScreenshot: prepareStatusBarForScreenshot,
             captureWithRetry: captureSimulatorScreenshotWithRetry,
             captureWithRunner: captureScreenshotViaRunner,
             shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
           },
-        );
+        });
       },
     );
 
@@ -981,7 +968,9 @@ test('captureSimulatorScreenshotWithFallback uses simulator runner fallback by d
 
   try {
     const outPath = path.join(tmpDir, 'out.png');
-    await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, outPath, 'com.example.app');
+    await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, outPath, {
+      appBundleId: 'com.example.app',
+    });
     assert.equal(mockRunIosRunnerCommand.mock.calls.length, 1);
     assert.equal(await fs.readFile(outPath, 'utf8'), 'default-fallback');
   } finally {

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -784,6 +784,26 @@ test('captureSimulatorScreenshotWithFallback continues when status bar preparati
   assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
 });
 
+test('captureSimulatorScreenshotWithFallback can skip session-backed simulator boot probe', async () => {
+  mockEnsureBootedSimulator.mockRejectedValue(new Error('should not probe boot state'));
+  mockPrepareStatusBarForScreenshot.mockResolvedValue(async () => {});
+  mockRetryWithPolicy.mockResolvedValue(undefined);
+
+  await captureSimulatorScreenshotWithFallback(
+    IOS_TEST_SIMULATOR,
+    '/tmp/out.png',
+    'com.example.app',
+    undefined,
+    undefined,
+    undefined,
+    { skipBootCheck: true },
+  );
+
+  assert.equal(mockEnsureBootedSimulator.mock.calls.length, 0);
+  assert.equal(mockRetryWithPolicy.mock.calls.length, 1);
+  assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
+});
+
 test('captureSimulatorScreenshotWithFallback ignores status bar restore failures', async () => {
   mockPrepareStatusBarForScreenshot.mockResolvedValue(async () => {
     throw new AppError('COMMAND_FAILED', 'status_bar clear failed');

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -804,6 +804,82 @@ test('captureSimulatorScreenshotWithFallback can skip session-backed simulator b
   assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
 });
 
+test('captureSimulatorScreenshotWithFallback boots skipped-check simulator after shutdown screenshot failure', async () => {
+  const ensureBooted = vi.fn(async () => {});
+  const prepareStatusBarForScreenshot = vi.fn(async () => async () => {});
+  let captureAttempts = 0;
+  const captureWithRetry = vi.fn(async () => {
+    captureAttempts += 1;
+    if (captureAttempts === 1) {
+      throw new AppError('COMMAND_FAILED', 'simctl screenshot failed', {
+        stderr: 'Unable to boot device in current state: Shutdown',
+        args: ['simctl', 'io', 'sim-1', 'screenshot', '/tmp/out.png'],
+      });
+    }
+  });
+  const captureWithRunner = vi.fn(async () => {});
+
+  await captureSimulatorScreenshotWithFallback(
+    IOS_TEST_SIMULATOR,
+    '/tmp/out.png',
+    'com.example.app',
+    undefined,
+    {
+      ensureBooted,
+      prepareStatusBarForScreenshot,
+      captureWithRetry,
+      captureWithRunner,
+      shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
+    },
+    undefined,
+    { skipBootCheck: true },
+  );
+
+  assert.equal(ensureBooted.mock.calls.length, 1);
+  assert.equal(captureWithRetry.mock.calls.length, 2);
+  assert.equal(captureWithRunner.mock.calls.length, 0);
+});
+
+test('captureSimulatorScreenshotWithFallback keeps runner fallback after skipped-check boot recovery', async () => {
+  const ensureBooted = vi.fn(async () => {});
+  const prepareStatusBarForScreenshot = vi.fn(async () => async () => {});
+  let captureAttempts = 0;
+  const captureWithRetry = vi.fn(async () => {
+    captureAttempts += 1;
+    if (captureAttempts === 1) {
+      throw new AppError('COMMAND_FAILED', 'simctl screenshot failed', {
+        stderr: 'Unable to boot device in current state: Shutdown',
+        args: ['simctl', 'io', 'sim-1', 'screenshot', '/tmp/out.png'],
+      });
+    }
+    throw new AppError('COMMAND_FAILED', 'xcrun timed out after 20000ms', {
+      args: ['simctl', 'io', 'sim-1', 'screenshot', '/tmp/out.png'],
+      timeoutMs: 20_000,
+    });
+  });
+  const captureWithRunner = vi.fn(async () => {});
+
+  await captureSimulatorScreenshotWithFallback(
+    IOS_TEST_SIMULATOR,
+    '/tmp/out.png',
+    'com.example.app',
+    undefined,
+    {
+      ensureBooted,
+      prepareStatusBarForScreenshot,
+      captureWithRetry,
+      captureWithRunner,
+      shouldFallbackToRunner: shouldRetryIosSimulatorScreenshot,
+    },
+    undefined,
+    { skipBootCheck: true },
+  );
+
+  assert.equal(ensureBooted.mock.calls.length, 1);
+  assert.equal(captureWithRetry.mock.calls.length, 2);
+  assert.equal(captureWithRunner.mock.calls.length, 1);
+});
+
 test('captureSimulatorScreenshotWithFallback ignores status bar restore failures', async () => {
   mockPrepareStatusBarForScreenshot.mockResolvedValue(async () => {
     throw new AppError('COMMAND_FAILED', 'status_bar clear failed');

--- a/src/platforms/ios/screenshot.ts
+++ b/src/platforms/ios/screenshot.ts
@@ -40,6 +40,14 @@ type SimulatorScreenshotFlowDeps = {
   shouldFallbackToRunner: (error: unknown) => boolean;
 };
 
+type SimulatorScreenshotFlowOptions = {
+  skipBootCheck?: boolean;
+};
+
+type IosScreenshotOptions = {
+  skipSimulatorBootCheck?: boolean;
+};
+
 const defaultSimulatorScreenshotFlowDeps: SimulatorScreenshotFlowDeps = {
   ensureBooted: ensureBootedSimulator,
   prepareStatusBarForScreenshot: prepareSimulatorStatusBarForScreenshot,
@@ -53,6 +61,7 @@ export async function screenshotIos(
   appBundleId?: string,
   fullscreen?: boolean,
   runnerOptions?: AppleRunnerCommandOptions,
+  options: IosScreenshotOptions = {},
 ): Promise<void> {
   if (device.platform === 'macos') {
     await captureScreenshotViaRunner(device, outPath, appBundleId, fullscreen, runnerOptions);
@@ -66,6 +75,7 @@ export async function screenshotIos(
       fullscreen,
       undefined,
       runnerOptions,
+      { skipBootCheck: options.skipSimulatorBootCheck },
     );
     return;
   }
@@ -93,6 +103,7 @@ export async function captureSimulatorScreenshotWithFallback(
   fullscreenOrDeps?: boolean | SimulatorScreenshotFlowDeps,
   deps: SimulatorScreenshotFlowDeps = defaultSimulatorScreenshotFlowDeps,
   runnerOptions?: AppleRunnerCommandOptions,
+  options: SimulatorScreenshotFlowOptions = {},
 ): Promise<void> {
   if (device.kind !== 'simulator') {
     throw new AppError(
@@ -105,7 +116,9 @@ export async function captureSimulatorScreenshotWithFallback(
   const effectiveDeps =
     typeof fullscreenOrDeps === 'object' && fullscreenOrDeps !== null ? fullscreenOrDeps : deps;
 
-  await effectiveDeps.ensureBooted(device);
+  if (!options.skipBootCheck) {
+    await effectiveDeps.ensureBooted(device);
+  }
   let restoreStatusBar = async () => {};
   try {
     restoreStatusBar = await effectiveDeps.prepareStatusBarForScreenshot(device);

--- a/src/platforms/ios/screenshot.ts
+++ b/src/platforms/ios/screenshot.ts
@@ -130,10 +130,20 @@ export async function captureSimulatorScreenshotWithFallback(
       await effectiveDeps.captureWithRetry(device, outPath);
       return;
     } catch (error) {
-      if (!effectiveDeps.shouldFallbackToRunner(error)) {
-        throw error;
+      let screenshotError = error;
+      if (options.skipBootCheck && shouldEnsureBootedAfterSimulatorScreenshotFailure(error)) {
+        await effectiveDeps.ensureBooted(device);
+        try {
+          await effectiveDeps.captureWithRetry(device, outPath);
+          return;
+        } catch (retryError) {
+          screenshotError = retryError;
+        }
       }
-      emitScreenshotFallbackDiagnostic(device, 'simctl_screenshot', error);
+      if (!effectiveDeps.shouldFallbackToRunner(screenshotError)) {
+        throw screenshotError;
+      }
+      emitScreenshotFallbackDiagnostic(device, 'simctl_screenshot', screenshotError);
     }
     await effectiveDeps.captureWithRunner(device, outPath, appBundleId, fullscreen, runnerOptions);
   } finally {
@@ -393,10 +403,7 @@ export function resolveSimulatorRunnerScreenshotCandidatePaths(
 export function shouldFallbackToRunnerForIosScreenshot(error: unknown): boolean {
   if (!(error instanceof AppError)) return false;
   if (error.code !== 'COMMAND_FAILED') return false;
-  const details = (error.details ?? {}) as { stdout?: unknown; stderr?: unknown };
-  const stdout = typeof details.stdout === 'string' ? details.stdout : '';
-  const stderr = typeof details.stderr === 'string' ? details.stderr : '';
-  const combined = `${error.message}\n${stdout}\n${stderr}`.toLowerCase();
+  const combined = commandFailureText(error);
   return (
     combined.includes("unknown option '--device'") ||
     (combined.includes('unknown subcommand') && combined.includes('screenshot')) ||
@@ -407,13 +414,7 @@ export function shouldFallbackToRunnerForIosScreenshot(error: unknown): boolean 
 export function shouldRetryIosSimulatorScreenshot(error: unknown): boolean {
   if (!(error instanceof AppError)) return false;
   if (error.code !== 'COMMAND_FAILED') return false;
-  const details = (error.details ?? {}) as { stdout?: unknown; stderr?: unknown; args?: unknown };
-  const stdout = typeof details.stdout === 'string' ? details.stdout : '';
-  const stderr = typeof details.stderr === 'string' ? details.stderr : '';
-  const args = Array.isArray(details.args)
-    ? details.args.filter((value): value is string => typeof value === 'string').join(' ')
-    : '';
-  const combined = `${error.message}\n${stdout}\n${stderr}\n${args}`.toLowerCase();
+  const combined = commandFailureText(error);
   return (
     combined.includes('timeout waiting for screen surfaces') ||
     (combined.includes('nsposixerrordomain') &&
@@ -421,6 +422,30 @@ export function shouldRetryIosSimulatorScreenshot(error: unknown): boolean {
       combined.includes('screenshot')) ||
     (combined.includes('timed out') && combined.includes('screenshot'))
   );
+}
+
+function shouldEnsureBootedAfterSimulatorScreenshotFailure(error: unknown): boolean {
+  if (!(error instanceof AppError)) return false;
+  if (error.code !== 'COMMAND_FAILED') return false;
+  const combined = commandFailureText(error);
+  return (
+    combined.includes('not booted') ||
+    combined.includes('current state: shutdown') ||
+    combined.includes('current state is shutdown') ||
+    combined.includes('current state=shutdown') ||
+    combined.includes('state: shutdown') ||
+    combined.includes('state=shutdown')
+  );
+}
+
+function commandFailureText(error: AppError): string {
+  const details = (error.details ?? {}) as { stdout?: unknown; stderr?: unknown; args?: unknown };
+  const stdout = typeof details.stdout === 'string' ? details.stdout : '';
+  const stderr = typeof details.stderr === 'string' ? details.stderr : '';
+  const args = Array.isArray(details.args)
+    ? details.args.filter((value): value is string => typeof value === 'string').join(' ')
+    : '';
+  return `${error.message}\n${stdout}\n${stderr}\n${args}`.toLowerCase();
 }
 
 export { prepareSimulatorStatusBarForScreenshot } from './screenshot-status-bar.ts';

--- a/src/platforms/ios/screenshot.ts
+++ b/src/platforms/ios/screenshot.ts
@@ -41,11 +41,11 @@ type SimulatorScreenshotFlowDeps = {
 };
 
 type SimulatorScreenshotFlowOptions = {
+  appBundleId?: string;
+  fullscreen?: boolean;
+  runnerOptions?: AppleRunnerCommandOptions;
   skipBootCheck?: boolean;
-};
-
-type IosScreenshotOptions = {
-  skipSimulatorBootCheck?: boolean;
+  deps?: SimulatorScreenshotFlowDeps;
 };
 
 const defaultSimulatorScreenshotFlowDeps: SimulatorScreenshotFlowDeps = {
@@ -58,25 +58,20 @@ const defaultSimulatorScreenshotFlowDeps: SimulatorScreenshotFlowDeps = {
 export async function screenshotIos(
   device: DeviceInfo,
   outPath: string,
-  appBundleId?: string,
-  fullscreen?: boolean,
-  runnerOptions?: AppleRunnerCommandOptions,
-  options: IosScreenshotOptions = {},
+  options: Omit<SimulatorScreenshotFlowOptions, 'deps'> = {},
 ): Promise<void> {
   if (device.platform === 'macos') {
-    await captureScreenshotViaRunner(device, outPath, appBundleId, fullscreen, runnerOptions);
+    await captureScreenshotViaRunner(
+      device,
+      outPath,
+      options.appBundleId,
+      options.fullscreen,
+      options.runnerOptions,
+    );
     return;
   }
   if (device.kind === 'simulator') {
-    await captureSimulatorScreenshotWithFallback(
-      device,
-      outPath,
-      appBundleId,
-      fullscreen,
-      undefined,
-      runnerOptions,
-      { skipBootCheck: options.skipSimulatorBootCheck },
-    );
+    await captureSimulatorScreenshotWithFallback(device, outPath, options);
     return;
   }
 
@@ -93,16 +88,18 @@ export async function screenshotIos(
     emitScreenshotFallbackDiagnostic(device, 'devicectl_screenshot', error);
   }
 
-  await captureScreenshotViaRunner(device, outPath, appBundleId, fullscreen, runnerOptions);
+  await captureScreenshotViaRunner(
+    device,
+    outPath,
+    options.appBundleId,
+    options.fullscreen,
+    options.runnerOptions,
+  );
 }
 
 export async function captureSimulatorScreenshotWithFallback(
   device: DeviceInfo,
   outPath: string,
-  appBundleId?: string,
-  fullscreenOrDeps?: boolean | SimulatorScreenshotFlowDeps,
-  deps: SimulatorScreenshotFlowDeps = defaultSimulatorScreenshotFlowDeps,
-  runnerOptions?: AppleRunnerCommandOptions,
   options: SimulatorScreenshotFlowOptions = {},
 ): Promise<void> {
   if (device.kind !== 'simulator') {
@@ -112,40 +109,44 @@ export async function captureSimulatorScreenshotWithFallback(
     );
   }
 
-  const fullscreen = typeof fullscreenOrDeps === 'boolean' ? fullscreenOrDeps : undefined;
-  const effectiveDeps =
-    typeof fullscreenOrDeps === 'object' && fullscreenOrDeps !== null ? fullscreenOrDeps : deps;
+  const deps = options.deps ?? defaultSimulatorScreenshotFlowDeps;
 
   if (!options.skipBootCheck) {
-    await effectiveDeps.ensureBooted(device);
+    await deps.ensureBooted(device);
   }
   let restoreStatusBar = async () => {};
   try {
-    restoreStatusBar = await effectiveDeps.prepareStatusBarForScreenshot(device);
+    restoreStatusBar = await deps.prepareStatusBarForScreenshot(device);
   } catch (error) {
     emitStatusBarDiagnostic(device, 'prepare_failed', error);
   }
   try {
     try {
-      await effectiveDeps.captureWithRetry(device, outPath);
+      await deps.captureWithRetry(device, outPath);
       return;
     } catch (error) {
       let screenshotError = error;
       if (options.skipBootCheck && shouldEnsureBootedAfterSimulatorScreenshotFailure(error)) {
-        await effectiveDeps.ensureBooted(device);
+        await deps.ensureBooted(device);
         try {
-          await effectiveDeps.captureWithRetry(device, outPath);
+          await deps.captureWithRetry(device, outPath);
           return;
         } catch (retryError) {
           screenshotError = retryError;
         }
       }
-      if (!effectiveDeps.shouldFallbackToRunner(screenshotError)) {
+      if (!deps.shouldFallbackToRunner(screenshotError)) {
         throw screenshotError;
       }
       emitScreenshotFallbackDiagnostic(device, 'simctl_screenshot', screenshotError);
     }
-    await effectiveDeps.captureWithRunner(device, outPath, appBundleId, fullscreen, runnerOptions);
+    await deps.captureWithRunner(
+      device,
+      outPath,
+      options.appBundleId,
+      options.fullscreen,
+      options.runnerOptions,
+    );
   } finally {
     await restoreStatusBar().catch((error) =>
       emitStatusBarDiagnostic(device, 'restore_failed', error),


### PR DESCRIPTION
## Summary

Skip the redundant `ensureBootedSimulator` probe for session-backed iOS simulator screenshots. The simulator screenshot path already uses `xcrun simctl io <udid> screenshot <path>` and keeps physical devices/macOS on their existing paths; this change avoids an extra `simctl list devices -j` call once the daemon has an active simulator session.

Closes #916

Touched files: 8. Scope stayed within screenshot command/runtime handoff, iOS simulator screenshot path selection, and focused tests.

## Validation

Static and focused checks passed:

- `node ./node_modules/oxfmt/bin/oxfmt --write ...`
- `./node_modules/.bin/vitest run --project unit src/platforms/ios/__tests__/index.test.ts src/daemon/__tests__/request-router-screenshot.test.ts` - 101 tests passed
- `./node_modules/.bin/tsc -p tsconfig.json`
- `./node_modules/.bin/oxlint . --deny-warnings`
- `./node_modules/.bin/rslib build`
- `node --test test/integration/smoke-*.test.ts` - 8 passed, 1 skipped
- `./node_modules/.bin/vitest run --project unit --testTimeout=15000` - 285/286 files passed; one unrelated `daemon-client` cleanup assertion failed in the aggregate run, then `./node_modules/.bin/vitest run --project unit src/utils/__tests__/daemon-client.test.ts --testTimeout=15000` passed 28/28 on rerun. The unrelated Android file that failed with default timeout also passed on rerun with `--testTimeout=15000`.

Simulator evidence on iPhone 17 simulator `D74E0B66-57EB-4EC1-92DC-DA0A30581FE7`, iOS 26.2, Settings app session:

- Bare candidate `xcrun simctl io <udid> screenshot <path>`: 1418, 1102, 1594, 2633, 2582 ms; median 1594 ms.
- Public `agent-device screenshot` before this change, after `open settings`: 5164, 4939, 5439, 5152, 5194 ms; median 5164 ms.
- Public `agent-device screenshot` after this change, after rebuild/daemon cleanup/open: 5636, 4739, 4699, 4838, 4905 ms; median 4838 ms.

The remaining gap is mostly simulator status-bar normalization/restoration, measured separately as roughly 700-970 ms per `status_bar` command. This PR keeps that behavior to preserve deterministic screenshots and host simulator state restoration.
