### PR TITLE
feat: expose opt-in agent-cost over MCP via includeCost — Phase 4 slice 2

### DIFF
--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -95,6 +95,65 @@ test('MCP tool schemas add MCP client config fields at the MCP boundary', () => 
     (devicesTool.inputSchema.properties?.mcpOutputFormat as { enum?: unknown[] } | undefined)?.enum,
     ['optimized', 'json'],
   );
+  assert.equal(
+    (devicesTool.inputSchema.properties?.includeCost as { type?: string } | undefined)?.type,
+    'boolean',
+  );
+});
+
+test('MCP includeCost:true opts into agent-cost: sets client.cost, strips the arg, surfaces cost', async () => {
+  const createdConfigs: unknown[] = [];
+  const calls: unknown[] = [];
+  const executor = createCommandToolExecutor({
+    createClient: (config) => {
+      createdConfigs.push(config);
+      return {} as AgentDeviceClient;
+    },
+    runCommand: async (_client, name, input) => {
+      calls.push({ name, input });
+      return { message: `Ran ${name}`, cost: { wallClockMs: 42 } };
+    },
+  });
+
+  const result = await executor.execute('wait', { includeCost: true });
+
+  // includeCost maps to the client `cost` config (→ meta.includeCost on the daemon).
+  assert.deepEqual(createdConfigs, [{ cost: true }]);
+  // includeCost is an MCP-boundary field and must not leak into the command input.
+  assert.deepEqual(calls, [{ name: 'wait', input: {} }]);
+  // The daemon-provided cost rides through structuredContent unchanged.
+  assert.deepEqual(result.structuredContent, { message: 'Ran wait', cost: { wallClockMs: 42 } });
+});
+
+test('MCP includeCost absent/false leaves the request shape untouched (no cost config)', async () => {
+  const createdConfigs: unknown[] = [];
+  const executor = createCommandToolExecutor({
+    createClient: (config) => {
+      createdConfigs.push(config);
+      return {} as AgentDeviceClient;
+    },
+    runCommand: async () => ({ message: 'ok' }),
+  });
+
+  const absent = await executor.execute('wait', {});
+  const explicitFalse = await executor.execute('wait', { includeCost: false });
+
+  // Neither path sets `cost` on the client config; both are byte-identical configs.
+  assert.deepEqual(createdConfigs, [{}, {}]);
+  assert.deepEqual(absent.structuredContent, { message: 'ok' });
+  assert.equal(JSON.stringify(absent), JSON.stringify(explicitFalse));
+});
+
+test('MCP includeCost rejects non-boolean values at the boundary', async () => {
+  const executor = createCommandToolExecutor({
+    createClient: () => ({}) as AgentDeviceClient,
+    runCommand: async () => ({}),
+  });
+
+  await assert.rejects(
+    executor.execute('wait', { includeCost: 'yes' }),
+    /Expected includeCost to be a boolean\./,
+  );
 });
 
 test('MCP session tool exposes state-dir resolution without a daemon round-trip', async () => {

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -105,11 +105,18 @@ function readMcpToolConfig(input: unknown): McpToolConfig {
 
 function readClientConfig(record: Record<string, unknown>): AgentDeviceClientConfig {
   const stateDir = record.stateDir;
+  const includeCost = record.includeCost;
   const client: AgentDeviceClientConfig = {};
   if (stateDir !== undefined && (typeof stateDir !== 'string' || stateDir.length === 0)) {
     throw new Error('Expected stateDir to be a non-empty string.');
   }
   if (typeof stateDir === 'string') client.stateDir = stateDir;
+  if (includeCost !== undefined && typeof includeCost !== 'boolean') {
+    throw new Error('Expected includeCost to be a boolean.');
+  }
+  // Only set when explicitly true so the default request shape is untouched
+  // (cost rides on response.data → structuredContent only when opted in).
+  if (includeCost === true) client.cost = true;
   return client;
 }
 
@@ -126,6 +133,7 @@ function stripMcpConfigFields(input: unknown): unknown {
   const {
     stateDir: _stateDir,
     mcpOutputFormat: _mcpOutputFormat,
+    includeCost: _includeCost,
     ...commandInput
   } = input as Record<string, unknown>;
   return commandInput;
@@ -142,6 +150,11 @@ function withMcpConfigSchema(schema: JsonSchema): JsonSchema {
         enum: ['optimized', 'json'],
         description:
           'MCP text content format. Defaults to optimized agent-friendly text; use json for JSON text. Structured content is always returned separately.',
+      },
+      includeCost: {
+        type: 'boolean',
+        description:
+          'Include per-command agent-cost (cost.wallClockMs, …) in structuredContent. Defaults to off; the default response shape is unchanged.',
       },
     },
   };


### PR DESCRIPTION
## What

Phase 4 (agent-cost), **slice 2**: let MCP agents opt into the agent-cost field that [slice 1 (#922)](https://github.com/callstack/agent-device/pull/922) added to the daemon response.

Slice 1 added `cost.wallClockMs` on `response.data` behind `--cost` / `meta.includeCost`. Because the MCP executor already returns the raw daemon `response.data` as `structuredContent`, the cost value *already* rides through to MCP — what was missing was a way for an MCP caller to **opt in**. This slice adds that boundary opt-in, mirroring the existing `stateDir` / `mcpOutputFormat` MCP config fields.

## Changes (`src/mcp/command-tools.ts`)

- `readClientConfig` reads an `includeCost` tool argument and sets `client.cost = true` **only when it is `true`** (→ `meta.includeCost` on the daemon). Non-boolean values are rejected at the boundary.
- `stripMcpConfigFields` strips `includeCost` so it never leaks into the command input as a flag.
- `withMcpConfigSchema` advertises `includeCost: boolean` in every tool's `inputSchema`, so agents can discover it.

## Default-off is byte-identical

With `includeCost` absent or `false`, the client config carries no `cost` (so `meta.includeCost` is stripped) and the MCP `structuredContent` is unchanged. Proven by the new tests:

- schema exposure: every tool advertises `includeCost: boolean`.
- `includeCost: true` → config is `{ cost: true }`, the arg is stripped from command input, and the daemon-provided `cost` surfaces in `structuredContent`.
- `includeCost` absent vs `false` → identical (no `cost` config); `JSON.stringify`-equal MCP results.
- non-boolean `includeCost` is rejected.

## Notes
- Additive / **semver-minor**.
- The daemon graft is unchanged; this is purely the MCP-edge opt-in.
- Deferred to follow-ups: per-command MCP `outputSchema`, and richer cost signals (`roundTrips`, `nodeCount`) — the latter ships in a parallel slice-3 PR.

## Verification
- `tsc --noEmit` exit 0
- `oxfmt` + `oxlint --deny-warnings` clean
- `fallow audit --base origin/main` clean
- `vitest run src/mcp` → 3 files / 19 tests pass
- Layering Guard grep empty