### PR TITLE
refactor: add provider device runtime foundation

### DIFF
--- a/src/__tests__/provider-device-runtime.test.ts
+++ b/src/__tests__/provider-device-runtime.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'vitest';
+import {
+  createProviderDeviceRuntimeRequestProviders,
+  configureProviderPortReverse,
+  getProviderDeviceInteractor,
+  installProviderDeviceApp,
+  removeProviderPortReverse,
+  setActiveProviderDeviceRuntimes,
+  type ProviderDeviceRuntime,
+} from '../provider-device-runtime.ts';
+import type { Interactor } from '../core/interactor-types.ts';
+import type { SimulatorLease } from '../daemon/lease-registry.ts';
+import type { DeviceInfo } from '../utils/device.ts';
+
+afterEach(() => {
+  setActiveProviderDeviceRuntimes([]);
+});
+
+test('provider device runtime registry delegates lifecycle, inventory, interactors, and installs to matching providers', async () => {
+  const world = makeProviderRuntimeWorld();
+  setActiveProviderDeviceRuntimes([world.missRuntime, world.hitRuntime]);
+  const requestProviders = createProviderDeviceRuntimeRequestProviders([
+    world.missRuntime,
+    world.hitRuntime,
+  ]);
+
+  assert.deepEqual(await requestProviders.leaseLifecycleProvider?.allocate?.(world.lease), {
+    provider: 'hit',
+  });
+  assert.deepEqual(
+    await requestProviders.deviceInventoryProvider?.({
+      platform: 'ios',
+      leaseId: world.lease.leaseId,
+      leaseProvider: 'hit',
+    }),
+    [world.device],
+  );
+  await assertProviderRuntimeDelegates(world);
+});
+
+function makeProviderRuntimeWorld() {
+  const lease: SimulatorLease = {
+    leaseId: 'lease-a',
+    tenantId: 'team-a',
+    runId: 'run-a',
+    backend: 'ios-instance',
+    leaseProvider: 'hit',
+    createdAt: 1,
+    heartbeatAt: 1,
+    expiresAt: 60_001,
+  };
+  const device: DeviceInfo = {
+    platform: 'ios',
+    kind: 'simulator',
+    id: 'provider:ios:lease-a',
+    name: 'Provider iOS',
+    booted: true,
+  };
+  const interactor = { open: async () => undefined } as unknown as Interactor;
+  const missRuntime = makeMissingRuntime();
+  const hitRuntime = makeRuntime({
+    provider: 'hit',
+    leaseResult: { provider: 'hit' },
+    devices: [device],
+    interactor,
+    installResult: { bundleId: 'com.example.app' },
+    portReverseResult: { provider: 'hit' },
+  });
+  return { lease, device, interactor, missRuntime, hitRuntime };
+}
+
+function makeMissingRuntime(): ProviderDeviceRuntime {
+  return makeRuntime({
+    provider: 'miss',
+    leaseResult: undefined,
+    devices: null,
+    interactor: undefined,
+    installResult: undefined,
+    portReverseResult: undefined,
+  });
+}
+
+async function assertProviderRuntimeDelegates(world: ReturnType<typeof makeProviderRuntimeWorld>) {
+  assert.equal(getProviderDeviceInteractor(world.device), world.interactor);
+  assert.deepEqual(
+    await installProviderDeviceApp(world.device, 'com.example.app', '/tmp/app.ipa'),
+    {
+      bundleId: 'com.example.app',
+    },
+  );
+  assert.deepEqual(
+    await configureProviderPortReverse({
+      leaseId: world.lease.leaseId,
+      provider: 'hit',
+      devicePort: 8097,
+      hostPort: 8097,
+      name: 'devtools',
+    }),
+    { provider: 'hit' },
+  );
+  assert.deepEqual(
+    await removeProviderPortReverse({
+      leaseId: world.lease.leaseId,
+      provider: 'hit',
+      devicePort: 8097,
+      hostPort: 8097,
+      name: 'devtools',
+    }),
+    { provider: 'hit' },
+  );
+}
+
+test('provider device install fails explicitly when an owning provider has no install hook', async () => {
+  const device: DeviceInfo = {
+    platform: 'android',
+    kind: 'device',
+    id: 'provider:android:lease-a',
+    name: 'Provider Android',
+    booted: true,
+  };
+  const runtime = makeRuntime({
+    provider: 'hit',
+    leaseResult: undefined,
+    devices: [device],
+    interactor: undefined,
+    installResult: undefined,
+    portReverseResult: undefined,
+    installHook: false,
+  });
+  setActiveProviderDeviceRuntimes([runtime]);
+
+  await assert.rejects(
+    () => installProviderDeviceApp(device, 'com.example.app', '/tmp/app.apk'),
+    /does not support install/,
+  );
+});
+
+function makeRuntime(options: {
+  provider: string;
+  leaseResult: Record<string, unknown> | undefined;
+  devices: DeviceInfo[] | null;
+  interactor: Interactor | undefined;
+  installResult: { bundleId: string } | undefined;
+  portReverseResult: Record<string, unknown> | undefined;
+  installHook?: boolean;
+}): ProviderDeviceRuntime {
+  return {
+    provider: options.provider,
+    leaseLifecycle: {
+      allocate: async () => options.leaseResult,
+      heartbeat: async () => options.leaseResult,
+      release: async () => options.leaseResult,
+    },
+    deviceInventoryProvider: async () => options.devices,
+    ownsDevice: (device) => options.devices?.some((entry) => entry.id === device.id) ?? false,
+    getInteractor: () => options.interactor,
+    ...(options.installHook === false ? {} : { installApp: async () => options.installResult }),
+    configurePortReverse: async () => options.portReverseResult,
+    removePortReverse: async () => options.portReverseResult,
+    shutdown: async () => undefined,
+  };
+}

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -26,6 +26,13 @@ export type CommandFlags = Omit<CliFlags, DaemonExcludedCliFlag> & {
   kind?: string;
   maestro?: MaestroRuntimeFlags;
   postGestureStabilization?: boolean;
+  leaseProvider?: string;
+  provider?: string;
+  deviceKey?: string;
+  clientId?: string;
+  devicePort?: number;
+  hostPort?: number;
+  portReverseName?: string;
   replayBackend?: string;
   shardCount?: number;
   shardIndex?: number;

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -22,9 +22,14 @@ type ResolveDeviceFlags = Pick<
   | 'device'
   | 'udid'
   | 'serial'
+  | 'leaseId'
   | 'iosSimulatorDeviceSet'
   | 'androidDeviceAllowlist'
->;
+> & {
+  leaseProvider?: string;
+  deviceKey?: string;
+  clientId?: string;
+};
 
 const resolveTargetDeviceCacheScope = new AsyncLocalStorage<Map<string, DeviceInfo>>();
 const deviceInventoryProviderScope = new AsyncLocalStorage<DeviceInventoryProvider>();
@@ -144,6 +149,12 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
         udid: flags.udid,
         serial: flags.serial,
       };
