### PR TITLE
feat: add opt-in agent-cost nodeCount signal — Phase 4 slice 3

### DIFF
--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -102,7 +102,14 @@ export type DaemonArtifact = {
   path?: string;
 };
 
-export type ResponseCost = { wallClockMs: number; runnerRoundTrips: number };
+export type ResponseCost = {
+  wallClockMs: number;
+  runnerRoundTrips: number;
+  // Number of UI/accessibility nodes in the response, when the command returns a
+  // node tree (e.g. snapshot). Absent for commands that produce no nodes, so an
+  // agent can size a snapshot before re-fetching at a different depth/scope.
+  nodeCount?: number;
+};
 
 export type DaemonResponseData = Record<string, unknown> & {
   artifacts?: DaemonArtifact[];

--- a/src/daemon/__tests__/request-router-cost.test.ts
+++ b/src/daemon/__tests__/request-router-cost.test.ts
@@ -118,6 +118,8 @@ test('(b) flag-on additive-only: cost block is the ONLY delta vs flag-off', asyn
     runnerRoundTrips: 0,
   });
   expect(cost?.wallClockMs).toBeGreaterThanOrEqual(0);
+  // This payload has no node tree, so nodeCount is omitted entirely.
+  expect('nodeCount' in (cost ?? {})).toBe(false);
 
   // Deleting the single added key must leave a payload deep-equal to flag-off.
   delete respFlagOn.data?.cost;
@@ -145,6 +147,38 @@ test('(c) runnerRoundTrips counts real iOS-runner round-trip diagnostics in scop
   // 1 preflight + 2 command_send = 3; the _skipped marker and unrelated phases
   // are excluded.
   expect(resp.data?.cost?.runnerRoundTrips).toBe(3);
+});
+
+test('(c2) nodeCount reports the node-tree size whenever data carries a nodes array, additive-only', async () => {
+  const { sessionStore, handler } = makeHandler();
+  sessionStore.set('cost-session', makeIosSession('cost-session'));
+
+  // The nodeCount read is command-agnostic: it triggers on any response.data that
+  // carries a `nodes` array (in production only the snapshot node-tree commands
+  // do). We drive it through the generic dispatch path with a node-bearing payload.
+  const nodeTreePayload = {
+    nodes: [
+      { ref: 'e1', type: 'Button', label: 'A' },
+      { ref: 'e2', type: 'Button', label: 'B' },
+      { ref: 'e3', type: 'Text', label: 'C' },
+    ],
+    truncated: false,
+  };
+  mockDispatch.mockImplementation(async () => structuredClone(nodeTreePayload));
+
+  const respFlagOff = await handler(baseRequest());
+  const respFlagOn = await handler(baseRequest({ meta: { includeCost: true } }));
+
+  expect(respFlagOff.ok).toBe(true);
+  expect(respFlagOn.ok).toBe(true);
+  if (!respFlagOff.ok || !respFlagOn.ok) return;
+
+  expect(respFlagOn.data?.cost?.nodeCount).toBe(3);
+  // Deleting the cost block leaves a payload deep-equal to flag-off: nodeCount is
+  // a pure read of the existing `nodes` array, never a mutation of the payload.
+  delete respFlagOn.data?.cost;
+  expect(respFlagOn.data).toEqual(respFlagOff.data);
+  expect(respFlagOff.data).toEqual(nodeTreePayload);
 });
 
 test('(d) error path: a failing request with includeCost:true produces NO cost', async () => {

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -113,6 +113,11 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
           wallClockMs: Date.now() - start,
           runnerRoundTrips: countDiagnosticEventsByPhase(RUNNER_ROUND_TRIP_PHASES),
         };
+        // Generic, command-agnostic: only the node-tree commands (snapshot) put a
+        // `nodes` array on response.data, so this reads as a number there and is
+        // omitted everywhere else.
+        const nodes = response.data?.nodes;
+        if (Array.isArray(nodes)) cost.nodeCount = nodes.length;
         return { ok: true, data: { ...(response.data ?? {}), cost } };
       },
     );


### PR DESCRIPTION
## What

Phase 4 (agent-cost), **slice 3**: add a `nodeCount` field to the opt-in `cost` block.

The `cost` block now carries three signals, all behind `--cost` / `meta.includeCost`:
- `wallClockMs` — per-command latency ([slice 1, #922](https://github.com/callstack/agent-device/pull/922))
- `runnerRoundTrips` — iOS-runner round-trips ([#925](https://github.com/callstack/agent-device/pull/925))
- `nodeCount` — **this PR** — the size of the UI/accessibility node tree a command returns

## Why

It lets an agent see how large a snapshot is **without parsing the full tree** — so it can decide to re-fetch at a different `--depth`/`--scope` (or switch to a digest) before spending tokens on the nodes themselves. This is the north-star-#2 token-efficiency lever.

## How (`src/daemon/request-router.ts`, `src/contracts.ts`)

`nodeCount` is **command-agnostic**. In production only the snapshot node-tree commands put a `nodes` array on `response.data`, so the graft reads it generically and omits the field everywhere else:

```ts
const nodes = response.data?.nodes;
if (Array.isArray(nodes)) cost.nodeCount = nodes.length;
```

`ResponseCost` gains an optional `nodeCount?: number` (absent when the command produces no nodes).

## Default-off is byte-identical

Same invariant as the rest of the cost block: gated on `meta.includeCost && response.ok`, and `nodeCount` is a **pure read** of the existing `nodes` array — it never mutates the payload. With the flag off the serialized `DaemonResponse` is unchanged (Maestro `.ad` recompare safe).

## Tests (`request-router-cost.test.ts`)
- new `(c2)`: a node-bearing payload → `cost.nodeCount === nodes.length`; deleting the cost block leaves a payload **deep-equal** to the flag-off response (additive-only, no mutation).
- extended `(b)`: a payload with no node tree → `nodeCount` is **omitted** from the cost block.

## Verification
- `tsc --noEmit` exit 0
- `oxfmt` + `oxlint --deny-warnings` clean
- `fallow audit --base origin/main` clean
- `vitest run daemon contracts client core` → 134 files / 1225 tests pass (cost test 6/6)
- Layering Guard grep empty

A reviewer can smoke `snapshot --cost` on a real device and confirm `cost.nodeCount` matches the returned `nodes` length, and is absent on a non-snapshot command like `home --cost`.