### PR TITLE
refactor: extract metro/ folder — Phase 5

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -5,7 +5,7 @@
     "src/index.ts",
     "src/io.ts",
     "src/artifacts.ts",
-    "src/metro.ts",
+    "src/metro/metro.ts",
     "src/remote-config.ts",
     "src/install-source.ts",
     "src/android-adb.ts",

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -90,7 +90,7 @@
         "count": 1
       }
     },
-    "src/client-metro.ts": {
+    "src/metro/client-metro.ts": {
       "crap_moderate": {
         "count": 3
       }

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
           io: 'src/io.ts',
           artifacts: 'src/artifacts.ts',
           batch: 'src/batch.ts',
-          metro: 'src/metro.ts',
+          metro: 'src/metro/metro.ts',
           'remote-config': 'src/remote-config.ts',
           'install-source': 'src/install-source.ts',
           'android-adb': 'src/android-adb.ts',

--- a/src/__tests__/client-metro-auto-companion.test.ts
+++ b/src/__tests__/client-metro-auto-companion.test.ts
@@ -4,12 +4,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-vi.mock('../client-metro-companion.ts', () => ({
+vi.mock('../metro/client-metro-companion.ts', () => ({
   ensureMetroCompanion: vi.fn(),
 }));
 
-import { ensureMetroCompanion } from '../client-metro-companion.ts';
-import { prepareMetroRuntime } from '../client-metro.ts';
+import { ensureMetroCompanion } from '../metro/client-metro-companion.ts';
+import { prepareMetroRuntime } from '../metro/client-metro.ts';
 
 const TEST_BRIDGE_SCOPE = {
   tenantId: 'tenant-1',

--- a/src/__tests__/client-metro-companion.test.ts
+++ b/src/__tests__/client-metro-companion.test.ts
@@ -22,7 +22,7 @@ import {
   readProcessStartTime,
   waitForProcessExit,
 } from '../utils/process-identity.ts';
-import { ensureMetroCompanion, stopMetroCompanion } from '../client-metro-companion.ts';
+import { ensureMetroCompanion, stopMetroCompanion } from '../metro/client-metro-companion.ts';
 import { ensureReactDevtoolsCompanion } from '../client-react-devtools-companion.ts';
 
 const TEST_BRIDGE_SCOPE = {

--- a/src/__tests__/client-metro-startup-cleanup.test.ts
+++ b/src/__tests__/client-metro-startup-cleanup.test.ts
@@ -15,7 +15,7 @@ vi.mock('../utils/process-identity.ts', () => ({
 
 import { runCmdDetached } from '../utils/exec.ts';
 import { waitForProcessExit } from '../utils/process-identity.ts';
-import { prepareMetroRuntime } from '../client-metro.ts';
+import { prepareMetroRuntime } from '../metro/client-metro.ts';
 
 afterEach(() => {
   vi.useRealTimers();

--- a/src/__tests__/client-metro.test.ts
+++ b/src/__tests__/client-metro.test.ts
@@ -8,7 +8,7 @@ import type { Socket } from 'node:net';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { prepareMetroRuntime, reloadMetro } from '../client-metro.ts';
+import { prepareMetroRuntime, reloadMetro } from '../metro/client-metro.ts';
 import { AppError } from '../kernel/errors.ts';
 import { isProcessAlive, waitForProcessExit } from '../utils/process-identity.ts';
 

--- a/src/__tests__/metro-protocol-public.test.ts
+++ b/src/__tests__/metro-protocol-public.test.ts
@@ -6,7 +6,7 @@ import {
   type MetroBridgeDescriptor,
   type MetroTunnelRequestMessage,
   type MetroTunnelResponseMessage,
-} from '../metro.ts';
+} from '../metro/metro.ts';
 
 // Type-only contract fixtures — these verify that the public subpath types
 // remain structurally stable. A rename or breaking shape change will fail

--- a/src/__tests__/metro-public.test.ts
+++ b/src/__tests__/metro-public.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, test, vi } from 'vitest';
 import assert from 'node:assert/strict';
 
-vi.mock('../client-metro.ts', async () => {
-  const actual = await vi.importActual<typeof import('../client-metro.ts')>('../client-metro.ts');
+vi.mock('../metro/client-metro.ts', async () => {
+  const actual = await vi.importActual<typeof import('../metro/client-metro.ts')>(
+    '../metro/client-metro.ts',
+  );
   return {
     ...actual,
     prepareMetroRuntime: vi.fn(),
@@ -10,13 +12,13 @@ vi.mock('../client-metro.ts', async () => {
   };
 });
 
-vi.mock('../client-metro-companion.ts', () => ({
+vi.mock('../metro/client-metro-companion.ts', () => ({
   ensureMetroCompanion: vi.fn(),
   stopMetroCompanion: vi.fn(),
 }));
 
-import { prepareMetroRuntime, reloadMetro } from '../client-metro.ts';
-import { ensureMetroCompanion, stopMetroCompanion } from '../client-metro-companion.ts';
+import { prepareMetroRuntime, reloadMetro } from '../metro/client-metro.ts';
+import { ensureMetroCompanion, stopMetroCompanion } from '../metro/client-metro-companion.ts';
 import {
   buildAndroidRuntimeHints,
   buildIosRuntimeHints,
@@ -25,7 +27,7 @@ import {
   reloadRemoteMetro,
   resolveRuntimeTransport,
   stopMetroTunnel,
-} from '../metro.ts';
+} from '../metro/metro.ts';
 
 const TEST_BRIDGE_SCOPE = {
   tenantId: 'tenant-1',

--- a/src/__tests__/remote-connection.test.ts
+++ b/src/__tests__/remote-connection.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-vi.mock('../client-metro-companion.ts', () => ({
+vi.mock('../metro/client-metro-companion.ts', () => ({
   stopMetroCompanion: vi.fn(),
 }));
 
@@ -23,7 +23,7 @@ import {
   materializeRemoteConnectionForCommand,
   PROXY_REMOTE_LEASE_TTL_MS,
 } from '../cli/commands/connection-runtime.ts';
-import { stopMetroCompanion } from '../client-metro-companion.ts';
+import { stopMetroCompanion } from '../metro/client-metro-companion.ts';
 import { AppError } from '../kernel/errors.ts';
 import {
   hashRemoteConfigFile,

--- a/src/cli/commands/connection-runtime.ts
+++ b/src/cli/commands/connection-runtime.ts
@@ -1,6 +1,6 @@
 import { resolveDaemonPaths } from '../../daemon/config.ts';
 import { stopReactDevtoolsCompanion } from '../../client-react-devtools-companion.ts';
-import { stopMetroTunnel } from '../../metro.ts';
+import { stopMetroTunnel } from '../../metro/metro.ts';
 import { resolveRemoteConfigProfile } from '../../remote-config.ts';
 import { resolveDevice, type DeviceInfo } from '../../kernel/device.ts';
 import { shouldAgentCdpUseRemoteBridgeUrl } from './agent-cdp.ts';
@@ -20,7 +20,7 @@ import { AppError } from '../../kernel/errors.ts';
 import type { LeaseBackend, SessionRuntimeHints } from '../../contracts.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import type { AgentDeviceClient, Lease } from '../../client.ts';
-import type { MetroPrepareKind } from '../../client-metro.ts';
+import type { MetroPrepareKind } from '../../metro/client-metro.ts';
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
 
 const leaseDeferredCommands = new Set([

--- a/src/client-companion-tunnel-worker.ts
+++ b/src/client-companion-tunnel-worker.ts
@@ -24,7 +24,7 @@ import {
 import type {
   MetroTunnelRequestMessage as MetroCompanionRequest,
   MetroTunnelResponseMessage,
-} from './metro.ts';
+} from './metro/metro.ts';
 import { normalizeBaseUrl } from './utils/url.ts';
 
 const COMPANION_REGISTER_TIMEOUT_MS = 5_000;

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -33,7 +33,7 @@ import type {
   MetroPrepareKind,
   PrepareMetroRuntimeResult,
   ReloadMetroResult,
-} from './client-metro.ts';
+} from './metro/client-metro.ts';
 import type { MetroBridgeScope } from './client-companion-tunnel-contract.ts';
 import type { AppsFilter } from './contracts/app-inventory.ts';
 import type { ScreenshotRequestFlags } from './contracts/screenshot.ts';

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { sendToDaemon } from './daemon-client.ts';
-import { prepareMetroRuntime, reloadMetro } from './client-metro.ts';
+import { prepareMetroRuntime, reloadMetro } from './metro/client-metro.ts';
 import { resolveDaemonPaths } from './daemon/config.ts';
 import { symbolicateCrashArtifact } from './platforms/ios/debug-symbols.ts';
 import { INTERNAL_COMMANDS } from './command-catalog.ts';

--- a/src/commands/metro/index.ts
+++ b/src/commands/metro/index.ts
@@ -1,4 +1,4 @@
-import type { MetroPrepareKind } from '../../client-metro.ts';
+import type { MetroPrepareKind } from '../../metro/client-metro.ts';
 import type {
   MetroPrepareOptions,
   MetroPrepareResult,

--- a/src/metro/client-metro-companion.ts
+++ b/src/metro/client-metro-companion.ts
@@ -4,8 +4,8 @@ import {
   type CompanionTunnelDefinition,
   type EnsureCompanionTunnelOptions,
   type StopCompanionTunnelOptions,
-} from './client-companion-tunnel.ts';
-import { METRO_COMPANION_RUN_ARG } from './client-companion-tunnel-contract.ts';
+} from '../client-companion-tunnel.ts';
+import { METRO_COMPANION_RUN_ARG } from '../client-companion-tunnel-contract.ts';
 
 const METRO_COMPANION_REGISTER_PATH = '/api/metro/companion/register';
 

--- a/src/metro/client-metro.ts
+++ b/src/metro/client-metro.ts
@@ -1,23 +1,23 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { sleep } from './utils/timeouts.ts';
+import { sleep } from '../utils/timeouts.ts';
 import { ensureMetroCompanion } from './client-metro-companion.ts';
-import type { MetroBridgeScope } from './client-companion-tunnel-contract.ts';
+import type { MetroBridgeScope } from '../client-companion-tunnel-contract.ts';
 import type {
   MetroBridgeDescriptor,
   MetroBridgeResult,
   MetroBridgeRuntimePayload,
   MetroRuntimeHints,
 } from './metro-types.ts';
-import { AppError } from './kernel/errors.ts';
-import { runCmdSync, runCmdDetached } from './utils/exec.ts';
-import { resolveUserPath } from './utils/path-resolution.ts';
-import { waitForProcessExit } from './utils/process-identity.ts';
-import { buildBundleUrl, normalizeBaseUrl } from './utils/url.ts';
+import { AppError } from '../kernel/errors.ts';
+import { runCmdSync, runCmdDetached } from '../utils/exec.ts';
+import { resolveUserPath } from '../utils/path-resolution.ts';
+import { waitForProcessExit } from '../utils/process-identity.ts';
+import { buildBundleUrl, normalizeBaseUrl } from '../utils/url.ts';
 import {
   resolveRuntimeTransportHints,
   type ResolvedRuntimeTransport,
-} from './utils/runtime-transport.ts';
+} from '../utils/runtime-transport.ts';
 
 const DEFAULT_METRO_HOST = 'localhost';
 const DEFAULT_METRO_PORT = 8081;
@@ -28,7 +28,10 @@ export type MetroPrepareKind = 'auto' | 'react-native' | 'expo';
 type ResolvedMetroKind = Exclude<MetroPrepareKind, 'auto'>;
 type EnvSource = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
-export type { CompanionTunnelScope, MetroBridgeScope } from './client-companion-tunnel-contract.ts';
+export type {
+  CompanionTunnelScope,
+  MetroBridgeScope,
+} from '../client-companion-tunnel-contract.ts';
 
 type PackageJsonShape = {
   dependencies?: Record<string, string>;

--- a/src/metro/metro-types.ts
+++ b/src/metro/metro-types.ts
@@ -1,4 +1,4 @@
-import type { SessionRuntimeHints } from './contracts.ts';
+import type { SessionRuntimeHints } from '../contracts.ts';
 
 /** Re-export of {@link SessionRuntimeHints} under the Metro-specific alias used by public API consumers. */
 export type MetroRuntimeHints = SessionRuntimeHints;

--- a/src/metro/metro.ts
+++ b/src/metro/metro.ts
@@ -1,4 +1,4 @@
-import type { SessionRuntimeHints } from './contracts.ts';
+import type { SessionRuntimeHints } from '../contracts.ts';
 import {
   buildMetroRuntimeHints,
   prepareMetroRuntime,
@@ -8,10 +8,13 @@ import {
   type ReloadMetroResult,
 } from './client-metro.ts';
 import { ensureMetroCompanion, stopMetroCompanion } from './client-metro-companion.ts';
-import type { MetroBridgeScope } from './client-companion-tunnel-contract.ts';
-import { resolveRuntimeTransportHints } from './utils/runtime-transport.ts';
-export { buildBundleUrl, normalizeBaseUrl } from './utils/url.ts';
-export type { CompanionTunnelScope, MetroBridgeScope } from './client-companion-tunnel-contract.ts';
+import type { MetroBridgeScope } from '../client-companion-tunnel-contract.ts';
+import { resolveRuntimeTransportHints } from '../utils/runtime-transport.ts';
+export { buildBundleUrl, normalizeBaseUrl } from '../utils/url.ts';
+export type {
+  CompanionTunnelScope,
+  MetroBridgeScope,
+} from '../client-companion-tunnel-contract.ts';
 
 export type {
   MetroBridgeDescriptor,

--- a/src/remote-config-schema.ts
+++ b/src/remote-config-schema.ts
@@ -6,7 +6,7 @@ import type {
   SessionIsolationMode,
 } from './contracts.ts';
 import { PLATFORM_SELECTORS, type DeviceTarget, type PlatformSelector } from './kernel/device.ts';
-import type { MetroPrepareKind } from './client-metro.ts';
+import type { MetroPrepareKind } from './metro/client-metro.ts';
 
 export type RemoteConfigMetroOptions = {
   metroProjectRoot?: string;


### PR DESCRIPTION
## Summary

Phase 5 (layering) slice from `plans/perfect-shape.md` §5.5 — extract the metro cluster from `src/` root into a `src/metro/` folder. **Pure path codemod, no behavior change.**

§5.5 target: `metro/ ← metro* · client-metro*`.

## Move set (→ `src/metro/`)

| file | importers | why it moves |
|---|---|---|
| `metro.ts` | 4 | the metro public surface (rslib `metro` entry) |
| `metro-types.ts` | 2 | metro-domain types, used only by metro/client-metro |
| `client-metro.ts` | 10 | the metro client driver |
| `client-metro-companion.ts` | 6 | metro companion lifecycle (`ensure/stopMetroCompanion`) |

These four form a cohesive metro domain: `metro.ts` → `client-metro*` + `metro-types`; `client-metro.ts` → `client-metro-companion` + `metro-types`. Moving them together keeps intra-folder imports as `./` (unchanged); only their edges to root infra (`contracts`, `kernel/errors`, `utils/*`, `client-companion-tunnel-contract`) and their external importers were rewritten.

### Deliberately kept OUT (stay at `src/` root)
The companion-tunnel cluster — `client-companion-tunnel-contract.ts`, `client-companion-tunnel.ts`, `client-companion-tunnel-worker.ts`, `companion-tunnel.ts`, `client-react-devtools-companion.ts` — is a **separate domain** (the future `companion/` slice, not part of `metro*`/`client-metro*`). Keeping it at root avoids a reverse/sibling churn and, critically, keeps the worker process entrypoint co-located with its spawner (see below). General-purpose infra (`utils`, `contracts`, `kernel`) also stays out.

## Worker-path verification (the critical risk for this slice)

`metro.ts` is itself an rslib **entrypoint** (`metro: 'src/metro.ts'`), and the companion tunnel runs as a **detached child process** whose entry is `src/companion-tunnel.ts` (rslib entry `internal/companion-tunnel`). That worker is *not* a `new Worker(new URL('./worker.ts'))` thread — `client-companion-tunnel.ts` resolves the entry **by name** relative to its own built location in `dist/` and spawns it via `runCmdDetached`.

- The spawner (`client-companion-tunnel.ts`) and the worker entry source (`companion-tunnel.ts`) **both stay at root** → entry-name resolution is unchanged.
- The worker bundle chain reaches the moved `metro.ts` (`companion-tunnel.ts` → `client-companion-tunnel-worker.ts` → `metro.ts`); that import was rewritten and re-bundled.
- Verified by **`npm run build` (exit 0)**, which emits **both** `dist/src/metro.js` and `dist/src/internal/companion-tunnel.js`. The `metro` output path is keyed by the entry *name*, so `package.json` `./metro` (→ `dist/src/metro.js`) is unaffected.

## Codemod

A resolve-based node codemod: for every `.ts` in `src`/`test`, each relative import/`vi.mock`/`vi.importActual` specifier is resolved to an absolute path against the file's *original* dir, mapped through the old→new move table, and rewritten relative to the file's *new* dir (compares resolved paths — no naive string replace). Three non-`.ts` references were updated to the new paths: the rslib `metro` entry, the `.fallowrc.json` entry list, and the `fallow-baselines/health.json` baseline key. `tsconfig` uses glob includes (no change).

## Verification (all green)

- `tsc -p tsconfig.json --noEmit` → exit 0
- `oxfmt --check src test` → exit 0; `oxlint src --deny-warnings` → exit 0
- **`npm run build` → exit 0** (metro entry + companion-tunnel worker bundle both emitted)
- `fallow audit --base origin/main` → CLEAN (no issues, 21 changed files)
- `vitest run` (full) → 314 files / 2892 tests passed; affected metro/client tests: 7 files / 58 tests passed
- Layering Guard (`git grep` for `commands/` imports in daemon/platforms/kernel) → EMPTY
- No stale references to the old paths anywhere (src/test/json); git tracks all 4 files as renames

Pure path codemod — no runtime behavior change.