### PR TITLE
feat: opt-in agent-cost wallClockMs behind --cost — Phase 4 slice 1

### DIFF
--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -221,6 +221,7 @@ function summarizeProviderScenarioFlagExclusions() {
         'help',
         'version',
         'verbose',
+        'cost',
       ],
     },
     {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -252,6 +252,7 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
           lockPlatform: binding.defaultPlatform,
           cwd: process.cwd(),
           debug: debugOutputEnabled,
+          cost: currentFlags.cost,
         });
         let parsedBatchSteps: BatchStep[] | undefined;
         if (command === 'batch') {

--- a/src/client-normalizers.ts
+++ b/src/client-normalizers.ts
@@ -352,6 +352,7 @@ export function buildMeta(options: InternalRequestOptions): DaemonRequest['meta'
     cwd: options.cwd,
     sessionExplicit: options.session !== undefined,
     debug: options.debug,
+    includeCost: options.cost,
     lockPolicy: options.lockPolicy,
     lockPlatform: options.lockPlatform,
     ...leaseScopeToRequestMeta(leaseScope),

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -69,6 +69,7 @@ export type AgentDeviceClientConfig = RemoteConnectionProfileFields & {
   runtime?: SessionRuntimeHints;
   cwd?: string;
   debug?: boolean;
+  cost?: boolean;
   iosXctestrunFile?: string;
   iosXctestDerivedDataPath?: string;
   iosXctestEnvDir?: string;
@@ -95,6 +96,7 @@ export type AgentDeviceRequestOverrides = Pick<
   | 'leaseTtlMs'
   | 'cwd'
   | 'debug'
+  | 'cost'
   | 'iosXctestrunFile'
   | 'iosXctestDerivedDataPath'
   | 'iosXctestEnvDir'

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -61,6 +61,7 @@ export type NetworkIncludeMode = (typeof NETWORK_INCLUDE_MODES)[number];
 export type DaemonRequestMeta = {
   requestId?: string;
   debug?: boolean;
+  includeCost?: boolean;
   cwd?: string;
   sessionExplicit?: boolean;
   tenantId?: string;
@@ -101,8 +102,11 @@ export type DaemonArtifact = {
   path?: string;
 };
 
+export type ResponseCost = { wallClockMs: number };
+
 export type DaemonResponseData = Record<string, unknown> & {
   artifacts?: DaemonArtifact[];
+  cost?: ResponseCost;
 };
 
 export type DaemonError = {
@@ -423,6 +427,7 @@ export const daemonCommandRequestSchema = schema<DaemonRequest>((input, path) =>
         : {
             requestId: optionalString(meta, 'requestId', `${path}.meta`),
             debug: optionalBoolean(meta, 'debug', `${path}.meta`),
+            includeCost: optionalBoolean(meta, 'includeCost', `${path}.meta`),
             cwd: optionalString(meta, 'cwd', `${path}.meta`),
             sessionExplicit: optionalBoolean(meta, 'sessionExplicit', `${path}.meta`),
             tenantId: optionalString(meta, 'tenantId', `${path}.meta`),

--- a/src/daemon-client.ts
+++ b/src/daemon-client.ts
@@ -48,6 +48,7 @@ export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<D
       ...(req.meta ?? {}),
       requestId,
       debug,
+      includeCost: req.meta?.includeCost,
       cwd: req.meta?.cwd,
       sessionExplicit: req.meta?.sessionExplicit,
       tenantId: req.meta?.tenantId ?? req.flags?.tenant,

--- a/src/daemon/__tests__/request-router-cost.test.ts
+++ b/src/daemon/__tests__/request-router-cost.test.ts
@@ -1,0 +1,157 @@
+import { test, expect, vi, beforeEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../core/dispatch.ts')>();
+  return { ...actual, dispatchCommand: vi.fn(async () => ({})) };
+});
+
+vi.mock('../../platforms/ios/runner-client.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../platforms/ios/runner-client.ts')>();
+  return { ...actual, stopIosRunnerSession: vi.fn(async () => {}) };
+});
+
+vi.mock('../device-ready.ts', () => ({ ensureDeviceReady: vi.fn(async () => {}) }));
+
+import { dispatchCommand } from '../../core/dispatch.ts';
+import { createRequestHandler } from '../request-router.ts';
+import type { DaemonRequest, SessionState } from '../types.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { daemonCommandRequestSchema } from '../../contracts.ts';
+
+const mockDispatch = vi.mocked(dispatchCommand);
+
+// A representative, structurally rich daemon payload so the parity assertions
+// exercise nested objects/arrays rather than a trivial flat record.
+const REPRESENTATIVE_PAYLOAD = {
+  message: 'home-ok',
+  detail: { nested: true, count: 3 },
+  items: [1, 2, 3],
+} as const;
+
+function makeIosSession(name: string): SessionState {
+  return {
+    name,
+    createdAt: 1_700_000_000_000,
+    actions: [],
+    device: {
+      platform: 'ios',
+      target: 'mobile',
+      id: 'SIM-001',
+      name: 'iPhone 16',
+      kind: 'simulator',
+      booted: true,
+      simulatorSetPath: '/tmp/tenant-a/set',
+    },
+  };
+}
+
+function makeHandler(sessionStore = makeSessionStore('agent-device-router-cost-')) {
+  return {
+    sessionStore,
+    handler: createRequestHandler({
+      logPath: path.join(os.tmpdir(), 'daemon.log'),
+      token: 'test-token',
+      sessionStore,
+      leaseRegistry: new LeaseRegistry(),
+      trackDownloadableArtifact: () => 'artifact-id',
+    }),
+  };
+}
+
+function baseRequest(overrides: Partial<DaemonRequest> = {}): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'cost-session',
+    command: 'home',
+    positionals: [],
+    flags: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockDispatch.mockReset();
+  mockDispatch.mockImplementation(async () => ({ ...REPRESENTATIVE_PAYLOAD }));
+});
+
+test('(a) flag-off identity: meta.includeCost absent === no meta at all, byte-identical and no cost', async () => {
+  const { sessionStore, handler } = makeHandler();
+  sessionStore.set('cost-session', makeIosSession('cost-session'));
+
+  const respNoMeta = await handler(baseRequest());
+  const respMetaWithoutCost = await handler(baseRequest({ meta: {} }));
+
+  // The serialized wire shape must be identical whether `meta` is omitted or
+  // present-without-includeCost. This is the Maestro `.ad` recompare invariant.
+  expect(JSON.stringify(respNoMeta)).toBe(JSON.stringify(respMetaWithoutCost));
+
+  expect(respNoMeta.ok).toBe(true);
+  expect(respMetaWithoutCost.ok).toBe(true);
+  if (respMetaWithoutCost.ok) {
+    expect('cost' in (respMetaWithoutCost.data ?? {})).toBe(false);
+  }
+  if (respNoMeta.ok) {
+    expect(respNoMeta.data).toEqual(REPRESENTATIVE_PAYLOAD);
+  }
+});
+
+test('(b) flag-on additive-only: cost.wallClockMs is the ONLY delta vs flag-off', async () => {
+  const { sessionStore, handler } = makeHandler();
+  sessionStore.set('cost-session', makeIosSession('cost-session'));
+
+  const respFlagOff = await handler(baseRequest());
+  const respFlagOn = await handler(baseRequest({ meta: { includeCost: true } }));
+
+  expect(respFlagOff.ok).toBe(true);
+  expect(respFlagOn.ok).toBe(true);
+  if (!respFlagOff.ok || !respFlagOn.ok) return;
+
+  const cost = respFlagOn.data?.cost;
+  expect(typeof cost?.wallClockMs).toBe('number');
+  expect(cost?.wallClockMs).toBeGreaterThanOrEqual(0);
+
+  // Deleting the single added key must leave a payload deep-equal to flag-off.
+  delete respFlagOn.data?.cost;
+  expect(respFlagOn.data).toEqual(respFlagOff.data);
+});
+
+test('(c) error path: a failing request with includeCost:true produces NO cost', async () => {
+  const { sessionStore, handler } = makeHandler();
+  sessionStore.set('cost-session', makeIosSession('cost-session'));
+
+  // Conflicting explicit selector under a reject lock policy fails before dispatch.
+  const failingRequest = baseRequest({
+    flags: { udid: 'SIM-999' },
+    meta: { lockPolicy: 'reject', includeCost: true },
+  });
+
+  const errOn = await handler(failingRequest);
+  expect(errOn.ok).toBe(false);
+  // The graft is gated on `response.ok`, so an error response is returned
+  // untouched: it carries an `error` (no `data`) and never a `cost` key.
+  expect('cost' in errOn).toBe(false);
+  expect((errOn as { data?: unknown }).data).toBeUndefined();
+  if (!errOn.ok) {
+    expect(errOn.error.code).toBe('INVALID_ARGS');
+    expect('cost' in errOn.error).toBe(false);
+  }
+});
+
+test('(d) boundary survival: meta.includeCost survives daemonCommandRequestSchema parsing', () => {
+  const parsed = daemonCommandRequestSchema.parse({
+    command: 'home',
+    positionals: [],
+    meta: { includeCost: true },
+  });
+  expect(parsed.meta?.includeCost).toBe(true);
+
+  const parsedOff = daemonCommandRequestSchema.parse({
+    command: 'home',
+    positionals: [],
+    meta: {},
+  });
+  expect(parsedOff.meta?.includeCost).toBeUndefined();
+});

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -4,6 +4,7 @@ import {
 } from '../core/dispatch-resolve.ts';
 import { AppError, normalizeError } from '../utils/errors.ts';
 import { timingSafeStringEqual } from '../utils/timing-safe-equal.ts';
+import type { ResponseCost } from '../contracts.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from './types.ts';
 import { SessionStore } from './session-store.ts';
 import { noActiveSessionError } from './handlers/response.ts';
@@ -79,8 +80,9 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
   const { sessionStore, leaseRegistry } = deps;
 
   async function handleRequest(req: DaemonRequest): Promise<DaemonResponse> {
+    const start = Date.now();
     const debug = Boolean(req.meta?.debug || req.flags?.verbose);
-    return await withDiagnosticsScope(
+    const response = await withDiagnosticsScope(
       {
         session: req.session,
         requestId: req.meta?.requestId,
@@ -107,6 +109,13 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
         }
       },
     );
+    // Phase 4 (agent-cost) graft: cost is purely additive and opt-in. With the
+    // flag off — or on an error response — the serialized DaemonResponse is
+    // byte-identical to today (Maestro `.ad` recompare diffs it). Mirrors the
+    // conditional `registerDownloadableArtifacts` spread in request-finalization.
+    if (!req.meta?.includeCost || !response.ok) return response;
+    const cost: ResponseCost = { wallClockMs: Date.now() - start };
+    return { ok: true, data: { ...(response.data ?? {}), cost } };
   }
 
   async function executeRequestScope(

--- a/src/utils/cli-flags.ts
+++ b/src/utils/cli-flags.ts
@@ -65,6 +65,7 @@ export type CliFlags = RemoteConfigMetroOptions &
     bundleUrl?: string;
     launchUrl?: string;
     verbose?: boolean;
+    cost?: boolean;
     snapshotInteractiveOnly?: boolean;
     snapshotDiff?: boolean;
     snapshotDepth?: number;
@@ -776,6 +777,13 @@ const FLAG_DEFINITIONS: readonly FlagDefinition[] = [
       'Enable debug diagnostics; test --verbose prints per-test step timings without debug logs',
   },
   {
+    key: 'cost',
+    names: ['--cost'],
+    type: 'boolean',
+    usageLabel: '--cost',
+    usageDescription: 'Include per-command wall-clock latency (cost.wallClockMs) in the response',
+  },
+  {
     key: 'json',
     names: ['--json'],
     type: 'boolean',
@@ -1131,7 +1139,14 @@ export const COMMON_COMMAND_SUPPORTED_FLAG_KEYS = flagKeys(
   'noRecord',
 );
 
-export const GLOBAL_FLAG_KEYS = new Set<FlagKey>(['json', 'config', 'help', 'version', 'verbose']);
+export const GLOBAL_FLAG_KEYS = new Set<FlagKey>([
+  'json',
+  'config',
+  'help',
+  'version',
+  'verbose',
+  'cost',
+]);
 
 const flagDefinitionByName = new Map<string, FlagDefinition>();
 for (const definition of FLAG_DEFINITIONS) {


### PR DESCRIPTION
## What

Phase 4 (agent-cost grafts), **slice 1**: add per-command wall-clock latency as a **purely additive, opt-in** response field, end to end.

When a request opts in (via the new global `--cost` flag / `meta.includeCost`), a successful `DaemonResponse` gains a single `cost.wallClockMs` key. When the flag is off — or the response is an error — the serialized response is **byte-identical to today**, so the Maestro `.ad` recompare path is unaffected.

## Design (mirrors two existing precedents)

**Opt-in flag plumbing — mirrors `--debug`:**
- `src/utils/cli-flags.ts`: new `{ key:'cost', names:['--cost'], type:'boolean' }` FlagDefinition; `cost?: boolean` on `CliFlags`; `'cost'` added to `GLOBAL_FLAG_KEYS` (accepted on every command).
- `src/client-types.ts`: `cost?: boolean` on `AgentDeviceClientConfig` and in the `AgentDeviceRequestOverrides` pick.
- `src/cli.ts`: `cost: currentFlags.cost` in `buildClientConfig`.
- `src/client-normalizers.ts`: `includeCost: options.cost` in `buildMeta` (stripUndefined'd, so absent when off).
- `src/contracts.ts`: `includeCost?: boolean` on `DaemonRequestMeta` **and** whitelisted in `daemonCommandRequestSchema` (`optionalBoolean(meta, 'includeCost', …)`) so it survives parse-at-boundary at the HTTP edge.
- `src/daemon-client.ts`: explicit `includeCost` forwarding for symmetry with the existing meta field list (the `...(req.meta ?? {})` spread already carried it).

**Response type:** `src/contracts.ts` adds `export type ResponseCost = { wallClockMs: number }` and `cost?: ResponseCost` on `DaemonResponseData` (alongside `artifacts?`).

**The graft — `src/daemon/request-router.ts` `handleRequest`** (the seam that owns the whole request incl. lock + execute + finalize and already reads `req.meta?.debug`): capture `const start = Date.now()` at the top, then after the response is produced:

```ts
if (!req.meta?.includeCost || !response.ok) return response; // flag off OR error ⇒ untouched
const cost: ResponseCost = { wallClockMs: Date.now() - start };
return { ok: true, data: { ...(response.data ?? {}), cost } };
```

This mirrors the conditional `registerDownloadableArtifacts` spread in `request-finalization.ts`: the response is returned unchanged unless opted in. The router (not finalize) owns the outer wall-clock, since finalize runs inside the locked scope and from multiple call sites.

## Byte-identical guarantee (Maestro-safe)

When `--cost` is off, `handleRequest` returns the exact `response` object untouched (no reconstruction), so key order and bytes are preserved. Proven by the parity test `src/daemon/__tests__/request-router-cost.test.ts`:

- **(a) flag-off identity:** a request with `meta.includeCost` absent is `JSON.stringify`-equal to the same request with no `meta` at all, and `'cost'` is not present in `data`.
- **(b) flag-on additive-only:** the same request with `meta.includeCost:true` yields `data.cost.wallClockMs` (a number ≥ 0); deleting that one key deep-equals the flag-off payload — the only delta is the added key.
- **(c) error path:** a failing request (reject lock policy) with `includeCost:true` produces no cost (gated on `response.ok`).
- **(d) boundary survival:** `meta.includeCost:true` survives `daemonCommandRequestSchema` parsing.

## Notes
- Additive / **semver-minor**.
- `cost` rides on `response.data`, so the typed client already surfaces it; explicit typing on the seeded `CommandResult` map was intentionally left out (it conflicts with the exact-equality contract test) and the MCP exposure plus richer signals (`roundTrips`, `nodeCount`) are deferred to follow-up slices.

## Verification
- `tsc --noEmit` exit 0
- `oxfmt --write` + `oxlint --deny-warnings` clean
- `fallow audit --base origin/main` clean (the new `ResponseCost` export + `cost` flag are used by the graft and plumbing)
- `vitest run daemon contracts client core` → 134 files / 1220 tests pass; new cost test 4/4
- Layering Guard grep empty

A reviewer should run an iOS smoke with `--cost` on/off to confirm the default wire shape is unchanged and the field appears only when opted in.