### PR TITLE
refactor: break snapshot.ts <-> snapshot-quality.ts type cycle — Phase 5 prep

### DIFF
--- a/src/utils/snapshot-quality.ts
+++ b/src/utils/snapshot-quality.ts
@@ -1,17 +1,8 @@
-import type { SnapshotNode } from './snapshot.ts';
+import type { SnapshotNode, SnapshotQualityVerdict } from './snapshot.ts';
 
-/**
- * Structured quality verdict computed once by the iOS runner's snapshot capture plan.
- * The daemon renders it; it never re-derives degradation from node shapes.
- */
-export type SnapshotQualityVerdict = {
-  state: 'healthy' | 'recovered' | 'sparse';
-  backend: 'tree' | 'queries' | 'private-ax';
-  reason?: string;
-  reasonCode?: 'ax-rejected' | 'sparse-tree' | 'budget' | 'no-nodes' | 'capture-failed';
-  effectiveDepth?: number;
-  collapsedLeafIndexes?: number[];
-};
+// The type lives in snapshot.ts (the foundational type module) to avoid a cyclic
+// import with SnapshotNode; re-exported here so existing callers are unaffected.
+export type { SnapshotQualityVerdict } from './snapshot.ts';
 
 const SNAPSHOT_QUALITY_STATES = new Set<SnapshotQualityVerdict['state']>([
   'healthy',

--- a/src/utils/snapshot.ts
+++ b/src/utils/snapshot.ts
@@ -1,4 +1,19 @@
-import type { SnapshotQualityVerdict } from './snapshot-quality.ts';
+/**
+ * Structured quality verdict computed once by the iOS runner's snapshot capture plan.
+ * The daemon renders it; it never re-derives degradation from node shapes.
+ *
+ * Defined here (the foundational snapshot type module) rather than in
+ * snapshot-quality.ts so SnapshotNode can reference it without a cyclic import;
+ * snapshot-quality.ts (the validation logic) re-exports it for existing callers.
+ */
+export type SnapshotQualityVerdict = {
+  state: 'healthy' | 'recovered' | 'sparse';
+  backend: 'tree' | 'queries' | 'private-ax';
+  reason?: string;
+  reasonCode?: 'ax-rejected' | 'sparse-tree' | 'budget' | 'no-nodes' | 'capture-failed';
+  effectiveDepth?: number;
+  collapsedLeafIndexes?: number[];
+};
 
 export type Rect = {
   x: number;


### PR DESCRIPTION
## What

A tiny, surgical **Phase 5 prerequisite** (option 2 of the layering plan): break a type-level import cycle so the foundational snapshot type module can move down into a `kernel/` layer next.

`snapshot.ts` — the foundational snapshot type module (`Rect`/`SnapshotNode`, **96 importers**, re-exported by `contracts.ts`) — imported `SnapshotQualityVerdict` from `snapshot-quality.ts`, which itself imports `SnapshotNode` from `snapshot.ts`. That mutual (type-level) dependency means `snapshot.ts` is **not a leaf**, which blocks moving it down to `kernel/` (a kernel module must not import "up").

## Change
- Move the `SnapshotQualityVerdict` **type definition** into `snapshot.ts` (it's referenced by a `SnapshotNode` field, so it belongs with the type it annotates).
- `snapshot-quality.ts` now imports the type from `snapshot.ts` for its own use and **re-exports** it (`export type { SnapshotQualityVerdict } from './snapshot.ts'`), so every existing `from './snapshot-quality.ts'` import across the codebase is unaffected.
- The validation logic (`readSnapshotQualityVerdict` + the `const` Sets) stays in `snapshot-quality.ts`.

## Result
`snapshot.ts` now has **zero imports** — a clean leaf — which unblocks:
1. the kernel-seed move (`snapshot.ts → src/kernel/`, the immediate follow-up PR), and
2. the eventual `snapshot/` domain extraction (everything importing `snapshot.ts` becomes a clean downward dep once it's in kernel).

No behavior change.

## Verification
- `tsc --noEmit` exit 0; `snapshot.ts` confirmed import-free
- `oxfmt` + `oxlint --deny-warnings` clean
- `fallow audit --base origin/main` clean
- `vitest run src/utils` → 36 files / 369 tests pass

Follow-up: the kernel-seed PR that moves `snapshot.ts` into `src/kernel/` is stacked on this one.