### PR TITLE
refactor: delete WaitCommandResult/AlertCommandResult mirror types — Phase 2c

### DIFF
--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -42,7 +42,7 @@ export type { BatchRunResult } from './core/batch.ts';
 import type { TargetShutdownResult } from './target-shutdown-contract.ts';
 export type { TargetShutdownResult } from './target-shutdown-contract.ts';
 import type { PerfAction, PerfArea, PerfKind, PerfSubject } from './contracts/perf.ts';
-import type { AlertAction, AlertInfo } from './alert-contract.ts';
+import type { AlertAction } from './alert-contract.ts';
 import type { DebugSymbolsOptions, DebugSymbolsResult } from './contracts/debug-symbols.ts';
 import type { RemoteConnectionProfileFields } from './remote-config-schema.ts';
 import type { CommandResult } from './core/command-descriptor/command-result.ts';
@@ -459,26 +459,6 @@ export type ClipboardCommandOptions =
       text: string;
     });
 
-export type WaitCommandResult = DaemonResponseData & {
-  waitedMs?: number;
-  text?: string;
-  selector?: string;
-};
-
-export type AlertCommandResult = DaemonResponseData & {
-  kind?: 'alertStatus' | 'alertHandled' | 'alertWait';
-  action?: AlertCommandOptions['action'];
-  alert?: AlertInfo | null;
-  handled?: boolean;
-  button?: string;
-  waitedMs?: number;
-  timedOut?: boolean;
-  platform?: AlertInfo['platform'];
-  accepted?: boolean;
-  dismissed?: boolean;
-  items?: string[];
-};
-
 export type ReactNativeCommandOptions = DeviceCommandBaseOptions & {
   action: 'dismiss-overlay';
 };
@@ -494,8 +474,8 @@ export type ViewportCommandOptions = DeviceCommandBaseOptions & {
 };
 
 export type AgentDeviceCommandClient = {
-  wait: (options: WaitCommandOptions) => Promise<WaitCommandResult>;
-  alert: (options?: AlertCommandOptions) => Promise<AlertCommandResult>;
+  wait: (options: WaitCommandOptions) => Promise<CommandRequestResult>;
+  alert: (options?: AlertCommandOptions) => Promise<CommandRequestResult>;
   appState: (options?: AppStateCommandOptions) => Promise<CommandResult<'appstate'>>;
   back: (options?: BackCommandOptions) => Promise<CommandResult<'back'>>;
   home: (options?: HomeCommandOptions) => Promise<CommandResult<'home'>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ export type {
   AlertCommandOptions,
   AlertInfo,
   AlertPlatform,
-  AlertCommandResult,
   AlertSource,
   AppCloseOptions,
   AppCloseResult,
@@ -119,7 +118,6 @@ export type {
   TraceOptions,
   TypeTextOptions,
   WaitCommandOptions,
-  WaitCommandResult,
 } from './client.ts';
 
 export type {

--- a/test/integration/provider-scenarios/android-lifecycle.test.ts
+++ b/test/integration/provider-scenarios/android-lifecycle.test.ts
@@ -353,7 +353,10 @@ test('Provider-backed integration Android alert wait polls until a dialog appear
         ...world.selection,
       });
       assert.equal(alertWait.kind, 'alertWait');
-      assert.equal(alertWait.alert?.source, 'permission');
+      // alert now returns the untyped CommandRequestResult bag (its iOS path is a
+      // dynamic runner Record, so the public type is no longer a closed shape).
+      const alertInfo = alertWait.alert as { source?: string } | null | undefined;
+      assert.equal(alertInfo?.source, 'permission');
       assert.ok(snapshotCount >= 2);
     },
   );


### PR DESCRIPTION
## What (breaking — intentional)

Phase 2(c): removes the last two hand-written result-type mirrors from `client-types.ts`. `wait` and `alert` are genuinely dynamic — `wait`'s daemon data is `toDaemonWaitData`'s `Record`, and `alert`'s iOS path is a generic runner `Record` — so per the typed-result doctrine they should be the untyped `CommandRequestResult`, not an invented closed shape.

- Delete `WaitCommandResult` / `AlertCommandResult`; `client.command.wait`/`alert` now return `CommandRequestResult`.
- Drop their public exports from `index.ts` and the now-unused `AlertInfo` import.
- One integration test that read the typed `alert.alert.source` now casts the untyped bag.

**This is a breaking public-API removal** (those two exported type names disappear) — done now that you've green-lit breaking changes in this pass. It completes the **result-type** half of the mirror deletion; the 13 closed commands already live in `src/contracts/*` via `CommandResultMap`. The **Options-type** half (deriving from `inputSchema`) is a separate follow-up.

## Verification
- `tsc --noEmit` 0; `oxfmt` + `oxlint --deny-warnings` clean; `fallow audit --base origin/main` clean; `vitest` client/contracts/mcp → 476 pass; Layering Guard empty.