### PR TITLE
fix: repoint MCP output-schemas import to kernel/device (unbreak main)

### DIFF
--- a/src/mcp/command-output-schemas.ts
+++ b/src/mcp/command-output-schemas.ts
@@ -4,7 +4,7 @@ import { booleanSchema, looseObjectSchema, stringSchema } from '../commands/comm
 import { BACK_MODES } from '../core/back-mode.ts';
 import { DEVICE_ROTATIONS } from '../core/device-rotation.ts';
 import { SESSION_SURFACES } from '../core/session-surface.ts';
-import { DEVICE_TARGETS, PLATFORMS } from '../utils/device.ts';
+import { DEVICE_TARGETS, PLATFORMS } from '../kernel/device.ts';
 
 /**
  * Hand-authored registry of per-command MCP `outputSchema`s, keyed by the daemon


### PR DESCRIPTION
**main is currently red.** #941 (MCP `outputSchema`) and #940 (move `errors/redaction/device` → `src/kernel/`) merged in an order where #940's import-rewrite codemod ran before #941's new `src/mcp/command-output-schemas.ts` existed — so that file still imports `../utils/device.ts`, which #940 deleted. tsc/build fail on `main`.

One-line fix: `../utils/device.ts` → `../kernel/device.ts`. Swept the tree — this is the **only** stale `utils/{device,errors,redaction}` import remaining.

Verified: `tsc --noEmit` 0, `oxlint --deny-warnings` clean, `vitest run src/mcp` pass.