### PR TITLE
refactor: consolidate apple/mobile platform family-groupings via shared predicates — Phase 3

### DIFF
--- a/src/daemon/handlers/session-open-target.ts
+++ b/src/daemon/handlers/session-open-target.ts
@@ -3,14 +3,14 @@ import {
   isWebUrl,
   resolveIosDeviceDeepLinkBundleId,
 } from '../../core/open-target.ts';
-import type { DeviceInfo } from '../../utils/device.ts';
+import { isApplePlatform, type DeviceInfo } from '../../utils/device.ts';
 
 async function resolveIosBundleIdForOpen(
   device: DeviceInfo,
   openTarget: string | undefined,
   currentAppBundleId?: string,
 ): Promise<string | undefined> {
-  if ((device.platform !== 'ios' && device.platform !== 'macos') || !openTarget) return undefined;
+  if (!isApplePlatform(device.platform) || !openTarget) return undefined;
   if (isDeepLinkTarget(openTarget)) {
     if (device.platform === 'macos') return undefined;
     if (device.kind === 'device') {

--- a/src/daemon/handlers/session-perf-xctrace.ts
+++ b/src/daemon/handlers/session-perf-xctrace.ts
@@ -1,4 +1,5 @@
 import { asAppError, normalizeError } from '../../utils/errors.ts';
+import { isApplePlatform } from '../../utils/device.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
 import {
@@ -40,7 +41,7 @@ export async function handleNativePerfCommand(
       'Android native profiling belongs to the Android perf rollout; Apple xctrace perf supports iOS and macOS sessions only.',
     );
   }
-  if (session.device.platform !== 'ios' && session.device.platform !== 'macos') {
+  if (!isApplePlatform(session.device.platform)) {
     return errorResponse(
       'UNSUPPORTED_OPERATION',
       `Apple xctrace perf is not supported on ${session.device.platform}.`,

--- a/src/daemon/handlers/session-perf.ts
+++ b/src/daemon/handlers/session-perf.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import type { SessionAction, SessionState } from '../types.ts';
 import { AppError, normalizeError } from '../../utils/errors.ts';
+import { isApplePlatform } from '../../utils/device.ts';
 import type { AndroidAdbExecutor } from '../../platforms/android/adb-executor.ts';
 import {
   ANDROID_HPROF_SNAPSHOT_DESCRIPTION,
@@ -546,7 +547,7 @@ function buildUnsupportedMemorySnapshotGuidance(
       hint: 'Use perf memory snapshot --kind android-hprof for Android Java heap artifacts.',
     };
   }
-  if (session.device.platform === 'ios' || session.device.platform === 'macos') {
+  if (isApplePlatform(session.device.platform)) {
     return {
       reason: `Apple perf memory snapshot supports memgraph, not ${kind}.`,
       hint: 'Use perf memory snapshot --kind memgraph for supported Apple app sessions.',
@@ -570,7 +571,7 @@ function buildMemorySnapshotSupport(session: SessionState): Record<string, unkno
         'Deferred until Android Perfetto/heapprofd plumbing is available in the perf trace slice.',
     };
   }
-  if (session.device.platform !== 'ios' && session.device.platform !== 'macos') {
+  if (!isApplePlatform(session.device.platform)) {
     return {
       platform: session.device.platform,
       defaultKind: 'memgraph',

--- a/src/daemon/handlers/session-test-discovery.ts
+++ b/src/daemon/handlers/session-test-discovery.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { AppError } from '../../utils/errors.ts';
-import type { PlatformSelector } from '../../utils/device.ts';
+import { isApplePlatform, type PlatformSelector } from '../../utils/device.ts';
 import { resolveRequestTrackingId } from '../request-cancel.ts';
 import { SessionStore } from '../session-store.ts';
 import { readReplayScriptMetadata, type ReplayScriptMetadata } from '../../replay/script.ts';
@@ -298,7 +298,7 @@ function looksLikeGlob(value: string): boolean {
 
 function matchesPlatformFilter(filter: PlatformSelector, candidate: PlatformSelector): boolean {
   if (filter === 'apple') {
-    return candidate === 'apple' || candidate === 'ios' || candidate === 'macos';
+    return isApplePlatform(candidate);
   }
   return candidate === filter;
 }

--- a/src/daemon/handlers/session-test-sharding.ts
+++ b/src/daemon/handlers/session-test-sharding.ts
@@ -4,6 +4,7 @@ import {
   resolveIosSimulatorDeviceSetPath,
 } from '../../utils/device-isolation.ts';
 import {
+  isMobilePlatform,
   matchesPlatformSelector,
   resolveAppleSimulatorSetPathForSelector,
   type DeviceInfo,
@@ -179,7 +180,7 @@ function resolveExplicitShardDevices(
 
 function isImplicitShardDevice(device: DeviceInfo, flags: CommandFlags | undefined): boolean {
   if (!isShardDeviceCandidate(device, flags)) return false;
-  if (device.platform !== 'ios' && device.platform !== 'android') return false;
+  if (!isMobilePlatform(device.platform)) return false;
   return device.booted !== false;
 }
 

--- a/src/daemon/handlers/snapshot-capture.ts
+++ b/src/daemon/handlers/snapshot-capture.ts
@@ -1,4 +1,5 @@
 import { dispatchCommand, type CommandFlags } from '../../core/dispatch.ts';
+import { isMobilePlatform } from '../../utils/device.ts';
 import { sleep } from '../../utils/timeouts.ts';
 import { runMacOsSnapshotAction } from '../../platforms/ios/macos-helper.ts';
 import { snapshotLinux } from '../../platforms/linux/snapshot.ts';
@@ -105,10 +106,7 @@ async function capturePostActionAwareSnapshot(
       pendingInteractionOutcome,
     );
   }
-  if (
-    (params.device.platform === 'ios' || params.device.platform === 'android') &&
-    params.session?.postGestureStabilization
-  ) {
+  if (isMobilePlatform(params.device.platform) && params.session?.postGestureStabilization) {
     return await capturePostGestureAwareSnapshot({ ...params, session: params.session });
   }
   const freshness = getActiveAndroidSnapshotFreshness(params.session);

--- a/src/daemon/interaction-outcome-policy.ts
+++ b/src/daemon/interaction-outcome-policy.ts
@@ -1,4 +1,5 @@
 import { dispatchCommand, type CommandFlags } from '../core/dispatch.ts';
+import { isMobilePlatform } from '../utils/device.ts';
 import type { SnapshotNode, SnapshotState } from '../utils/snapshot.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
 import { contextFromFlags } from './context.ts';
@@ -187,7 +188,7 @@ export function areInteractionSurfaceSignaturesStable(
 }
 
 function supportsInteractionOutcomePolicy(session: SessionState): boolean {
-  return session.device.platform === 'ios' || session.device.platform === 'android';
+  return isMobilePlatform(session.device.platform);
 }
 
 function retryCommandForTap(command: string): string | undefined {

--- a/src/daemon/post-gesture-stabilization.ts
+++ b/src/daemon/post-gesture-stabilization.ts
@@ -1,4 +1,5 @@
 import { emitDiagnostic } from '../utils/diagnostics.ts';
+import { isMobilePlatform } from '../utils/device.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
 import type { SnapshotState } from '../utils/snapshot.ts';
 import { sleep } from '../utils/timeouts.ts';
@@ -97,5 +98,5 @@ function isPostGestureStabilizingAction(
 }
 
 function supportsPostGestureStabilization(platform: SessionState['device']['platform']): boolean {
-  return platform === 'ios' || platform === 'android';
+  return isMobilePlatform(platform);
 }

--- a/src/platforms/ios/apple-runner-platform.ts
+++ b/src/platforms/ios/apple-runner-platform.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../../utils/errors.ts';
-import { resolveApplePlatformName, type DeviceInfo } from '../../utils/device.ts';
+import { isApplePlatform, resolveApplePlatformName, type DeviceInfo } from '../../utils/device.ts';
 
 export type RunnerApplePlatformName = 'iOS' | 'tvOS' | 'macOS';
 
@@ -75,7 +75,7 @@ const RUNNER_PLATFORM_PROFILES: Record<RunnerApplePlatformName, RunnerPlatformPr
 };
 
 export function resolveRunnerPlatformName(device: DeviceInfo): RunnerApplePlatformName {
-  if (device.platform !== 'ios' && device.platform !== 'macos') {
+  if (!isApplePlatform(device.platform)) {
     throw new AppError(
       'UNSUPPORTED_PLATFORM',
       `Unsupported platform for Apple runner: ${device.platform}`,

--- a/src/platforms/ios/perf-xctrace.ts
+++ b/src/platforms/ios/perf-xctrace.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { DeviceInfo } from '../../utils/device.ts';
+import { isApplePlatform, type DeviceInfo } from '../../utils/device.ts';
 import { AppError } from '../../utils/errors.ts';
 import { runCmdBackground, type ExecBackgroundResult, type ExecResult } from '../../utils/exec.ts';
 import { uniqueStrings } from '../../daemon/action-utils.ts';
@@ -209,7 +209,7 @@ async function resolveAppleXctracePerfTarget(
   device: DeviceInfo,
   appBundleId: string,
 ): Promise<{ pids: number[]; processNames: string[] }> {
-  if (device.platform !== 'ios' && device.platform !== 'macos') {
+  if (!isApplePlatform(device.platform)) {
     throw new AppError('UNSUPPORTED_OPERATION', 'Apple xctrace perf is not supported on Android.', {
       platform: device.platform,
       hint: 'Android native profiling belongs to the Android perf rollout and is not implemented under Apple xctrace.',

--- a/src/platforms/ios/runner-session.ts
+++ b/src/platforms/ios/runner-session.ts
@@ -2,7 +2,7 @@ import { AppError, toAppErrorCode } from '../../utils/errors.ts';
 import { runCmdBackground, type ExecResult, type ExecBackgroundResult } from '../../utils/exec.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
 import { Deadline } from '../../utils/retry.ts';
-import type { DeviceInfo } from '../../utils/device.ts';
+import { isApplePlatform, type DeviceInfo } from '../../utils/device.ts';
 import type { RunnerLogicalLeaseContext } from '../../core/runner-lease-context.ts';
 import type { AppleRunnerLifecycleOptions } from './runner-provider.ts';
 import { emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
@@ -478,7 +478,7 @@ async function verifyDeveloperModeForIosRunner(device: DeviceInfo): Promise<void
 }
 
 export function validateRunnerDevice(device: DeviceInfo): void {
-  if (device.platform !== 'ios' && device.platform !== 'macos') {
+  if (!isApplePlatform(device.platform)) {
     throw new AppError(
       'UNSUPPORTED_PLATFORM',
       `Unsupported platform for iOS runner: ${device.platform}`,

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -45,6 +45,11 @@ export function isApplePlatform(
   return platform === 'apple' || platform === 'ios' || platform === 'macos';
 }
 
+export function isMobilePlatform(platform: Platform): boolean {
+  // Leaf-platform family predicate: the two phone/tablet device platforms.
+  return platform === 'ios' || platform === 'android';
+}
+
 export function isPlatform(value: unknown): value is Platform {
   // Leaf-platform membership derived from the canonical PLATFORMS tuple (excludes the
   // `apple` selector, which is not a concrete device platform).


### PR DESCRIPTION
## What

Phase 3 (PlatformPlugin / ADR-0009) next slice: consolidate scattered **inline platform family-grouping branches** into the shared leaf predicates `isApplePlatform` (already in `src/utils/device.ts`) and a newly-added `isMobilePlatform`. This trims the open-coded `platform === '…'` branches that motivate Phase 3. **Strictly behaviorless** — every consolidated site returns an identical boolean for every possible platform input.

`isMobilePlatform` was **added** to `src/utils/device.ts` (used by ≥1 mobile site):

```ts
export function isMobilePlatform(platform: Platform): boolean {
  // Leaf-platform family predicate: the two phone/tablet device platforms.
  return platform === 'ios' || platform === 'android';
}
```

It is a simple leaf predicate (no registry, no core import — keeps `utils` at the bottom of the DAG, no cycle).

## Consolidated sites

### Apple grouping → `isApplePlatform(...)` (8 sites)

| Site (file:line) | Before | After |
|---|---|---|
| `src/daemon/handlers/session-test-discovery.ts:301` | `candidate === 'apple' \|\| candidate === 'ios' \|\| candidate === 'macos'` | `isApplePlatform(candidate)` |
| `src/daemon/handlers/session-perf.ts:550` | `=== 'ios' \|\| === 'macos'` | `isApplePlatform(session.device.platform)` |
| `src/daemon/handlers/session-perf.ts:574` | `!== 'ios' && !== 'macos'` | `!isApplePlatform(session.device.platform)` |
| `src/daemon/handlers/session-open-target.ts:13` | `(!== 'ios' && !== 'macos') \|\| !openTarget` | `!isApplePlatform(device.platform) \|\| !openTarget` |
| `src/daemon/handlers/session-perf-xctrace.ts:44` | `!== 'ios' && !== 'macos'` | `!isApplePlatform(session.device.platform)` |
| `src/platforms/ios/apple-runner-platform.ts:78` | `!== 'ios' && !== 'macos'` | `!isApplePlatform(device.platform)` |
| `src/platforms/ios/runner-session.ts:481` | `!== 'ios' && !== 'macos'` | `!isApplePlatform(device.platform)` |
| `src/platforms/ios/perf-xctrace.ts:212` | `!== 'ios' && !== 'macos'` | `!isApplePlatform(device.platform)` |

### Mobile grouping → `isMobilePlatform(...)` (4 sites)

| Site (file:line) | Before | After |
|---|---|---|
| `src/daemon/handlers/snapshot-capture.ts:109` | `=== 'ios' \|\| === 'android'` | `isMobilePlatform(params.device.platform)` |
| `src/daemon/interaction-outcome-policy.ts:191` | `=== 'ios' \|\| === 'android'` | `isMobilePlatform(session.device.platform)` |
| `src/daemon/post-gesture-stabilization.ts:101` | `=== 'ios' \|\| === 'android'` | `isMobilePlatform(platform)` |
| `src/daemon/handlers/session-test-sharding.ts:183` | `!== 'ios' && !== 'android'` | `!isMobilePlatform(device.platform)` |

## Intent verification (per site)

For each candidate the enclosing function was read and confirmed to mean exactly "is an Apple platform" / "is a mobile platform":

- **Apple sites** are all guards/branches whose `ios`/`macos` pair semantically means "Apple" (Apple runner profile, Apple xctrace perf, Apple memory-snapshot support, iOS/macOS open-target bundle resolution). Each input is a leaf `Platform` (`device.platform` / `session.device.platform`), except `session-test-discovery.ts:301` whose input is a `PlatformSelector` — there the inline body was **literally** `isApplePlatform`'s body (`'apple' || 'ios' || 'macos'`), so the swap is exact for all selector inputs including `'apple'`.
- Negated Apple sites preserve type-narrowing: `isApplePlatform` is a **type guard** (`platform is ApplePlatform | 'apple'`), so `!isApplePlatform(...)` narrows the fall-through to `'ios' | 'macos'` exactly as the inline `!== 'ios' && !== 'macos'` did. tsc passes with no new casts.
- Since the inputs are leaf `Platform` (never the `'apple'` selector), `isApplePlatform`'s extra `=== 'apple'` disjunct is dead at these sites — boolean output is identical to `ios || macos` for every possible input.
- **Mobile sites** are all leaf-`Platform` booleans (post-gesture stabilization applies to ios/android; interaction-outcome policy supported on ios/android; implicit shard devices are mobile). `isMobilePlatform` is a plain boolean (not a type guard) and no site relied on narrowing after the swap.

## Deliberately SKIPPED (with reasons)

**Not behaviorless / not a clean family grouping:**
- `src/client-shared.ts:43` — discriminator (`android ? serial : ios ? udid`), different behavior per platform, not a grouping.
- `src/core/command-descriptor/registry.ts:49` — `android || (ios && target !== 'tv')`, carries a `target` check, not a clean mobile grouping.
- `src/core/command-descriptor/registry.ts:213-215` — inside a `supports()` device closure (out of scope per ADR-0009 / plan §7) and enumerates `android || linux || macos`, not a family grouping.
- `src/core/platform-inventory.ts:90` — `macos || (apple && desktop)`, host-Mac fast-path, not a clean apple grouping.
- `src/utils/session-binding.ts:86` — `ios || android || apple`, includes `'apple'` selector; not a mobile grouping.
- `src/compat/maestro/flow-control.ts:193` — `android || ios || web`, includes `web`; not a mobile grouping.
- `src/daemon/handlers/session-perf.ts:325-327` — `android || ios || macos` (all three), not a two-member family grouping.

**Input is not a leaf `Platform` and/or the comparison is a type-narrowing validation guard (swapping would lose narrowing or fail to typecheck):**
- `src/daemon/handlers/session-runtime.ts:65` (input `unknown`), `:83` (input includes `'apple'`/`undefined`, returns narrowed `RuntimePlatform`).
- `src/daemon/handlers/install-source.ts:37`, `src/upload-client.ts:167`, `src/client-normalizers.ts:173`, `src/daemon/http-server.ts:357` — validation/narrowing returning a narrowed `'ios' | 'android'` literal from `string` / `unknown` / `PlatformSelector | undefined`.
- `src/replay/script-utils.ts:111`, `:271` — narrowing guards over `'ios' | 'android' | undefined` / raw `string` (the literal compare also narrows for assignment/push).
- `src/cli/commands/connection-runtime.ts:380`, `:552` — input `CliFlags['platform']` = `PlatformSelector | undefined` (includes `'apple'`); not a leaf `Platform`.
- `src/compat/maestro/command-mapper.ts:157`, `src/compat/maestro/runtime-assertions.ts:443` — input is `'ios' | 'android' | undefined` (Maestro context / optional-chained flags), not a leaf `Platform`; also load-bearing `compat/maestro` engine.

## Out of scope (deferred per ADR-0009)

- No `ios`+`macos` → `apple` `Platform` collapse and no `platforms/apple/` directory move (ADR-0009 last/highest-diff steps).
- Untouched: the `supports()` / `unsupportedHint()` device closures, the interactor factory / device discovery, and the Apple runner-profile tables (`RUNNER_PLATFORM_PROFILES` in `apple-runner-platform.ts` is left in place — only a guard above it changed).

## Verification

- `tsc -p tsconfig.json --noEmit` → exit 0
- `oxfmt --write` + `oxlint --deny-warnings` on all 12 changed files → clean
- `fallow audit --base origin/main` → **clean** (no newly-unused exports; `isMobilePlatform` is used)
- `vitest run dispatch core daemon utils compat` → **167 files / 1524 tests passed**
- Layering Guard `git grep -n -E "from '.*commands/" -- src/daemon src/platforms ':!src/**/__tests__/**' ':!*.test.ts'` → **empty**

A reviewer iOS smoke is recommended.
