### PR TITLE
feat: opt-in agent-cost runnerRoundTrips — Phase 4 slice 2

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -102,7 +102,7 @@ export type DaemonArtifact = {
   path?: string;
 };
 
-export type ResponseCost = { wallClockMs: number };
+export type ResponseCost = { wallClockMs: number; runnerRoundTrips: number };
 
 export type DaemonResponseData = Record<string, unknown> & {
   artifacts?: DaemonArtifact[];

--- a/src/daemon/__tests__/request-router-cost.test.ts
+++ b/src/daemon/__tests__/request-router-cost.test.ts
@@ -20,6 +20,7 @@ import type { DaemonRequest, SessionState } from '../types.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
 import { daemonCommandRequestSchema } from '../../contracts.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);
 
@@ -98,7 +99,7 @@ test('(a) flag-off identity: meta.includeCost absent === no meta at all, byte-id
   }
 });
 
-test('(b) flag-on additive-only: cost.wallClockMs is the ONLY delta vs flag-off', async () => {
+test('(b) flag-on additive-only: cost block is the ONLY delta vs flag-off', async () => {
   const { sessionStore, handler } = makeHandler();
   sessionStore.set('cost-session', makeIosSession('cost-session'));
 
@@ -109,8 +110,13 @@ test('(b) flag-on additive-only: cost.wallClockMs is the ONLY delta vs flag-off'
   expect(respFlagOn.ok).toBe(true);
   if (!respFlagOff.ok || !respFlagOn.ok) return;
 
+  // The cost block now carries BOTH wallClockMs and runnerRoundTrips, both
+  // numbers ≥ 0. A request that never touches the iOS runner reports 0 — honest.
   const cost = respFlagOn.data?.cost;
-  expect(typeof cost?.wallClockMs).toBe('number');
+  expect(cost).toMatchObject({
+    wallClockMs: expect.any(Number),
+    runnerRoundTrips: 0,
+  });
   expect(cost?.wallClockMs).toBeGreaterThanOrEqual(0);
 
   // Deleting the single added key must leave a payload deep-equal to flag-off.
@@ -118,7 +124,30 @@ test('(b) flag-on additive-only: cost.wallClockMs is the ONLY delta vs flag-off'
   expect(respFlagOn.data).toEqual(respFlagOff.data);
 });
 
-test('(c) error path: a failing request with includeCost:true produces NO cost', async () => {
+test('(c) runnerRoundTrips counts real iOS-runner round-trip diagnostics in scope', async () => {
+  const { sessionStore, handler } = makeHandler();
+  sessionStore.set('cost-session', makeIosSession('cost-session'));
+
+  // The mocked dispatch runs inside the request's diagnostics scope, so emitting
+  // here is equivalent to the runner-session emitting these phases per round-trip.
+  mockDispatch.mockImplementation(async () => {
+    emitDiagnostic({ phase: 'ios_runner_readiness_preflight' }); // real round-trip
+    emitDiagnostic({ phase: 'ios_runner_command_send' }); // real round-trip
+    emitDiagnostic({ phase: 'ios_runner_command_send' }); // real round-trip
+    emitDiagnostic({ level: 'debug', phase: 'ios_runner_readiness_preflight_skipped' }); // NOT
+    emitDiagnostic({ phase: 'some_other_phase' }); // NOT
+    return { ...REPRESENTATIVE_PAYLOAD };
+  });
+
+  const resp = await handler(baseRequest({ meta: { includeCost: true } }));
+  expect(resp.ok).toBe(true);
+  if (!resp.ok) return;
+  // 1 preflight + 2 command_send = 3; the _skipped marker and unrelated phases
+  // are excluded.
+  expect(resp.data?.cost?.runnerRoundTrips).toBe(3);
+});
+
+test('(d) error path: a failing request with includeCost:true produces NO cost', async () => {
   const { sessionStore, handler } = makeHandler();
   sessionStore.set('cost-session', makeIosSession('cost-session'));
 
@@ -140,7 +169,7 @@ test('(c) error path: a failing request with includeCost:true produces NO cost',
   }
 });
 
-test('(d) boundary survival: meta.includeCost survives daemonCommandRequestSchema parsing', () => {
+test('(e) boundary survival: meta.includeCost survives daemonCommandRequestSchema parsing', () => {
   const parsed = daemonCommandRequestSchema.parse({
     command: 'home',
     positionals: [],

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -20,6 +20,7 @@ import {
   withRequestPlatformProviderScope,
 } from './request-platform-providers.ts';
 import {
+  countDiagnosticEventsByPhase,
   emitDiagnostic,
   flushDiagnosticsToSessionFile,
   getDiagnosticsMeta,
@@ -40,6 +41,15 @@ import { createAgentBrowserWebProvider } from '../platforms/web/agent-browser-pr
 // ---------------------------------------------------------------------------
 // Request handler API
 // ---------------------------------------------------------------------------
+
+// Diagnostic phases emitted once per real iOS-runner round-trip. `..._command_send`
+// is the command itself; `..._readiness_preflight` is the pre-command uptime probe
+// (a real network round-trip). The `..._skipped` / `..._recovered` markers do NOT
+// hit the runner and are intentionally excluded.
+const RUNNER_ROUND_TRIP_PHASES = [
+  'ios_runner_command_send',
+  'ios_runner_readiness_preflight',
+] as const;
 
 export type RequestRouterDeps = {
   logPath: string;
@@ -82,7 +92,7 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
   async function handleRequest(req: DaemonRequest): Promise<DaemonResponse> {
     const start = Date.now();
     const debug = Boolean(req.meta?.debug || req.flags?.verbose);
-    const response = await withDiagnosticsScope(
+    return await withDiagnosticsScope(
       {
         session: req.session,
         requestId: req.meta?.requestId,
@@ -91,31 +101,40 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
         logPath,
       },
       async () => {
-        if (!timingSafeStringEqual(req.token, token)) {
-          return unauthorizedResponse();
-        }
-
-        try {
-          return await withTargetDeviceResolutionScope(deviceInventoryProvider, async () => {
-            const scope = await createRequestExecutionScope({
-              req,
-              sessionStore,
-              leaseRegistry,
-            });
-            return await executeRequestScope(scope);
-          });
-        } catch (error) {
-          return finalizeThrownRequestError(error);
-        }
+        const response = await runRequestWithinScope(req);
+        // Phase 4 (agent-cost) graft: cost is purely additive and opt-in. With
+        // the flag off — or on an error response — the serialized DaemonResponse
+        // is byte-identical to today (Maestro `.ad` recompare diffs it). Mirrors
+        // the conditional `registerDownloadableArtifacts` spread in
+        // request-finalization. Runs inside the diagnostics scope so it can read
+        // this request's accumulated runner-round-trip tally.
+        if (!req.meta?.includeCost || !response.ok) return response;
+        const cost: ResponseCost = {
+          wallClockMs: Date.now() - start,
+          runnerRoundTrips: countDiagnosticEventsByPhase(RUNNER_ROUND_TRIP_PHASES),
+        };
+        return { ok: true, data: { ...(response.data ?? {}), cost } };
       },
     );
-    // Phase 4 (agent-cost) graft: cost is purely additive and opt-in. With the
-    // flag off — or on an error response — the serialized DaemonResponse is
-    // byte-identical to today (Maestro `.ad` recompare diffs it). Mirrors the
-    // conditional `registerDownloadableArtifacts` spread in request-finalization.
-    if (!req.meta?.includeCost || !response.ok) return response;
-    const cost: ResponseCost = { wallClockMs: Date.now() - start };
-    return { ok: true, data: { ...(response.data ?? {}), cost } };
+  }
+
+  async function runRequestWithinScope(req: DaemonRequest): Promise<DaemonResponse> {
+    if (!timingSafeStringEqual(req.token, token)) {
+      return unauthorizedResponse();
+    }
+
+    try {
+      return await withTargetDeviceResolutionScope(deviceInventoryProvider, async () => {
+        const scope = await createRequestExecutionScope({
+          req,
+          sessionStore,
+          leaseRegistry,
+        });
+        return await executeRequestScope(scope);
+      });
+    } catch (error) {
+      return finalizeThrownRequestError(error);
+    }
   }
 
   async function executeRequestScope(

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -31,6 +31,11 @@ type DiagnosticsScope = DiagnosticsScopeOptions & {
   diagnosticId: string;
   events: DiagnosticEvent[];
   liveWrittenEventCount: number;
+  // Running per-phase emit tally. Unlike `events`, this is NOT cleared by
+  // `flushDiagnosticsToSessionFile`, so consumers (e.g. the agent-cost graft)
+  // can count phase occurrences for the whole request even in debug mode where
+  // events are streamed out and reset mid-flight.
+  phaseCounts: Map<string, number>;
 };
 
 const diagnosticsStorage = new AsyncLocalStorage<DiagnosticsScope>();
@@ -52,6 +57,7 @@ export async function withDiagnosticsScope<T>(
     diagnosticId: createDiagnosticId(),
     events: [],
     liveWrittenEventCount: 0,
+    phaseCounts: new Map(),
   };
   return await diagnosticsStorage.run(scope, fn);
 }
@@ -80,6 +86,22 @@ export function getDiagnosticsMeta(): {
   };
 }
 
+/**
+ * Sum the number of diagnostic events emitted in the current scope whose phase
+ * is one of `phases`. Backed by the flush-surviving `phaseCounts` tally, so it
+ * stays accurate for the whole request even under `--debug` (where `events` is
+ * streamed out and reset). Returns 0 when called outside a diagnostics scope.
+ */
+export function countDiagnosticEventsByPhase(phases: readonly string[]): number {
+  const scope = diagnosticsStorage.getStore();
+  if (!scope) return 0;
+  let total = 0;
+  for (const phase of phases) {
+    total += scope.phaseCounts.get(phase) ?? 0;
+  }
+  return total;
+}
+
 export function emitDiagnostic(event: {
   level?: DiagnosticLevel;
   phase: string;
@@ -99,6 +121,7 @@ export function emitDiagnostic(event: {
     data: event.data ? redactDiagnosticData(event.data) : undefined,
   };
   scope.events.push(payload);
+  scope.phaseCounts.set(event.phase, (scope.phaseCounts.get(event.phase) ?? 0) + 1);
   if (!scope.debug) return;
   const fileLine = `${JSON.stringify(payload)}\n`;
   try {


### PR DESCRIPTION
## Phase 4 (agent-cost) — Slice 2: `runnerRoundTrips`

Extends the slice-1 opt-in cost block with `runnerRoundTrips` — the count of real iOS-runner round-trips a command made, read from the per-request diagnostics scope. Reuses the existing `--cost` flag (no new flag).

### What changed
- `src/contracts.ts`: `ResponseCost` is now `{ wallClockMs: number; runnerRoundTrips: number }`. `runnerRoundTrips` is always present when `--cost` is on; it is `0` for commands/platforms that never hit the iOS runner (honest, not omitted).
- `src/utils/diagnostics.ts`: added a flush-surviving per-phase tally (`phaseCounts`) on the diagnostics scope plus a minimal accessor `countDiagnosticEventsByPhase(phases)`. The tally is incremented in `emitDiagnostic` and is **not** cleared by `flushDiagnosticsToSessionFile`, so the count stays accurate even under `--debug` (where `events` is streamed out and reset mid-flight).
- `src/daemon/request-router.ts`: the agent-cost graft now runs **inside** `withDiagnosticsScope` so it can read the request's accumulated tally, and populates `runnerRoundTrips` by counting the `ios_runner_command_send` and `ios_runner_readiness_preflight` phases (both real network round-trips). The `..._readiness_preflight_skipped` / `..._recovered` markers do not hit the runner and are excluded.

### Invariant — default wire shape byte-identical (Maestro-safe)
With `--cost` OFF — or on an error response — the serialized `DaemonResponse` is byte-identical to today. Cost is purely additive and opt-in. Parity-tested.

### Tests (`request-router-cost.test.ts`)
- (a) flag-off identity: `meta` omitted === `meta:{}` present, byte-identical, no `cost` key.
- (b) flag-on additive-only: cost carries BOTH `wallClockMs` and `runnerRoundTrips` (numbers ≥ 0); deleting `cost` deep-equals the flag-off payload — still the only delta.
- (c) `runnerRoundTrips` counts real round-trip diagnostics in scope (1 preflight + 2 command_send = 3; `_skipped`/unrelated phases excluded); no-runner request → 0.
- (d) error path with `includeCost:true` → no `cost`.
- (e) boundary: `meta.includeCost` survives schema parsing.

Additive / semver-minor. Measures the batch-collapses-N-round-trips signal.
