### PR TITLE
perf: reduce iOS simulator screenshot overhead

### DIFF
--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -293,6 +293,11 @@ function summarizeProviderScenarioFlagExclusions() {
       owner: 'handler and Android platform unit tests',
       keys: ['headless'],
     },
+    {
+      name: 'Apple screenshot status-bar normalization',
+      owner: 'iOS platform and screenshot-diff runtime tests',
+      keys: ['screenshotNormalizeStatusBar'],
+    },
   ];
 }
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -70,6 +70,7 @@ export type BackendScreenshotOptions = {
   fullscreen?: boolean;
   overlayRefs?: boolean;
   stabilize?: boolean;
+  normalizeStatusBar?: boolean;
   surface?: SessionSurface;
 };
 

--- a/src/cli/commands/screenshot.ts
+++ b/src/cli/commands/screenshot.ts
@@ -70,6 +70,7 @@ export const diffCommand: ClientCommandHandler = async ({ positionals, flags, cl
     ...(outputPath ? { out: { kind: 'path', path: outputPath } } : {}),
     threshold: parseCliThreshold(flags.threshold),
     overlayRefs: flags.overlayRefs,
+    normalizeStatusBar: flags.screenshotNormalizeStatusBar,
     surface: flags.surface,
   });
 
@@ -89,6 +90,7 @@ function createClientScreenshotBackend(
         session: context.session,
         overlayRefs: options?.overlayRefs,
         fullscreen: options?.fullscreen,
+        normalizeStatusBar: options?.normalizeStatusBar,
         stabilize: options?.stabilize,
         surface: options?.surface,
       });

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -372,6 +372,7 @@ export type CaptureScreenshotOptions = AgentDeviceRequestOverrides & {
   fullscreen?: boolean;
   maxSize?: number;
   stabilize?: boolean;
+  normalizeStatusBar?: boolean;
   surface?: SessionSurface;
 };
 

