### PR TITLE
feat: infer install target from artifact

### DIFF
--- a/src/__tests__/remote-connection.test.ts
+++ b/src/__tests__/remote-connection.test.ts
@@ -701,6 +701,73 @@ test('proxy open resolves device key before allocating lease', async () => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
 
+test('proxy install allocates a device lease before dispatch', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-connect-proxy-install-'));
+  const stateDir = path.join(tempRoot, '.state');
+  const remoteConfigPath = path.join(tempRoot, 'remote.json');
+  fs.writeFileSync(remoteConfigPath, JSON.stringify({ daemonBaseUrl: 'https://daemon.example' }));
+  writeRemoteConnectionState({
+    stateDir,
+    state: {
+      version: 1,
+      session: 'adc-proxy',
+      remoteConfigPath,
+      remoteConfigHash: hashRemoteConfigFile(remoteConfigPath),
+      daemon: { baseUrl: 'https://daemon.example' },
+      tenant: 'proxy',
+      runId: 'proxy-client-1',
+      leaseProvider: 'proxy',
+      clientId: 'client-1',
+      connectedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  });
+  let allocateRequest: Parameters<AgentDeviceClient['leases']['allocate']>[0] | undefined;
+
+  const materialized = await materializeRemoteConnectionForCommand({
+    command: 'install',
+    flags: {
+      json: true,
+      help: false,
+      version: false,
+      stateDir,
+      remoteConfig: remoteConfigPath,
+      daemonBaseUrl: 'https://daemon.example',
+      tenant: 'proxy',
+      runId: 'proxy-client-1',
+      session: 'adc-proxy',
+      platform: 'android',
+    },
+    client: createTestClient({
+      allocate: async (request) => {
+        allocateRequest = request;
+        return {
+          leaseId: 'android-lease-1',
+          tenantId: request.tenant,
+          runId: request.runId,
+          backend: request.leaseBackend ?? 'android-instance',
+          leaseProvider: request.leaseProvider,
+          clientId: request.clientId,
+          deviceKey: request.deviceKey,
+        };
+      },
+    }),
+  });
+
+  assert.equal(allocateRequest?.leaseProvider, 'proxy');
+  assert.equal(allocateRequest?.clientId, 'client-1');
+  assert.equal(allocateRequest?.deviceKey, 'android:mobile:emulator-5554');
+  assert.equal(allocateRequest?.ttlMs, PROXY_REMOTE_LEASE_TTL_MS);
+  assert.equal(allocateRequest?.leaseBackend, 'android-instance');
+  assert.equal(materialized.flags.leaseId, 'android-lease-1');
+  assert.equal(materialized.flags.serial, 'emulator-5554');
+  const state = readRemoteConnectionState({ stateDir, session: 'adc-proxy' });
+  assert.equal(state?.leaseId, 'android-lease-1');
+  assert.equal(state?.deviceKey, 'android:mobile:emulator-5554');
+  assert.equal(state?.leaseProvider, 'proxy');
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
 test('proxy commands without active device lease fail before allocation', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-connect-proxy-closed-'));
   const stateDir = path.join(tempRoot, '.state');

--- a/src/cli/commands/connection-runtime.ts
+++ b/src/cli/commands/connection-runtime.ts
@@ -21,6 +21,7 @@ import type { LeaseBackend, SessionRuntimeHints } from '../../contracts.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import type { AgentDeviceClient, Lease } from '../../client.ts';
 import type { MetroPrepareKind } from '../../client-metro.ts';
+import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
 
 const leaseDeferredCommands = new Set([
   'connect',
@@ -31,6 +32,12 @@ const leaseDeferredCommands = new Set([
   'session',
 ]);
 const runtimeDeferredCommands = new Set(['open']);
+const proxyLeaseAllocatingCommands: ReadonlySet<string> = new Set([
+  PUBLIC_COMMANDS.open,
+  PUBLIC_COMMANDS.install,
+  PUBLIC_COMMANDS.reinstall,
+  INTERNAL_COMMANDS.installSource,
+]);
 export const PROXY_REMOTE_LEASE_TTL_MS = 5 * 60 * 1000;
 
 export async function materializeRemoteConnectionForCommand(options: {
@@ -661,7 +668,7 @@ async function resolveProxyLeaseState(options: {
   flags: CliFlags;
   leaseBackend?: LeaseBackend;
 }): Promise<{ state: RemoteConnectionState; device?: DeviceInfo }> {
-  if (options.command !== 'open') {
+  if (!proxyLeaseAllocatingCommands.has(options.command)) {
     if (options.state.leaseId && options.state.deviceKey) return { state: options.state };
     throw new AppError(
       'INVALID_ARGS',

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -177,6 +177,12 @@ export type SessionCloseResult = {
   identifiers: AgentDeviceIdentifiers;
 };
 
+export type AppInstallOptions = AgentDeviceRequestOverrides &
+  AgentDeviceSelectionOptions & {
+    app?: string;
+    appPath: string;
+  };
+
 export type AppDeployOptions = AgentDeviceRequestOverrides &
   AgentDeviceSelectionOptions & {
     app: string;
@@ -955,7 +961,7 @@ export type AgentDeviceClient = {
     ) => Promise<SessionCloseResult>;
   };
   apps: {
-    install: (options: AppDeployOptions) => Promise<AppDeployResult>;
+    install: (options: AppInstallOptions) => Promise<AppDeployResult>;
     reinstall: (options: AppDeployOptions) => Promise<AppDeployResult>;
     installFromSource: (
       options: AppInstallFromSourceOptions,

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,7 @@ import type {
   AgentDeviceDaemonTransport,
   AppCloseOptions,
   AppDeployOptions,
+  AppInstallOptions,
   AppInstallFromSourceOptions,
   AppListOptions,
   AppOpenOptions,
@@ -142,7 +143,7 @@ export function createAgentDeviceClient(
       },
     },
     apps: {
-      install: async (options: AppDeployOptions) =>
+      install: async (options: AppInstallOptions) =>
         normalizeDeployResult(
           await executeCommand('install', options),
           resolveRequestSession(options),

--- a/src/commands/management/install.ts
+++ b/src/commands/management/install.ts
@@ -26,7 +26,7 @@ import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import { managementCliOutputFormatters } from './output.ts';
 
 const installCommandMetadata = defineFieldCommandMetadata('install', 'Install an app binary.', {
-  app: requiredField(stringField()),
+  app: stringField('Optional app identifier hint.'),
   appPath: requiredField(stringField('Path to app binary.')),
 });
 
@@ -66,7 +66,9 @@ const installFromSourceCommandDefinition = defineExecutableCommand(
 );
 
 const installCliSchema = {
-  positionalArgs: ['app', 'path'],
+  usageOverride: 'install <path> | install <app> <path>',
+  listUsageOverride: 'install <path>',
+  positionalArgs: ['appOrPath', 'path?'],
 } as const satisfies CommandSchemaOverride;
 
 const reinstallCliSchema = {
@@ -84,11 +86,10 @@ const installFromSourceCliSchema = {
   allowedFlags: ['header', 'githubActionsArtifact', 'installSource', 'retainPaths', 'retentionMs'],
 } as const satisfies CommandSchemaOverride;
 
-const installCliReader: CliReader = (positionals, flags) =>
-  installInputFromCli(positionals, flags, 'install');
+const installCliReader: CliReader = (positionals, flags) => installInputFromCli(positionals, flags);
 
 const reinstallCliReader: CliReader = (positionals, flags) =>
-  installInputFromCli(positionals, flags, 'reinstall');
+  reinstallInputFromCli(positionals, flags);
 
 const installFromSourceCliReader: CliReader = (positionals, flags) => ({
   ...commonInputFromFlags(flags),
@@ -98,7 +99,7 @@ const installFromSourceCliReader: CliReader = (positionals, flags) => ({
 });
 
 const installDaemonWriter: DaemonWriter = direct(PUBLIC_COMMANDS.install, (input) =>
-  requiredPair(input.app, input.appPath),
+  installPositionals(input.app, input.appPath),
 );
 
 const reinstallDaemonWriter: DaemonWriter = direct(PUBLIC_COMMANDS.reinstall, (input) =>
@@ -149,16 +150,27 @@ export const installManagementCommandFacets = [
   installFromSourceCommandFacet,
 ] as const;
 
-function installInputFromCli(
-  positionals: string[],
-  flags: CliFlags,
-  command: 'install' | 'reinstall',
-): Record<string, unknown> {
+function installInputFromCli(positionals: string[], flags: CliFlags): Record<string, unknown> {
+  const [first, second] = positionals;
+  const hasExplicitApp = second !== undefined;
   return {
     ...commonInputFromFlags(flags),
-    app: requiredString(positionals[0], `${command} requires app`),
-    appPath: requiredString(positionals[1], `${command} requires path`),
+    ...(hasExplicitApp ? { app: requiredString(first, 'install requires app') } : {}),
+    appPath: requiredString(hasExplicitApp ? second : first, 'install requires path'),
   };
+}
+
+function reinstallInputFromCli(positionals: string[], flags: CliFlags): Record<string, unknown> {
+  return {
+    ...commonInputFromFlags(flags),
+    app: requiredString(positionals[0], 'reinstall requires app'),
+    appPath: requiredString(positionals[1], 'reinstall requires path'),
+  };
+}
+
+function installPositionals(app: unknown, appPath: unknown): string[] {
+  const path = requiredDaemonString(appPath, 'missing app path');
+  return typeof app === 'string' && app.length > 0 ? [app, path] : [path];
 }
 
 function requiredPair(first: unknown, second: unknown): string[] {

--- a/src/daemon-artifacts.ts
+++ b/src/daemon-artifacts.ts
@@ -75,10 +75,11 @@ async function prepareRemoteInstallPackage(
   info: DaemonArtifactEndpoint,
   positionals: string[],
 ): Promise<string | undefined> {
-  const rawPath = positionals[1];
+  const pathIndex = positionals.length === 1 ? 0 : 1;
+  const rawPath = positionals[pathIndex];
   if (rawPath === undefined) return undefined;
   if (rawPath.startsWith('remote:')) {
-    positionals[1] = rawPath.slice('remote:'.length);
+    positionals[pathIndex] = rawPath.slice('remote:'.length);
     return undefined;
   }
 

--- a/src/daemon-client-lifecycle.ts
+++ b/src/daemon-client-lifecycle.ts
@@ -163,7 +163,7 @@ async function ensureRemoteDaemon(settings: DaemonClientSettings): Promise<Ensur
   }
   throw new AppError('COMMAND_FAILED', 'Remote daemon is unavailable', {
     daemonBaseUrl: settings.remoteBaseUrl,
-    hint: 'Verify AGENT_DEVICE_DAEMON_BASE_URL points to a reachable daemon with GET /health and POST /rpc.',
+    hint: 'Verify AGENT_DEVICE_DAEMON_BASE_URL points to a reachable daemon with GET /health and POST /rpc. If this CLI was connected with connect proxy, run agent-device disconnect to return to the local daemon.',
   });
 }
 

--- a/src/daemon/handlers/__tests__/session-reinstall.test.ts
+++ b/src/daemon/handlers/__tests__/session-reinstall.test.ts
@@ -185,6 +185,51 @@ test('install omits app id fields when platform op cannot resolve them', async (
   }
 });
 
+test('install accepts path without app id hint', async () => {
+  const sessionStore = makeStore();
+  const session = makeSession('default', {
+    platform: 'android',
+    id: 'emulator-5554',
+    name: 'Pixel',
+    kind: 'emulator',
+    booted: true,
+  });
+  sessionStore.set('default', session);
+  mockResolveTargetDevice.mockResolvedValue(session.device!);
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-install-path-only-'));
+  const appPath = path.join(tempRoot, 'Sample.apk');
+  fs.writeFileSync(appPath, 'placeholder');
+
+  mockDefaultInstallOpsAndroid.mockImplementation(async (_device, app, pathToBinary) => {
+    expect(app).toBe('');
+    expect(pathToBinary).toBe(appPath);
+    return { package: 'com.example.detected' };
+  });
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'install',
+      positionals: [appPath],
+      flags: {},
+    },
+    sessionName: 'default',
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+    invoke,
+  });
+
+  expect(response).toBeTruthy();
+  if (!response) return;
+  expect(response.ok).toBe(true);
+  if (response.ok) {
+    expect(response.data?.app).toBe('com.example.detected');
+    expect(response.data?.appId).toBe('com.example.detected');
+    expect(response.data?.package).toBe('com.example.detected');
+    expect(response.data?.appPath).toBe(appPath);
+  }
+});
+
 test('reinstall resolves uploaded artifacts by id and cleans temp files after completion', async () => {
   const sessionStore = makeStore();
   const session = makeSession('default', {

--- a/src/daemon/handlers/session-deploy.ts
+++ b/src/daemon/handlers/session-deploy.ts
@@ -95,14 +95,9 @@ export async function handleAppDeployCommand(params: {
   const flags = req.flags ?? {};
   const guard = requireSessionOrExplicitSelector(command, session, flags);
   if (guard) return guard;
-  const app = req.positionals?.[0]?.trim();
-  const appPathInput = req.positionals?.[1]?.trim();
-  if (!app || !appPathInput) {
-    return errorResponse(
-      'INVALID_ARGS',
-      `${command} requires: ${command} <app> <path-to-app-binary>`,
-    );
-  }
+  const deployTarget = resolveDeployTarget(command, req.positionals ?? []);
+  if (!deployTarget.ok) return deployTarget.response;
+  const { app, appPathInput } = deployTarget;
   const uploadedArtifactId = req.meta?.uploadedArtifactId;
 
   try {
@@ -120,50 +115,10 @@ export async function handleAppDeployCommand(params: {
     const unsupported = requireCommandSupported(command, device);
     if (unsupported) return unsupported;
 
-    let result: DeployCommandResult;
-
-    if (device.platform === 'ios') {
-      const iosResult = await deployOps.ios(device, app, appPath);
-      const bundleId = iosResult.bundleId;
-      result = bundleId
-        ? {
-            app,
-            appPath,
-            platform: 'ios',
-            appId: bundleId,
-            bundleId,
-            appName: iosResult.appName,
-            launchTarget: iosResult.launchTarget,
-          }
-        : {
-            app,
-            appPath,
-            platform: 'ios',
-            appName: iosResult.appName,
-            launchTarget: iosResult.launchTarget,
-          };
-    } else {
-      const androidResult = await deployOps.android(device, app, appPath);
-      const pkg = androidResult.package;
-      result = pkg
-        ? {
-            app,
-            appPath,
-            platform: 'android',
-            appId: pkg,
-            package: pkg,
-            packageName: pkg,
-            appName: androidResult.appName,
-            launchTarget: androidResult.launchTarget,
-          }
-        : {
-            app,
-            appPath,
-            platform: 'android',
-            appName: androidResult.appName,
-            launchTarget: androidResult.launchTarget,
-          };
-    }
+    const result =
+      device.platform === 'ios'
+        ? buildIosDeployResult(app, appPath, await deployOps.ios(device, app, appPath))
+        : buildAndroidDeployResult(app, appPath, await deployOps.android(device, app, appPath));
 
     const data = withSuccessText(result, buildDeployMessage(result));
     recordSessionAction(sessionStore, session, req, command, data);
@@ -177,4 +132,67 @@ export async function handleAppDeployCommand(params: {
 
 function buildDeployMessage(result: DeployCommandResult): string {
   return `Installed: ${result.appName ?? resolveDeployResultTarget(result)}`;
+}
+
+function buildIosDeployResult(
+  app: string,
+  appPath: string,
+  iosResult: Awaited<ReturnType<AppDeployOps['ios']>>,
+): IosDeployCommandResult {
+  const bundleId = iosResult.bundleId;
+  const resultApp = app || bundleId || iosResult.launchTarget || appPath;
+  return {
+    app: resultApp,
+    appPath,
+    platform: 'ios',
+    ...(bundleId ? { appId: bundleId, bundleId } : {}),
+    appName: iosResult.appName,
+    launchTarget: iosResult.launchTarget,
+  };
+}
+
+function buildAndroidDeployResult(
+  app: string,
+  appPath: string,
+  androidResult: Awaited<ReturnType<AppDeployOps['android']>>,
+): AndroidDeployCommandResult {
+  const pkg = androidResult.package;
+  const resultApp = app || pkg || androidResult.launchTarget || appPath;
+  return {
+    app: resultApp,
+    appPath,
+    platform: 'android',
+    ...(pkg ? { appId: pkg, package: pkg, packageName: pkg } : {}),
+    appName: androidResult.appName,
+    launchTarget: androidResult.launchTarget,
+  };
+}
+
+function resolveDeployTarget(
+  command: 'install' | 'reinstall',
+  positionals: string[],
+): { ok: true; app: string; appPathInput: string } | { ok: false; response: DaemonResponse } {
+  const first = positionals[0]?.trim();
+  const second = positionals[1]?.trim();
+  if (command === 'install') {
+    const appPathInput = second ?? first;
+    if (!appPathInput) {
+      return {
+        ok: false,
+        response: errorResponse('INVALID_ARGS', 'install requires: install <path-to-app-binary>'),
+      };
+    }
+    return { ok: true, app: second ? (first ?? '') : '', appPathInput };
+  }
+
+  if (!first || !second) {
+    return {
+      ok: false,
+      response: errorResponse(
+        'INVALID_ARGS',
+        'reinstall requires: reinstall <app> <path-to-app-binary>',
+      ),
+    };
+  }
+  return { ok: true, app: first, appPathInput: second };
 }

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -384,6 +384,14 @@ test('parseArgs accepts install command args', () => {
   assert.deepEqual(parsed.positionals, ['com.example.app', './build/app.apk']);
 });
 
+test('parseArgs accepts install with artifact path only', () => {
+  const parsed = parseArgs(['install', './build/app.apk'], {
+    strictFlags: true,
+  });
+  assert.equal(parsed.command, 'install');
+  assert.deepEqual(parsed.positionals, ['./build/app.apk']);
+});
+
 test('parseArgs accepts install-from-source url and repeated headers', () => {
   const parsed = parseArgs(
     [

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -871,6 +871,37 @@ test('sendToDaemon rejects remote daemon RPC protocol mismatches before RPC', as
   }
 });
 
+test('sendToDaemon hints to disconnect when a remote daemon is unavailable', async () => {
+  const restoreHttpRequest = mockEventHttpRequest(({ res }) => {
+    res.statusCode = 503;
+    res.emit('end');
+  });
+
+  try {
+    await withRemoteDaemonEnv(async () => {
+      let error: unknown;
+      try {
+        await sendToDaemon({
+          session: 'default',
+          command: 'session',
+          positionals: ['list'],
+          flags: {},
+          meta: { requestId: 'req-remote-unavailable' },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      assert.ok(error instanceof Error);
+      assert.equal((error as any).code, 'COMMAND_FAILED');
+      assert.equal(error.message, 'Remote daemon is unavailable');
+      assert.match(String((error as any).details?.hint ?? ''), /agent-device disconnect/);
+    });
+  } finally {
+    restoreHttpRequest();
+  }
+});
+
 test('sendToDaemon sends lease helpers as top-level JSON-RPC methods over HTTP', async () => {
   const rpcRequests: Record<string, unknown>[] = [];
   const originalHttpRequest = http.request;

--- a/test/integration/provider-scenarios/remote-daemon-client.test.ts
+++ b/test/integration/provider-scenarios/remote-daemon-client.test.ts
@@ -324,14 +324,16 @@ function writeRemoteSuccess(
 }
 
 function writeInstallSuccess(res: http.ServerResponse, payload: RemoteRpcRequest): void {
+  const positionals = payload.params?.positionals ?? [];
+  const appPath = positionals.length === 1 ? positionals[0] : positionals[1];
   writeJson(res, 200, {
     jsonrpc: '2.0',
     id: payload.id,
     result: {
       ok: true,
       data: {
-        app: payload.params?.positionals?.[0],
-        appPath: payload.params?.positionals?.[1],
+        app: positionals.length === 1 ? 'com.example.demo' : positionals[0],
+        appPath,
         platform: 'android',
         package: 'com.example.demo',
       },
@@ -456,7 +458,6 @@ async function assertInstallUpload(
   uploadRequests: UploadRequest[],
 ): Promise<void> {
   const install = await client.apps.install({
-    app: 'Demo',
     appPath: paths.localApkPath,
     platform: 'android',
   });
@@ -469,7 +470,7 @@ async function assertInstallUpload(
 
   const installRpc = rpcRequests.at(-1);
   assert.equal(installRpc?.params?.command, 'install');
-  assert.equal(installRpc?.params?.positionals?.[1], paths.localApkPath);
+  assert.deepEqual(installRpc?.params?.positionals, [paths.localApkPath]);
   assert.equal(installRpc?.params?.meta?.uploadedArtifactId, 'upload-demo.apk');
 }
 


### PR DESCRIPTION
## Summary

Allow install to accept an artifact path directly: agent-device install PATH, while preserving the existing install APP PATH form for explicit hints.

Proxy/direct-remote install now allocates a device lease directly, so users can install first and then open the installed app without running a dummy open command. Remote unavailable errors also hint to run disconnect when the local CLI is still connected to an old proxy.

Touched files: 12 across the PR. Scope is limited to install command parsing/projection, deploy handling, remote artifact preparation, proxy lease materialization, and focused tests.

## Validation

Verified CLI help renders install PATH | install APP PATH. Ran quick static checks, Fallow, focused CLI/deploy/provider tests, focused remote/proxy daemon-client tests, and the full unit/smoke bundle successfully.