### PR TITLE
refactor: extract provider device runtime seam

### DIFF
--- a/src/__tests__/limrun-runtime.test.ts
+++ b/src/__tests__/limrun-runtime.test.ts
@@ -6,6 +6,7 @@ import { afterEach, test, vi } from 'vitest';
 import { LimrunRuntime, readLocalhostUrlPort } from '../cloud/limrun-runtime.ts';
 import type { SimulatorLease } from '../daemon/lease-registry.ts';
 import { runCmd } from '../utils/exec.ts';
+import type { DeviceInfo } from '../utils/device.ts';
 
 const limrunMockState = vi.hoisted(() => {
   const androidTunnelClose = vi.fn();
@@ -91,27 +92,59 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-test('Limrun runtime identifies direct CLI usage to the Limrun API', async () => {
-  const runtime = new LimrunRuntime({
+type AllocateLease = NonNullable<LimrunRuntime['leaseLifecycle']['allocate']>;
+type ReleaseLease = NonNullable<LimrunRuntime['leaseLifecycle']['release']>;
+
+function createLimrunTestRuntime(): LimrunRuntime {
+  return new LimrunRuntime({
     apiKey: 'lim_test_key',
     version: '9.9.9-test',
   });
+}
 
-  const lease: SimulatorLease = {
-    leaseId: 'lease-a',
+function makeLease(
+  backend: SimulatorLease['backend'],
+  leaseId = backend === 'ios-instance' ? 'lease-ios' : 'lease-android',
+): SimulatorLease {
+  return {
+    leaseId,
     tenantId: 'team-a',
     runId: 'run-a',
-    backend: 'ios-instance',
+    backend,
     leaseProvider: 'limrun',
     createdAt: 1,
     heartbeatAt: 1,
     expiresAt: 60_001,
   };
+}
+
+function requireAllocateLease(runtime: LimrunRuntime): AllocateLease {
+  const allocateLease = runtime.leaseLifecycle.allocate;
+  if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
+  return allocateLease;
+}
+
+function requireReleaseLease(runtime: LimrunRuntime): ReleaseLease {
+  const releaseLease = runtime.leaseLifecycle.release;
+  if (!releaseLease) throw new Error('Limrun runtime must provide lease release');
+  return releaseLease;
+}
+
+async function allocateDevice(runtime: LimrunRuntime, lease: SimulatorLease): Promise<DeviceInfo> {
+  const allocated = await requireAllocateLease(runtime)(lease);
+  const device = allocated?.device;
+  if (!device || typeof device !== 'object') {
+    throw new Error('Limrun runtime must return allocated device metadata');
+  }
+  return device as DeviceInfo;
+}
+
+test('Limrun runtime identifies direct CLI usage to the Limrun API', async () => {
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('ios-instance', 'lease-a');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    await allocateLease(lease);
+    await requireAllocateLease(runtime)(lease);
 
     assert.deepEqual(limrunMockState.constructorOptions[0]?.defaultHeaders, {
       'x-agent-device-client': 'agent-device-cli',
@@ -133,32 +166,12 @@ test('Limrun runtime identifies direct CLI usage to the Limrun API', async () =>
 });
 
 test('Limrun Android reverses localhost URL ports through the persistent ADB tunnel', async () => {
-  const runtime = new LimrunRuntime({
-    apiKey: 'lim_test_key',
-    version: '9.9.9-test',
-  });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-android',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'android-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('android-instance');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    const allocated = await allocateLease(lease);
-    const device = allocated?.device;
-    if (!device || typeof device !== 'object') {
-      throw new Error('Limrun runtime must return allocated device metadata');
-    }
-    const interactor = runtime.getInteractor(
-      device as Parameters<LimrunRuntime['getInteractor']>[0],
-    );
+    const device = await allocateDevice(runtime, lease);
+    const interactor = runtime.getInteractor(device);
     if (!interactor) throw new Error('Limrun runtime must return an interactor');
 
     await interactor.open('exp://127.0.0.1:8081');
@@ -180,8 +193,7 @@ test('Limrun Android reverses localhost URL ports through the persistent ADB tun
       '-s',
       '127.0.0.1:62001',
       'reverse',
-      '--remove',
-      'tcp:8081',
+      '--remove-all',
     ]);
     assert.deepEqual(vi.mocked(runCmd).mock.calls[2]?.[1], ['disconnect', '127.0.0.1:62001']);
     assert.equal(limrunMockState.androidTunnelClose.mock.calls.length, 1);
@@ -190,43 +202,49 @@ test('Limrun Android reverses localhost URL ports through the persistent ADB tun
   }
 });
 
-test('Limrun Android installs direct local artifacts through Limrun assets', async () => {
-  const runtime = new LimrunRuntime({
-    apiKey: 'lim_test_key',
-    version: '9.9.9-test',
-  });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-android',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'android-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
+test('Limrun Android ADB command failures include the selected tunnel serial in diagnostics', async () => {
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('android-instance');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    const allocated = await allocateLease(lease);
-    const device = allocated?.device;
-    if (!device || typeof device !== 'object') {
-      throw new Error('Limrun runtime must return allocated device metadata');
-    }
-    assert.deepEqual(
-      (device as Parameters<LimrunRuntime['installApp']>[0]).capabilities?.supportedCommands?.slice(
-        0,
-        3,
-      ),
-      ['install', 'install-from-source', 'reinstall'],
-    );
+    const device = await allocateDevice(runtime, lease);
+    const interactor = runtime.getInteractor(device);
+    if (!interactor) throw new Error('Limrun runtime must return an interactor');
+    vi.mocked(runCmd).mockResolvedValueOnce({
+      stdout: '',
+      stderr: 'launch failed',
+      exitCode: 1,
+    });
 
-    const result = await runtime.installApp(
-      device as Parameters<LimrunRuntime['installApp']>[0],
-      'com.example.android',
-      '/tmp/app-debug.apk',
+    await assert.rejects(
+      () => interactor.open('com.example.android'),
+      (error) => {
+        const details = (error as { details?: Record<string, unknown> }).details;
+        assert.equal(
+          details?.command,
+          'adb -s 127.0.0.1:62001 shell monkey -p com.example.android -c android.intent.category.LAUNCHER 1',
+        );
+        return true;
+      },
     );
+  } finally {
+    await runtime.shutdown();
+  }
+});
+
+test('Limrun Android installs direct local artifacts through Limrun assets', async () => {
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('android-instance');
+
+  try {
+    const device = await allocateDevice(runtime, lease);
+    assert.deepEqual(device.capabilities?.supportedCommands?.slice(0, 3), [
+      'install',
+      'install-from-source',
+      'reinstall',
+    ]);
+
+    const result = await runtime.installApp(device, 'com.example.android', '/tmp/app-debug.apk');
 
     const assetCalls = limrunMockState.assetsGetOrUpload.mock.calls as unknown as Array<
       [Record<string, unknown>]
@@ -252,36 +270,13 @@ test('Limrun iOS installs direct local artifacts through Limrun assets', async (
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-limrun-install-'));
   const ipaPath = path.join(tempRoot, 'Demo.ipa');
   fs.writeFileSync(ipaPath, 'demo');
-  const runtime = new LimrunRuntime({
-    apiKey: 'lim_test_key',
-    version: '9.9.9-test',
-  });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-ios',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'ios-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('ios-instance');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    const allocated = await allocateLease(lease);
-    const device = allocated?.device;
-    if (!device || typeof device !== 'object') {
-      throw new Error('Limrun runtime must return allocated device metadata');
-    }
+    const device = await allocateDevice(runtime, lease);
 
-    const result = await runtime.installApp(
-      device as Parameters<LimrunRuntime['installApp']>[0],
-      'com.example.ios',
-      ipaPath,
-      { relaunch: true },
-    );
+    const result = await runtime.installApp(device, 'com.example.ios', ipaPath, { relaunch: true });
 
     const assetCalls = limrunMockState.assetsGetOrUpload.mock.calls as unknown as Array<
       [Record<string, unknown>]
@@ -306,25 +301,11 @@ test('Limrun iOS installs direct local artifacts through Limrun assets', async (
 });
 
 test('Limrun Android configures and removes an explicit port reverse', async () => {
-  const runtime = new LimrunRuntime({
-    apiKey: 'lim_test_key',
-    version: '9.9.9-test',
-  });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-android',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'android-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('android-instance');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    await allocateLease(lease);
+    await requireAllocateLease(runtime)(lease);
 
     assert.deepEqual(
       await runtime.configurePortReverse({
@@ -371,25 +352,11 @@ test('Limrun deletes iOS instance when post-create validation fails', async () =
     metadata: { id: 'ios-instance-missing-api' },
     status: { token: 'instance-token' },
   } as never);
-  const runtime = new LimrunRuntime({
-    apiKey: 'lim_test_key',
-    version: '9.9.9-test',
-  });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-ios',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'ios-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('ios-instance');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    await assert.rejects(() => allocateLease(lease), /did not expose apiUrl/);
+    await assert.rejects(() => requireAllocateLease(runtime)(lease), /did not expose apiUrl/);
     assert.deepEqual(limrunMockState.iosDelete.mock.calls[0], ['ios-instance-missing-api']);
   } finally {
     await runtime.shutdown();
@@ -404,25 +371,11 @@ test('Limrun deletes Android instance when post-create validation fails', async 
       apiUrl: 'https://android.example',
     },
   } as never);
-  const runtime = new LimrunRuntime({
-    apiKey: 'lim_test_key',
-    version: '9.9.9-test',
-  });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-android',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'android-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('android-instance');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    if (!allocateLease) throw new Error('Limrun runtime must provide lease allocation');
-    await assert.rejects(() => allocateLease(lease), /did not expose API and ADB/);
+    await assert.rejects(() => requireAllocateLease(runtime)(lease), /did not expose API and ADB/);
     assert.deepEqual(limrunMockState.androidDelete.mock.calls[0], ['android-instance-missing-adb']);
   } finally {
     await runtime.shutdown();
@@ -430,28 +383,12 @@ test('Limrun deletes Android instance when post-create validation fails', async 
 });
 
 test('Limrun keeps session tracked when release fails so release can be retried', async () => {
-  const runtime = new LimrunRuntime({
-    apiKey: 'lim_test_key',
-    version: '9.9.9-test',
-  });
-  const lease: SimulatorLease = {
-    leaseId: 'lease-android',
-    tenantId: 'team-a',
-    runId: 'run-a',
-    backend: 'android-instance',
-    leaseProvider: 'limrun',
-    createdAt: 1,
-    heartbeatAt: 1,
-    expiresAt: 60_001,
-  };
+  const runtime = createLimrunTestRuntime();
+  const lease = makeLease('android-instance');
 
   try {
-    const allocateLease = runtime.leaseLifecycle.allocate;
-    const releaseLease = runtime.leaseLifecycle.release;
-    if (!allocateLease || !releaseLease) {
-      throw new Error('Limrun runtime must provide lease lifecycle hooks');
-    }
-    await allocateLease(lease);
+    const releaseLease = requireReleaseLease(runtime);
+    await requireAllocateLease(runtime)(lease);
     limrunMockState.androidDelete.mockRejectedValueOnce(new Error('temporary delete failure'));
 
     await assert.rejects(() => releaseLease(lease), /temporary delete failure/);

--- a/src/__tests__/provider-device-runtime.test.ts
+++ b/src/__tests__/provider-device-runtime.test.ts
@@ -1,21 +1,21 @@
 import assert from 'node:assert/strict';
 import { afterEach, test } from 'vitest';
 import {
-  composeCloudDeviceInventoryProvider,
-  composeCloudLeaseProvider,
-  getCloudInteractor,
-  setActiveCloudRuntimes,
-  type CloudDeviceRuntime,
-} from '../cloud/cloud-runtime.ts';
+  createProviderDeviceRuntimeRequestProviders,
+  getProviderDeviceInteractor,
+  installProviderDeviceApp,
+  setActiveProviderDeviceRuntimes,
+  type ProviderDeviceRuntime,
+} from '../provider-device-runtime.ts';
 import type { Interactor } from '../core/interactor-types.ts';
 import type { SimulatorLease } from '../daemon/lease-registry.ts';
 import type { DeviceInfo } from '../utils/device.ts';
 
 afterEach(() => {
-  setActiveCloudRuntimes([]);
+  setActiveProviderDeviceRuntimes([]);
 });
 
-test('cloud runtime registry delegates inventory, leases, and interactors to matching providers', async () => {
+test('provider device runtime registry delegates lifecycle, inventory, interactors, and installs to matching providers', async () => {
   const lease: SimulatorLease = {
     leaseId: 'lease-a',
     tenantId: 'team-a',
@@ -39,33 +39,43 @@ test('cloud runtime registry delegates inventory, leases, and interactors to mat
     leaseResult: undefined,
     devices: null,
     interactor: undefined,
+    installResult: undefined,
   });
   const hitRuntime = makeRuntime({
     provider: 'hit',
     leaseResult: { provider: 'hit' },
     devices: [device],
     interactor,
+    installResult: { bundleId: 'com.example.app' },
   });
 
-  setActiveCloudRuntimes([missRuntime, hitRuntime]);
+  setActiveProviderDeviceRuntimes([missRuntime, hitRuntime]);
+  const requestProviders = createProviderDeviceRuntimeRequestProviders([missRuntime, hitRuntime]);
 
-  const leaseLifecycle = composeCloudLeaseProvider([missRuntime, hitRuntime]);
-  const inventoryProvider = composeCloudDeviceInventoryProvider([missRuntime, hitRuntime]);
-
-  assert.deepEqual(await leaseLifecycle?.allocate?.(lease), { provider: 'hit' });
+  assert.deepEqual(await requestProviders.leaseLifecycleProvider?.allocate?.(lease), {
+    provider: 'hit',
+  });
   assert.deepEqual(
-    await inventoryProvider?.({ platform: 'ios', leaseId: 'lease-a', leaseProvider: 'hit' }),
+    await requestProviders.deviceInventoryProvider?.({
+      platform: 'ios',
+      leaseId: 'lease-a',
+      leaseProvider: 'hit',
+    }),
     [device],
   );
-  assert.equal(getCloudInteractor(device), interactor);
+  assert.equal(getProviderDeviceInteractor(device), interactor);
+  assert.deepEqual(await installProviderDeviceApp(device, 'com.example.app', '/tmp/app.ipa'), {
+    bundleId: 'com.example.app',
+  });
 });
 
 function makeRuntime(options: {
-  provider?: string;
+  provider: string;
   leaseResult: Record<string, unknown> | undefined;
   devices: DeviceInfo[] | null;
   interactor: Interactor | undefined;
-}): CloudDeviceRuntime {
+  installResult: { bundleId: string } | undefined;
+}): ProviderDeviceRuntime {
   return {
     provider: options.provider,
     leaseLifecycle: {
@@ -76,6 +86,7 @@ function makeRuntime(options: {
     deviceInventoryProvider: async () => options.devices,
     ownsDevice: (device) => options.devices?.some((entry) => entry.id === device.id) ?? false,
     getInteractor: () => options.interactor,
+    installApp: async () => options.installResult,
     shutdown: async () => undefined,
   };
 }

--- a/src/cloud/limrun-android-adb.ts
+++ b/src/cloud/limrun-android-adb.ts
@@ -1,0 +1,106 @@
+import {
+  createAndroidPortReverseManager,
+  type AndroidAdbExecutorOptions,
+} from '../platforms/android/adb-executor.ts';
+import { AppError } from '../utils/errors.ts';
+import { runCmd } from '../utils/exec.ts';
+import type { LimrunAndroidSession } from './limrun-session.ts';
+
+export async function runLimrunAndroidAdb(
+  session: LimrunAndroidSession,
+  args: string[],
+  options?: AndroidAdbExecutorOptions,
+): Promise<void> {
+  const result = await runLimrunAndroidAdbCommand(session, args, {
+    ...options,
+    timeoutMs: options?.timeoutMs ?? 30_000,
+  });
+  if (result.exitCode !== 0 && options?.allowFailure !== true) {
+    throw new AppError('COMMAND_FAILED', 'Limrun Android ADB command failed', {
+      command: result.command.join(' '),
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+  }
+}
+
+export async function ensureAndroidPortReverse(
+  session: LimrunAndroidSession,
+  options: {
+    devicePort: number;
+    hostPort: number;
+    name: string;
+  },
+): Promise<void> {
+  await getLimrunAndroidPortReverse(session).ensure(
+    {
+      local: tcpEndpoint(options.devicePort),
+      remote: tcpEndpoint(options.hostPort),
+      ownerId: options.name,
+    },
+    { timeoutMs: 30_000 },
+  );
+}
+
+export async function removeAndroidPortReverse(
+  session: LimrunAndroidSession,
+  devicePort: number,
+): Promise<void> {
+  await getLimrunAndroidPortReverse(session)
+    .remove(tcpEndpoint(devicePort), { timeoutMs: 10_000 })
+    .catch(() => {});
+}
+
+export async function cleanupAndroidAdbTunnel(session: LimrunAndroidSession): Promise<void> {
+  const serial = session.adbSerial;
+  if (serial) {
+    await runLimrunAndroidAdbCommand(session, ['reverse', '--remove-all'], {
+      allowFailure: true,
+      timeoutMs: 10_000,
+    }).catch(() => {});
+    await runCmd('adb', ['disconnect', serial], {
+      allowFailure: true,
+      timeoutMs: 10_000,
+    }).catch(() => {});
+  }
+  session.portReverse = undefined;
+  session.adbTunnel?.close();
+  session.adbTunnel = undefined;
+  session.adbSerial = undefined;
+}
+
+function getLimrunAndroidPortReverse(session: LimrunAndroidSession) {
+  if (session.portReverse) return session.portReverse;
+  session.portReverse = createAndroidPortReverseManager(
+    async (args, options) => await runLimrunAndroidAdbCommand(session, args, options),
+  );
+  return session.portReverse;
+}
+
+async function runLimrunAndroidAdbCommand(
+  session: LimrunAndroidSession,
+  args: string[],
+  options?: AndroidAdbExecutorOptions,
+) {
+  const serial = await ensurePersistentAndroidAdbSerial(session);
+  const command = ['adb', '-s', serial, ...args];
+  const result = await runCmd(command[0]!, command.slice(1), {
+    ...options,
+    timeoutMs: options?.timeoutMs ?? 30_000,
+  });
+  return { ...result, command };
+}
+
+function tcpEndpoint(port: number): `tcp:${number}` {
+  return `tcp:${port}`;
+}
+
+async function ensurePersistentAndroidAdbSerial(session: LimrunAndroidSession): Promise<string> {
+  if (session.adbTunnel && session.adbSerial) return session.adbSerial;
+  const tunnel = await session.client.startAdbTunnel();
+  const serial = `${tunnel.address.address}:${tunnel.address.port}`;
+  session.adbTunnel = tunnel;
+  session.adbSerial = serial;
+  return serial;
+}

--- a/src/cloud/limrun-android-interactor.ts
+++ b/src/cloud/limrun-android-interactor.ts
@@ -1,0 +1,204 @@
+import type { Interactor, SnapshotResult } from '../core/interactor-types.ts';
+import type { AndroidAdbExecutorOptions } from '../platforms/android/adb-executor.ts';
+import { ensureAndroidPortReverse, runLimrunAndroidAdb } from './limrun-android-adb.ts';
+import { SETTINGS_INTENT, type LimrunAndroidSession } from './limrun-session.ts';
+import { mapAndroidNode, toAndroidSelector, writeDataUriFile } from './limrun-snapshot.ts';
+import {
+  isAndroidSettingsTarget,
+  looksLikeUrl,
+  readLocalhostUrlPort,
+  unsupported,
+} from './limrun-utils.ts';
+
+export class LimrunAndroidInteractor implements Interactor {
+  private readonly session: LimrunAndroidSession;
+
+  constructor(session: LimrunAndroidSession) {
+    this.session = session;
+  }
+
+  async open(app: string, options?: { url?: string }): Promise<void> {
+    if (options?.url) {
+      await this.ensureReverseForUrl(options.url, 'launch-url');
+      await this.runAdb([
+        'shell',
+        'monkey',
+        '-p',
+        app,
+        '-c',
+        'android.intent.category.LAUNCHER',
+        '1',
+      ]);
+      await this.session.client.openUrl(options.url);
+      return;
+    }
+    if (looksLikeUrl(app)) {
+      await this.ensureReverseForUrl(app, 'open-url');
+      await this.session.client.openUrl(app);
+      return;
+    }
+    if (isAndroidSettingsTarget(app)) {
+      await this.runAdb(['shell', 'am', 'start', '-W', '-a', SETTINGS_INTENT]);
+      return;
+    }
+    await this.runAdb([
+      'shell',
+      'monkey',
+      '-p',
+      app,
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '1',
+    ]);
+  }
+
+  async openDevice(): Promise<void> {}
+
+  async close(app: string): Promise<void> {
+    if (app) await this.runAdb(['shell', 'am', 'force-stop', app], { allowFailure: true });
+  }
+
+  async tap(x: number, y: number): Promise<void> {
+    await this.session.client.tap({ x, y });
+  }
+
+  async tapElementSelector(selector: {
+    key: 'id' | 'label' | 'text' | 'value';
+    value: string;
+  }): Promise<void> {
+    await this.session.client.tap({ selector: toAndroidSelector(selector) });
+  }
+
+  async doubleTap(x: number, y: number): Promise<void> {
+    await this.tap(x, y);
+    await this.tap(x, y);
+  }
+
+  async swipe(x1: number, y1: number, x2: number, y2: number, durationMs?: number) {
+    await this.runAdb([
+      'shell',
+      'input',
+      'swipe',
+      String(Math.round(x1)),
+      String(Math.round(y1)),
+      String(Math.round(x2)),
+      String(Math.round(y2)),
+      String(durationMs ?? 300),
+    ]);
+  }
+
+  async pan(x1: number, y1: number, x2: number, y2: number, durationMs?: number) {
+    await this.swipe(x1, y1, x2, y2, durationMs);
+  }
+
+  async fling(x1: number, y1: number, x2: number, y2: number, durationMs?: number) {
+    await this.swipe(x1, y1, x2, y2, durationMs);
+  }
+
+  async longPress(x: number, y: number, durationMs?: number) {
+    await this.swipe(x, y, x, y, durationMs ?? 800);
+  }
+
+  async focus(x: number, y: number): Promise<void> {
+    await this.tap(x, y);
+  }
+
+  async type(text: string): Promise<void> {
+    await this.session.client.setText(undefined, text);
+  }
+
+  async fill(x: number, y: number, text: string): Promise<void> {
+    await this.session.client.setText({ x, y }, text);
+  }
+
+  async fillElementSelector(
+    selector: { key: 'id' | 'label' | 'text' | 'value'; value: string },
+    text: string,
+  ): Promise<void> {
+    await this.session.client.setText({ selector: toAndroidSelector(selector) }, text);
+  }
+
+  async scroll(direction: 'up' | 'down' | 'left' | 'right', options?: { pixels?: number }) {
+    await this.session.client.scrollScreen(direction, options?.pixels);
+  }
+
+  async pinch(): Promise<never> {
+    return unsupportedAndroid('pinch');
+  }
+
+  async screenshot(outPath: string): Promise<void> {
+    const screenshot = await this.session.client.screenshot();
+    await writeDataUriFile(outPath, screenshot.dataUri);
+  }
+
+  async snapshot(): Promise<SnapshotResult> {
+    const tree = await this.session.client.getElementTree();
+    return {
+      nodes: tree.nodes.map(mapAndroidNode),
+      ...readOptionalTruncation(tree),
+      backend: 'android',
+    };
+  }
+
+  async back(): Promise<void> {
+    await this.session.client.pressKey('BACK');
+  }
+
+  async home(): Promise<void> {
+    await this.session.client.pressKey('HOME');
+  }
+
+  async rotate(): Promise<never> {
+    return unsupportedAndroid('rotate');
+  }
+
+  async rotateGesture(): Promise<never> {
+    return unsupportedAndroid('rotate', 'rotate gestures');
+  }
+
+  async transformGesture(): Promise<never> {
+    return unsupportedAndroid('transform', 'transform gestures');
+  }
+
+  async appSwitcher(): Promise<void> {
+    await this.session.client.pressKey('APP_SWITCH');
+  }
+
+  async readClipboard(): Promise<never> {
+    return unsupportedAndroid('clipboard', 'clipboard read');
+  }
+
+  async writeClipboard(): Promise<never> {
+    return unsupportedAndroid('clipboard', 'clipboard write');
+  }
+
+  async setSetting(): Promise<never> {
+    return unsupportedAndroid('settings', 'settings changes');
+  }
+
+  private async runAdb(args: string[], options?: AndroidAdbExecutorOptions): Promise<void> {
+    await runLimrunAndroidAdb(this.session, args, options);
+  }
+
+  private async ensureReverseForUrl(url: string, name: string): Promise<void> {
+    const port = readLocalhostUrlPort(url);
+    if (!port) return;
+    await ensureAndroidPortReverse(this.session, {
+      devicePort: port,
+      hostPort: port,
+      name,
+    });
+  }
+}
+
+function readOptionalTruncation(value: unknown): Pick<SnapshotResult, 'truncated'> {
+  const truncated =
+    value && typeof value === 'object' && 'truncated' in value
+      ? (value as { truncated?: unknown }).truncated
+      : undefined;
+  return typeof truncated === 'boolean' ? { truncated } : {};
+}
+
+function unsupportedAndroid(command: string, label = command): never {
+  return unsupported(command, `Limrun Android direct sessions do not expose ${label} yet.`);
+}

--- a/src/cloud/limrun-install.ts
+++ b/src/cloud/limrun-install.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type Limrun from '@limrun/api';
+import type {
+  ProviderDeviceInstallOptions,
+  ProviderDeviceInstallResult,
+} from '../provider-device-runtime.ts';
+import { runCmd } from '../utils/exec.ts';
+import { AppError } from '../utils/errors.ts';
+import { runLimrunAndroidAdb } from './limrun-android-adb.ts';
+import type { LimrunAndroidSession, LimrunIosSession } from './limrun-session.ts';
+import {
+  buildAndroidAssetName,
+  inferAndroidAppName,
+  inferAppNameFromPath,
+  normalizeOptionalString,
+} from './limrun-utils.ts';
+
+export async function installLimrunIosApp(
+  limrun: Limrun,
+  session: LimrunIosSession,
+  installablePath: string,
+  options?: ProviderDeviceInstallOptions,
+): Promise<ProviderDeviceInstallResult> {
+  const prepared = await prepareLimrunIosAsset(installablePath);
+  try {
+    const asset = await limrun.assets.getOrUpload({
+      path: prepared.uploadPath,
+      name: prepared.assetName,
+    });
+    const result = await session.client.installApp(asset.signedDownloadUrl, {
+      md5: asset.md5,
+      launchMode: options?.relaunch ? 'RelaunchIfRunning' : 'ForegroundIfRunning',
+    });
+    const bundleId = normalizeOptionalString(result.bundleId) ?? options?.appIdentifierHint;
+    return {
+      ...(bundleId ? { bundleId, launchTarget: bundleId } : {}),
+      appName: inferAppNameFromPath(installablePath),
+    };
+  } finally {
+    await prepared.cleanup();
+  }
+}
+
+export async function installLimrunAndroidApp(
+  limrun: Limrun,
+  session: LimrunAndroidSession,
+  installablePath: string,
+  options?: ProviderDeviceInstallOptions,
+): Promise<ProviderDeviceInstallResult> {
+  const packageName = normalizeOptionalString(options?.packageNameHint);
+  if (options?.relaunch && packageName) {
+    await runLimrunAndroidAdb(session, ['shell', 'am', 'force-stop', packageName], {
+      allowFailure: true,
+    });
+  }
+  const asset = await limrun.assets.getOrUpload({
+    path: installablePath,
+    name: buildAndroidAssetName(packageName, installablePath),
+  });
+  await session.client.sendAsset(asset.signedDownloadUrl);
+  return {
+    ...(packageName ? { packageName, launchTarget: packageName } : {}),
+    ...(packageName ? { appName: inferAndroidAppName(packageName) } : {}),
+  };
+}
+
+async function prepareLimrunIosAsset(artifactPath: string): Promise<{
+  uploadPath: string;
+  assetName: string;
+  cleanup: () => Promise<void>;
+}> {
+  const stat = await fs.promises.stat(artifactPath);
+  if (!stat.isDirectory()) {
+    return {
+      uploadPath: artifactPath,
+      assetName: path.basename(artifactPath),
+      cleanup: async () => {},
+    };
+  }
+
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-limrun-ios-app-'));
+  const zipPath = path.join(tempDir, `${path.basename(artifactPath)}.zip`);
+  const result = await runCmd('zip', ['-qr', zipPath, path.basename(artifactPath)], {
+    cwd: path.dirname(artifactPath),
+    timeoutMs: 120_000,
+  });
+  if (result.exitCode !== 0) {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+    throw new AppError('COMMAND_FAILED', 'Failed to package iOS .app for Limrun install', {
+      command: ['zip', '-qr', zipPath, path.basename(artifactPath)].join(' '),
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+  }
+  return {
+    uploadPath: zipPath,
+    assetName: path.basename(zipPath),
+    cleanup: async () => {
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/src/cloud/limrun-ios-interactor.ts
+++ b/src/cloud/limrun-ios-interactor.ts
@@ -1,0 +1,154 @@
+import type { Interactor, SnapshotOptions, SnapshotResult } from '../core/interactor-types.ts';
+import {
+  flattenIosTree,
+  toIosSelector,
+  writeBase64File,
+  type IosTreeNode,
+} from './limrun-snapshot.ts';
+import type { LimrunIosSession } from './limrun-session.ts';
+import { looksLikeUrl, resolveIosTarget, unsupported } from './limrun-utils.ts';
+
+export class LimrunIosInteractor implements Interactor {
+  private readonly session: LimrunIosSession;
+
+  constructor(session: LimrunIosSession) {
+    this.session = session;
+  }
+
+  async open(app: string, options?: { url?: string }): Promise<void> {
+    if (options?.url) {
+      await this.session.client.launchApp(app);
+      await this.session.client.openUrl(options.url);
+      return;
+    }
+    if (looksLikeUrl(app)) {
+      await this.session.client.openUrl(app);
+      return;
+    }
+    await this.session.client.launchApp(resolveIosTarget(app));
+  }
+
+  async openDevice(): Promise<void> {}
+
+  async close(app: string): Promise<void> {
+    if (app) await this.session.client.terminateApp(resolveIosTarget(app)).catch(() => {});
+  }
+
+  async tap(x: number, y: number): Promise<void> {
+    await this.session.client.tap(x, y);
+  }
+
+  async tapElementSelector(selector: {
+    key: 'id' | 'label' | 'text' | 'value';
+    value: string;
+  }): Promise<Record<string, unknown> | void> {
+    await this.session.client.tapElement(toIosSelector(selector));
+  }
+
+  async doubleTap(x: number, y: number): Promise<void> {
+    await this.tap(x, y);
+    await this.tap(x, y);
+  }
+
+  async swipe(): Promise<never> {
+    return unsupportedIos('swipe');
+  }
+
+  async pan(): Promise<never> {
+    return unsupportedIos('pan');
+  }
+
+  async fling(): Promise<never> {
+    return unsupportedIos('fling');
+  }
+
+  async longPress(): Promise<never> {
+    return unsupportedIos('longpress', 'long press');
+  }
+
+  async focus(x: number, y: number): Promise<void> {
+    await this.tap(x, y);
+  }
+
+  async type(text: string, delayMs?: number): Promise<void> {
+    if (delayMs && delayMs > 0) {
+      for (const char of Array.from(text)) {
+        await this.session.client.typeText(char);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+      return;
+    }
+    await this.session.client.typeText(text);
+  }
+
+  async fill(x: number, y: number, text: string): Promise<void> {
+    await this.tap(x, y);
+    await this.session.client.typeText(text);
+  }
+
+  async fillElementSelector(
+    selector: { key: 'id' | 'label' | 'text' | 'value'; value: string },
+    text: string,
+  ): Promise<void> {
+    await this.session.client.setElementValue(text, toIosSelector(selector));
+  }
+
+  async scroll(direction: 'up' | 'down' | 'left' | 'right', options?: { pixels?: number }) {
+    await this.session.client.scroll(direction, options?.pixels ?? 300);
+  }
+
+  async pinch(): Promise<never> {
+    return unsupportedIos('pinch', 'multi-touch pinch');
+  }
+
+  async screenshot(outPath: string): Promise<void> {
+    const screenshot = await this.session.client.screenshot();
+    await writeBase64File(outPath, screenshot.base64);
+  }
+
+  async snapshot(_options?: SnapshotOptions): Promise<SnapshotResult> {
+    const treeJson = await this.session.client.elementTree();
+    const parsed = JSON.parse(treeJson) as IosTreeNode | IosTreeNode[];
+    return { nodes: flattenIosTree(parsed), backend: 'xctest' };
+  }
+
+  async back(): Promise<void> {
+    await this.session.client.pressKey('escape');
+  }
+
+  async home(): Promise<never> {
+    return unsupportedIos('home');
+  }
+
+  async rotate(orientation: 'portrait' | 'landscape-left' | 'landscape-right'): Promise<void> {
+    await this.session.client.setOrientation(orientation === 'portrait' ? 'Portrait' : 'Landscape');
+  }
+
+  async rotateGesture(): Promise<never> {
+    return unsupportedIos('rotate', 'rotate gestures');
+  }
+
+  async transformGesture(): Promise<never> {
+    return unsupportedIos('transform', 'transform gestures');
+  }
+
+  async appSwitcher(): Promise<never> {
+    return unsupportedIos('app-switcher', 'app switcher');
+  }
+
+  async readClipboard(): Promise<never> {
+    return unsupportedIos('clipboard', 'clipboard read');
+  }
+
+  async writeClipboard(): Promise<never> {
+    return unsupportedIos('clipboard', 'clipboard write');
+  }
+
+  async setSetting(): Promise<never> {
+    return unsupportedIos('settings', 'settings changes');
+  }
+}
+
+function unsupportedIos(command: string, label = command): never {
+  return unsupported(command, `Limrun iOS direct sessions do not expose ${label} yet.`);
+}

--- a/src/cloud/limrun-runtime.ts
+++ b/src/cloud/limrun-runtime.ts
@@ -1,29 +1,19 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import Limrun from '@limrun/api';
-import {
-  createInstanceClient as createAndroidInstanceClient,
-  type InstanceClient as LimrunAndroidClient,
-} from '@limrun/api/instance-client';
-import {
-  createInstanceClient as createIosInstanceClient,
-  type InstanceClient as LimrunIosClient,
-} from '@limrun/api/ios-client';
+import { createInstanceClient as createAndroidInstanceClient } from '@limrun/api/instance-client';
+import { createInstanceClient as createIosInstanceClient } from '@limrun/api/ios-client';
 import { AppError } from '../utils/errors.ts';
-import { runCmd } from '../utils/exec.ts';
 import { readVersion } from '../utils/version.ts';
 import type { DeviceInfo } from '../utils/device.ts';
-import type { Interactor, SnapshotOptions, SnapshotResult } from '../core/interactor-types.ts';
+import type { Interactor } from '../core/interactor-types.ts';
 import type { DeviceInventoryProvider } from '../core/dispatch-resolve.ts';
-import type { AndroidAdbExecutorOptions } from '../platforms/android/adb-executor.ts';
 import type { LeaseLifecycleProvider } from '../daemon/handlers/lease.ts';
 import type { DeviceLease } from '../daemon/lease-registry.ts';
 import type {
-  CloudAppInstallOptions,
-  CloudAppInstallResult,
-  CloudDeviceRuntime,
-} from './cloud-runtime.ts';
+  ProviderDeviceInstallOptions,
+  ProviderDeviceInstallResult,
+  ProviderDeviceRuntime,
+  ProviderPortReverseOptions,
+} from '../provider-device-runtime.ts';
 import {
   buildLimrunDevice,
   LIMRUN_PROVIDER,
@@ -32,54 +22,22 @@ import {
   readLimrunLeaseIdFromInventoryRequest,
 } from './limrun-device.ts';
 import {
-  flattenIosTree,
-  mapAndroidNode,
-  toAndroidSelector,
-  toIosSelector,
-  writeBase64File,
-  writeDataUriFile,
-  type IosTreeNode,
-} from './limrun-snapshot.ts';
+  cleanupAndroidAdbTunnel,
+  ensureAndroidPortReverse,
+  removeAndroidPortReverse,
+} from './limrun-android-adb.ts';
+import { LimrunAndroidInteractor } from './limrun-android-interactor.ts';
+import { installLimrunAndroidApp, installLimrunIosApp } from './limrun-install.ts';
+import { LimrunIosInteractor } from './limrun-ios-interactor.ts';
+import {
+  LIMRUN_CLIENT_HEADER,
+  type LimrunInstance,
+  type LimrunRuntimeOptions,
+  type LimrunRuntimeSession,
+} from './limrun-session.ts';
+import { unsupported } from './limrun-utils.ts';
 
-type LimrunAdbTunnel = Awaited<ReturnType<LimrunAndroidClient['startAdbTunnel']>>;
-
-type LimrunInstance = {
-  metadata: { id: string };
-  status: {
-    token: string;
-    apiUrl?: string;
-    adbWebSocketUrl?: string;
-    state?: string;
-  };
-};
-
-type LimrunRuntimeSession =
-  | {
-      platform: 'ios';
-      lease: DeviceLease;
-      instanceId: string;
-      device: DeviceInfo;
-      client: LimrunIosClient;
-    }
-  | {
-      platform: 'android';
-      lease: DeviceLease;
-      instanceId: string;
-      device: DeviceInfo;
-      client: LimrunAndroidClient;
-      adbTunnel?: LimrunAdbTunnel;
-      adbSerial?: string;
-      reversedPorts: Map<number, string>;
-    };
-
-type LimrunRuntimeOptions = {
-  apiKey: string;
-  region?: string;
-  version?: string;
-};
-
-const LIMRUN_CLIENT_HEADER = 'agent-device-cli';
-const SETTINGS_INTENT = 'android.settings.SETTINGS';
+export { readLocalhostUrlPort } from './limrun-utils.ts';
 
 export function createLimrunRuntimeFromEnv(env: NodeJS.ProcessEnv): LimrunRuntime | undefined {
   const apiKey = env.LIMRUN_API_KEY?.trim() || env.LIM_API_KEY?.trim();
@@ -91,7 +49,7 @@ export function createLimrunRuntimeFromEnv(env: NodeJS.ProcessEnv): LimrunRuntim
   });
 }
 
-export class LimrunRuntime implements CloudDeviceRuntime {
+export class LimrunRuntime implements ProviderDeviceRuntime {
   private readonly limrun: Limrun;
   private readonly sessions = new Map<string, LimrunRuntimeSession>();
   private readonly options: LimrunRuntimeOptions;
@@ -141,8 +99,8 @@ export class LimrunRuntime implements CloudDeviceRuntime {
     device: DeviceInfo,
     app: string,
     appPath: string,
-    options?: CloudAppInstallOptions,
-  ): Promise<CloudAppInstallResult | undefined> {
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined> {
     return await this.installInstallablePath(device, appPath, {
       ...options,
       appIdentifierHint: options?.appIdentifierHint ?? app,
@@ -153,8 +111,8 @@ export class LimrunRuntime implements CloudDeviceRuntime {
   async installInstallablePath(
     device: DeviceInfo,
     installablePath: string,
-    options?: CloudAppInstallOptions,
-  ): Promise<CloudAppInstallResult | undefined> {
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined> {
     const session = this.getSessionForDevice(device);
     if (!session) return undefined;
     return session.platform === 'ios'
@@ -162,12 +120,9 @@ export class LimrunRuntime implements CloudDeviceRuntime {
       : await installLimrunAndroidApp(this.limrun, session, installablePath, options);
   }
 
-  async configurePortReverse(options: {
-    leaseId: string;
-    devicePort: number;
-    hostPort: number;
-    name: string;
-  }): Promise<Record<string, unknown> | undefined> {
+  async configurePortReverse(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined> {
     const session = this.sessions.get(options.leaseId);
     if (!session) return undefined;
     if (session.platform !== 'android') {
@@ -177,30 +132,17 @@ export class LimrunRuntime implements CloudDeviceRuntime {
       );
     }
     await ensureAndroidPortReverse(session, options);
-    return {
-      leaseId: options.leaseId,
-      devicePort: options.devicePort,
-      hostPort: options.hostPort,
-      name: options.name,
-    };
+    return portReverseResult(options);
   }
 
-  async removePortReverse(options: {
-    leaseId: string;
-    devicePort: number;
-    hostPort: number;
-    name: string;
-  }): Promise<Record<string, unknown> | undefined> {
+  async removePortReverse(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined> {
     const session = this.sessions.get(options.leaseId);
     if (!session) return undefined;
     if (session.platform !== 'android') return undefined;
     await removeAndroidPortReverse(session, options.devicePort);
-    return {
-      leaseId: options.leaseId,
-      devicePort: options.devicePort,
-      hostPort: options.hostPort,
-      name: options.name,
-    };
+    return portReverseResult(options);
   }
 
   async shutdown(): Promise<void> {
@@ -279,7 +221,6 @@ export class LimrunRuntime implements CloudDeviceRuntime {
         instanceId: instance.metadata.id,
         device: buildLimrunDevice('android', lease, instance.metadata.id),
         client,
-        reversedPorts: new Map(),
       };
     } catch (error) {
       await this.limrun.androidInstances.delete(instance.metadata.id).catch(() => {});
@@ -327,611 +268,11 @@ export class LimrunRuntime implements CloudDeviceRuntime {
   }
 }
 
-async function installLimrunIosApp(
-  limrun: Limrun,
-  session: Extract<LimrunRuntimeSession, { platform: 'ios' }>,
-  installablePath: string,
-  options?: CloudAppInstallOptions,
-): Promise<CloudAppInstallResult> {
-  const prepared = await prepareLimrunIosAsset(installablePath);
-  try {
-    const asset = await limrun.assets.getOrUpload({
-      path: prepared.uploadPath,
-      name: prepared.assetName,
-    });
-    const result = await session.client.installApp(asset.signedDownloadUrl, {
-      md5: asset.md5,
-      launchMode: options?.relaunch ? 'RelaunchIfRunning' : 'ForegroundIfRunning',
-    });
-    const bundleId = normalizeOptionalString(result.bundleId) ?? options?.appIdentifierHint;
-    return {
-      ...(bundleId ? { bundleId, launchTarget: bundleId } : {}),
-      appName: inferAppNameFromPath(installablePath),
-    };
-  } finally {
-    await prepared.cleanup();
-  }
-}
-
-async function installLimrunAndroidApp(
-  limrun: Limrun,
-  session: Extract<LimrunRuntimeSession, { platform: 'android' }>,
-  installablePath: string,
-  options?: CloudAppInstallOptions,
-): Promise<CloudAppInstallResult> {
-  const packageName = normalizeOptionalString(options?.packageNameHint);
-  if (options?.relaunch && packageName) {
-    await runLimrunAndroidAdb(session, ['shell', 'am', 'force-stop', packageName], {
-      allowFailure: true,
-    });
-  }
-  const asset = await limrun.assets.getOrUpload({
-    path: installablePath,
-    name: buildAndroidAssetName(packageName, installablePath),
-  });
-  await session.client.sendAsset(asset.signedDownloadUrl);
+function portReverseResult(options: ProviderPortReverseOptions): Record<string, unknown> {
   return {
-    ...(packageName ? { packageName, launchTarget: packageName } : {}),
-    ...(packageName ? { appName: inferAndroidAppName(packageName) } : {}),
+    leaseId: options.leaseId,
+    devicePort: options.devicePort,
+    hostPort: options.hostPort,
+    name: options.name,
   };
-}
-
-async function prepareLimrunIosAsset(artifactPath: string): Promise<{
-  uploadPath: string;
-  assetName: string;
-  cleanup: () => Promise<void>;
-}> {
-  const stat = await fs.promises.stat(artifactPath);
-  if (!stat.isDirectory()) {
-    return {
-      uploadPath: artifactPath,
-      assetName: path.basename(artifactPath),
-      cleanup: async () => {},
-    };
-  }
-
-  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-limrun-ios-app-'));
-  const zipPath = path.join(tempDir, `${path.basename(artifactPath)}.zip`);
-  const result = await runCmd('zip', ['-qr', zipPath, path.basename(artifactPath)], {
-    cwd: path.dirname(artifactPath),
-    timeoutMs: 120_000,
-  });
-  if (result.exitCode !== 0) {
-    await fs.promises.rm(tempDir, { recursive: true, force: true });
-    throw new AppError('COMMAND_FAILED', 'Failed to package iOS .app for Limrun install', {
-      command: ['zip', '-qr', zipPath, path.basename(artifactPath)].join(' '),
-      exitCode: result.exitCode,
-      stdout: result.stdout,
-      stderr: result.stderr,
-    });
-  }
-  return {
-    uploadPath: zipPath,
-    assetName: path.basename(zipPath),
-    cleanup: async () => {
-      await fs.promises.rm(tempDir, { recursive: true, force: true });
-    },
-  };
-}
-
-async function runLimrunAndroidAdb(
-  session: Extract<LimrunRuntimeSession, { platform: 'android' }>,
-  args: string[],
-  options?: AndroidAdbExecutorOptions,
-): Promise<void> {
-  const serial = await ensurePersistentAndroidAdbSerial(session);
-  const result = await runCmd('adb', ['-s', serial, ...args], {
-    allowFailure: options?.allowFailure,
-    timeoutMs: options?.timeoutMs ?? 30_000,
-    signal: options?.signal,
-  });
-  if (result.exitCode !== 0 && options?.allowFailure !== true) {
-    throw new AppError('COMMAND_FAILED', 'Limrun Android ADB command failed', {
-      command: ['adb', '-s', serial, ...args].join(' '),
-      exitCode: result.exitCode,
-      stdout: result.stdout,
-      stderr: result.stderr,
-    });
-  }
-}
-
-class LimrunIosInteractor implements Interactor {
-  private readonly session: Extract<LimrunRuntimeSession, { platform: 'ios' }>;
-
-  constructor(session: Extract<LimrunRuntimeSession, { platform: 'ios' }>) {
-    this.session = session;
-  }
-
-  async open(app: string, options?: { url?: string }): Promise<void> {
-    if (options?.url) {
-      await this.session.client.launchApp(app);
-      await this.session.client.openUrl(options.url);
-      return;
-    }
-    if (looksLikeUrl(app)) {
-      await this.session.client.openUrl(app);
-      return;
-    }
-    await this.session.client.launchApp(resolveIosTarget(app));
-  }
-
-  async openDevice(): Promise<void> {}
-
-  async close(app: string): Promise<void> {
-    if (app) await this.session.client.terminateApp(resolveIosTarget(app)).catch(() => {});
-  }
-
-  async tap(x: number, y: number): Promise<void> {
-    await this.session.client.tap(x, y);
-  }
-
-  async tapElementSelector(selector: {
-    key: 'id' | 'label' | 'text' | 'value';
-    value: string;
-  }): Promise<Record<string, unknown> | void> {
-    await this.session.client.tapElement(toIosSelector(selector));
-  }
-
-  async doubleTap(x: number, y: number): Promise<void> {
-    await this.tap(x, y);
-    await this.tap(x, y);
-  }
-
-  async swipe(): Promise<never> {
-    throw unsupported('swipe', 'Limrun iOS direct sessions do not expose swipe yet.');
-  }
-
-  async pan(): Promise<never> {
-    throw unsupported('pan', 'Limrun iOS direct sessions do not expose pan yet.');
-  }
-
-  async fling(): Promise<never> {
-    throw unsupported('fling', 'Limrun iOS direct sessions do not expose fling yet.');
-  }
-
-  async longPress(): Promise<never> {
-    throw unsupported('longpress', 'Limrun iOS direct sessions do not expose long press yet.');
-  }
-
-  async focus(x: number, y: number): Promise<void> {
-    await this.tap(x, y);
-  }
-
-  async type(text: string, delayMs?: number): Promise<void> {
-    if (delayMs && delayMs > 0) {
-      for (const char of Array.from(text)) {
-        await this.session.client.typeText(char);
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-      }
-      return;
-    }
-    await this.session.client.typeText(text);
-  }
-
-  async fill(x: number, y: number, text: string): Promise<void> {
-    await this.tap(x, y);
-    await this.session.client.typeText(text);
-  }
-
-  async fillElementSelector(
-    selector: { key: 'id' | 'label' | 'text' | 'value'; value: string },
-    text: string,
-  ): Promise<void> {
-    await this.session.client.setElementValue(text, toIosSelector(selector));
-  }
-
-  async scroll(direction: 'up' | 'down' | 'left' | 'right', options?: { pixels?: number }) {
-    await this.session.client.scroll(direction, options?.pixels ?? 300);
-  }
-
-  async pinch(): Promise<never> {
-    throw unsupported('pinch', 'Limrun iOS direct sessions do not expose multi-touch pinch yet.');
-  }
-
-  async screenshot(outPath: string): Promise<void> {
-    const screenshot = await this.session.client.screenshot();
-    await writeBase64File(outPath, screenshot.base64);
-  }
-
-  async snapshot(_options?: SnapshotOptions): Promise<SnapshotResult> {
-    const treeJson = await this.session.client.elementTree();
-    const parsed = JSON.parse(treeJson) as IosTreeNode | IosTreeNode[];
-    return { nodes: flattenIosTree(parsed), backend: 'xctest' };
-  }
-
-  async back(): Promise<void> {
-    await this.session.client.pressKey('escape');
-  }
-
-  async home(): Promise<never> {
-    throw unsupported('home', 'Limrun iOS direct sessions do not expose home yet.');
-  }
-
-  async rotate(orientation: 'portrait' | 'landscape-left' | 'landscape-right'): Promise<void> {
-    await this.session.client.setOrientation(orientation === 'portrait' ? 'Portrait' : 'Landscape');
-  }
-
-  async rotateGesture(): Promise<never> {
-    throw unsupported('rotate', 'Limrun iOS direct sessions do not expose rotate gestures yet.');
-  }
-
-  async transformGesture(): Promise<never> {
-    throw unsupported(
-      'transform',
-      'Limrun iOS direct sessions do not expose transform gestures yet.',
-    );
-  }
-
-  async appSwitcher(): Promise<never> {
-    throw unsupported('app-switcher', 'Limrun iOS direct sessions do not expose app switcher yet.');
-  }
-
-  async readClipboard(): Promise<never> {
-    throw unsupported('clipboard', 'Limrun iOS direct sessions do not expose clipboard read yet.');
-  }
-
-  async writeClipboard(): Promise<never> {
-    throw unsupported('clipboard', 'Limrun iOS direct sessions do not expose clipboard write yet.');
-  }
-
-  async setSetting(): Promise<never> {
-    throw unsupported('settings', 'Limrun iOS direct sessions do not expose settings changes yet.');
-  }
-}
-
-class LimrunAndroidInteractor implements Interactor {
-  private readonly session: Extract<LimrunRuntimeSession, { platform: 'android' }>;
-
-  constructor(session: Extract<LimrunRuntimeSession, { platform: 'android' }>) {
-    this.session = session;
-  }
-
-  async open(app: string, options?: { url?: string }): Promise<void> {
-    if (options?.url) {
-      await this.ensureReverseForUrl(options.url, 'launch-url');
-      await this.runAdb([
-        'shell',
-        'monkey',
-        '-p',
-        app,
-        '-c',
-        'android.intent.category.LAUNCHER',
-        '1',
-      ]);
-      await this.session.client.openUrl(options.url);
-      return;
-    }
-    if (looksLikeUrl(app)) {
-      await this.ensureReverseForUrl(app, 'open-url');
-      await this.session.client.openUrl(app);
-      return;
-    }
-    if (isAndroidSettingsTarget(app)) {
-      await this.runAdb(['shell', 'am', 'start', '-W', '-a', SETTINGS_INTENT]);
-      return;
-    }
-    await this.runAdb([
-      'shell',
-      'monkey',
-      '-p',
-      app,
-      '-c',
-      'android.intent.category.LAUNCHER',
-      '1',
-    ]);
-  }
-
-  async openDevice(): Promise<void> {}
-
-  async close(app: string): Promise<void> {
-    if (app) await this.runAdb(['shell', 'am', 'force-stop', app], { allowFailure: true });
-  }
-
-  async tap(x: number, y: number): Promise<void> {
-    await this.session.client.tap({ x, y });
-  }
-
-  async tapElementSelector(selector: {
-    key: 'id' | 'label' | 'text' | 'value';
-    value: string;
-  }): Promise<void> {
-    await this.session.client.tap({ selector: toAndroidSelector(selector) });
-  }
-
-  async doubleTap(x: number, y: number): Promise<void> {
-    await this.tap(x, y);
-    await this.tap(x, y);
-  }
-
-  async swipe(x1: number, y1: number, x2: number, y2: number, durationMs?: number) {
-    await this.runAdb([
-      'shell',
-      'input',
-      'swipe',
-      String(Math.round(x1)),
-      String(Math.round(y1)),
-      String(Math.round(x2)),
-      String(Math.round(y2)),
-      String(durationMs ?? 300),
-    ]);
-  }
-
-  async pan(x1: number, y1: number, x2: number, y2: number, durationMs?: number) {
-    await this.swipe(x1, y1, x2, y2, durationMs);
-  }
-
-  async fling(x1: number, y1: number, x2: number, y2: number, durationMs?: number) {
-    await this.swipe(x1, y1, x2, y2, durationMs);
-  }
-
-  async longPress(x: number, y: number, durationMs?: number) {
-    await this.swipe(x, y, x, y, durationMs ?? 800);
-  }
-
-  async focus(x: number, y: number): Promise<void> {
-    await this.tap(x, y);
-  }
-
-  async type(text: string): Promise<void> {
-    await this.session.client.setText(undefined, text);
-  }
-
-  async fill(x: number, y: number, text: string): Promise<void> {
-    await this.session.client.setText({ x, y }, text);
-  }
-
-  async fillElementSelector(
-    selector: { key: 'id' | 'label' | 'text' | 'value'; value: string },
-    text: string,
-  ): Promise<void> {
-    await this.session.client.setText({ selector: toAndroidSelector(selector) }, text);
-  }
-
-  async scroll(direction: 'up' | 'down' | 'left' | 'right', options?: { pixels?: number }) {
-    await this.session.client.scrollScreen(direction, options?.pixels);
-  }
-
-  async pinch(): Promise<never> {
-    throw unsupported('pinch', 'Limrun Android direct sessions do not expose pinch yet.');
-  }
-
-  async screenshot(outPath: string): Promise<void> {
-    const screenshot = await this.session.client.screenshot();
-    await writeDataUriFile(outPath, screenshot.dataUri);
-  }
-
-  async snapshot(): Promise<SnapshotResult> {
-    const tree = await this.session.client.getElementTree();
-    return {
-      nodes: tree.nodes.map(mapAndroidNode),
-      ...readOptionalTruncation(tree),
-      backend: 'android',
-    };
-  }
-
-  async back(): Promise<void> {
-    await this.session.client.pressKey('BACK');
-  }
-
-  async home(): Promise<void> {
-    await this.session.client.pressKey('HOME');
-  }
-
-  async rotate(): Promise<never> {
-    throw unsupported('rotate', 'Limrun Android direct sessions do not expose rotate yet.');
-  }
-
-  async rotateGesture(): Promise<never> {
-    throw unsupported(
-      'rotate',
-      'Limrun Android direct sessions do not expose rotate gestures yet.',
-    );
-  }
-
-  async transformGesture(): Promise<never> {
-    throw unsupported(
-      'transform',
-      'Limrun Android direct sessions do not expose transform gestures yet.',
-    );
-  }
-
-  async appSwitcher(): Promise<void> {
-    await this.session.client.pressKey('APP_SWITCH');
-  }
-
-  async readClipboard(): Promise<never> {
-    throw unsupported(
-      'clipboard',
-      'Limrun Android direct sessions do not expose clipboard read yet.',
-    );
-  }
-
-  async writeClipboard(): Promise<never> {
-    throw unsupported(
-      'clipboard',
-      'Limrun Android direct sessions do not expose clipboard write yet.',
-    );
-  }
-
-  async setSetting(): Promise<never> {
-    throw unsupported(
-      'settings',
-      'Limrun Android direct sessions do not expose settings changes yet.',
-    );
-  }
-
-  private async runAdb(args: string[], options?: AndroidAdbExecutorOptions): Promise<void> {
-    await runLimrunAndroidAdb(this.session, args, options);
-  }
-
-  private async ensureReverseForUrl(url: string, name: string): Promise<void> {
-    const port = readLocalhostUrlPort(url);
-    if (!port) return;
-    await ensureAndroidPortReverse(this.session, {
-      devicePort: port,
-      hostPort: port,
-      name,
-    });
-  }
-}
-
-async function ensureAndroidPortReverse(
-  session: Extract<LimrunRuntimeSession, { platform: 'android' }>,
-  options: {
-    devicePort: number;
-    hostPort: number;
-    name: string;
-  },
-): Promise<void> {
-  const existing = session.reversedPorts.get(options.devicePort);
-  if (existing === options.name) return;
-  if (existing && existing !== options.name) {
-    throw new AppError('INVALID_ARGS', `Limrun Android port reverse already exists`, {
-      devicePort: options.devicePort,
-      existingName: existing,
-      requestedName: options.name,
-    });
-  }
-  const serial = await ensurePersistentAndroidAdbSerial(session);
-  const result = await runCmd(
-    'adb',
-    ['-s', serial, 'reverse', `tcp:${options.devicePort}`, `tcp:${options.hostPort}`],
-    {
-      timeoutMs: 30_000,
-    },
-  );
-  if (result.exitCode !== 0) {
-    throw new AppError('COMMAND_FAILED', 'Limrun Android ADB reverse failed', {
-      command: [
-        'adb',
-        '-s',
-        serial,
-        'reverse',
-        `tcp:${options.devicePort}`,
-        `tcp:${options.hostPort}`,
-      ].join(' '),
-      exitCode: result.exitCode,
-      stdout: result.stdout,
-      stderr: result.stderr,
-    });
-  }
-  session.reversedPorts.set(options.devicePort, options.name);
-}
-
-async function removeAndroidPortReverse(
-  session: Extract<LimrunRuntimeSession, { platform: 'android' }>,
-  devicePort: number,
-): Promise<void> {
-  if (!session.reversedPorts.has(devicePort)) return;
-  const serial = await ensurePersistentAndroidAdbSerial(session);
-  await runCmd('adb', ['-s', serial, 'reverse', '--remove', `tcp:${devicePort}`], {
-    allowFailure: true,
-    timeoutMs: 10_000,
-  }).catch(() => {});
-  session.reversedPorts.delete(devicePort);
-}
-
-function readOptionalTruncation(value: unknown): Pick<SnapshotResult, 'truncated'> {
-  const truncated =
-    value && typeof value === 'object' && 'truncated' in value
-      ? (value as { truncated?: unknown }).truncated
-      : undefined;
-  return typeof truncated === 'boolean' ? { truncated } : {};
-}
-
-async function ensurePersistentAndroidAdbSerial(
-  session: Extract<LimrunRuntimeSession, { platform: 'android' }>,
-): Promise<string> {
-  if (session.adbTunnel && session.adbSerial) return session.adbSerial;
-  const tunnel = await session.client.startAdbTunnel();
-  const serial = `${tunnel.address.address}:${tunnel.address.port}`;
-  session.adbTunnel = tunnel;
-  session.adbSerial = serial;
-  return serial;
-}
-
-async function cleanupAndroidAdbTunnel(
-  session: Extract<LimrunRuntimeSession, { platform: 'android' }>,
-): Promise<void> {
-  const serial = session.adbSerial;
-  if (serial) {
-    await Promise.allSettled(
-      Array.from(session.reversedPorts.keys()).map((port) =>
-        runCmd('adb', ['-s', serial, 'reverse', '--remove', `tcp:${port}`], {
-          allowFailure: true,
-          timeoutMs: 10_000,
-        }),
-      ),
-    );
-    await runCmd('adb', ['disconnect', serial], {
-      allowFailure: true,
-      timeoutMs: 10_000,
-    }).catch(() => {});
-  }
-  session.reversedPorts.clear();
-  session.adbTunnel?.close();
-  session.adbTunnel = undefined;
-  session.adbSerial = undefined;
-}
-
-function resolveIosTarget(app: string): string {
-  const normalized = app.trim().toLowerCase();
-  if (normalized === 'settings') return 'com.apple.Preferences';
-  return app;
-}
-
-function isAndroidSettingsTarget(app: string): boolean {
-  const normalized = app.trim().toLowerCase();
-  return normalized === 'settings' || normalized === 'com.android.settings';
-}
-
-function normalizeOptionalString(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? normalized : undefined;
-}
-
-function inferAppNameFromPath(appPath: string): string | undefined {
-  const base = path.basename(appPath).replace(/\.(?:app|ipa|apk|aab|zip)$/i, '');
-  return base || undefined;
-}
-
-function inferAndroidAppName(packageName: string): string | undefined {
-  const segments = packageName.split('.').filter(Boolean);
-  const last = segments.at(-1);
-  return last ? last.replace(/[_-]+/g, ' ') : undefined;
-}
-
-function buildAndroidAssetName(packageName: string | undefined, artifactPath: string): string {
-  const extension = path.extname(artifactPath) || '.apk';
-  const prefix = packageName?.replace(/[^a-zA-Z0-9_.-]+/g, '-') || 'android-app';
-  return `${prefix}${extension}`;
-}
-
-function looksLikeUrl(value: string): boolean {
-  return /^[a-z][a-z0-9+.-]*:/i.test(value.trim());
-}
-
-export function readLocalhostUrlPort(value: string): number | undefined {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return undefined;
-  }
-  const hostname = url.hostname.toLowerCase();
-  if (
-    hostname !== 'localhost' &&
-    hostname !== '127.0.0.1' &&
-    hostname !== '::1' &&
-    hostname !== '[::1]'
-  ) {
-    return undefined;
-  }
-  const port = Number(url.port);
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) return undefined;
-  return port;
-}
-
-function unsupported(command: string, message: string): never {
-  throw new AppError('UNSUPPORTED_OPERATION', message, { command });
 }

--- a/src/cloud/limrun-session.ts
+++ b/src/cloud/limrun-session.ts
@@ -1,0 +1,47 @@
+import type { InstanceClient as LimrunAndroidClient } from '@limrun/api/instance-client';
+import type { InstanceClient as LimrunIosClient } from '@limrun/api/ios-client';
+import type { DeviceLease } from '../daemon/lease-registry.ts';
+import type { AndroidPortReverseProvider } from '../platforms/android/adb-executor.ts';
+import type { DeviceInfo } from '../utils/device.ts';
+
+export type LimrunAdbTunnel = Awaited<ReturnType<LimrunAndroidClient['startAdbTunnel']>>;
+
+export type LimrunInstance = {
+  metadata: { id: string };
+  status: {
+    token: string;
+    apiUrl?: string;
+    adbWebSocketUrl?: string;
+    state?: string;
+  };
+};
+
+export type LimrunIosSession = {
+  platform: 'ios';
+  lease: DeviceLease;
+  instanceId: string;
+  device: DeviceInfo;
+  client: LimrunIosClient;
+};
+
+export type LimrunAndroidSession = {
+  platform: 'android';
+  lease: DeviceLease;
+  instanceId: string;
+  device: DeviceInfo;
+  client: LimrunAndroidClient;
+  adbTunnel?: LimrunAdbTunnel;
+  adbSerial?: string;
+  portReverse?: AndroidPortReverseProvider;
+};
+
+export type LimrunRuntimeSession = LimrunIosSession | LimrunAndroidSession;
+
+export type LimrunRuntimeOptions = {
+  apiKey: string;
+  region?: string;
+  version?: string;
+};
+
+export const LIMRUN_CLIENT_HEADER = 'agent-device-cli';
+export const SETTINGS_INTENT = 'android.settings.SETTINGS';

--- a/src/cloud/limrun-utils.ts
+++ b/src/cloud/limrun-utils.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import { AppError } from '../utils/errors.ts';
+
+export function resolveIosTarget(app: string): string {
+  const normalized = app.trim().toLowerCase();
+  if (normalized === 'settings') return 'com.apple.Preferences';
+  return app;
+}
+
+export function isAndroidSettingsTarget(app: string): boolean {
+  const normalized = app.trim().toLowerCase();
+  return normalized === 'settings' || normalized === 'com.android.settings';
+}
+
+export function normalizeOptionalString(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+export function inferAppNameFromPath(appPath: string): string | undefined {
+  const base = path.basename(appPath).replace(/\.(?:app|ipa|apk|aab|zip)$/i, '');
+  return base || undefined;
+}
+
+export function inferAndroidAppName(packageName: string): string | undefined {
+  const segments = packageName.split('.').filter(Boolean);
+  const last = segments.at(-1);
+  return last ? last.replace(/[_-]+/g, ' ') : undefined;
+}
+
+export function buildAndroidAssetName(
+  packageName: string | undefined,
+  artifactPath: string,
+): string {
+  const extension = path.extname(artifactPath) || '.apk';
+  const prefix = packageName?.replace(/[^a-zA-Z0-9_.-]+/g, '-') || 'android-app';
+  return `${prefix}${extension}`;
+}
+
+export function looksLikeUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value.trim());
+}
+
+export function readLocalhostUrlPort(value: string): number | undefined {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (
+    hostname !== 'localhost' &&
+    hostname !== '127.0.0.1' &&
+    hostname !== '::1' &&
+    hostname !== '[::1]'
+  ) {
+    return undefined;
+  }
+  const port = Number(url.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) return undefined;
+  return port;
+}
+
+export function unsupported(command: string, message: string): never {
+  throw new AppError('UNSUPPORTED_OPERATION', message, { command });
+}

--- a/src/core/interactors.ts
+++ b/src/core/interactors.ts
@@ -1,15 +1,15 @@
 import type { DeviceInfo } from '../utils/device.ts';
 import { AppError } from '../utils/errors.ts';
-import { getCloudInteractor, isCloudDevice } from '../cloud/cloud-runtime.ts';
+import { getProviderDeviceInteractor, isActiveProviderDevice } from '../provider-device-runtime.ts';
 import type { Interactor, RunnerContext } from './interactor-types.ts';
 
 export async function getInteractor(
   device: DeviceInfo,
   runnerContext: RunnerContext,
 ): Promise<Interactor> {
-  if (isCloudDevice(device)) {
-    const cloudInteractor = getCloudInteractor(device);
-    if (cloudInteractor) return cloudInteractor;
+  if (isActiveProviderDevice(device)) {
+    const providerInteractor = getProviderDeviceInteractor(device);
+    if (providerInteractor) return providerInteractor;
   }
 
   switch (device.platform) {

--- a/src/daemon-runtime.ts
+++ b/src/daemon-runtime.ts
@@ -12,11 +12,10 @@ import { teardownSessionResources } from './daemon/session-teardown.ts';
 import { closeDaemonServers } from './daemon/server-shutdown.ts';
 import { createLimrunRuntimeFromEnv } from './cloud/limrun-runtime.ts';
 import {
-  composeCloudDeviceInventoryProvider,
-  composeCloudLeaseProvider,
-  setActiveCloudRuntimes,
-  type CloudDeviceRuntime,
-} from './cloud/cloud-runtime.ts';
+  createProviderDeviceRuntimeRequestProviders,
+  setActiveProviderDeviceRuntimes,
+  type ProviderDeviceRuntime,
+} from './provider-device-runtime.ts';
 import type { SessionState } from './daemon/types.ts';
 import {
   emitDiagnostic,
@@ -79,11 +78,12 @@ export async function startDaemonRuntime(
 
   cleanupStaleAppLogProcesses(sessionsDir);
 
-  const cloudRuntimes: CloudDeviceRuntime[] = [];
+  const providerRuntimes: ProviderDeviceRuntime[] = [];
   const limrunRuntime = createLimrunRuntimeFromEnv(env);
-  if (limrunRuntime) cloudRuntimes.push(limrunRuntime);
-  setActiveCloudRuntimes(cloudRuntimes);
-  const leaseLifecycleProvider = composeCloudLeaseProvider(cloudRuntimes);
+  if (limrunRuntime) providerRuntimes.push(limrunRuntime);
+  setActiveProviderDeviceRuntimes(providerRuntimes);
+  const providerRuntimeProviders = createProviderDeviceRuntimeRequestProviders(providerRuntimes);
+  const leaseLifecycleProvider = providerRuntimeProviders.leaseLifecycleProvider;
   const releaseExpiredLease = (lease: DeviceLease) => {
     void leaseLifecycleProvider?.release?.(lease).catch((error) => {
       stderr.write(
@@ -114,7 +114,7 @@ export async function startDaemonRuntime(
     sessionStore,
     leaseRegistry,
     leaseLifecycleProvider,
-    deviceInventoryProvider: composeCloudDeviceInventoryProvider(cloudRuntimes),
+    deviceInventoryProvider: providerRuntimeProviders.deviceInventoryProvider,
     trackDownloadableArtifact,
   });
 
@@ -211,8 +211,8 @@ export async function startDaemonRuntime(
   if (!acquireDaemonLock(baseDir, lockPath, lockData)) {
     stderr.write('Daemon lock is held by another process; exiting.\n');
     setRunnerLeaseOwnerStateDir(undefined);
-    setActiveCloudRuntimes([]);
-    await Promise.allSettled(cloudRuntimes.map((runtime) => runtime.shutdown()));
+    setActiveProviderDeviceRuntimes([]);
+    await Promise.allSettled(providerRuntimes.map((runtime) => runtime.shutdown()));
     exit(0);
     return null;
   }
@@ -233,8 +233,8 @@ export async function startDaemonRuntime(
     removeInfo(infoPath);
     releaseDaemonLock(lockPath);
     setRunnerLeaseOwnerStateDir(undefined);
-    setActiveCloudRuntimes([]);
-    await Promise.allSettled(cloudRuntimes.map((runtime) => runtime.shutdown()));
+    setActiveProviderDeviceRuntimes([]);
+    await Promise.allSettled(providerRuntimes.map((runtime) => runtime.shutdown()));
     exit(1);
     return null;
   }
@@ -255,8 +255,8 @@ export async function startDaemonRuntime(
     await teardownDaemonSessions();
     const { stopAllIosRunnerSessions } = await import('./platforms/ios/runner-client.ts');
     await stopAllIosRunnerSessions();
-    await Promise.allSettled(cloudRuntimes.map((runtime) => runtime.shutdown()));
-    setActiveCloudRuntimes([]);
+    await Promise.allSettled(providerRuntimes.map((runtime) => runtime.shutdown()));
+    setActiveProviderDeviceRuntimes([]);
     // Best effort: stop the PNG worker so an in-flight job cannot delay exit.
     await Promise.race([
       terminatePngWorker().catch(() => {}),

--- a/src/daemon/__tests__/device-ready.test.ts
+++ b/src/daemon/__tests__/device-ready.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 import { promises as fs } from 'node:fs';
 import type { DeviceInfo } from '../../utils/device.ts';
-import { setActiveCloudRuntimes, type CloudDeviceRuntime } from '../../cloud/cloud-runtime.ts';
+import {
+  setActiveProviderDeviceRuntimes,
+  type ProviderDeviceRuntime,
+} from '../../provider-device-runtime.ts';
 
 vi.mock('../../utils/exec.ts', () => ({
   runCmd: vi.fn(),
@@ -45,7 +48,7 @@ beforeEach(() => {
 
 afterEach(() => {
   clearDeviceReadyCacheForTests();
-  setActiveCloudRuntimes([]);
+  setActiveProviderDeviceRuntimes([]);
   vi.useRealTimers();
 });
 
@@ -63,7 +66,7 @@ test('ensureDeviceReady caches successful simulator readiness checks', async () 
 });
 
 test('ensureDeviceReady skips Limrun-managed devices', async () => {
-  setActiveCloudRuntimes([makeCloudRuntime('limrun:')]);
+  setActiveProviderDeviceRuntimes([makeProviderDeviceRuntime('limrun:')]);
   await ensureDeviceReady({
     ...IOS_SIMULATOR,
     id: 'limrun:ios:lease-a',
@@ -77,7 +80,7 @@ test('ensureDeviceReady skips Limrun-managed devices', async () => {
   expect(mockWaitForAndroidBoot).not.toHaveBeenCalled();
 });
 
-function makeCloudRuntime(idPrefix: string): CloudDeviceRuntime {
+function makeProviderDeviceRuntime(idPrefix: string): ProviderDeviceRuntime {
   return {
     provider: 'limrun',
     leaseLifecycle: {},

--- a/src/daemon/device-ready.ts
+++ b/src/daemon/device-ready.ts
@@ -5,7 +5,7 @@ import { promises as fs } from 'node:fs';
 import { AppError } from '../utils/errors.ts';
 import { resolveIosDevicectlHint, IOS_DEVICECTL_DEFAULT_HINT } from '../platforms/ios/devicectl.ts';
 import { runXcrun } from '../platforms/ios/tool-provider.ts';
-import { isCloudDevice } from '../cloud/cloud-runtime.ts';
+import { isActiveProviderDevice } from '../provider-device-runtime.ts';
 
 const IOS_DEVICE_READY_TIMEOUT_MS = 15_000;
 const IOS_DEVICE_READY_COMMAND_TIMEOUT_BUFFER_MS = 3_000;
@@ -24,7 +24,7 @@ export async function ensureDeviceReady(
   device: DeviceInfo,
   options: DeviceReadyOptions = {},
 ): Promise<void> {
-  if (isCloudDevice(device)) return;
+  if (isActiveProviderDevice(device)) return;
 
   const cacheKey = deviceReadyCacheKey(device);
   const cachedUntil = readyCache.get(cacheKey);

--- a/src/daemon/handlers/install-source.ts
+++ b/src/daemon/handlers/install-source.ts
@@ -1,4 +1,4 @@
-import { installCloudInstallablePath } from '../../cloud/cloud-runtime.ts';
+import { installProviderDeviceInstallablePath } from '../../provider-device-runtime.ts';
 import { isCommandSupportedOnDevice } from '../../core/capabilities.ts';
 import { resolveTargetDevice, type CommandFlags } from '../../core/dispatch.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
@@ -195,13 +195,17 @@ export async function handleInstallFromSourceCommand(params: {
         signal: requestSignal,
       });
       return await completeInstall(prepared, async (retained) => {
-        const cloudResult = await installCloudInstallablePath(device, prepared.installablePath, {
-          appIdentifierHint: prepared.bundleId,
-        });
-        if (!cloudResult) {
+        const providerResult = await installProviderDeviceInstallablePath(
+          device,
+          prepared.installablePath,
+          {
+            appIdentifierHint: prepared.bundleId,
+          },
+        );
+        if (!providerResult) {
           await installIosInstallablePath(device, prepared.installablePath);
         }
-        const bundleId = cloudResult?.bundleId ?? prepared.bundleId;
+        const bundleId = providerResult?.bundleId ?? prepared.bundleId;
         if (!bundleId) {
           throw new AppError(
             'COMMAND_FAILED',
@@ -211,10 +215,10 @@ export async function handleInstallFromSourceCommand(params: {
         return {
           ...retainedInstallResultFields(retained),
           bundleId,
-          ...((cloudResult?.appName ?? prepared.appName)
-            ? { appName: cloudResult?.appName ?? prepared.appName }
+          ...((providerResult?.appName ?? prepared.appName)
+            ? { appName: providerResult?.appName ?? prepared.appName }
             : {}),
-          launchTarget: cloudResult?.launchTarget ?? bundleId,
+          launchTarget: providerResult?.launchTarget ?? bundleId,
         };
       });
     }
@@ -227,11 +231,15 @@ export async function handleInstallFromSourceCommand(params: {
       signal: requestSignal,
     });
     return await completeInstall(prepared, async (retained) => {
-      const cloudResult = await installCloudInstallablePath(device, prepared.installablePath, {
-        packageNameHint: prepared.packageName,
-      });
-      let packageName = cloudResult?.packageName;
-      if (!cloudResult) {
+      const providerResult = await installProviderDeviceInstallablePath(
+        device,
+        prepared.installablePath,
+        {
+          packageNameHint: prepared.packageName,
+        },
+      );
+      let packageName = providerResult?.packageName;
+      if (!providerResult) {
         packageName = await installAndroidInstallablePathAndResolvePackageName(
           device,
           prepared.installablePath,

--- a/src/daemon/handlers/session-deploy.ts
+++ b/src/daemon/handlers/session-deploy.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { installCloudApp } from '../../cloud/cloud-runtime.ts';
+import { installProviderDeviceApp } from '../../provider-device-runtime.ts';
 import { cleanupUploadedArtifact, prepareUploadedArtifact } from '../artifact-tracking.ts';
 import { isCommandSupportedOnDevice } from '../../core/capabilities.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
@@ -55,21 +55,21 @@ type DeployCommandResult = IosDeployCommandResult | AndroidDeployCommandResult;
 
 export const defaultReinstallOps: ReinstallOps = {
   ios: async (device, app, appPath) => {
-    const cloudResult = await installCloudApp(device, app, appPath, {
+    const providerResult = await installProviderDeviceApp(device, app, appPath, {
       relaunch: true,
       appIdentifierHint: app,
     });
-    if (cloudResult?.bundleId) return { bundleId: cloudResult.bundleId };
+    if (providerResult?.bundleId) return { bundleId: providerResult.bundleId };
 
     const { reinstallIosApp } = await import('../../platforms/ios/apps.ts');
     return await reinstallIosApp(device, app, appPath);
   },
   android: async (device, app, appPath) => {
-    const cloudResult = await installCloudApp(device, app, appPath, {
+    const providerResult = await installProviderDeviceApp(device, app, appPath, {
       relaunch: true,
       packageNameHint: app,
     });
-    if (cloudResult?.packageName) return { package: cloudResult.packageName };
+    if (providerResult?.packageName) return { package: providerResult.packageName };
 
     const { reinstallAndroidApp } = await import('../../platforms/android/app-lifecycle.ts');
     return await reinstallAndroidApp(device, app, appPath);
@@ -78,14 +78,14 @@ export const defaultReinstallOps: ReinstallOps = {
 
 export const defaultInstallOps: InstallOps = {
   ios: async (device, app, appPath) => {
-    const cloudResult = await installCloudApp(device, app, appPath, {
+    const providerResult = await installProviderDeviceApp(device, app, appPath, {
       appIdentifierHint: app,
     });
-    if (cloudResult) {
+    if (providerResult) {
       return {
-        bundleId: cloudResult.bundleId,
-        appName: cloudResult.appName,
-        launchTarget: cloudResult.launchTarget,
+        bundleId: providerResult.bundleId,
+        appName: providerResult.appName,
+        launchTarget: providerResult.launchTarget,
       };
     }
 
@@ -98,14 +98,14 @@ export const defaultInstallOps: InstallOps = {
     };
   },
   android: async (device, _app, appPath) => {
-    const cloudResult = await installCloudApp(device, _app, appPath, {
+    const providerResult = await installProviderDeviceApp(device, _app, appPath, {
       packageNameHint: _app,
     });
-    if (cloudResult) {
+    if (providerResult) {
       return {
-        package: cloudResult.packageName,
-        appName: cloudResult.appName,
-        launchTarget: cloudResult.launchTarget,
+        package: providerResult.packageName,
+        appName: providerResult.appName,
+        launchTarget: providerResult.launchTarget,
       };
     }
 

--- a/src/daemon/handlers/session-runtime-command.ts
+++ b/src/daemon/handlers/session-runtime-command.ts
@@ -9,7 +9,10 @@ import {
   mergeRuntimeHints,
   toRuntimePlatform,
 } from './session-runtime.ts';
-import { configureCloudPortReverse, removeCloudPortReverse } from '../../cloud/cloud-runtime.ts';
+import {
+  configureProviderPortReverse,
+  removeProviderPortReverse,
+} from '../../provider-device-runtime.ts';
 
 export async function handleRuntimeCommand(params: {
   req: DaemonRequest;
@@ -101,12 +104,12 @@ async function handlePortReverseCommand(
   const options = { leaseId, provider, devicePort, hostPort, name };
   const result =
     action === 'port-reverse'
-      ? await configureCloudPortReverse(options)
-      : await removeCloudPortReverse(options);
+      ? await configureProviderPortReverse(options)
+      : await removeProviderPortReverse(options);
   if (!result) {
     return errorResponse(
       'UNSUPPORTED_OPERATION',
-      'No active cloud runtime supports port reverse for this lease.',
+      'No active provider device runtime supports port reverse for this lease.',
     );
   }
   return {

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -12,7 +12,7 @@ import {
 } from '../platforms/android/open-target.ts';
 import { buildSimctlArgsForDevice } from '../platforms/ios/simctl.ts';
 import { runXcrun } from '../platforms/ios/tool-provider.ts';
-import { isCloudDevice } from '../cloud/cloud-runtime.ts';
+import { isActiveProviderDevice } from '../provider-device-runtime.ts';
 
 const ANDROID_DEV_PREFS_PATH = 'shared_prefs/ReactNativeDevPrefs.xml';
 const ANDROID_DEBUG_HOST_KEY = 'debug_http_host';
@@ -44,7 +44,7 @@ export async function applyRuntimeHintsToApp(params: {
   runtime: SessionRuntimeHints | undefined;
 }): Promise<void> {
   const { device, appId, runtime } = params;
-  if (isCloudDevice(device)) return;
+  if (isActiveProviderDevice(device)) return;
   if (!appId) return;
   const transport = resolveRuntimeTransportHints(runtime);
   if (!transport) return;

--- a/src/provider-device-runtime.ts
+++ b/src/provider-device-runtime.ts
@@ -1,24 +1,24 @@
-import type { Interactor } from '../core/interactor-types.ts';
-import type { DeviceInventoryProvider } from '../core/dispatch-resolve.ts';
-import type { LeaseLifecycleProvider } from '../daemon/handlers/lease.ts';
-import type { DeviceLease } from '../daemon/lease-registry.ts';
-import type { DeviceInfo } from '../utils/device.ts';
+import type { Interactor } from './core/interactor-types.ts';
+import type { DeviceInventoryProvider } from './core/dispatch-resolve.ts';
+import type { LeaseLifecycleProvider } from './daemon/handlers/lease.ts';
+import type { DeviceLease } from './daemon/lease-registry.ts';
+import type { DeviceInfo } from './utils/device.ts';
 
-export type CloudAppInstallResult = {
+export type ProviderDeviceInstallResult = {
   bundleId?: string;
   packageName?: string;
   appName?: string;
   launchTarget?: string;
 };
 
-export type CloudAppInstallOptions = {
+export type ProviderDeviceInstallOptions = {
   relaunch?: boolean;
   appIdentifierHint?: string;
   packageNameHint?: string;
 };
 
-export type CloudDeviceRuntime = {
-  provider?: string;
+export type ProviderDeviceRuntime = {
+  provider: string;
   leaseLifecycle: LeaseLifecycleProvider;
   deviceInventoryProvider: DeviceInventoryProvider;
   ownsDevice(device: DeviceInfo): boolean;
@@ -27,23 +27,23 @@ export type CloudDeviceRuntime = {
     device: DeviceInfo,
     app: string,
     appPath: string,
-    options?: CloudAppInstallOptions,
-  ): Promise<CloudAppInstallResult | undefined>;
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined>;
   installInstallablePath?(
     device: DeviceInfo,
     installablePath: string,
-    options?: CloudAppInstallOptions,
-  ): Promise<CloudAppInstallResult | undefined>;
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined>;
   configurePortReverse?(
-    options: CloudPortReverseOptions,
+    options: ProviderPortReverseOptions,
   ): Promise<Record<string, unknown> | undefined>;
   removePortReverse?(
-    options: CloudPortReverseOptions,
+    options: ProviderPortReverseOptions,
   ): Promise<Record<string, unknown> | undefined>;
   shutdown(): Promise<void>;
 };
 
-export type CloudPortReverseOptions = {
+export type ProviderPortReverseOptions = {
   leaseId: string;
   provider?: string;
   devicePort: number;
@@ -51,14 +51,19 @@ export type CloudPortReverseOptions = {
   name: string;
 };
 
-let activeCloudRuntimes: CloudDeviceRuntime[] = [];
+export type ProviderDeviceRuntimeRequestProviders = {
+  leaseLifecycleProvider?: LeaseLifecycleProvider;
+  deviceInventoryProvider?: DeviceInventoryProvider;
+};
 
-export function setActiveCloudRuntimes(runtimes: CloudDeviceRuntime[]): void {
-  activeCloudRuntimes = [...runtimes];
+let activeProviderDeviceRuntimes: ProviderDeviceRuntime[] = [];
+
+export function setActiveProviderDeviceRuntimes(runtimes: ProviderDeviceRuntime[]): void {
+  activeProviderDeviceRuntimes = [...runtimes];
 }
 
-export function getCloudInteractor(device: DeviceInfo): Interactor | undefined {
-  for (const runtime of activeCloudRuntimes) {
+export function getProviderDeviceInteractor(device: DeviceInfo): Interactor | undefined {
+  for (const runtime of activeProviderDeviceRuntimes) {
     if (!runtime.ownsDevice(device)) continue;
     const interactor = runtime.getInteractor(device);
     if (interactor) return interactor;
@@ -66,19 +71,17 @@ export function getCloudInteractor(device: DeviceInfo): Interactor | undefined {
   return undefined;
 }
 
-export function isActiveCloudDevice(device: DeviceInfo): boolean {
-  return activeCloudRuntimes.some((runtime) => runtime.ownsDevice(device));
+export function isActiveProviderDevice(device: DeviceInfo): boolean {
+  return activeProviderDeviceRuntimes.some((runtime) => runtime.ownsDevice(device));
 }
 
-export const isCloudDevice = isActiveCloudDevice;
-
-export async function installCloudApp(
+export async function installProviderDeviceApp(
   device: DeviceInfo,
   app: string,
   appPath: string,
-  options?: CloudAppInstallOptions,
-): Promise<CloudAppInstallResult | undefined> {
-  for (const runtime of activeCloudRuntimes) {
+  options?: ProviderDeviceInstallOptions,
+): Promise<ProviderDeviceInstallResult | undefined> {
+  for (const runtime of activeProviderDeviceRuntimes) {
     if (!runtime.ownsDevice(device)) continue;
     const result = await runtime.installApp?.(device, app, appPath, options);
     if (result) return result;
@@ -86,12 +89,12 @@ export async function installCloudApp(
   return undefined;
 }
 
-export async function installCloudInstallablePath(
+export async function installProviderDeviceInstallablePath(
   device: DeviceInfo,
   installablePath: string,
-  options?: CloudAppInstallOptions,
-): Promise<CloudAppInstallResult | undefined> {
-  for (const runtime of activeCloudRuntimes) {
+  options?: ProviderDeviceInstallOptions,
+): Promise<ProviderDeviceInstallResult | undefined> {
+  for (const runtime of activeProviderDeviceRuntimes) {
     if (!runtime.ownsDevice(device)) continue;
     const result = await runtime.installInstallablePath?.(device, installablePath, options);
     if (result) return result;
@@ -99,10 +102,10 @@ export async function installCloudInstallablePath(
   return undefined;
 }
 
-export async function configureCloudPortReverse(
-  options: CloudPortReverseOptions,
+export async function configureProviderPortReverse(
+  options: ProviderPortReverseOptions,
 ): Promise<Record<string, unknown> | undefined> {
-  for (const runtime of activeCloudRuntimes) {
+  for (const runtime of activeProviderDeviceRuntimes) {
     if (!runtimeMatchesProvider(runtime, options.provider)) continue;
     const result = await runtime.configurePortReverse?.(options);
     if (result) return result;
@@ -110,10 +113,10 @@ export async function configureCloudPortReverse(
   return undefined;
 }
 
-export async function removeCloudPortReverse(
-  options: CloudPortReverseOptions,
+export async function removeProviderPortReverse(
+  options: ProviderPortReverseOptions,
 ): Promise<Record<string, unknown> | undefined> {
-  for (const runtime of activeCloudRuntimes) {
+  for (const runtime of activeProviderDeviceRuntimes) {
     if (!runtimeMatchesProvider(runtime, options.provider)) continue;
     const result = await runtime.removePortReverse?.(options);
     if (result) return result;
@@ -121,8 +124,17 @@ export async function removeCloudPortReverse(
   return undefined;
 }
 
-export function composeCloudLeaseProvider(
-  runtimes: CloudDeviceRuntime[],
+export function createProviderDeviceRuntimeRequestProviders(
+  runtimes: ProviderDeviceRuntime[],
+): ProviderDeviceRuntimeRequestProviders {
+  return {
+    leaseLifecycleProvider: composeLeaseProvider(runtimes),
+    deviceInventoryProvider: composeDeviceInventoryProvider(runtimes),
+  };
+}
+
+function composeLeaseProvider(
+  runtimes: ProviderDeviceRuntime[],
 ): LeaseLifecycleProvider | undefined {
   if (runtimes.length === 0) return undefined;
   return {
@@ -132,8 +144,8 @@ export function composeCloudLeaseProvider(
   };
 }
 
-export function composeCloudDeviceInventoryProvider(
-  runtimes: CloudDeviceRuntime[],
+function composeDeviceInventoryProvider(
+  runtimes: ProviderDeviceRuntime[],
 ): DeviceInventoryProvider | undefined {
   if (runtimes.length === 0) return undefined;
   return async (request) => {
@@ -147,7 +159,7 @@ export function composeCloudDeviceInventoryProvider(
 }
 
 async function firstProviderResult(
-  runtimes: CloudDeviceRuntime[],
+  runtimes: ProviderDeviceRuntime[],
   method: keyof LeaseLifecycleProvider,
   lease: DeviceLease,
 ): Promise<Record<string, unknown> | undefined> {
@@ -161,7 +173,7 @@ async function firstProviderResult(
 }
 
 function runtimeMatchesProvider(
-  runtime: CloudDeviceRuntime,
+  runtime: ProviderDeviceRuntime,
   provider: string | undefined,
 ): boolean {
   return runtime.provider === provider;

--- a/test/integration/installed-package-metro.test.ts
+++ b/test/integration/installed-package-metro.test.ts
@@ -78,6 +78,7 @@ function linkRuntimeDependencies(installedPackageRoot: string, consumerRoot: str
     const sourcePath = path.join(repoRoot, 'node_modules', dependencyName);
     const targetPath = path.join(consumerNodeModules, dependencyName);
     if (!fs.existsSync(sourcePath) || fs.existsSync(targetPath)) continue;
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
     fs.symlinkSync(sourcePath, targetPath, 'junction');
   }
 }

--- a/test/integration/provider-scenarios/provider-device-runtime.test.ts
+++ b/test/integration/provider-scenarios/provider-device-runtime.test.ts
@@ -1,0 +1,339 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  createProviderDeviceRuntimeRequestProviders,
+  setActiveProviderDeviceRuntimes,
+  type ProviderDeviceRuntime,
+  type ProviderPortReverseOptions,
+} from '../../../src/provider-device-runtime.ts';
+import type { DeviceInventoryProvider } from '../../../src/core/dispatch-resolve.ts';
+import type { Interactor, SnapshotResult } from '../../../src/core/interactor-types.ts';
+import type { LeaseLifecycleProvider } from '../../../src/daemon/handlers/lease.ts';
+import type { DeviceLease } from '../../../src/daemon/lease-registry.ts';
+import type { DaemonRequest } from '../../../src/daemon/types.ts';
+import type { DeviceInfo } from '../../../src/utils/device.ts';
+import { assertRpcOk } from './assertions.ts';
+import { createProviderScenarioHarness, withProviderScenarioResource } from './harness.ts';
+import { runProviderScenario } from './scenario.ts';
+
+const FAKE_PROVIDER = 'fake-provider';
+const DEVTOOLS_PORT_REVERSE = { devicePort: 8097, hostPort: 8097, portReverseName: 'devtools' };
+const ABSENT_FAKE_PROVIDER_INTERACTOR_PROPERTIES = new Set([
+  'then',
+  'tapElementSelector',
+  'fillElementSelector',
+  'setViewport',
+]);
+
+type FakeProviderCall = {
+  type:
+    | 'lease.allocate'
+    | 'lease.heartbeat'
+    | 'lease.release'
+    | 'inventory'
+    | 'open'
+    | 'tap'
+    | 'snapshot'
+    | 'portReverse.ensure'
+    | 'portReverse.remove';
+  [key: string]: unknown;
+};
+
+type FakeProviderSession = {
+  device: DeviceInfo;
+  interactor: Interactor;
+};
+
+test('Provider-backed scenario composes lease, inventory, dispatch, and port reverse providers', async () => {
+  await withProviderScenarioResource(createFakeProviderWorld, async ({ daemon, runtime }) => {
+    const allocate = await daemon.callCommand('lease_allocate', [], leaseFlags(), {
+      meta: leaseMeta(),
+    });
+    const { lease } = assertRpcOk<{ lease: DeviceLease }>(allocate);
+    const flags = leaseFlags(lease.leaseId);
+    const meta = leaseMeta(lease.leaseId);
+    const portReverse = {
+      provider: FAKE_PROVIDER,
+      leaseId: lease.leaseId,
+      devicePort: DEVTOOLS_PORT_REVERSE.devicePort,
+      hostPort: DEVTOOLS_PORT_REVERSE.hostPort,
+      name: DEVTOOLS_PORT_REVERSE.portReverseName,
+    };
+
+    await runProviderScenario(
+      daemon,
+      [
+        {
+          name: 'heartbeat',
+          command: 'lease_heartbeat',
+          expectData: { provider: { provider: FAKE_PROVIDER } },
+        },
+        {
+          name: 'open',
+          command: 'open',
+          positionals: ['com.example.demo'],
+          expectData: {
+            platform: 'android',
+            id: runtime.deviceIdForLease(lease.leaseId),
+            serial: runtime.deviceIdForLease(lease.leaseId),
+          },
+        },
+        {
+          name: 'click',
+          command: 'click',
+          positionals: ['10', '20'],
+        },
+        {
+          name: 'snapshot',
+          command: 'snapshot',
+        },
+        {
+          name: 'port-reverse',
+          command: 'runtime',
+          positionals: ['port-reverse'],
+          flags: DEVTOOLS_PORT_REVERSE,
+          expectData: {
+            action: 'port-reverse',
+            ...portReverse,
+          },
+        },
+        {
+          name: 'port-reverse-remove',
+          command: 'runtime',
+          positionals: ['port-reverse-remove'],
+          flags: DEVTOOLS_PORT_REVERSE,
+          expectData: {
+            action: 'port-reverse-remove',
+            ...portReverse,
+          },
+        },
+        {
+          name: 'release',
+          command: 'lease_release',
+          expectData: { released: true, provider: { provider: FAKE_PROVIDER } },
+        },
+      ],
+      { flags, meta },
+    );
+
+    const session = daemon.session();
+    const deviceId = runtime.deviceIdForLease(lease.leaseId);
+    assert.equal(session?.device.id, deviceId);
+    assert.equal(session?.lease?.leaseId, lease.leaseId);
+    assert.deepEqual(
+      runtime.calls.find((call) => call.type === 'open'),
+      { type: 'open', deviceId, app: 'com.example.demo', url: undefined },
+    );
+    assert.deepEqual(
+      runtime.calls.find((call) => call.type === 'tap'),
+      { type: 'tap', deviceId, x: 10, y: 20 },
+    );
+    assert.deepEqual(
+      runtime.calls.map((call) => call.type),
+      [
+        'lease.allocate',
+        'lease.heartbeat',
+        'inventory',
+        'open',
+        'tap',
+        'snapshot',
+        'portReverse.ensure',
+        'portReverse.remove',
+        'lease.release',
+      ],
+    );
+  });
+}, 15_000);
+
+async function createFakeProviderWorld() {
+  const runtime = new FakeProviderDeviceRuntime();
+  setActiveProviderDeviceRuntimes([runtime]);
+  const providerRuntimeProviders = createProviderDeviceRuntimeRequestProviders([runtime]);
+  const daemon = await createProviderScenarioHarness({
+    ...providerRuntimeProviders,
+    deviceInventoryProvider: providerRuntimeProviders.deviceInventoryProvider!,
+  });
+  return {
+    daemon,
+    runtime,
+    close: async () => {
+      setActiveProviderDeviceRuntimes([]);
+      await runtime.shutdown();
+      await daemon.close();
+    },
+  };
+}
+
+class FakeProviderDeviceRuntime implements ProviderDeviceRuntime {
+  readonly provider = FAKE_PROVIDER;
+  readonly calls: FakeProviderCall[] = [];
+  private readonly sessionsByLeaseId = new Map<string, FakeProviderSession>();
+
+  readonly leaseLifecycle: LeaseLifecycleProvider = {
+    allocate: async (lease) => {
+      if (lease.leaseProvider !== this.provider) return undefined;
+      const device = this.createDevice(lease);
+      const interactor = createFakeProviderInteractor(device, this.calls);
+      this.sessionsByLeaseId.set(lease.leaseId, { device, interactor });
+      this.calls.push({
+        type: 'lease.allocate',
+        leaseId: lease.leaseId,
+        provider: lease.leaseProvider,
+        deviceId: device.id,
+      });
+      return { provider: this.provider, deviceId: device.id };
+    },
+    heartbeat: async (lease) => {
+      if (lease.leaseProvider !== this.provider) return undefined;
+      this.calls.push({
+        type: 'lease.heartbeat',
+        leaseId: lease.leaseId,
+        provider: lease.leaseProvider,
+      });
+      return { provider: this.provider };
+    },
+    release: async (lease) => {
+      if (lease.leaseProvider !== this.provider) return undefined;
+      this.sessionsByLeaseId.delete(lease.leaseId);
+      this.calls.push({
+        type: 'lease.release',
+        leaseId: lease.leaseId,
+        provider: lease.leaseProvider,
+      });
+      return { provider: this.provider };
+    },
+  };
+
+  readonly deviceInventoryProvider: DeviceInventoryProvider = async (request) => {
+    if (request.leaseProvider !== this.provider) return null;
+    const leaseId = request.leaseId;
+    if (!leaseId) return [];
+    const session = this.sessionsByLeaseId.get(leaseId);
+    if (!session) return [];
+    this.calls.push({
+      type: 'inventory',
+      leaseId,
+      platform: request.platform,
+    });
+    return [session.device];
+  };
+
+  ownsDevice(device: DeviceInfo): boolean {
+    return device.id.startsWith('fake-provider:android:');
+  }
+
+  getInteractor(device: DeviceInfo): Interactor | undefined {
+    return [...this.sessionsByLeaseId.values()].find((session) => session.device.id === device.id)
+      ?.interactor;
+  }
+
+  async configurePortReverse(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (options.provider !== this.provider) return undefined;
+    this.calls.push({ type: 'portReverse.ensure', options });
+    return { provider: this.provider, ...options };
+  }
+
+  async removePortReverse(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (options.provider !== this.provider) return undefined;
+    this.calls.push({ type: 'portReverse.remove', options });
+    return { provider: this.provider, ...options };
+  }
+
+  async shutdown(): Promise<void> {
+    this.sessionsByLeaseId.clear();
+  }
+
+  deviceIdForLease(leaseId: string): string {
+    return `fake-provider:android:${leaseId}`;
+  }
+
+  private createDevice(lease: DeviceLease): DeviceInfo {
+    return {
+      platform: 'android',
+      id: this.deviceIdForLease(lease.leaseId),
+      name: 'Fake Provider Android',
+      kind: 'device',
+      target: 'mobile',
+      booted: true,
+    };
+  }
+}
+
+function createFakeProviderInteractor(device: DeviceInfo, calls: FakeProviderCall[]): Interactor {
+  return new Proxy<Partial<Interactor>>(
+    {
+      open: async (app, options) => {
+        calls.push({ type: 'open', deviceId: device.id, app, url: options?.url });
+      },
+      tap: async (x, y) => {
+        calls.push({ type: 'tap', deviceId: device.id, x, y });
+        return { backend: 'fake-provider', x, y };
+      },
+      snapshot: async (options): Promise<SnapshotResult> => {
+        calls.push({
+          type: 'snapshot',
+          deviceId: device.id,
+          interactiveOnly: options?.interactiveOnly,
+        });
+        return {
+          backend: 'android',
+          nodes: [
+            {
+              index: 0,
+              type: 'TextView',
+              label: 'Provider Ready',
+              rect: { x: 0, y: 0, width: 120, height: 40 },
+              enabled: true,
+              visibleToUser: true,
+            },
+          ],
+        };
+      },
+    },
+    {
+      get(target, property, receiver) {
+        if (property in target) return Reflect.get(target, property, receiver);
+        if (
+          typeof property === 'string' &&
+          ABSENT_FAKE_PROVIDER_INTERACTOR_PROPERTIES.has(property)
+        ) {
+          return undefined;
+        }
+        if (typeof property === 'string') {
+          return () => throwUnexpectedProviderInteraction(property);
+        }
+        return undefined;
+      },
+    },
+  ) as Interactor;
+}
+
+function leaseFlags(leaseId?: string): DaemonRequest['flags'] {
+  return {
+    platform: 'android',
+    tenant: 'team-a',
+    runId: 'run-a',
+    leaseId,
+    leaseProvider: FAKE_PROVIDER,
+  };
+}
+
+function leaseMeta(leaseId?: string): DaemonRequest['meta'] {
+  return {
+    tenantId: 'team-a',
+    runId: 'run-a',
+    leaseId,
+    leaseBackend: 'android-instance',
+    leaseProvider: FAKE_PROVIDER,
+    deviceKey: 'android-a',
+    clientId: 'client-a',
+  };
+}
+
+function throwUnexpectedProviderInteraction(method: string): never {
+  throw new Error(`Unexpected fake provider interactor call: ${method}`);
+}

--- a/test/integration/provider-scenarios/scenario.ts
+++ b/test/integration/provider-scenarios/scenario.ts
@@ -7,11 +7,17 @@ export type ProviderScenarioState = {
   response(name: string): ProviderScenarioRpcResult;
 };
 
+export type ProviderScenarioDefaults = {
+  flags?: DaemonRequest['flags'];
+  meta?: DaemonRequest['meta'];
+};
+
 export type ProviderScenarioStep = {
   name: string;
   command: string;
   positionals?: string[];
   flags?: DaemonRequest['flags'];
+  meta?: DaemonRequest['meta'];
   expectStatus?: number;
   expectData?: Record<string, unknown>;
   assert?: (
@@ -23,6 +29,7 @@ export type ProviderScenarioStep = {
 export async function runProviderScenario(
   daemon: Pick<ProviderScenarioHarness, 'callCommand'>,
   steps: readonly ProviderScenarioStep[],
+  defaults: ProviderScenarioDefaults = {},
 ): Promise<ProviderScenarioState> {
   const responses = new Map<string, ProviderScenarioRpcResult>();
 
@@ -38,7 +45,17 @@ export async function runProviderScenario(
   };
 
   for (const step of steps) {
-    const response = await daemon.callCommand(step.command, step.positionals, step.flags);
+    const response = await daemon.callCommand(
+      step.command,
+      step.positionals,
+      {
+        ...defaults.flags,
+        ...step.flags,
+      },
+      {
+        meta: mergeRequestObject(defaults.meta, step.meta),
+      },
+    );
     const expectedStatus = step.expectStatus ?? 200;
     assert.equal(
       response.statusCode,
@@ -55,13 +72,25 @@ export async function runProviderScenario(
   return state;
 }
 
+function mergeRequestObject<T extends object>(
+  base: T | undefined,
+  override: T | undefined,
+): T | undefined {
+  if (!base) return override;
+  if (!override) return base;
+  return { ...base, ...override };
+}
+
 function assertDataContains(
   name: string,
   response: ProviderScenarioRpcResult,
   expected: Record<string, unknown>,
 ): void {
   const data = response.json?.result?.data;
-  assert.ok(data && typeof data === 'object', `${name} did not return result data`);
+  assert.ok(
+    data && typeof data === 'object',
+    `${name} did not return result data: ${JSON.stringify(response.json)}`,
+  );
   for (const [key, value] of Object.entries(expected)) {
     assert.deepEqual(data[key], value, `${name} result data mismatch for ${key}`);
   }


### PR DESCRIPTION
## Summary

Extract provider-neutral runtime seams from the direct Limrun runtime.
<details>

- Renames `src/cloud/cloud-runtime.ts` to `src/provider-device-runtime.ts` and narrows it to provider id, lease lifecycle composition, device inventory composition, active-device/interactor lookup, install hooks, optional port reverse hooks, and shutdown.
- Keeps Limrun-specific SDK calls, instance/session handling, asset upload/install logic, ADB tunnel/reverse handling, snapshot mapping, and iOS/Android client interactors in `src/cloud/limrun-*` adapter modules.
- Wires daemon runtime, install/deploy, readiness, runtime hints, and port reverse through the provider seam so later BrowserStack/AWS providers can share lease/inventory/interactor/install/port-reverse runtime plumbing without depending on Limrun internals.
- Adds a provider-backed daemon scenario test plus focused provider-runtime unit coverage. No BrowserStack, AWS, or WebDriver provider code is included.

</details>

## Validation

`pnpm check:quick` passed. Focused runtime/scenario tests passed with `vitest run src/__tests__/provider-device-runtime.test.ts src/__tests__/limrun-runtime.test.ts test/integration/provider-scenarios/provider-device-runtime.test.ts`; the full provider scenario suite passed with `vitest run test/integration/provider-scenarios`. Daemon entrypoint transport tests passed outside the sandbox because they bind localhost. Touched files pass `oxfmt --check` and `git diff --check`.

`pnpm check:fallow --base origin/main` was attempted but stayed silent for roughly 90 seconds and was stopped; no fallow result is included.