--- a/src/commands/capture/diff.ts
+++ b/src/commands/capture/diff.ts
@@ -34,7 +34,8 @@ const diffCommandDefinition = defineExecutableCommand(diffCommandMetadata, (clie
 const diffCliSchema = {
   usageOverride:
     'diff snapshot | diff screenshot --baseline <path> [current.png] [--out <diff.png>] [--threshold <0-1>] [--overlay-refs]',
-  helpDescription: 'Diff accessibility snapshot or compare screenshots pixel-by-pixel',
+  helpDescription:
+    'Diff accessibility snapshot or compare screenshots pixel-by-pixel. Live iOS simulator screenshot diffs normalize status-bar chrome by default; use screenshot --normalize-status-bar when capturing reusable baselines.',
   summary: 'Diff snapshot or screenshot',
   positionalArgs: ['kind', 'current?'],
   allowedFlags: [...SNAPSHOT_FLAGS, 'baseline', 'threshold', 'out', 'overlayRefs'],

--- a/src/commands/capture/index.test.ts
+++ b/src/commands/capture/index.test.ts
@@ -97,6 +97,20 @@ describe('capture command interface', () => {
     });
   });
 
+  test('reads and writes screenshot status-bar normalization flag', () => {
+    const input = screenshotCliReader(['page.png'], flags({ screenshotNormalizeStatusBar: true }));
+    expect(input).toMatchObject({
+      path: 'page.png',
+      normalizeStatusBar: true,
+    });
+    expect(screenshotDaemonWriter(input)).toMatchObject({
+      command: 'screenshot',
+      options: {
+        screenshotNormalizeStatusBar: true,
+      },
+    });
+  });
+
   test('reads diff snapshot input only', () => {
     expect(
       diffCliReader(['snapshot'], flags({ snapshotDepth: 4, out: './diff.json' })),

--- a/src/commands/capture/runtime/diff-screenshot.test.ts
+++ b/src/commands/capture/runtime/diff-screenshot.test.ts
@@ -58,6 +58,7 @@ test('runtime diff screenshot captures live current image and cleans temporary c
     assert.equal(typeof capturedCurrentPath, 'string');
     assert.equal(fs.existsSync(capturedCurrentPath!), false);
     assert.equal(capturedOptions?.surface, 'menubar');
+    assert.equal(capturedOptions?.normalizeStatusBar, true);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/src/commands/capture/runtime/diff-screenshot.ts
+++ b/src/commands/capture/runtime/diff-screenshot.ts
@@ -30,6 +30,7 @@ export type DiffScreenshotCommandOptions = CommandContext & {
   currentOverlayOut?: FileOutputRef;
   threshold?: number;
   overlayRefs?: boolean;
+  normalizeStatusBar?: boolean;
   surface?: BackendScreenshotOptions['surface'];
 };
 
@@ -131,7 +132,7 @@ async function captureLiveCurrentScreenshot(
     ext: '.png',
   });
   try {
-    await captureScreenshot(runtime, options, temp.path, screenshotSurfaceOptions(options));
+    await captureScreenshot(runtime, options, temp.path, liveDiffScreenshotOptions(options));
   } catch (error) {
     await temp.cleanup();
     throw error;
@@ -162,7 +163,7 @@ async function maybeAttachCurrentOverlay(
   try {
     const overlayResult = await captureScreenshot(runtime, options, overlayOutput.path, {
       overlayRefs: true,
-      ...screenshotSurfaceOptions(options),
+      ...liveDiffScreenshotOptions(options),
     });
     const overlayArtifact = await overlayOutput.publish();
     if (overlayArtifact) artifacts.push(overlayArtifact);
@@ -208,10 +209,13 @@ async function captureScreenshot(
   );
 }
 
-function screenshotSurfaceOptions(
-  options: Pick<DiffScreenshotCommandOptions, 'surface'>,
+function liveDiffScreenshotOptions(
+  options: Pick<DiffScreenshotCommandOptions, 'normalizeStatusBar' | 'surface'>,
 ): BackendScreenshotOptions {
-  return options.surface ? { surface: options.surface } : {};
+  return {
+    normalizeStatusBar: options.normalizeStatusBar ?? true,
+    ...(options.surface ? { surface: options.surface } : {}),
+  };
 }
 
 function resolveCurrentOverlayOutputRef(

--- a/src/commands/capture/runtime/screenshot.ts
+++ b/src/commands/capture/runtime/screenshot.ts
@@ -40,6 +40,7 @@ export const screenshotCommand: RuntimeCommand<
         fullscreen: options.fullscreen,
         overlayRefs: options.overlayRefs,
         stabilize: options.stabilize,
+        normalizeStatusBar: options.normalizeStatusBar,
         surface: options.surface,
       },
     );

--- a/src/commands/capture/screenshot-options.test.ts
+++ b/src/commands/capture/screenshot-options.test.ts
@@ -17,12 +17,14 @@ test('screenshot flag projection maps CLI flags to runtime options', () => {
       screenshotFullscreen: true,
       screenshotMaxSize: 1024,
       screenshotNoStabilize: true,
+      screenshotNormalizeStatusBar: true,
     }),
     {
       overlayRefs: true,
       fullscreen: true,
       maxSize: 1024,
       stabilize: false,
+      normalizeStatusBar: true,
     },
   );
 });
@@ -34,12 +36,14 @@ test('screenshot flag projection maps public options to request flags', () => {
       fullscreen: true,
       maxSize: 512,
       stabilize: false,
+      normalizeStatusBar: true,
     }),
     {
       overlayRefs: true,
       screenshotFullscreen: true,
       screenshotMaxSize: 512,
       screenshotNoStabilize: true,
+      screenshotNormalizeStatusBar: true,
     },
   );
 });
@@ -58,14 +62,23 @@ test('screenshot script flags use the shared recorded flag contract', () => {
   assert.deepEqual(result, { handled: true, nextIndex: 1 });
   result = readScreenshotScriptFlag({ args: ['--no-stabilize'], index: 0, flags });
   assert.deepEqual(result, { handled: true, nextIndex: 0 });
+  result = readScreenshotScriptFlag({ args: ['--normalize-status-bar'], index: 0, flags });
+  assert.deepEqual(result, { handled: true, nextIndex: 0 });
 
   appendScreenshotScriptFlags(parts, flags);
 
-  assert.deepEqual(parts, ['--fullscreen', '--max-size', '640', '--no-stabilize']);
+  assert.deepEqual(parts, [
+    '--fullscreen',
+    '--max-size',
+    '640',
+    '--no-stabilize',
+    '--normalize-status-bar',
+  ]);
   assert.deepEqual(SCREENSHOT_ACTION_FLAG_KEYS, [
     'screenshotFullscreen',
     'screenshotMaxSize',
     'screenshotNoStabilize',
+    'screenshotNormalizeStatusBar',
   ]);
   assert.deepEqual(
     SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS.map((definition) => definition.key),
@@ -77,5 +90,6 @@ test('screenshot script flags use the shared recorded flag contract', () => {
     'screenshotFullscreen',
     'screenshotMaxSize',
     'screenshotNoStabilize',
+    'screenshotNormalizeStatusBar',
   ]);
 });

--- a/src/commands/capture/screenshot.ts
+++ b/src/commands/capture/screenshot.ts
@@ -26,6 +26,7 @@ const screenshotCommandMetadata = defineFieldCommandMetadata(
     fullscreen: booleanField(),
     maxSize: integerField(),
     stabilize: booleanField(),
+    normalizeStatusBar: booleanField(),
     surface: enumField(SESSION_SURFACES),
   },
 );