+      const leaseScope = {
+        leaseId: flags.leaseId,
+        leaseProvider: flags.leaseProvider,
+        deviceKey: flags.deviceKey,
+        clientId: flags.clientId,
+      };
       if (selector.target && !selector.platform) {
         throw new AppError(
           'INVALID_ARGS',
@@ -153,6 +164,7 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
 
       const injectedDevices = await readInjectedDeviceInventory({
         ...selector,
+        ...leaseScope,
         iosSimulatorSetPath,
         androidSerialAllowlist: androidSerialAllowlist
           ? Array.from(androidSerialAllowlist).sort()
@@ -175,6 +187,7 @@ export async function resolveTargetDevice(flags: ResolveDeviceFlags): Promise<De
 
       const devices = await listLocalDeviceInventory({
         ...selector,
+        ...leaseScope,
         iosSimulatorSetPath,
         androidSerialAllowlist: androidSerialAllowlist
           ? Array.from(androidSerialAllowlist).sort()
@@ -268,6 +281,10 @@ function buildResolveTargetDeviceCacheKey(params: {
     device: flags.device,
     udid: flags.udid,
     serial: flags.serial,
+    leaseId: flags.leaseId,
+    leaseProvider: flags.leaseProvider,
+    deviceKey: flags.deviceKey,
+    clientId: flags.clientId,
     iosSimulatorSetPath,
     androidSerialAllowlist: androidSerialAllowlist
       ? Array.from(androidSerialAllowlist).sort()

--- a/src/core/interactors.ts
+++ b/src/core/interactors.ts
@@ -1,11 +1,22 @@
 import type { DeviceInfo } from '../utils/device.ts';
 import { AppError } from '../utils/errors.ts';
+import { getProviderDeviceInteractor, isActiveProviderDevice } from '../provider-device-runtime.ts';
 import type { Interactor, RunnerContext } from './interactor-types.ts';
 
 export async function getInteractor(
   device: DeviceInfo,
   runnerContext: RunnerContext,
 ): Promise<Interactor> {
+  if (isActiveProviderDevice(device)) {
+    const providerInteractor = getProviderDeviceInteractor(device);
+    if (providerInteractor) return providerInteractor;
+    throw new AppError(
+      'UNSUPPORTED_OPERATION',
+      'Provider device runtime does not have an active interactor for this device.',
+      { deviceId: device.id, platform: device.platform },
+    );
+  }
+
   switch (device.platform) {
     case 'android': {
       const { createAndroidInteractor } = await import('./interactors/android.ts');

--- a/src/core/platform-inventory.ts
+++ b/src/core/platform-inventory.ts
@@ -6,6 +6,10 @@ export type DeviceInventoryRequest = {
   deviceName?: string;
   udid?: string;
   serial?: string;
+  leaseId?: string;
+  leaseProvider?: string;
+  deviceKey?: string;
+  clientId?: string;
   iosSimulatorSetPath?: string;
   androidSerialAllowlist?: string[];
 };

--- a/src/daemon/__tests__/lease-registry.test.ts
+++ b/src/daemon/__tests__/lease-registry.test.ts
@@ -50,7 +50,7 @@ test('heartbeatLease extends active lease and releaseLease is idempotent', () =>
   assert.equal(heartbeat.expiresAt, 25_000);
 
   const released = registry.releaseLease({ leaseId: lease.leaseId });
-  assert.deepEqual(released, { released: true });
+  assert.deepEqual(released, { released: true, lease: heartbeat });
   const releasedAgain = registry.releaseLease({ leaseId: lease.leaseId });
   assert.deepEqual(releasedAgain, { released: false });
 });

--- a/src/daemon/__tests__/request-handler-catalog.test.ts
+++ b/src/daemon/__tests__/request-handler-catalog.test.ts
@@ -142,6 +142,60 @@ test('lease handler preserves device-aware lease fields', async () => {
   assert.equal(heartbeatLease.leaseProvider, 'proxy');
 });
 
+test('lease release calls provider hook using the released lease without heartbeat mutation', async () => {
+  const leaseRegistry = new LeaseRegistry();
+  const releaseCalls: string[] = [];
+  const allocateResponse = await handleLeaseCommands({
+    req: {
+      command: INTERNAL_COMMANDS.leaseAllocate,
+      token: 'test-token',
+      session: 'catalog-test',
+      meta: {
+        tenantId: 'tenant-a',
+        runId: 'run-a',
+        leaseBackend: 'android-instance',
+        leaseProvider: 'fake-provider',
+        leaseTtlMs: 20_000,
+      },
+      positionals: [],
+    },
+    leaseRegistry,
+  });
+  assert.equal(allocateResponse?.ok, true);
+  const lease = readLeaseResponse(allocateResponse);
+
+  const releaseResponse = await handleLeaseCommands({
+    req: {
+      command: INTERNAL_COMMANDS.leaseRelease,
+      token: 'test-token',
+      session: 'catalog-test',
+      meta: {
+        tenantId: 'tenant-a',
+        runId: 'run-a',
+        leaseId: lease.leaseId,
+        leaseBackend: 'android-instance',
+        leaseProvider: 'fake-provider',
+        leaseTtlMs: 1,
+      },
+      positionals: [],
+    },
+    leaseRegistry,
+    leaseLifecycleProvider: {
+      release: async (releasedLease) => {
+        releaseCalls.push(releasedLease.leaseId);
+        return { provider: releasedLease.leaseProvider };
+      },
+    },
+  });
+
+  assert.equal(releaseResponse?.ok, true);
+  assert.deepEqual(releaseCalls, [lease.leaseId]);
+  assert.deepEqual(releaseResponse.data, {
+    released: true,
+    provider: { provider: 'fake-provider' },
+  });
+});
+
 function catalogCommandsForRoute(route: Exclude<DaemonCommandRoute, 'generic'>): string[] {
   return [...Object.values(PUBLIC_COMMANDS), ...Object.values(INTERNAL_COMMANDS)].filter(
     (command) => getDaemonCommandRoute(command) === route,

--- a/src/daemon/device-ready.ts
+++ b/src/daemon/device-ready.ts
@@ -5,6 +5,7 @@ import { promises as fs } from 'node:fs';
 import { AppError } from '../utils/errors.ts';
 import { resolveIosDevicectlHint, IOS_DEVICECTL_DEFAULT_HINT } from '../platforms/ios/devicectl.ts';
 import { runXcrun } from '../platforms/ios/tool-provider.ts';
+import { isActiveProviderDevice } from '../provider-device-runtime.ts';
 
 const IOS_DEVICE_READY_TIMEOUT_MS = 15_000;
 const IOS_DEVICE_READY_COMMAND_TIMEOUT_BUFFER_MS = 3_000;
@@ -24,6 +25,8 @@ export async function ensureDeviceReady(
   device: DeviceInfo,
   options: DeviceReadyOptions = {},
 ): Promise<void> {
+  if (isActiveProviderDevice(device)) return;
+
   const cacheKey = deviceReadyCacheKey(device);
   const cachedUntil = readyCache.get(cacheKey);
   if (cachedUntil !== undefined) {

--- a/src/daemon/handlers/install-source.ts
+++ b/src/daemon/handlers/install-source.ts
@@ -1,3 +1,7 @@
+import {
+  installProviderDeviceInstallablePath,
+  type ProviderDeviceInstallResult,
+} from '../../provider-device-runtime.ts';
 import { resolveTargetDevice, type CommandFlags } from '../../core/dispatch.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
 import { getRequestSignal } from '../request-cancel.ts';
@@ -31,6 +35,17 @@ type InstallFromSourceResult = {
   installablePath?: string;
   materializationId?: string;
   materializationExpiresAt?: string;
+};
+
+type CompleteInstallFromSourceParams = {
+  prepared: PreparedInstallArtifact;
+  retention: ReturnType<typeof resolveRetainMaterializedPaths>;
+  req: DaemonRequest;
+  resolvedSourceCleanup: () => void;
+  session: SessionState | undefined;
+  sessionName: string;
+  sessionStore: SessionStore;
+  buildResult(retained: RetainedMaterializedPaths | undefined): Promise<InstallFromSourceResult>;
 };
 
 function normalizePlatform(platform: CommandFlags['platform']): 'ios' | 'android' | undefined {
@@ -144,94 +159,167 @@ export async function handleInstallFromSourceCommand(params: {
     if (unsupported) return unsupported;
 
     const requestSignal = getRequestSignal(req.meta?.requestId);
-    const completeInstall = async (
-      prepared: PreparedInstallArtifact,
-      buildResult: (
-        retained: RetainedMaterializedPaths | undefined,
-      ) => Promise<InstallFromSourceResult>,
-    ): Promise<DaemonResponse> => {
-      let retained: RetainedMaterializedPaths | undefined;
-      try {
-        retained = await maybeRetainInstallArtifact({
-          prepared,
-          retention,
-          req,
-          session,
-          sessionName,
-        });
-        const result = await buildResult(retained);
-        const data = withSuccessText(result, buildInstallFromSourceMessage(result));
-        recordInstallFromSourceAction({ session, sessionStore, req, data });
-        return { ok: true, data };
-      } catch (error) {
-        if (retained) {
-          await cleanupRetainedMaterializedPaths(
-            retained.materializationId,
-            req.meta?.tenantId,
-          ).catch(() => {});
-        }
-        throw error;
-      } finally {
-        await prepared.cleanup();
-        resolvedSource.cleanup();
-      }
-    };
-
     if (device.platform === 'ios') {
-      const { installIosInstallablePath } = await import('../../platforms/ios/apps.ts');
       const { prepareIosInstallArtifact } = await import('../../platforms/ios/install-artifact.ts');
       const prepared = await prepareIosInstallArtifact(resolvedSource.source, {
         signal: requestSignal,
       });
-      return await completeInstall(prepared, async (retained) => {
-        await installIosInstallablePath(device, prepared.installablePath);
-        if (!prepared.bundleId) {
-          throw new AppError(
-            'COMMAND_FAILED',
-            'Installed iOS app identity could not be resolved from the artifact',
-          );
-        }
-        return {
-          ...retainedInstallResultFields(retained),
-          bundleId: prepared.bundleId,
-          ...(prepared.appName ? { appName: prepared.appName } : {}),
-          launchTarget: prepared.bundleId,
-        };
+      return await completeInstallFromSource({
+        prepared,
+        retention,
+        req,
+        resolvedSourceCleanup: () => resolvedSource.cleanup(),
+        session,
+        sessionName,
+        sessionStore,
+        buildResult: async (retained) =>
+          await installPreparedIosArtifact(device, prepared, retained),
       });
     }
 
     const { prepareAndroidInstallArtifact } =
       await import('../../platforms/android/install-artifact.ts');
-    const { installAndroidInstallablePathAndResolvePackageName } =
-      await import('../../platforms/android/app-lifecycle.ts');
     const prepared = await prepareAndroidInstallArtifact(resolvedSource.source, {
       signal: requestSignal,
     });
-    return await completeInstall(prepared, async (retained) => {
-      const packageName = await installAndroidInstallablePathAndResolvePackageName(
-        device,
-        prepared.installablePath,
-        prepared.packageName,
-      );
-      if (!packageName) {
-        throw new AppError(
-          'COMMAND_FAILED',
-          'Installed Android app identity could not be resolved from the artifact or device state',
-        );
-      }
-      const { inferAndroidAppName } = await import('../../platforms/android/app-lifecycle.ts');
-      const appName = inferAndroidAppName(packageName);
-      return {
-        ...retainedInstallResultFields(retained),
-        packageName,
-        ...(appName ? { appName } : {}),
-        launchTarget: packageName,
-      };
+    return await completeInstallFromSource({
+      prepared,
+      retention,
+      req,
+      resolvedSourceCleanup: () => resolvedSource.cleanup(),
+      session,
+      sessionName,
+      sessionStore,
+      buildResult: async (retained) =>
+        await installPreparedAndroidArtifact(device, prepared, retained),
     });
   } catch (error) {
     const normalized = normalizeError(error);
     return { ok: false, error: normalized };
   }
+}
+
+async function completeInstallFromSource(
+  params: CompleteInstallFromSourceParams,
+): Promise<DaemonResponse> {
+  let retained: RetainedMaterializedPaths | undefined;
+  try {
+    retained = await maybeRetainInstallArtifact(params);
+    const result = await params.buildResult(retained);
+    const data = withSuccessText(result, buildInstallFromSourceMessage(result));
+    recordInstallFromSourceAction({
+      session: params.session,
+      sessionStore: params.sessionStore,
+      req: params.req,
+      data,
+    });
+    return { ok: true, data };
+  } catch (error) {
+    if (retained) {
+      await cleanupRetainedMaterializedPaths(
+        retained.materializationId,
+        params.req.meta?.tenantId,
+      ).catch(() => {});
+    }
+    throw error;
+  } finally {
+    await params.prepared.cleanup();
+    params.resolvedSourceCleanup();
+  }
+}
+
+async function installPreparedIosArtifact(
+  device: SessionState['device'],
+  prepared: PreparedInstallArtifact & { bundleId?: string; appName?: string },
+  retained: RetainedMaterializedPaths | undefined,
+): Promise<InstallFromSourceResult> {
+  const providerResult = await installProviderDeviceInstallablePath(
+    device,
+    prepared.installablePath,
+    { appIdentifierHint: prepared.bundleId },
+  );
+  if (!providerResult) {
+    const { installIosInstallablePath } = await import('../../platforms/ios/apps.ts');
+    await installIosInstallablePath(device, prepared.installablePath);
+  }
+  return buildIosInstallFromSourceResult(prepared, providerResult, retained);
+}
+
+async function installPreparedAndroidArtifact(
+  device: SessionState['device'],
+  prepared: PreparedInstallArtifact & { packageName?: string },
+  retained: RetainedMaterializedPaths | undefined,
+): Promise<InstallFromSourceResult> {
+  const providerResult = await installProviderDeviceInstallablePath(
+    device,
+    prepared.installablePath,
+    { packageNameHint: prepared.packageName },
+  );
+  const packageName = await resolveAndroidPackageName(device, prepared, providerResult);
+  const { inferAndroidAppName } = await import('../../platforms/android/app-lifecycle.ts');
+  const appName = inferAndroidAppName(packageName);
+  return {
+    ...retainedInstallResultFields(retained),
+    packageName,
+    ...optionalAppNameField(providerResult?.appName ?? appName),
+    launchTarget: providerResult?.launchTarget ?? packageName,
+  };
+}
+
+function buildIosInstallFromSourceResult(
+  prepared: PreparedInstallArtifact & { bundleId?: string; appName?: string },
+  providerResult: ProviderDeviceInstallResult | undefined,
+  retained: RetainedMaterializedPaths | undefined,
+): InstallFromSourceResult {
+  const bundleId = resolveIosBundleId(prepared, providerResult);
+  const appName = providerResult?.appName ?? prepared.appName;
+  return {
+    ...retainedInstallResultFields(retained),
+    bundleId,
+    ...optionalAppNameField(appName),
+    launchTarget: providerResult?.launchTarget ?? bundleId,
+  };
+}
+
+function resolveIosBundleId(
+  prepared: PreparedInstallArtifact & { bundleId?: string },
+  providerResult: ProviderDeviceInstallResult | undefined,
+): string {
+  const bundleId = providerResult?.bundleId ?? prepared.bundleId;
+  if (bundleId) return bundleId;
+  throw new AppError(
+    'COMMAND_FAILED',
+    'Installed iOS app identity could not be resolved from the artifact',
+  );
+}
+
+function optionalAppNameField(appName: string | undefined): { appName?: string } {
+  return appName ? { appName } : {};
+}
+
+async function resolveAndroidPackageName(
+  device: SessionState['device'],
+  prepared: PreparedInstallArtifact & { packageName?: string },
+  providerResult: ProviderDeviceInstallResult | undefined,
+): Promise<string> {
+  const providerPackageName = providerResult?.packageName ?? providerResult?.launchTarget;
+  if (providerPackageName) {
+    return providerPackageName;
+  }
+  const { installAndroidInstallablePathAndResolvePackageName } =
+    await import('../../platforms/android/app-lifecycle.ts');
+  const packageName = await installAndroidInstallablePathAndResolvePackageName(
+    device,
+    prepared.installablePath,
+    prepared.packageName,
+  );
+  if (!packageName) {
+    throw new AppError(
+      'COMMAND_FAILED',
+      'Installed Android app identity could not be resolved from the artifact or device state',
+    );
+  }
+  return packageName;
 }
 
 function buildInstallFromSourceMessage(result: {

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -46,7 +46,10 @@ import {
   readSimpleIosSelectorTarget,
   type DirectIosSelectorTarget,
 } from '../direct-ios-selector.ts';
-import { ensureAndroidBlockingSystemDialogReady } from '../android-system-dialog.ts';
+import {
+  ensureAndroidBlockingSystemDialogReady,
+  type AndroidBlockingDialogReadinessResult,
+} from '../android-system-dialog.ts';
 
 export async function handleTouchInteractionCommands(
   params: InteractionHandlerParams & {
@@ -148,6 +151,7 @@ async function dispatchTargetedTouchViaRuntime(
         durationMs,
       }),
     afterRun: async (result) => {
+      if (session.lease?.leaseProvider) return;
       await assertAndroidPressStayedInApp(
         session,
         formatTouchTargetLabel(parsedTarget.target, result),
@@ -527,18 +531,15 @@ async function dispatchRuntimeInteraction<
   const runtime = createInteractionRuntime(params);
   const actionStartedAt = Date.now();
   try {
-    const readiness = await ensureAndroidBlockingSystemDialogReady({
+    const { readiness, runtimeResult } = await runWithAndroidDialogReadinessCheck(
       session,
-      command: params.req.command,
-      phase: 'before-command',
-    });
-    const runtimeResult = await options.run(runtime);
-    await options.afterRun?.(runtimeResult);
-    await ensureAndroidBlockingSystemDialogReady({
-      session,
-      command: params.req.command,
-      phase: 'after-command',
-    });
+      params.req.command,
+      async () => {
+        const result = await options.run(runtime);
+        await options.afterRun?.(result);
+        return result;
+      },
+    );
     const actionFinishedAt = Date.now();
     const { result, responseData } = await options.buildPayloads(runtimeResult);
     if (readiness.status === 'recovered') {
@@ -563,6 +564,31 @@ async function dispatchRuntimeInteraction<
     if (isAndroidEscapeError(appError)) throw appError;
     return appErrorResponse(error);
   }
+}
+
+async function runWithAndroidDialogReadinessCheck<TResult>(
+  session: SessionState,
+  command: string,
+  run: () => Promise<TResult>,
+): Promise<{
+  readiness: AndroidBlockingDialogReadinessResult;
+  runtimeResult: TResult;
+}> {
+  if (session.lease?.leaseProvider) {
+    return { readiness: { status: 'clear' }, runtimeResult: await run() };
+  }
+  const readiness = await ensureAndroidBlockingSystemDialogReady({
+    session,
+    command,
+    phase: 'before-command',
+  });
+  const runtimeResult = await run();
+  await ensureAndroidBlockingSystemDialogReady({
+    session,
+    command,
+    phase: 'after-command',
+  });
+  return { readiness, runtimeResult };
 }
 
 async function refreshAndroidRefSnapshotIfFreshnessActive(

--- a/src/daemon/handlers/lease.ts
+++ b/src/daemon/handlers/lease.ts
@@ -1,5 +1,5 @@
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
-import type { LeaseRegistry } from '../lease-registry.ts';
+import type { DeviceLease, LeaseRegistry } from '../lease-registry.ts';
 import { resolveLeaseScope } from '../lease-context.ts';
 import {
   leaseScopeToAllocateRequest,
@@ -7,34 +7,62 @@ import {
   leaseScopeToReleaseRequest,
 } from '../../core/lease-scope.ts';
 
+export type LeaseLifecycleProvider = {
+  allocate?: (lease: DeviceLease) => Promise<Record<string, unknown> | undefined>;
+  heartbeat?: (lease: DeviceLease) => Promise<Record<string, unknown> | undefined>;
+  release?: (lease: DeviceLease) => Promise<Record<string, unknown> | undefined>;
+};
+
 type LeaseHandlerArgs = {
   req: DaemonRequest;
   leaseRegistry: LeaseRegistry;
+  leaseLifecycleProvider?: LeaseLifecycleProvider;
 };
 
 export async function handleLeaseCommands(args: LeaseHandlerArgs): Promise<DaemonResponse | null> {
-  const { req, leaseRegistry } = args;
+  const { req, leaseRegistry, leaseLifecycleProvider } = args;
   const leaseScope = resolveLeaseScope(req);
   switch (req.command) {
     case 'lease_allocate': {
       const lease = leaseRegistry.allocateLease(leaseScopeToAllocateRequest(leaseScope));
+      let providerData: Record<string, unknown> | undefined;
+      try {
+        providerData = await leaseLifecycleProvider?.allocate?.(lease);
+      } catch (error) {
+        leaseRegistry.releaseLease(
+          leaseScopeToReleaseRequest({
+            leaseId: lease.leaseId,
+            tenantId: lease.tenantId,
+            runId: lease.runId,
+            leaseBackend: lease.backend,
+            leaseProvider: lease.leaseProvider,
+            deviceKey: lease.deviceKey,
+            clientId: lease.clientId,
+          }),
+        );
+        throw error;
+      }
       return {
         ok: true,
-        data: { lease },
+        data: { lease, ...(providerData ? { provider: providerData } : {}) },
       };
     }
     case 'lease_heartbeat': {
       const lease = leaseRegistry.heartbeatLease(leaseScopeToHeartbeatRequest(leaseScope));
+      const providerData = await leaseLifecycleProvider?.heartbeat?.(lease);
       return {
         ok: true,
-        data: { lease },
+        data: { lease, ...(providerData ? { provider: providerData } : {}) },
       };
     }
     case 'lease_release': {
       const result = leaseRegistry.releaseLease(leaseScopeToReleaseRequest(leaseScope));
+      const providerData = result.lease
+        ? await leaseLifecycleProvider?.release?.(result.lease)
+        : undefined;
       return {
         ok: true,
-        data: result,
+        data: { released: result.released, ...(providerData ? { provider: providerData } : {}) },
       };
     }
     default:

--- a/src/daemon/handlers/session-deploy.ts
+++ b/src/daemon/handlers/session-deploy.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { installProviderDeviceApp } from '../../provider-device-runtime.ts';
 import { cleanupUploadedArtifact, prepareUploadedArtifact } from '../artifact-tracking.ts';
 import type { DeviceInfo } from '../../utils/device.ts';
 import type { DaemonRequest, DaemonResponse } from '../types.ts';
@@ -53,10 +54,26 @@ type DeployCommandResult = IosDeployCommandResult | AndroidDeployCommandResult;
 
 export const defaultReinstallOps: ReinstallOps = {
   ios: async (device, app, appPath) => {
+    const providerResult = await installProviderDeviceApp(device, app, appPath, {
+      relaunch: true,
+      appIdentifierHint: app,
+    });
+    if (providerResult) {
+      return { bundleId: providerResult.bundleId ?? providerResult.launchTarget ?? app };
+    }
+
     const { reinstallIosApp } = await import('../../platforms/ios/apps.ts');
     return await reinstallIosApp(device, app, appPath);
   },
   android: async (device, app, appPath) => {
+    const providerResult = await installProviderDeviceApp(device, app, appPath, {
+      relaunch: true,
+      packageNameHint: app,
+    });
+    if (providerResult) {
+      return { package: providerResult.packageName ?? providerResult.launchTarget ?? app };
+    }
+
     const { reinstallAndroidApp } = await import('../../platforms/android/app-lifecycle.ts');
     return await reinstallAndroidApp(device, app, appPath);
   },
@@ -64,6 +81,17 @@ export const defaultReinstallOps: ReinstallOps = {
 
 export const defaultInstallOps: InstallOps = {
   ios: async (device, app, appPath) => {
+    const providerResult = await installProviderDeviceApp(device, app, appPath, {
+      appIdentifierHint: app,
+    });
+    if (providerResult) {
+      return {
+        bundleId: providerResult.bundleId,
+        appName: providerResult.appName,
+        launchTarget: providerResult.launchTarget,
+      };
+    }
+
     const { installIosApp } = await import('../../platforms/ios/apps.ts');
     const result = await installIosApp(device, appPath, { appIdentifierHint: app });
     return {
@@ -73,6 +101,17 @@ export const defaultInstallOps: InstallOps = {
     };
   },
   android: async (device, _app, appPath) => {
+    const providerResult = await installProviderDeviceApp(device, _app, appPath, {
+      packageNameHint: _app,
+    });
+    if (providerResult) {
+      return {
+        package: providerResult.packageName,
+        appName: providerResult.appName,
+        launchTarget: providerResult.launchTarget,
+      };
+    }
+
     const { installAndroidApp } = await import('../../platforms/android/app-lifecycle.ts');
     const result = await installAndroidApp(device, appPath);
     return {

--- a/src/daemon/handlers/session-runtime-command.ts
+++ b/src/daemon/handlers/session-runtime-command.ts
@@ -8,6 +8,23 @@ import {
   mergeRuntimeHints,
   toRuntimePlatform,
 } from './session-runtime.ts';
+import {
+  configureProviderPortReverse,
+  type ProviderPortReverseOptions,
+  removeProviderPortReverse,
+} from '../../provider-device-runtime.ts';
+
+type RuntimeAction = 'set' | 'show' | 'clear';
+type PortReverseAction = 'port-reverse' | 'port-reverse-remove';
+type PortReverseParseResult =
+  | { ok: true; options: ProviderPortReverseOptions }
+  | { ok: false; response: DaemonResponse };
+type PortReverseRequiredFields =
+  | { ok: true; leaseId: string; provider: string }
+  | { ok: false; response: DaemonResponse };
+type PortReversePorts =
+  | { ok: true; devicePort: number; hostPort: number }
+  | { ok: false; response: DaemonResponse };
 
 export async function handleRuntimeCommand(params: {
   req: DaemonRequest;
@@ -16,32 +33,73 @@ export async function handleRuntimeCommand(params: {
 }): Promise<DaemonResponse> {
   const { req, sessionName, sessionStore } = params;
   const action = (req.positionals?.[0] ?? 'show').toLowerCase();
+  if (isPortReverseAction(action)) {
+    return await handlePortReverseCommand(req, action);
+  }
+  if (!isRuntimeAction(action)) {
+    return errorResponse(
+      'INVALID_ARGS',
+      'runtime requires set, show, clear, port-reverse, or port-reverse-remove',
+    );
+  }
   const session = sessionStore.get(sessionName);
   const current = sessionStore.getRuntimeHints(sessionName);
-  if (!['set', 'show', 'clear'].includes(action)) {
-    return errorResponse('INVALID_ARGS', 'runtime requires set, show, or clear');
-  }
   if (action === 'clear') {
-    if (hasRuntimeTransportHints(current) && session?.appBundleId) {
-      await clearRuntimeHintsFromApp({
-        device: session.device,
-        appId: session.appBundleId,
-      });
-    }
-    const cleared = sessionStore.clearRuntimeHints(sessionName);
-    return { ok: true, data: { session: sessionName, cleared } };
+    return await clearRuntimeCommand(sessionName, sessionStore, session, current);
   }
   if (action === 'show') {
-    return {
-      ok: true,
-      data: {
-        session: sessionName,
-        configured: Boolean(current),
-        runtime: current,
-      },
-    };
+    return showRuntimeCommand(sessionName, current);
   }
 
+  return setRuntimeCommand({ req, sessionName, sessionStore, session, current });
+}
+
+function isRuntimeAction(action: string): action is RuntimeAction {
+  return action === 'set' || action === 'show' || action === 'clear';
+}
+
+function isPortReverseAction(action: string): action is PortReverseAction {
+  return action === 'port-reverse' || action === 'port-reverse-remove';
+}
+
+async function clearRuntimeCommand(
+  sessionName: string,
+  sessionStore: SessionStore,
+  session: ReturnType<SessionStore['get']>,
+  current: ReturnType<SessionStore['getRuntimeHints']>,
+): Promise<DaemonResponse> {
+  if (hasRuntimeTransportHints(current) && session?.appBundleId) {
+    await clearRuntimeHintsFromApp({
+      device: session.device,
+      appId: session.appBundleId,
+    });
+  }
+  const cleared = sessionStore.clearRuntimeHints(sessionName);
+  return { ok: true, data: { session: sessionName, cleared } };
+}
+
+function showRuntimeCommand(
+  sessionName: string,
+  current: ReturnType<SessionStore['getRuntimeHints']>,
+): DaemonResponse {
+  return {
+    ok: true,
+    data: {
+      session: sessionName,
+      configured: Boolean(current),
+      runtime: current,
+    },
+  };
+}
+
+function setRuntimeCommand(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  sessionStore: SessionStore;
+  session: ReturnType<SessionStore['get']>;
+  current: ReturnType<SessionStore['getRuntimeHints']>;
+}): DaemonResponse {
+  const { req, sessionName, sessionStore, session, current } = params;
   const platform = toRuntimePlatform(
     req.flags?.platform ?? current?.platform ?? session?.device.platform,
   );
@@ -73,4 +131,97 @@ export async function handleRuntimeCommand(params: {
       runtime: nextRuntime,
     },
   };
+}
+
+async function handlePortReverseCommand(
+  req: DaemonRequest,
+  action: PortReverseAction,
+): Promise<DaemonResponse> {
+  const parsed = readPortReverseOptions(req);
+  if (!parsed.ok) return parsed.response;
+  const result = await executePortReverseAction(action, parsed.options);
+  if (!result) {
+    return errorResponse(
+      'UNSUPPORTED_OPERATION',
+      'No active provider device runtime supports port reverse for this lease.',
+    );
+  }
+  return {
+    ok: true,
+    data: {
+      action,
+      ...result,
+    },
+  };
+}
+
+function readPortReverseOptions(req: DaemonRequest): PortReverseParseResult {
+  const required = readRequiredPortReverseFields(req);
+  if (!required.ok) return required;
+  const ports = readPortReversePorts(req);
+  if (!ports.ok) return ports;
+  const name = req.flags?.portReverseName?.trim() || 'runtime';
+  return {
+    ok: true,
+    options: {
+      leaseId: required.leaseId,
+      provider: required.provider,
+      devicePort: ports.devicePort,
+      hostPort: ports.hostPort,
+      name,
+    },
+  };
+}
+
+function readRequiredPortReverseFields(req: DaemonRequest): PortReverseRequiredFields {
+  const leaseId = req.flags?.leaseId;
+  const provider = req.flags?.leaseProvider;
+  if (!leaseId) {
+    return {
+      ok: false,
+      response: errorResponse(
+        'INVALID_ARGS',
+        'runtime port-reverse requires a resolved remote lease.',
+      ),
+    };
+  }
+  if (!provider) {
+    return {
+      ok: false,
+      response: errorResponse('INVALID_ARGS', 'runtime port-reverse requires a lease provider.'),
+    };
+  }
+  return { ok: true, leaseId, provider };
+}
+
+function readPortReversePorts(req: DaemonRequest): PortReversePorts {
+  const devicePort = readTcpPort(req.flags?.devicePort);
+  const hostPort = readTcpPort(req.flags?.hostPort ?? req.flags?.devicePort);
+  if (!devicePort || !hostPort) {
+    return {
+      ok: false,
+      response: errorResponse(
+        'INVALID_ARGS',
+        'runtime port-reverse requires numeric devicePort and hostPort values from 1 to 65535.',
+      ),
+    };
+  }
+  return { ok: true, devicePort, hostPort };
+}
+
+async function executePortReverseAction(
+  action: PortReverseAction,
+  options: ProviderPortReverseOptions,
+): Promise<Record<string, unknown> | undefined> {
+  if (action === 'port-reverse') {
+    return await configureProviderPortReverse(options);
+  }
+  return await removeProviderPortReverse(options);
+}
+
+function readTcpPort(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 65_535) {
+    return undefined;
+  }
+  return value;
 }

--- a/src/daemon/lease-registry.ts
+++ b/src/daemon/lease-registry.ts
@@ -293,7 +293,7 @@ export class LeaseRegistry {
     return this.refreshLease(lease, leaseTtlMs);
   }
 
-  releaseLease(request: ReleaseLeaseRequest): { released: boolean } {
+  releaseLease(request: ReleaseLeaseRequest): { released: boolean; lease?: DeviceLease } {
     const leaseId = this.normalizeRequiredLeaseId(request.leaseId);
     this.cleanupExpiredLeases();
     const lease = this.leases.get(leaseId);
@@ -304,7 +304,7 @@ export class LeaseRegistry {
     this.assertOptionalScopeMatch(lease, request);
     this.leases.delete(leaseId);
     this.unbindLease(lease);
-    return { released: true };
+    return { released: true, lease: { ...lease } };
   }
 
   assertLeaseAdmission(request: AdmissionRequest): void {

--- a/src/daemon/request-handler-chain.ts
+++ b/src/daemon/request-handler-chain.ts
@@ -3,6 +3,7 @@ import type { AndroidAdbExecutor } from '../platforms/android/adb-executor.ts';
 import { AppError } from '../utils/errors.ts';
 import { getDaemonCommandRoute } from './daemon-command-registry.ts';
 import type { DaemonCommandContext } from './context.ts';
+import type { LeaseLifecycleProvider } from './handlers/lease.ts';
 import type { LeaseRegistry } from './lease-registry.ts';
 import type { SessionStore } from './session-store.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse } from './types.ts';
@@ -21,6 +22,7 @@ type RequestHandlerChainParams = {
   logPath: string;
   sessionStore: SessionStore;
   leaseRegistry: LeaseRegistry;
+  leaseLifecycleProvider?: LeaseLifecycleProvider;
   invoke: DaemonInvokeFn;
   invokeReplayAction?: DaemonInvokeFn;
   androidAdbExecutor?: AndroidAdbExecutor;
@@ -59,7 +61,11 @@ async function runLeaseHandler(params: RequestHandlerChainParams): Promise<Daemo
   return expectHandlerResponse(
     params.req.command,
     'lease',
-    await handleLeaseCommands({ req: params.req, leaseRegistry: params.leaseRegistry }),
+    await handleLeaseCommands({
+      req: params.req,
+      leaseRegistry: params.leaseRegistry,
+      leaseLifecycleProvider: params.leaseLifecycleProvider,
+    }),
   );
 }
 

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -37,6 +37,7 @@ import {
 } from './request-execution-scope.ts';
 import { canRunReplayScopedAction } from './daemon-command-registry.ts';
 import { createAgentBrowserWebProvider } from '../platforms/web/agent-browser-provider.ts';
+import type { LeaseLifecycleProvider } from './handlers/lease.ts';
 
 // ---------------------------------------------------------------------------
 // Request handler API
@@ -65,6 +66,8 @@ export type RequestRouterDeps = {
   appLogProvider?: AppLogProviderResolver;
   recordingProvider?: RecordingProviderResolver;
   deviceInventoryProvider?: DeviceInventoryProvider;
+  leaseLifecycleProvider?: LeaseLifecycleProvider;
+  providerDeviceRuntimeScope?: <T>(task: () => Promise<T>) => Promise<T>;
   trackDownloadableArtifact: (opts: {
     artifactPath: string;
     tenantId?: string;
@@ -85,6 +88,8 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
     appLogProvider,
     recordingProvider,
     deviceInventoryProvider,
+    leaseLifecycleProvider,
+    providerDeviceRuntimeScope,
     trackDownloadableArtifact,
   } = deps;
   const { sessionStore, leaseRegistry } = deps;
@@ -154,12 +159,17 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
       });
       if (locked.type === 'response') return locked.response;
       const lockedScope = locked.scope;
-      const executeLocked = async (providerScope: RequestPlatformProviderScope) =>
-        await executeLockedRequest({
-          lockedScope,
-          providerScope,
-          allowReplayActions: inheritedProviderScope === undefined,
-        });
+      const executeLocked = async (providerScope: RequestPlatformProviderScope) => {
+        const runLockedRequest = async () =>
+          await executeLockedRequest({
+            lockedScope,
+            providerScope,
+            allowReplayActions: inheritedProviderScope === undefined,
+          });
+        return providerDeviceRuntimeScope
+          ? await providerDeviceRuntimeScope(runLockedRequest)
+          : await runLockedRequest();
+      };
 
       return inheritedProviderScope
         ? await executeLocked(inheritedProviderScope)
@@ -200,6 +210,7 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
       logPath: lockedScope.logPath,
       sessionStore,
       leaseRegistry,
+      leaseLifecycleProvider,
       invoke: handleRequest,
       invokeReplayAction: allowReplayActions
         ? createReplayScopedActionInvoker(lockedScope, providerScope)

--- a/src/daemon/runtime-hints.ts
+++ b/src/daemon/runtime-hints.ts
@@ -12,6 +12,7 @@ import {
 } from '../platforms/android/open-target.ts';
 import { buildSimctlArgsForDevice } from '../platforms/ios/simctl.ts';
 import { runXcrun } from '../platforms/ios/tool-provider.ts';
+import { isActiveProviderDevice } from '../provider-device-runtime.ts';
 
 const ANDROID_DEV_PREFS_PATH = 'shared_prefs/ReactNativeDevPrefs.xml';
 const ANDROID_DEBUG_HOST_KEY = 'debug_http_host';
@@ -43,6 +44,7 @@ export async function applyRuntimeHintsToApp(params: {
   runtime: SessionRuntimeHints | undefined;
 }): Promise<void> {
   const { device, appId, runtime } = params;
+  if (isActiveProviderDevice(device)) return;
   if (!appId) return;
   const transport = resolveRuntimeTransportHints(runtime);
   if (!transport) return;

--- a/src/provider-device-runtime.ts
+++ b/src/provider-device-runtime.ts
@@ -1,0 +1,217 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Interactor } from './core/interactor-types.ts';
+import type { DeviceInventoryProvider } from './core/dispatch-resolve.ts';
+import type { LeaseLifecycleProvider } from './daemon/handlers/lease.ts';
+import type { DeviceLease } from './daemon/lease-registry.ts';
+import type { DeviceInfo } from './utils/device.ts';
+import { AppError } from './utils/errors.ts';
+
+export type ProviderDeviceInstallResult = {
+  bundleId?: string;
+  packageName?: string;
+  appName?: string;
+  launchTarget?: string;
+};
+
+export type ProviderDeviceInstallOptions = {
+  relaunch?: boolean;
+  appIdentifierHint?: string;
+  packageNameHint?: string;
+};
+
+export type ProviderDeviceRuntime = {
+  provider: string;
+  leaseLifecycle: LeaseLifecycleProvider;
+  deviceInventoryProvider: DeviceInventoryProvider;
+  ownsDevice(device: DeviceInfo): boolean;
+  getInteractor(device: DeviceInfo): Interactor | undefined;
+  installApp?(
+    device: DeviceInfo,
+    app: string,
+    appPath: string,
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined>;
+  installInstallablePath?(
+    device: DeviceInfo,
+    installablePath: string,
+    options?: ProviderDeviceInstallOptions,
+  ): Promise<ProviderDeviceInstallResult | undefined>;
+  configurePortReverse?(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined>;
+  removePortReverse?(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined>;
+  shutdown(): Promise<void>;
+};
+
+export type ProviderPortReverseOptions = {
+  leaseId: string;
+  provider?: string;
+  devicePort: number;
+  hostPort: number;
+  name: string;
+};
+
+export type ProviderDeviceRuntimeRequestProviders = {
+  leaseLifecycleProvider?: LeaseLifecycleProvider;
+  deviceInventoryProvider?: DeviceInventoryProvider;
+  providerDeviceRuntimeScope?: <T>(task: () => Promise<T>) => Promise<T>;
+};
+
+let activeProviderDeviceRuntimes: ProviderDeviceRuntime[] = [];
+const providerDeviceRuntimeScope = new AsyncLocalStorage<ProviderDeviceRuntime[]>();
+
+export function setActiveProviderDeviceRuntimes(runtimes: ProviderDeviceRuntime[]): void {
+  activeProviderDeviceRuntimes = [...runtimes];
+}
+
+async function withProviderDeviceRuntimeScope<T>(
+  runtimes: ProviderDeviceRuntime[],
+  task: () => Promise<T>,
+): Promise<T> {
+  return await providerDeviceRuntimeScope.run([...runtimes], task);
+}
+
+export function getProviderDeviceInteractor(device: DeviceInfo): Interactor | undefined {
+  for (const runtime of getActiveProviderDeviceRuntimes()) {
+    if (!runtime.ownsDevice(device)) continue;
+    const interactor = runtime.getInteractor(device);
+    if (interactor) return interactor;
+  }
+  return undefined;
+}
+
+export function isActiveProviderDevice(device: DeviceInfo): boolean {
+  return getActiveProviderDeviceRuntimes().some((runtime) => runtime.ownsDevice(device));
+}
+
+export async function installProviderDeviceApp(
+  device: DeviceInfo,
+  app: string,
+  appPath: string,
+  options?: ProviderDeviceInstallOptions,
+): Promise<ProviderDeviceInstallResult | undefined> {
+  for (const runtime of getActiveProviderDeviceRuntimes()) {
+    if (!runtime.ownsDevice(device)) continue;
+    if (!runtime.installApp) {
+      throw unsupportedProviderOperation(runtime, device, 'install');
+    }
+    const result = await runtime.installApp?.(device, app, appPath, options);
+    if (result) return result;
+    throw unsupportedProviderOperation(runtime, device, 'install');
+  }
+  return undefined;
+}
+
+export async function installProviderDeviceInstallablePath(
+  device: DeviceInfo,
+  installablePath: string,
+  options?: ProviderDeviceInstallOptions,
+): Promise<ProviderDeviceInstallResult | undefined> {
+  for (const runtime of getActiveProviderDeviceRuntimes()) {
+    if (!runtime.ownsDevice(device)) continue;
+    if (!runtime.installInstallablePath) {
+      throw unsupportedProviderOperation(runtime, device, 'install_from_source');
+    }
+    const result = await runtime.installInstallablePath?.(device, installablePath, options);
+    if (result) return result;
+    throw unsupportedProviderOperation(runtime, device, 'install_from_source');
+  }
+  return undefined;
+}
+
+export async function configureProviderPortReverse(
+  options: ProviderPortReverseOptions,
+): Promise<Record<string, unknown> | undefined> {
+  for (const runtime of getActiveProviderDeviceRuntimes()) {
+    if (!runtimeMatchesProvider(runtime, options.provider)) continue;
+    const result = await runtime.configurePortReverse?.(options);
+    if (result) return result;
+  }
+  return undefined;
+}
+
+export async function removeProviderPortReverse(
+  options: ProviderPortReverseOptions,
+): Promise<Record<string, unknown> | undefined> {
+  for (const runtime of getActiveProviderDeviceRuntimes()) {
+    if (!runtimeMatchesProvider(runtime, options.provider)) continue;
+    const result = await runtime.removePortReverse?.(options);
+    if (result) return result;
+  }
+  return undefined;
+}
+
+function getActiveProviderDeviceRuntimes(): ProviderDeviceRuntime[] {
+  return providerDeviceRuntimeScope.getStore() ?? activeProviderDeviceRuntimes;
+}
+
+export function createProviderDeviceRuntimeRequestProviders(
+  runtimes: ProviderDeviceRuntime[],
+): ProviderDeviceRuntimeRequestProviders {
+  return {
+    leaseLifecycleProvider: composeLeaseProvider(runtimes),
+    deviceInventoryProvider: composeDeviceInventoryProvider(runtimes),
+    providerDeviceRuntimeScope: async (task) =>
+      await withProviderDeviceRuntimeScope(runtimes, task),
+  };
+}
+
+function composeLeaseProvider(
+  runtimes: ProviderDeviceRuntime[],
+): LeaseLifecycleProvider | undefined {
+  if (runtimes.length === 0) return undefined;
+  return {
+    allocate: async (lease) => await firstProviderResult(runtimes, 'allocate', lease),
+    heartbeat: async (lease) => await firstProviderResult(runtimes, 'heartbeat', lease),
+    release: async (lease) => await firstProviderResult(runtimes, 'release', lease),
+  };
+}
+
+function composeDeviceInventoryProvider(
+  runtimes: ProviderDeviceRuntime[],
+): DeviceInventoryProvider | undefined {
+  if (runtimes.length === 0) return undefined;
+  return async (request) => {
+    for (const runtime of runtimes) {
+      if (!runtimeMatchesProvider(runtime, request.leaseProvider)) continue;
+      const devices = await runtime.deviceInventoryProvider(request);
+      if (devices) return devices;
+    }
+    return null;
+  };
+}
+
+async function firstProviderResult(
+  runtimes: ProviderDeviceRuntime[],
+  method: keyof LeaseLifecycleProvider,
+  lease: DeviceLease,
+): Promise<Record<string, unknown> | undefined> {
+  for (const runtime of runtimes) {
+    if (!runtimeMatchesProvider(runtime, lease.leaseProvider)) continue;
+    const handler = runtime.leaseLifecycle[method];
+    const result = handler ? await handler(lease) : undefined;
+    if (result) return result;
+  }
+  return undefined;
+}
+
+function runtimeMatchesProvider(
+  runtime: ProviderDeviceRuntime,
+  provider: string | undefined,
+): boolean {
+  return runtime.provider === provider;
+}
+
+function unsupportedProviderOperation(
+  runtime: ProviderDeviceRuntime,
+  device: DeviceInfo,
+  operation: string,
+): never {
+  throw new AppError(
+    'UNSUPPORTED_OPERATION',
+    `Provider device runtime ${runtime.provider} does not support ${operation} for this device.`,
+    { provider: runtime.provider, deviceId: device.id, platform: device.platform },
+  );
+}

--- a/test/integration/provider-scenarios/provider-device-runtime.test.ts
+++ b/test/integration/provider-scenarios/provider-device-runtime.test.ts
@@ -1,0 +1,408 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'vitest';
+import {
+  createProviderDeviceRuntimeRequestProviders,
+  type ProviderDeviceRuntime,
+  type ProviderPortReverseOptions,
+} from '../../../src/provider-device-runtime.ts';
+import type { DeviceInventoryProvider } from '../../../src/core/dispatch-resolve.ts';
+import type { Interactor, SnapshotResult } from '../../../src/core/interactor-types.ts';
+import type { LeaseLifecycleProvider } from '../../../src/daemon/handlers/lease.ts';
+import type { DeviceLease } from '../../../src/daemon/lease-registry.ts';
+import type { DaemonRequest } from '../../../src/daemon/types.ts';
+import type { DeviceInfo } from '../../../src/utils/device.ts';
+import { assertRpcOk } from './assertions.ts';
+import {
+  createProviderScenarioHarness,
+  withProviderScenarioResource,
+  withProviderScenarioTempDir,
+} from './harness.ts';
+import { runProviderScenario, type ProviderScenarioStep } from './scenario.ts';
+
+const FAKE_PROVIDER = 'fake-provider';
+const DEVTOOLS_PORT_REVERSE = { devicePort: 8097, hostPort: 8097, portReverseName: 'devtools' };
+const ABSENT_FAKE_PROVIDER_INTERACTOR_PROPERTIES = new Set([
+  'then',
+  'tapElementSelector',
+  'fillElementSelector',
+  'setViewport',
+]);
+
+type FakeProviderCall = {
+  type:
+    | 'lease.allocate'
+    | 'lease.heartbeat'
+    | 'lease.release'
+    | 'inventory'
+    | 'install'
+    | 'open'
+    | 'tap'
+    | 'snapshot'
+    | 'portReverse.ensure'
+    | 'portReverse.remove';
+  [key: string]: unknown;
+};
+
+type FakeProviderSession = {
+  device: DeviceInfo;
+  interactor: Interactor;
+};
+
+test('Provider-backed scenario composes lease, inventory, dispatch, and port reverse providers', async () => {
+  await withProviderScenarioResource(createFakeProviderWorld, async ({ daemon, runtime }) => {
+    await runFakeProviderScenario(daemon, runtime);
+  });
+}, 15_000);
+
+async function runFakeProviderScenario(
+  daemon: Awaited<ReturnType<typeof createProviderScenarioHarness>>,
+  runtime: FakeProviderDeviceRuntime,
+): Promise<void> {
+  await withProviderScenarioTempDir('agent-device-provider-runtime-', async (tempDir) => {
+    const appPath = path.join(tempDir, 'demo.apk');
+    fs.writeFileSync(appPath, 'fake apk');
+    const lease = await allocateFakeProviderLease(daemon);
+    await runProviderScenario(daemon, providerScenarioSteps(appPath, lease, runtime), {
+      flags: leaseFlags(lease.leaseId),
+      meta: leaseMeta(lease.leaseId),
+    });
+    assertFakeProviderScenarioResult(daemon, runtime, lease, appPath);
+  });
+}
+
+async function allocateFakeProviderLease(
+  daemon: Awaited<ReturnType<typeof createProviderScenarioHarness>>,
+): Promise<DeviceLease> {
+  const allocate = await daemon.callCommand('lease_allocate', [], leaseFlags(), {
+    meta: leaseMeta(),
+  });
+  return assertRpcOk<{ lease: DeviceLease }>(allocate).lease;
+}
+
+function providerScenarioSteps(
+  appPath: string,
+  lease: DeviceLease,
+  runtime: FakeProviderDeviceRuntime,
+): ProviderScenarioStep[] {
+  const portReverse = expectedPortReverseData(lease.leaseId);
+  return [
+    {
+      name: 'heartbeat',
+      command: 'lease_heartbeat',
+      expectData: { provider: { provider: FAKE_PROVIDER } },
+    },
+    {
+      name: 'install',
+      command: 'install',
+      positionals: [appPath],
+      expectData: { platform: 'android', packageName: 'com.example.installed' },
+    },
+    {
+      name: 'open',
+      command: 'open',
+      positionals: ['com.example.demo'],
+      expectData: {
+        platform: 'android',
+        id: runtime.deviceIdForLease(lease.leaseId),
+        serial: runtime.deviceIdForLease(lease.leaseId),
+      },
+    },
+    { name: 'click', command: 'click', positionals: ['10', '20'], expectData: { x: 10, y: 20 } },
+    { name: 'snapshot', command: 'snapshot' },
+    {
+      name: 'port-reverse',
+      command: 'runtime',
+      positionals: ['port-reverse'],
+      flags: DEVTOOLS_PORT_REVERSE,
+      expectData: { action: 'port-reverse', ...portReverse },
+    },
+    {
+      name: 'port-reverse-remove',
+      command: 'runtime',
+      positionals: ['port-reverse-remove'],
+      flags: DEVTOOLS_PORT_REVERSE,
+      expectData: { action: 'port-reverse-remove', ...portReverse },
+    },
+    {
+      name: 'release',
+      command: 'lease_release',
+      expectData: { released: true, provider: { provider: FAKE_PROVIDER } },
+    },
+  ];
+}
+
+function expectedPortReverseData(leaseId: string): Record<string, unknown> {
+  return {
+    provider: FAKE_PROVIDER,
+    leaseId,
+    devicePort: DEVTOOLS_PORT_REVERSE.devicePort,
+    hostPort: DEVTOOLS_PORT_REVERSE.hostPort,
+    name: DEVTOOLS_PORT_REVERSE.portReverseName,
+  };
+}
+
+function assertFakeProviderScenarioResult(
+  daemon: Awaited<ReturnType<typeof createProviderScenarioHarness>>,
+  runtime: FakeProviderDeviceRuntime,
+  lease: DeviceLease,
+  appPath: string,
+): void {
+  const deviceId = runtime.deviceIdForLease(lease.leaseId);
+  const session = daemon.session();
+  assert.equal(session?.device.id, deviceId);
+  assert.equal(session?.lease?.leaseId, lease.leaseId);
+  assert.deepEqual(
+    runtime.calls.find((call) => call.type === 'install'),
+    {
+      type: 'install',
+      deviceId,
+      app: '',
+      appPath,
+    },
+  );
+  assert.deepEqual(
+    runtime.calls.find((call) => call.type === 'open'),
+    {
+      type: 'open',
+      deviceId,
+      app: 'com.example.demo',
+      url: undefined,
+    },
+  );
+  assert.deepEqual(
+    runtime.calls.find((call) => call.type === 'tap'),
+    {
+      type: 'tap',
+      deviceId,
+      x: 10,
+      y: 20,
+    },
+  );
+  assertFakeProviderCallOrder(runtime.calls);
+}
+
+function assertFakeProviderCallOrder(calls: FakeProviderCall[]): void {
+  assert.deepEqual(
+    calls.map((call) => call.type),
+    [
+      'lease.allocate',
+      'lease.heartbeat',
+      'inventory',
+      'install',
+      'inventory',
+      'open',
+      'tap',
+      'snapshot',
+      'portReverse.ensure',
+      'portReverse.remove',
+      'lease.release',
+    ],
+  );
+}
+
+async function createFakeProviderWorld() {
+  const runtime = new FakeProviderDeviceRuntime();
+  const providerRuntimeProviders = createProviderDeviceRuntimeRequestProviders([runtime]);
+  const daemon = await createProviderScenarioHarness({
+    ...providerRuntimeProviders,
+    deviceInventoryProvider: providerRuntimeProviders.deviceInventoryProvider!,
+  });
+  return {
+    daemon,
+    runtime,
+    close: async () => {
+      await runtime.shutdown();
+      await daemon.close();
+    },
+  };
+}
+
+class FakeProviderDeviceRuntime implements ProviderDeviceRuntime {
+  readonly provider = FAKE_PROVIDER;
+  readonly calls: FakeProviderCall[] = [];
+  private readonly sessionsByLeaseId = new Map<string, FakeProviderSession>();
+
+  readonly leaseLifecycle: LeaseLifecycleProvider = {
+    allocate: async (lease) => {
+      if (lease.leaseProvider !== this.provider) return undefined;
+      const device = this.createDevice(lease);
+      const interactor = createFakeProviderInteractor(device, this.calls);
+      this.sessionsByLeaseId.set(lease.leaseId, { device, interactor });
+      this.calls.push({
+        type: 'lease.allocate',
+        leaseId: lease.leaseId,
+        provider: lease.leaseProvider,
+        deviceId: device.id,
+      });
+      return { provider: this.provider, deviceId: device.id };
+    },
+    heartbeat: async (lease) => {
+      if (lease.leaseProvider !== this.provider) return undefined;
+      this.calls.push({
+        type: 'lease.heartbeat',
+        leaseId: lease.leaseId,
+        provider: lease.leaseProvider,
+      });
+      return { provider: this.provider };
+    },
+    release: async (lease) => {
+      if (lease.leaseProvider !== this.provider) return undefined;
+      this.sessionsByLeaseId.delete(lease.leaseId);
+      this.calls.push({
+        type: 'lease.release',
+        leaseId: lease.leaseId,
+        provider: lease.leaseProvider,
+      });
+      return { provider: this.provider };
+    },
+  };
+
+  readonly deviceInventoryProvider: DeviceInventoryProvider = async (request) => {
+    if (request.leaseProvider !== this.provider) return null;
+    const leaseId = request.leaseId;
+    if (!leaseId) return [];
+    const session = this.sessionsByLeaseId.get(leaseId);
+    if (!session) return [];
+    this.calls.push({
+      type: 'inventory',
+      leaseId,
+      platform: request.platform,
+    });
+    return [session.device];
+  };
+
+  ownsDevice(device: DeviceInfo): boolean {
+    return device.id.startsWith('fake-provider:android:');
+  }
+
+  getInteractor(device: DeviceInfo): Interactor | undefined {
+    return [...this.sessionsByLeaseId.values()].find((session) => session.device.id === device.id)
+      ?.interactor;
+  }
+
+  async installApp(
+    device: DeviceInfo,
+    app: string,
+    appPath: string,
+  ): Promise<{ packageName: string; appName: string; launchTarget: string } | undefined> {
+    if (!this.ownsDevice(device)) return undefined;
+    this.calls.push({ type: 'install', deviceId: device.id, app, appPath });
+    return {
+      packageName: 'com.example.installed',
+      appName: 'Installed Demo',
+      launchTarget: 'com.example.installed',
+    };
+  }
+
+  async configurePortReverse(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (options.provider !== this.provider) return undefined;
+    this.calls.push({ type: 'portReverse.ensure', options });
+    return { provider: this.provider, ...options };
+  }
+
+  async removePortReverse(
+    options: ProviderPortReverseOptions,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (options.provider !== this.provider) return undefined;
+    this.calls.push({ type: 'portReverse.remove', options });
+    return { provider: this.provider, ...options };
+  }
+
+  async shutdown(): Promise<void> {
+    this.sessionsByLeaseId.clear();
+  }
+
+  deviceIdForLease(leaseId: string): string {
+    return `fake-provider:android:${leaseId}`;
+  }
+
+  private createDevice(lease: DeviceLease): DeviceInfo {
+    return {
+      platform: 'android',
+      id: this.deviceIdForLease(lease.leaseId),
+      name: 'Fake Provider Android',
+      kind: 'device',
+      target: 'mobile',
+      booted: true,
+    };
+  }
+}
+
+function createFakeProviderInteractor(device: DeviceInfo, calls: FakeProviderCall[]): Interactor {
+  return new Proxy<Partial<Interactor>>(
+    {
+      open: async (app, options) => {
+        calls.push({ type: 'open', deviceId: device.id, app, url: options?.url });
+      },
+      tap: async (x, y) => {
+        calls.push({ type: 'tap', deviceId: device.id, x, y });
+        return { backend: 'fake-provider', x, y };
+      },
+      snapshot: async (options): Promise<SnapshotResult> => {
+        calls.push({
+          type: 'snapshot',
+          deviceId: device.id,
+          interactiveOnly: options?.interactiveOnly,
+        });
+        return {
+          backend: 'android',
+          nodes: [
+            {
+              index: 0,
+              type: 'TextView',
+              label: 'Provider Ready',
+              rect: { x: 0, y: 0, width: 120, height: 40 },
+              enabled: true,
+              visibleToUser: true,
+            },
+          ],
+        };
+      },
+    },
+    {
+      get(target, property, receiver) {
+        if (property in target) return Reflect.get(target, property, receiver);
+        if (
+          typeof property === 'string' &&
+          ABSENT_FAKE_PROVIDER_INTERACTOR_PROPERTIES.has(property)
+        ) {
+          return undefined;
+        }
+        if (typeof property === 'string') {
+          return () => throwUnexpectedProviderInteraction(property);
+        }
+        return undefined;
+      },
+    },
+  ) as Interactor;
+}
+
+function leaseFlags(leaseId?: string): DaemonRequest['flags'] {
+  return {
+    platform: 'android',
+    tenant: 'team-a',
+    runId: 'run-a',
+    leaseId,
+    leaseProvider: FAKE_PROVIDER,
+  };
+}
+
+function leaseMeta(leaseId?: string): DaemonRequest['meta'] {
+  return {
+    tenantId: 'team-a',
+    runId: 'run-a',
+    leaseId,
+    leaseBackend: 'android-instance',
+    leaseProvider: FAKE_PROVIDER,
+    deviceKey: 'android-a',
+    clientId: 'client-a',
+  };
+}
+
+function throwUnexpectedProviderInteraction(method: string): never {
+  throw new Error(`Unexpected fake provider interactor call: ${method}`);
+}

--- a/test/integration/provider-scenarios/scenario.ts
+++ b/test/integration/provider-scenarios/scenario.ts
@@ -7,11 +7,17 @@ export type ProviderScenarioState = {
   response(name: string): ProviderScenarioRpcResult;
 };
 
+export type ProviderScenarioDefaults = {
+  flags?: DaemonRequest['flags'];
+  meta?: DaemonRequest['meta'];
+};
+
 export type ProviderScenarioStep = {
   name: string;
   command: string;
   positionals?: string[];
   flags?: DaemonRequest['flags'];
+  meta?: DaemonRequest['meta'];
   expectStatus?: number;
   expectData?: Record<string, unknown>;
   assert?: (
@@ -23,6 +29,7 @@ export type ProviderScenarioStep = {
 export async function runProviderScenario(
   daemon: Pick<ProviderScenarioHarness, 'callCommand'>,
   steps: readonly ProviderScenarioStep[],
+  defaults: ProviderScenarioDefaults = {},
 ): Promise<ProviderScenarioState> {
   const responses = new Map<string, ProviderScenarioRpcResult>();
 
@@ -38,13 +45,29 @@ export async function runProviderScenario(
   };
 
   for (const step of steps) {
-    const response = await daemon.callCommand(step.command, step.positionals, step.flags);
+    const response = await daemon.callCommand(
+      step.command,
+      step.positionals,
+      {
+        ...defaults.flags,
+        ...step.flags,
+      },
+      {
+        meta: mergeRequestObject(defaults.meta, step.meta),
+      },
+    );
     const expectedStatus = step.expectStatus ?? 200;
     assert.equal(
       response.statusCode,
       expectedStatus,
       `${step.name} expected status ${expectedStatus}: ${JSON.stringify(response.json)}`,
     );
+    if (expectedStatus === 200) {
+      assert.ok(
+        response.json?.result,
+        `${step.name} returned JSON-RPC error: ${JSON.stringify(response.json?.error)}`,
+      );
+    }
     if (step.expectData) {
       assertDataContains(step.name, response, step.expectData);
     }
@@ -55,13 +78,25 @@ export async function runProviderScenario(
   return state;
 }
 
+function mergeRequestObject<T extends object>(
+  base: T | undefined,
+  override: T | undefined,
+): T | undefined {
+  if (!base) return override;
+  if (!override) return base;
+  return { ...base, ...override };
+}
+
 function assertDataContains(
   name: string,
   response: ProviderScenarioRpcResult,
   expected: Record<string, unknown>,
 ): void {
   const data = response.json?.result?.data;
-  assert.ok(data && typeof data === 'object', `${name} did not return result data`);
+  assert.ok(
+    data && typeof data === 'object',
+    `${name} did not return result data: ${JSON.stringify(response.json)}`,
+  );
   for (const [key, value] of Object.entries(expected)) {
     assert.deepEqual(data[key], value, `${name} result data mismatch for ${key}`);
   }


### PR DESCRIPTION
## Summary

Add a main-targeted provider device runtime foundation with no concrete provider dependency.
<details>

- Adds `src/provider-device-runtime.ts` with provider id matching, lease lifecycle composition, device inventory composition, active provider-device/interactor lookup, install result/options types, install hooks, optional port reverse hooks, and shutdown.
- Wires the existing daemon through provider-neutral hooks for lease lifecycle, inventory resolution, interactor dispatch, install/install-from-source fallback, readiness/runtime-hint bypass for provider-owned devices, and request-level runtime port reverse actions.
- Adds fake-provider unit and provider-scenario coverage proving lease -> inventory -> interactor dispatch, install, and port-reverse composition through the real daemon path.
- Does not add `@limrun/api`, `src/cloud/limrun-*`, BrowserStack, AWS, or WebDriver implementation.

</details>

## Validation

Verified on a branch based on `origin/main`:

- `pnpm check:quick`
- `pnpm exec vitest run src/__tests__/provider-device-runtime.test.ts test/integration/provider-scenarios/provider-device-runtime.test.ts`
- `pnpm exec vitest run test/integration/provider-scenarios`
- `pnpm exec vitest run src/daemon/__tests__/request-handler-catalog.test.ts src/daemon/handlers/__tests__/install-source.test.ts src/daemon/handlers/__tests__/session.test.ts`
- touched-file `oxfmt --check`
- `git diff HEAD --check`