@@ -37,7 +38,7 @@ const screenshotCommandDefinition = defineExecutableCommand(
 
 const screenshotCliSchema = {
   helpDescription:
-    'Capture screenshot (web defaults to the viewport; use --fullscreen, --full, or -f for the entire page. macOS app sessions default to the app window; use --fullscreen for full desktop, --max-size to downscale, --overlay-refs to annotate current refs, or --no-stabilize for low-latency Android capture loops)',
+    'Capture screenshot (web defaults to the viewport; use --fullscreen, --full, or -f for the entire page. macOS app sessions default to the app window; use --fullscreen for full desktop, --max-size to downscale, --overlay-refs to annotate current refs, --normalize-status-bar for deterministic iOS simulator chrome, or --no-stabilize for low-latency Android capture loops)',
   summary:
     'Capture screenshot with optional web full-page, desktop, downscale, or ref overlay modes',
   positionalArgs: ['path?'],

--- a/src/commands/runtime-types.ts
+++ b/src/commands/runtime-types.ts
@@ -30,6 +30,7 @@ export type ScreenshotCommandOptions = CommandContext & {
   overlayRefs?: boolean;
   maxSize?: number;
   stabilize?: boolean;
+  normalizeStatusBar?: boolean;
   appId?: string;
   appBundleId?: string;
   surface?: SessionSurface;

--- a/src/contracts/screenshot.ts
+++ b/src/contracts/screenshot.ts
@@ -6,12 +6,14 @@ export const SCREENSHOT_COMMAND_FLAG_KEYS = [
   'screenshotFullscreen',
   'screenshotMaxSize',
   'screenshotNoStabilize',
+  'screenshotNormalizeStatusBar',
 ] as const;
 
 export const SCREENSHOT_ACTION_FLAG_KEYS = [
   'screenshotFullscreen',
   'screenshotMaxSize',
   'screenshotNoStabilize',
+  'screenshotNormalizeStatusBar',
 ] as const;
 
 type ScreenshotSpecificFlagKey = (typeof SCREENSHOT_ACTION_FLAG_KEYS)[number];
@@ -50,6 +52,14 @@ export const SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS: readonly ScreenshotSpecificFl
     usageDescription:
       'Screenshot: skip Android demo-mode/status-bar stabilization and settle delay for low-latency capture loops',
   },
+  {
+    key: 'screenshotNormalizeStatusBar',
+    names: ['--normalize-status-bar'],
+    type: 'boolean',
+    usageLabel: '--normalize-status-bar',
+    usageDescription:
+      'Screenshot: on iOS simulators temporarily normalize status-bar chrome for deterministic screenshot diffs',
+  },
 ];
 
 export type ScreenshotRequestFlags = {
@@ -58,16 +68,20 @@ export type ScreenshotRequestFlags = {
   screenshotFullscreen?: boolean;
   screenshotMaxSize?: number;
   screenshotNoStabilize?: boolean;
+  screenshotNormalizeStatusBar?: boolean;
 };
 
 export type ScreenshotDispatchFlags = Pick<
   ScreenshotRequestFlags,
-  'screenshotFullscreen' | 'screenshotNoStabilize'
+  'screenshotFullscreen' | 'screenshotNoStabilize' | 'screenshotNormalizeStatusBar'
 >;
 
 export type ScreenshotRuntimeFlags = Pick<
   ScreenshotRequestFlags,
-  'screenshotFullscreen' | 'screenshotMaxSize' | 'screenshotNoStabilize'
+  | 'screenshotFullscreen'
+  | 'screenshotMaxSize'
+  | 'screenshotNoStabilize'
+  | 'screenshotNormalizeStatusBar'
 >;
 
 export type ScreenshotPublicOptions = {
@@ -75,6 +89,7 @@ export type ScreenshotPublicOptions = {
   fullscreen?: boolean;
   maxSize?: number;
   stabilize?: boolean;
+  normalizeStatusBar?: boolean;
 };
 
 export type ScreenshotRuntimeOptions = {
@@ -82,6 +97,7 @@ export type ScreenshotRuntimeOptions = {
   fullscreen?: boolean;
   maxSize?: number;
   stabilize?: boolean;
+  normalizeStatusBar?: boolean;
 };
 
 export function screenshotOptionsFromFlags(
@@ -92,6 +108,7 @@ export function screenshotOptionsFromFlags(
     fullscreen: flags?.screenshotFullscreen,
     maxSize: flags?.screenshotMaxSize,
     stabilize: flags?.screenshotNoStabilize ? false : undefined,
+    normalizeStatusBar: flags?.screenshotNormalizeStatusBar,
   });
 }
 
@@ -104,6 +121,8 @@ export function screenshotFlagsFromOptions(
     screenshotMaxSize: options.screenshotMaxSize ?? options.maxSize,
     screenshotNoStabilize:
       options.screenshotNoStabilize ?? (options.stabilize === false ? true : undefined),
+    screenshotNormalizeStatusBar:
+      options.screenshotNormalizeStatusBar ?? options.normalizeStatusBar,
   });
 }
 
@@ -116,6 +135,7 @@ export function appendScreenshotScriptFlags(
     parts.push('--max-size', String(flags.screenshotMaxSize));
   }
   if (flags?.screenshotNoStabilize) parts.push('--no-stabilize');
+  if (flags?.screenshotNormalizeStatusBar) parts.push('--normalize-status-bar');
 }
 
 export function readScreenshotScriptFlag(params: {
@@ -131,6 +151,10 @@ export function readScreenshotScriptFlag(params: {
   }
   if (token === '--no-stabilize') {
     flags.screenshotNoStabilize = true;
+    return { handled: true, nextIndex: index };
+  }
+  if (token === '--normalize-status-bar') {
+    flags.screenshotNormalizeStatusBar = true;
     return { handled: true, nextIndex: index };
   }
   if (token === '--max-size') {

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -338,6 +338,7 @@ async function handleScreenshotCommand(
   await interactor.screenshot(screenshotPath, {
     appBundleId: context?.appBundleId,
     fullscreen: screenshotOptions.fullscreen,
+    normalizeStatusBar: screenshotOptions.normalizeStatusBar,
     stabilize: screenshotOptions.stabilize,
     surface: context?.surface,
     skipIosSimulatorBootCheck: context?.skipIosSimulatorBootCheck,

--- a/src/core/interactor-types.ts
+++ b/src/core/interactor-types.ts
@@ -41,6 +41,7 @@ export type { BackMode };
 export type ScreenshotOptions = {
   appBundleId?: string;
   fullscreen?: boolean;
+  normalizeStatusBar?: boolean;
   stabilize?: boolean;
   surface?: SessionSurface;
   skipIosSimulatorBootCheck?: boolean;

--- a/src/core/interactors/apple.ts
+++ b/src/core/interactors/apple.ts
@@ -51,7 +51,8 @@ export function createAppleInteractor(
         appBundleId: options?.appBundleId,
         fullscreen: options?.fullscreen,
         runnerOptions: runnerOpts,
-        skipBootCheck: options?.skipIosSimulatorBootCheck,
+        normalizeStatusBar: options?.normalizeStatusBar,
+        skipIosSimulatorBootCheck: options?.skipIosSimulatorBootCheck,
       });
     },
     snapshot: async (options) => {

--- a/src/platforms/ios/__tests__/index.test.ts
+++ b/src/platforms/ios/__tests__/index.test.ts
@@ -68,7 +68,10 @@ import {
   resolveSimulatorRunnerScreenshotCandidatePaths,
 } from '../screenshot.ts';
 import { ensureBootedSimulator, openIosSimulatorApp } from '../simulator.ts';
-import { prepareSimulatorStatusBarForScreenshot as prepareStatusBarForScreenshot } from '../screenshot-status-bar.ts';
+import {
+  invalidateSimulatorStatusBarOverrideCache,
+  prepareSimulatorStatusBarForScreenshot as prepareStatusBarForScreenshot,
+} from '../screenshot-status-bar.ts';
 import { runIosRunnerCommand } from '../runner-client.ts';
 import { iosRunnerOverrides } from '../interactions.ts';
 import { IOS_SIMULATOR_TERMINATE_TIMEOUT_MS } from '../config.ts';
@@ -157,6 +160,7 @@ const mockPrepareStatusBarForScreenshot = vi.mocked(prepareStatusBarForScreensho
 
 beforeEach(() => {
   vi.resetAllMocks();
+  invalidateSimulatorStatusBarOverrideCache(IOS_TEST_SIMULATOR);
   mockRunCmd.mockImplementation(execActual.runCmd);
   mockRetryWithPolicy.mockImplementation(retryActual.retryWithPolicy);
   mockRunIosRunnerCommand.mockImplementation(runnerActual.runIosRunnerCommand);
@@ -783,7 +787,9 @@ test('captureSimulatorScreenshotWithFallback continues when status bar preparati
   mockRetryWithPolicy.mockResolvedValue(undefined);
   await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
     appBundleId: 'com.example.app',
+    normalizeStatusBar: true,
   });
+  assert.equal(mockPrepareStatusBarForScreenshot.mock.calls.length, 1);
   assert.equal(mockRetryWithPolicy.mock.calls.length > 0, true);
   assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
 });
@@ -795,7 +801,7 @@ test('captureSimulatorScreenshotWithFallback can skip session-backed simulator b
 
   await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
     appBundleId: 'com.example.app',
-    skipBootCheck: true,
+    skipIosSimulatorBootCheck: true,
   });
 
   assert.equal(mockEnsureBootedSimulator.mock.calls.length, 0);
@@ -820,7 +826,7 @@ test('captureSimulatorScreenshotWithFallback boots skipped-check simulator after
 
   await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
     appBundleId: 'com.example.app',
-    skipBootCheck: true,
+    skipIosSimulatorBootCheck: true,
     deps: {
       ensureBooted,
       prepareStatusBarForScreenshot,
@@ -856,7 +862,7 @@ test('captureSimulatorScreenshotWithFallback keeps runner fallback after skipped
 
   await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
     appBundleId: 'com.example.app',
-    skipBootCheck: true,
+    skipIosSimulatorBootCheck: true,
     deps: {
       ensureBooted,
       prepareStatusBarForScreenshot,
@@ -880,7 +886,24 @@ test('captureSimulatorScreenshotWithFallback ignores status bar restore failures
   mockRetryWithPolicy.mockResolvedValue(undefined);
   await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
     appBundleId: 'com.example.app',
+    normalizeStatusBar: true,
   });
+  assert.equal(mockPrepareStatusBarForScreenshot.mock.calls.length, 1);
+  assert.equal(mockRetryWithPolicy.mock.calls.length > 0, true);
+  assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
+});
+
+test('captureSimulatorScreenshotWithFallback skips status bar normalization by default', async () => {
+  mockPrepareStatusBarForScreenshot.mockResolvedValue(async () => {});
+  mockEnsureBootedSimulator.mockResolvedValue(undefined);
+  mockOpenIosSimulatorApp.mockResolvedValue(undefined);
+  mockRetryWithPolicy.mockResolvedValue(undefined);
+
+  await captureSimulatorScreenshotWithFallback(IOS_TEST_SIMULATOR, '/tmp/out.png', {
+    appBundleId: 'com.example.app',
+  });
+
+  assert.equal(mockPrepareStatusBarForScreenshot.mock.calls.length, 0);
   assert.equal(mockRetryWithPolicy.mock.calls.length > 0, true);
   assert.equal(mockRunIosRunnerCommand.mock.calls.length, 0);
 });
@@ -1045,6 +1068,45 @@ exit 1
         'simctl status_bar sim-1 override --time 9:41 --dataNetwork wifi --wifiMode active --wifiBars 3 --batteryState charged --batteryLevel 100',
         'simctl status_bar sim-1 clear',
         'simctl status_bar sim-1 override --dataNetwork hide --wifiMode failed --wifiBars 0 --cellularMode failed --cellularBars 0 --operatorName No Service',
+      ]);
+    },
+  );
+});
+
+test('prepareSimulatorStatusBarForScreenshot skips known redundant status bar commands', async () => {
+  await withMockedXcrun(
+    'agent-device-ios-status-bar-no-overrides-test-',
+    `#!/bin/sh
+echo "$*" >> "$AGENT_DEVICE_TEST_ARGS_FILE"
+if [ "$1" = "simctl" ] && [ "$2" = "status_bar" ] && [ "$4" = "list" ]; then
+  cat <<'OUT'
+Current Status Bar Overrides:
+=============================
+OUT
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "status_bar" ] && [ "$4" = "clear" ]; then
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "status_bar" ] && [ "$4" = "override" ]; then
+  exit 0
+fi
+echo "unexpected xcrun args: $*" >&2
+exit 1
+`,
+    async ({ argsLogPath }) => {
+      const restoreFirst = await prepareSimulatorStatusBarForScreenshot(IOS_TEST_SIMULATOR);
+      await restoreFirst();
+      const restoreSecond = await prepareSimulatorStatusBarForScreenshot(IOS_TEST_SIMULATOR);
+      await restoreSecond();
+
+      const logLines = (await fs.readFile(argsLogPath, 'utf8')).trim().split('\n').filter(Boolean);
+      assert.deepEqual(logLines, [
+        'simctl status_bar sim-1 list',
+        'simctl status_bar sim-1 override --time 9:41 --dataNetwork wifi --wifiMode active --wifiBars 3 --batteryState charged --batteryLevel 100',
+        'simctl status_bar sim-1 clear',
+        'simctl status_bar sim-1 override --time 9:41 --dataNetwork wifi --wifiMode active --wifiBars 3 --batteryState charged --batteryLevel 100',
+        'simctl status_bar sim-1 clear',
       ]);
     },
   );

--- a/src/platforms/ios/apps.ts
+++ b/src/platforms/ios/apps.ts
@@ -65,6 +65,10 @@ import {
   writeMacOsClipboardText,
 } from './macos-apps.ts';
 import { runMacOsPermissionAction, type MacOsPermissionTarget } from './macos-helper.ts';
+import {
+  invalidateSimulatorStatusBarOverrideCache,
+  rememberClearedStatusBarOverrides,
+} from './screenshot-status-bar.ts';
 export {
   screenshotIos,
   shouldFallbackToRunnerForIosScreenshot,
@@ -566,6 +570,7 @@ export async function setIosSetting(
       const enabled = parseSettingState(state);
       const mode = enabled ? 'active' : 'failed';
       await runSimctl(device, ['status_bar', device.id, 'override', '--wifiMode', mode]);
+      invalidateSimulatorStatusBarOverrideCache(device);
       return;
     }
     case 'airplane': {
@@ -588,8 +593,10 @@ export async function setIosSetting(
           '--operatorName',
           '',
         ]);
+        invalidateSimulatorStatusBarOverrideCache(device);
       } else {
         await runSimctl(device, ['status_bar', device.id, 'clear']);
+        rememberClearedStatusBarOverrides(device);
       }
       return;
     }

--- a/src/platforms/ios/screenshot-status-bar.ts
+++ b/src/platforms/ios/screenshot-status-bar.ts
@@ -58,20 +58,28 @@ function runSimctl(device: DeviceInfo, args: string[], options?: ExecOptions) {
   return runSimctlForDevice(device, args, options);
 }
 
+const devicesKnownWithoutStatusBarOverrides = new Set<string>();
+
 export async function prepareSimulatorStatusBarForScreenshot(
   device: DeviceInfo,
 ): Promise<() => Promise<void>> {
   let previousOverrides: RestorableStatusBarOverrides | null = null;
   let canRestorePreviousOverrides = false;
-  try {
-    previousOverrides = await readSimulatorStatusBarOverrides(device);
+  if (hasKnownClearedStatusBarOverrides(device)) {
     canRestorePreviousOverrides = true;
-  } catch (error) {
-    emitStatusBarDiagnostic(device, 'snapshot_failed', error);
+  } else {
+    try {
+      previousOverrides = await readSimulatorStatusBarOverrides(device);
+      canRestorePreviousOverrides = true;
+    } catch (error) {
+      emitStatusBarDiagnostic(device, 'snapshot_failed', error);
+    }
   }
 
   try {
-    await clearSimulatorStatusBarOverride(device);
+    if (!canRestorePreviousOverrides || previousOverrides) {
+      await clearSimulatorStatusBarOverride(device);
+    }
     await applySimulatorStatusBarOverrideArgs(device, DETERMINISTIC_SCREENSHOT_STATUS_BAR_ARGS);
   } catch (error) {
     emitStatusBarDiagnostic(device, 'prepare_failed', error);
@@ -90,11 +98,31 @@ async function restoreSimulatorStatusBarOverrides(
   overrides: RestorableStatusBarOverrides | null,
 ): Promise<void> {
   await clearSimulatorStatusBarOverride(device);
-  if (!overrides) return;
+  if (!overrides) {
+    rememberClearedStatusBarOverrides(device);
+    return;
+  }
   await applySimulatorStatusBarOverrideArgs(
     device,
     buildRestorableStatusBarOverrideArgs(overrides),
   );
+  invalidateSimulatorStatusBarOverrideCache(device);
+}
+
+export function invalidateSimulatorStatusBarOverrideCache(device: DeviceInfo): void {
+  devicesKnownWithoutStatusBarOverrides.delete(statusBarOverrideCacheKey(device));
+}
+
+export function rememberClearedStatusBarOverrides(device: DeviceInfo): void {
+  devicesKnownWithoutStatusBarOverrides.add(statusBarOverrideCacheKey(device));
+}
+
+function hasKnownClearedStatusBarOverrides(device: DeviceInfo): boolean {
+  return devicesKnownWithoutStatusBarOverrides.has(statusBarOverrideCacheKey(device));
+}
+
+function statusBarOverrideCacheKey(device: DeviceInfo): string {
+  return `${device.platform}:${device.kind}:${device.id}`;
 }
 
 async function readSimulatorStatusBarOverrides(

--- a/src/platforms/ios/screenshot.ts
+++ b/src/platforms/ios/screenshot.ts
@@ -43,8 +43,9 @@ type SimulatorScreenshotFlowDeps = {
 type SimulatorScreenshotFlowOptions = {
   appBundleId?: string;
   fullscreen?: boolean;
+  normalizeStatusBar?: boolean;
   runnerOptions?: AppleRunnerCommandOptions;
-  skipBootCheck?: boolean;
+  skipIosSimulatorBootCheck?: boolean;
   deps?: SimulatorScreenshotFlowDeps;
 };
 
@@ -111,14 +112,16 @@ export async function captureSimulatorScreenshotWithFallback(
 
   const deps = options.deps ?? defaultSimulatorScreenshotFlowDeps;
 
-  if (!options.skipBootCheck) {
+  if (!options.skipIosSimulatorBootCheck) {
     await deps.ensureBooted(device);
   }
   let restoreStatusBar = async () => {};
-  try {
-    restoreStatusBar = await deps.prepareStatusBarForScreenshot(device);
-  } catch (error) {
-    emitStatusBarDiagnostic(device, 'prepare_failed', error);
+  if (options.normalizeStatusBar === true) {
+    try {
+      restoreStatusBar = await deps.prepareStatusBarForScreenshot(device);
+    } catch (error) {
+      emitStatusBarDiagnostic(device, 'prepare_failed', error);
+    }
   }
   try {
     try {
@@ -126,7 +129,10 @@ export async function captureSimulatorScreenshotWithFallback(
       return;
     } catch (error) {
       let screenshotError = error;
-      if (options.skipBootCheck && shouldEnsureBootedAfterSimulatorScreenshotFailure(error)) {
+      if (
+        options.skipIosSimulatorBootCheck &&
+        shouldEnsureBootedAfterSimulatorScreenshotFailure(error)
+      ) {
         await deps.ensureBooted(device);
         try {
           await deps.captureWithRetry(device, outPath);

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1003,6 +1003,7 @@ test('parseArgs recognizes screenshot flags', () => {
       '--max-size',
       '1024',
       '--no-stabilize',
+      '--normalize-status-bar',
     ],
     {
       strictFlags: true,
@@ -1013,6 +1014,7 @@ test('parseArgs recognizes screenshot flags', () => {
   assert.equal(parsed.flags.screenshotFullscreen, true);
   assert.equal(parsed.flags.screenshotMaxSize, 1024);
   assert.equal(parsed.flags.screenshotNoStabilize, true);
+  assert.equal(parsed.flags.screenshotNormalizeStatusBar, true);
 });
 
 test('usageForCommand documents screenshot web aliases and stabilization flags', () => {
@@ -1022,6 +1024,15 @@ test('usageForCommand documents screenshot web aliases and stabilization flags',
   assert.match(help, /entire page/i);
   assert.match(help, /--no-stabilize/);
   assert.match(help, /low-latency Android capture loops/);
+  assert.match(help, /--normalize-status-bar/);
+  assert.match(help, /deterministic iOS simulator chrome/);
+});
+
+test('usageForCommand documents screenshot diff normalization', () => {
+  const help = usageForCommand('diff');
+  if (help === null) throw new Error('Expected diff help text');
+  assert.match(help, /Live iOS simulator screenshot diffs normalize status-bar chrome by default/);
+  assert.match(help, /screenshot --normalize-status-bar/);
 });
 
 test('parseArgs recognizes viewport command', () => {

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -762,6 +762,7 @@ agent-device screenshot                 # Auto filename
 agent-device screenshot page.png        # Explicit screenshot path
 agent-device screenshot page.png --max-size 1024  # Downscale longest edge for agent-friendly artifacts
 agent-device screenshot page.png --overlay-refs  # Draw current @eN refs and target rectangles onto the PNG
+agent-device screenshot baseline.png --normalize-status-bar  # Normalize iOS simulator chrome for reusable diff baselines
 agent-device screenshot page.png --platform web --fullscreen  # On web, --fullscreen/--full/-f captures the entire document
 agent-device viewport 1280 900 --platform web                # Resize the active web viewport for fixed-layout or 100vh apps
 agent-device screenshot textedit.png    # App-session window capture on macOS
@@ -781,8 +782,9 @@ agent-device record stop                # Stop active recording
 - Recordings always produce a video artifact. When touch visualization is enabled, they also produce a gesture telemetry sidecar that can be used for post-processing or inspection.
 - `screenshot --max-size <px>` preserves aspect ratio and only downscales when the saved PNG's longest edge is larger than the requested size.
 - `screenshot --overlay-refs` captures a fresh full snapshot and burns visible `@eN` refs plus their target rectangles into the saved PNG.
+- `screenshot --normalize-status-bar` temporarily normalizes iOS simulator status-bar chrome for deterministic screenshot baselines; ordinary screenshots leave the simulator's current chrome visible.
 - `screenshot --max-size <px> --overlay-refs` writes a smaller image and draws refs for that final image size; avoid very small max sizes when text, icons, or labels need to remain readable.
-- `diff screenshot` compares the current live screenshot to `--baseline`, or compares `--baseline` to an optional saved `current.png` path without requiring an active session, then prints ranked changed regions with screen-space rectangles, shape, size, density, average color, and luminance, and writes a diff PNG with a light grayscale current-screen context, red-tinted changed pixels, and outlined changed regions when `--out` is provided. JSON also includes normalized bounds.
+- `diff screenshot` compares the current live screenshot to `--baseline`, or compares `--baseline` to an optional saved `current.png` path without requiring an active session, then prints ranked changed regions with screen-space rectangles, shape, size, density, average color, and luminance, and writes a diff PNG with a light grayscale current-screen context, red-tinted changed pixels, and outlined changed regions when `--out` is provided. Live iOS simulator diffs normalize status-bar chrome by default; use `screenshot --normalize-status-bar` when capturing reusable baselines. JSON also includes normalized bounds.
 - If `tesseract` is installed, `diff screenshot` also adds best-effort OCR text deltas, movement clusters, and bbox size-change hints to the text and JSON output. OCR improves descriptions only; it does not change the pixel comparison or the diff PNG.
 - When OCR is available, `diff screenshot` also reports best-effort non-text visual deltas by masking OCR text boxes out of the diff and clustering remaining residuals. These are hints for icons, controls, and separators, not semantic icon recognition.
 - `diff screenshot --overlay-refs` additionally writes a separate current-screen overlay guide for live captures without using that annotated image for the pixel comparison. If current-screen refs intersect changed regions, the output lists the best ref matches under those regions. Saved-image comparisons do not have live accessibility refs, so `--overlay-refs` is unavailable when a `current.png` path is provided.


### PR DESCRIPTION
## Summary

Make iOS simulator screenshots fast by default while keeping deterministic status-bar normalization available for screenshot diffs.

Regular `screenshot` now leaves simulator chrome untouched unless `--normalize-status-bar` is passed. Live `diff screenshot` still normalizes by default, and docs/help point reusable baselines at `screenshot --normalize-status-bar`.

For session-backed simulator screenshots, reuse the booted simulator state from `open` instead of doing a redundant boot-state probe. Status-bar normalization also caches the no-overrides state and skips redundant `list`/`clear` work while invalidating the cache when `settings wifi` or `settings airplane` changes status-bar overrides.

Touched files: 22. Scope stayed within screenshot command/runtime handoff, iOS simulator screenshot/status-bar handling, CLI help/docs, focused tests, and the integration progress flag-classification guard.

## Validation

Static and focused checks passed:

- `pnpm exec vitest run src/utils/__tests__/args.test.ts src/commands/capture/index.test.ts src/commands/capture/screenshot-options.test.ts src/commands/capture/runtime/diff-screenshot.test.ts src/daemon/__tests__/request-router-screenshot.test.ts src/platforms/ios/__tests__/index.test.ts` - 254 tests passed
- `node --experimental-strip-types scripts/integration-progress.ts --check`
- `pnpm check:quick`
- `pnpm build`
- `git diff --check origin/main...HEAD`

Manual simulator timing on iPhone 17 Pro simulator `C25DBB5B-9254-4293-A8D5-2785C78DE03A`, Settings app session, 5 runs after rebuild + daemon clean/open:

| Candidate | Runs (ms) | Median | Mean |
| --- | ---: | ---: | ---: |
| Bare `xcrun simctl io <udid> screenshot <path>` | 944, 940, 935, 943, 938 | 940 | 940 |
| Public `agent-device screenshot` after session-backed boot-check skip | 1033, 1015, 1010, 1039, 1027 | 1027 | 1025 |
| Public `agent-device screenshot --normalize-status-bar` after status-bar cache/skip work | 3728, 3040, 3020, 3019, 3211 | 3040 | 3204 |

A breakdown showed the expensive pieces were `ensureBootedSimulator` at roughly 740 ms median and `simctl status_bar` subcommands at roughly 650-670 ms each. All manual `agent-device` sessions were closed.
