### PR TITLE
refactor: move contracts.ts into src/kernel — Phase 5

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -10,7 +10,7 @@
     "src/install-source.ts",
     "src/android-adb.ts",
     "src/android-snapshot-helper.ts",
-    "src/contracts.ts",
+    "src/kernel/contracts.ts",
     "src/selectors.ts",
     "src/finders.ts",
     "src/bin.ts",

--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -133,7 +133,7 @@
         "count": 1
       }
     },
-    "src/contracts.ts": {
+    "src/kernel/contracts.ts": {
       "crap_moderate": {
         "count": 1
       }

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
           'install-source': 'src/install-source.ts',
           'android-adb': 'src/android-adb.ts',
           'android-snapshot-helper': 'src/android-snapshot-helper.ts',
-          contracts: 'src/contracts.ts',
+          contracts: 'src/kernel/contracts.ts',
           selectors: 'src/selectors.ts',
           finders: 'src/finders.ts',
           'internal/bin': 'src/bin.ts',

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { createAgentDeviceClient, type AgentDeviceClientConfig } from '../client.ts';
 import { runCommand } from '../commands/command-surface.ts';
-import type { DaemonRequest, DaemonResponse } from '../contracts.ts';
+import type { DaemonRequest, DaemonResponse } from '../kernel/contracts.ts';
 import { AppError } from '../kernel/errors.ts';
 
 function createTransport(

--- a/src/__tests__/contracts-schema-public.test.ts
+++ b/src/__tests__/contracts-schema-public.test.ts
@@ -26,7 +26,7 @@ import {
   type AppErrorCode,
   type Rect,
   type SnapshotNode,
-} from '../contracts.ts';
+} from '../kernel/contracts.ts';
 
 const invalidArgsCode = 'INVALID_ARGS' satisfies AppErrorCode;
 const rect = { x: 1, y: 2, width: 3, height: 4 } satisfies Rect;

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -1,7 +1,7 @@
 import type { AlertAction, AlertInfo } from './alert-contract.ts';
 import type { AppsFilter } from './contracts/app-inventory.ts';
 import type { Point, SnapshotNode, SnapshotOptions, SnapshotState } from './kernel/snapshot.ts';
-import type { NetworkIncludeMode } from './contracts.ts';
+import type { NetworkIncludeMode } from './kernel/contracts.ts';
 import type { DeviceTarget, Platform, PlatformSelector } from './kernel/device.ts';
 import type { BackMode } from './core/back-mode.ts';
 import type { RepeatedInput } from './commands/command-input.ts';

--- a/src/batch-contract.ts
+++ b/src/batch-contract.ts
@@ -1,4 +1,4 @@
-import { daemonRuntimeSchema, type SessionRuntimeHints } from './contracts.ts';
+import { daemonRuntimeSchema, type SessionRuntimeHints } from './kernel/contracts.ts';
 import { AppError } from './kernel/errors.ts';
 import { isRecord } from './utils/parsing.ts';
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,7 @@ import {
 } from './remote-connection-state.ts';
 import { resolveRemoteAuthForCli } from './cli/auth-session.ts';
 import type { CliFlags, FlagKey } from './utils/cli-flags.ts';
-import type { SessionRuntimeHints } from './contracts.ts';
+import type { SessionRuntimeHints } from './kernel/contracts.ts';
 
 type CliDeps = {
   sendToDaemon: typeof sendToDaemon;

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -1,5 +1,5 @@
 import type { BatchStep } from '../client-types.ts';
-import { type SessionRuntimeHints } from '../contracts.ts';
+import { type SessionRuntimeHints } from '../kernel/contracts.ts';
 import { parseBatchStepRuntime } from '../batch-contract.ts';
 import { readInputFromCli } from '../commands/cli-grammar.ts';
 import { isCommandName, type CommandName } from '../commands/command-metadata.ts';

--- a/src/cli/commands/__tests__/generic.test.ts
+++ b/src/cli/commands/__tests__/generic.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { createAgentDeviceClient } from '../../../client.ts';
-import type { DaemonResponse } from '../../../contracts.ts';
+import type { DaemonResponse } from '../../../kernel/contracts.ts';
 import type { CliFlags } from '../../../utils/cli-flags.ts';
 import type { ClientBackedCliCommandName } from '../../../command-catalog.ts';
 import { runGenericClientBackedCommand } from '../generic.ts';

--- a/src/cli/commands/__tests__/screenshot.test.ts
+++ b/src/cli/commands/__tests__/screenshot.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { createAgentDeviceClient } from '../../../client.ts';
-import type { DaemonResponse } from '../../../contracts.ts';
+import type { DaemonResponse } from '../../../kernel/contracts.ts';
 import type { CliFlags } from '../../../utils/cli-flags.ts';
 import { screenshotCommand } from '../screenshot.ts';
 

--- a/src/cli/commands/agent-cdp.ts
+++ b/src/cli/commands/agent-cdp.ts
@@ -1,7 +1,7 @@
 import { runCmdStreaming } from '../../utils/exec.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { isRemoteBridgeBackend } from './remote-bridge.ts';
-import type { SessionRuntimeHints } from '../../contracts.ts';
+import type { SessionRuntimeHints } from '../../kernel/contracts.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 
 const AGENT_CDP_VERSION = '1.6.0';

--- a/src/cli/commands/connection-runtime.ts
+++ b/src/cli/commands/connection-runtime.ts
@@ -17,7 +17,7 @@ import {
 import { profileToCliFlags } from '../../utils/remote-config.ts';
 import type { BatchStep } from '../../client-types.ts';
 import { AppError } from '../../kernel/errors.ts';
-import type { LeaseBackend, SessionRuntimeHints } from '../../contracts.ts';
+import type { LeaseBackend, SessionRuntimeHints } from '../../kernel/contracts.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import type { AgentDeviceClient, Lease } from '../../client.ts';
 import type { MetroPrepareKind } from '../../metro/client-metro.ts';

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -24,7 +24,7 @@ import {
   stopReactDevtoolsCleanup,
 } from './connection-runtime.ts';
 import { writeCommandOutput } from './shared.ts';
-import type { LeaseBackend } from '../../contracts.ts';
+import type { LeaseBackend } from '../../kernel/contracts.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import type { ClientCommandHandler } from './router-types.ts';
 

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -6,7 +6,7 @@ import type { CliOutput } from '../../commands/command-contract.ts';
 import type { ReplaySuiteResult } from '../../daemon/types.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import { readCommandMessage } from '../../utils/success-text.ts';
-import { isNonDefaultResponseLevel } from '../../contracts.ts';
+import { isNonDefaultResponseLevel } from '../../kernel/contracts.ts';
 import { writeCommandOutput } from './shared.ts';
 import type { ClientBackedCliCommandName } from '../../command-catalog.ts';
 import type { ClientCommandParams } from './router-types.ts';

--- a/src/cli/commands/screenshot.ts
+++ b/src/cli/commands/screenshot.ts
@@ -1,6 +1,6 @@
 import { formatScreenshotDiffText, formatSnapshotDiffText } from '../../utils/output.ts';
 import { AppError } from '../../kernel/errors.ts';
-import { isNonDefaultResponseLevel } from '../../contracts.ts';
+import { isNonDefaultResponseLevel } from '../../kernel/contracts.ts';
 import { resolveUserPath } from '../../utils/path-resolution.ts';
 import type { AgentDeviceBackend } from '../../backend.ts';
 import type { AgentDeviceClient, CaptureScreenshotResult } from '../../client.ts';

--- a/src/client-types.ts
+++ b/src/client-types.ts
@@ -11,7 +11,7 @@ import type {
   ResponseLevel,
   SessionIsolationMode,
   SessionRuntimeHints,
-} from './contracts.ts';
+} from './kernel/contracts.ts';
 import type { DeviceKind, DeviceTarget, Platform, PlatformSelector } from './kernel/device.ts';
 import type { BackMode } from './core/back-mode.ts';
 import type { ClickButton } from './core/click-button.ts';

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,7 +47,7 @@ import type {
   MetroPrepareOptions,
 } from './client-types.ts';
 import type { CommandResult } from './core/command-descriptor/command-result.ts';
-import { isNonDefaultResponseLevel, type ResponseLevel } from './contracts.ts';
+import { isNonDefaultResponseLevel, type ResponseLevel } from './kernel/contracts.ts';
 import { readSerializedSnapshotCaptureAnnotations } from './snapshot-capture-annotations.ts';
 import { readSnapshotDiagnosticsSummary } from './snapshot-diagnostics.ts';
 import type { CommandFlags } from './core/dispatch-context.ts';

--- a/src/commands/batch/metadata.ts
+++ b/src/commands/batch/metadata.ts
@@ -7,7 +7,7 @@ import {
   readBatchStepRecord,
   type BatchStepErrorFactory,
 } from '../../batch-contract.ts';
-import { type SessionRuntimeHints } from '../../contracts.ts';
+import { type SessionRuntimeHints } from '../../kernel/contracts.ts';
 import {
   STRUCTURED_BATCH_COMMAND_NAMES,
   readStructuredBatchCommandName,

--- a/src/commands/batch/public.test.ts
+++ b/src/commands/batch/public.test.ts
@@ -8,7 +8,7 @@ import {
   runBatch,
   validateAndNormalizeBatchSteps,
 } from '../../batch.ts';
-import type { DaemonRequest } from '../../contracts.ts';
+import type { DaemonRequest } from '../../kernel/contracts.ts';
 
 test('public batch entrypoint exports daemon-compatible orchestration helpers', async () => {
   const seenCommands: string[] = [];

--- a/src/commands/management/install.ts
+++ b/src/commands/management/install.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
-import type { DaemonInstallSource } from '../../contracts.ts';
+import type { DaemonInstallSource } from '../../kernel/contracts.ts';
 import type { CliFlags } from '../../utils/cli-flags.ts';
 import type { CommandSchemaOverride } from '../../utils/cli-command-schema-types.ts';
 import { AppError } from '../../kernel/errors.ts';

--- a/src/commands/observability/index.ts
+++ b/src/commands/observability/index.ts
@@ -1,5 +1,5 @@
 import type { LogsOptions, NetworkOptions } from '../../client-types.ts';
-import { NETWORK_INCLUDE_MODES, type NetworkIncludeMode } from '../../contracts.ts';
+import { NETWORK_INCLUDE_MODES, type NetworkIncludeMode } from '../../kernel/contracts.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { parseStringMember } from '../../utils/string-enum.ts';
 import type { CommandSchemaOverride } from '../../utils/cli-command-schema-types.ts';

--- a/src/commands/observability/output.ts
+++ b/src/commands/observability/output.ts
@@ -1,5 +1,5 @@
 import type { BackendNetworkEntry } from '../../backend.ts';
-import type { NetworkIncludeMode } from '../../contracts.ts';
+import type { NetworkIncludeMode } from '../../kernel/contracts.ts';
 import type { NetworkEntry } from '../../daemon/network-log.ts';
 import type { CliOutput } from '../command-contract.ts';
 import { resultOutput, type CliOutputFormatter } from '../output-common.ts';

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -1,4 +1,4 @@
-import { type DaemonRequest, type DaemonResponse } from '../contracts.ts';
+import { type DaemonRequest, type DaemonResponse } from '../kernel/contracts.ts';
 import { AppError, asAppError } from '../kernel/errors.ts';
 import { isRecord } from '../utils/parsing.ts';
 import {

--- a/src/core/lease-scope.ts
+++ b/src/core/lease-scope.ts
@@ -1,4 +1,4 @@
-import type { LeaseBackend } from '../contracts.ts';
+import type { LeaseBackend } from '../kernel/contracts.ts';
 import { stripUndefined } from '../utils/parsing.ts';
 
 const PROXY_LEASE_PROVIDER = 'proxy';

--- a/src/daemon-error.ts
+++ b/src/daemon-error.ts
@@ -1,5 +1,5 @@
 import { AppError, toAppErrorCode } from './kernel/errors.ts';
-import type { DaemonError } from './contracts.ts';
+import type { DaemonError } from './kernel/contracts.ts';
 
 export function throwDaemonError(error: DaemonError): never {
   throw new AppError(toAppErrorCode(error.code), error.message, {

--- a/src/daemon/__tests__/request-router-cost.test.ts
+++ b/src/daemon/__tests__/request-router-cost.test.ts
@@ -19,7 +19,7 @@ import { createRequestHandler } from '../request-router.ts';
 import type { DaemonRequest, SessionState } from '../types.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
-import { daemonCommandRequestSchema } from '../../contracts.ts';
+import { daemonCommandRequestSchema } from '../../kernel/contracts.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);

--- a/src/daemon/__tests__/request-router-response-level.test.ts
+++ b/src/daemon/__tests__/request-router-response-level.test.ts
@@ -35,7 +35,7 @@ import { createRequestHandler } from '../request-router.ts';
 import type { DaemonRequest, SessionState } from '../types.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
 import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
-import { daemonCommandRequestSchema } from '../../contracts.ts';
+import { daemonCommandRequestSchema } from '../../kernel/contracts.ts';
 
 const mockDispatch = vi.mocked(dispatchCommand);
 

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -9,7 +9,7 @@ import type {
   DaemonServerMode,
   DaemonTransportPreference,
   SessionIsolationMode,
-} from '../contracts.ts';
+} from '../kernel/contracts.ts';
 export type { DaemonServerMode, DaemonTransportPreference, SessionIsolationMode };
 
 export type DaemonPaths = {

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -34,7 +34,7 @@ import {
 import { handleNativePerfCommand as handleAndroidNativePerfCommand } from './session-native-perf.ts';
 import { errorResponse, requireCommandSupported, type DaemonFailureResponse } from './response.ts';
 import { handleNativePerfCommand as handleAppleNativePerfCommand } from './session-perf-xctrace.ts';
-import { NETWORK_INCLUDE_MODES, type NetworkIncludeMode } from '../../contracts.ts';
+import { NETWORK_INCLUDE_MODES, type NetworkIncludeMode } from '../../kernel/contracts.ts';
 import type { LogBackend } from '../network-log.ts';
 import {
   LOG_ACTION_VALUES as LOG_ACTIONS,

--- a/src/daemon/http-server.ts
+++ b/src/daemon/http-server.ts
@@ -8,8 +8,8 @@ import type {
   JsonRpcId,
   JsonRpcRequestEnvelope,
   LeaseBackend,
-} from '../contracts.ts';
-import { commandRpcParamsSchema } from '../contracts.ts';
+} from '../kernel/contracts.ts';
+import { commandRpcParamsSchema } from '../kernel/contracts.ts';
 import type { DaemonInstallSource, DaemonInvokeFn, DaemonRequest } from './types.ts';
 import { normalizeTenantId } from './config.ts';
 import {

--- a/src/daemon/lease-context.ts
+++ b/src/daemon/lease-context.ts
@@ -1,5 +1,5 @@
 import type { DaemonRequest } from './types.ts';
-import type { LeaseBackend } from '../contracts.ts';
+import type { LeaseBackend } from '../kernel/contracts.ts';
 import type { DeviceLease } from './lease-registry.ts';
 import type { RunnerLogicalLeaseContext } from '../core/runner-lease-context.ts';
 import { stripUndefined } from '../utils/parsing.ts';

--- a/src/daemon/lease-registry.ts
+++ b/src/daemon/lease-registry.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import type { LeaseBackend } from '../contracts.ts';
+import type { LeaseBackend } from '../kernel/contracts.ts';
 import { AppError } from '../kernel/errors.ts';
 import { normalizeTenantId } from './config.ts';
 

--- a/src/daemon/network-log.ts
+++ b/src/daemon/network-log.ts
@@ -18,7 +18,7 @@ const ANDROID_NEARBY_LINE_RADIUS = 5;
 const ANDROID_PACKET_SCAN_RADIUS = 12;
 const NETWORK_LOG_MEMORY_PATH = '<memory>';
 
-import type { NetworkIncludeMode } from '../contracts.ts';
+import type { NetworkIncludeMode } from '../kernel/contracts.ts';
 export type { NetworkIncludeMode };
 export type LogBackend = 'ios-simulator' | 'ios-device' | 'android' | 'macos';
 

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -5,7 +5,7 @@ import {
 import { AppError, normalizeError, retriableForErrorCode } from '../kernel/errors.ts';
 import { supportedPlatformsForCommand } from '../core/capabilities.ts';
 import { timingSafeStringEqual } from '../utils/timing-safe-equal.ts';
-import type { DaemonError, ResponseCost } from '../contracts.ts';
+import type { DaemonError, ResponseCost } from '../kernel/contracts.ts';
 import type { DaemonInvokeFn, DaemonRequest, DaemonResponse, DaemonResponseData } from './types.ts';
 import { RESPONSE_VIEWS } from './response-views.ts';
 import { SessionStore } from './session-store.ts';

--- a/src/daemon/response-views.ts
+++ b/src/daemon/response-views.ts
@@ -1,4 +1,4 @@
-import type { ResponseLevel } from '../contracts.ts';
+import type { ResponseLevel } from '../kernel/contracts.ts';
 import type { ScreenshotOverlayRef, SnapshotNode } from '../kernel/snapshot.ts';
 import type { DaemonResponseData } from './types.ts';
 

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -8,8 +8,8 @@ import type {
   DaemonError,
   LeaseBackend,
   SessionRuntimeHints as PublicSessionRuntimeHints,
-} from '../contracts.ts';
-export type { DaemonLockPolicy } from '../contracts.ts';
+} from '../kernel/contracts.ts';
+export type { DaemonLockPolicy } from '../kernel/contracts.ts';
 import type { CommandFlags } from '../core/dispatch.ts';
 import type { GestureReferenceFrame, ScrollDirection } from '../core/scroll-gesture.ts';
 import type { LogBackend } from './network-log.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export type {
 } from './cli-test-reporters/types.ts';
 
 export type { CommandResult } from './core/command-descriptor/command-result.ts';
-export type { ResponseLevel } from './contracts.ts';
+export type { ResponseLevel } from './kernel/contracts.ts';
 export type { BootCommandResult, ShutdownCommandResult } from './contracts/device.ts';
 export type { ViewportCommandResult } from './contracts/viewport.ts';
 

--- a/src/kernel/contracts.ts
+++ b/src/kernel/contracts.ts
@@ -1,14 +1,14 @@
-export type { AppErrorCode } from './kernel/errors.ts';
-export { defaultHintForCode, normalizeError } from './kernel/errors.ts';
+export type { AppErrorCode } from './errors.ts';
+export { defaultHintForCode, normalizeError } from './errors.ts';
 export type {
   DebugSymbolsCrashFrame,
   DebugSymbolsCrashSummary,
   DebugSymbolsImage,
   DebugSymbolsOptions,
   DebugSymbolsResult,
-} from './contracts/debug-symbols.ts';
-import type { PlatformSelector } from './kernel/device.ts';
-import { PLATFORM_SELECTORS } from './kernel/device.ts';
+} from '../contracts/debug-symbols.ts';
+import type { PlatformSelector } from './device.ts';
+import { PLATFORM_SELECTORS } from './device.ts';
 
 export type SessionRuntimeHints = {
   platform?: 'ios' | 'android';
@@ -212,8 +212,8 @@ export type JsonRpcRequestEnvelope<TParams = unknown> = {
   params?: TParams;
 };
 
-export { centerOfRect } from './kernel/snapshot.ts';
-export type { Rect, SnapshotNode } from './kernel/snapshot.ts';
+export { centerOfRect } from './snapshot.ts';
+export type { Rect, SnapshotNode } from './snapshot.ts';
 
 type RuntimeSchema<T> = {
   parse(input: unknown): T;

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -1,6 +1,6 @@
 import type { AgentDeviceClient, AgentDeviceClientConfig } from '../client-types.ts';
 import type { JsonSchema } from '../commands/command-contract.ts';
-import { RESPONSE_LEVELS, type ResponseLevel } from '../contracts.ts';
+import { RESPONSE_LEVELS, type ResponseLevel } from '../kernel/contracts.ts';
 import { formatCliOutput } from '../commands/cli-output.ts';
 import {
   isCommandName,

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -1,6 +1,6 @@
 import { listCommandTools, commandToolExecutor, type ToolResult } from './command-tools.ts';
 import { readVersion } from '../utils/version.ts';
-import type { JsonRpcId, JsonRpcRequestEnvelope } from '../contracts.ts';
+import type { JsonRpcId, JsonRpcRequestEnvelope } from '../kernel/contracts.ts';
 
 const MCP_SERVER_NAME = 'agent-device';
 const SUPPORTED_PROTOCOL_VERSION = '2025-11-25';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,5 @@
 import { handleMcpMessage, type JsonRpcMessage } from './router.ts';
-import { jsonRpcRequestSchema, type JsonRpcId } from '../contracts.ts';
+import { jsonRpcRequestSchema, type JsonRpcId } from '../kernel/contracts.ts';
 
 type JsonRpcResponse = Awaited<NonNullable<ReturnType<typeof handleMcpMessage>>>;
 type MessageSink = (payload: unknown) => void;

--- a/src/metro/metro-types.ts
+++ b/src/metro/metro-types.ts
@@ -1,4 +1,4 @@
-import type { SessionRuntimeHints } from '../contracts.ts';
+import type { SessionRuntimeHints } from '../kernel/contracts.ts';
 
 /** Re-export of {@link SessionRuntimeHints} under the Metro-specific alias used by public API consumers. */
 export type MetroRuntimeHints = SessionRuntimeHints;

--- a/src/metro/metro.ts
+++ b/src/metro/metro.ts
@@ -1,4 +1,4 @@
-import type { SessionRuntimeHints } from '../contracts.ts';
+import type { SessionRuntimeHints } from '../kernel/contracts.ts';
 import {
   buildMetroRuntimeHints,
   prepareMetroRuntime,

--- a/src/remote-config-schema.ts
+++ b/src/remote-config-schema.ts
@@ -4,7 +4,7 @@ import type {
   DaemonTransportPreference,
   LeaseBackend,
   SessionIsolationMode,
-} from './contracts.ts';
+} from './kernel/contracts.ts';
 import { PLATFORM_SELECTORS, type DeviceTarget, type PlatformSelector } from './kernel/device.ts';
 import type { MetroPrepareKind } from './metro/client-metro.ts';
 

--- a/src/remote-connection-state.ts
+++ b/src/remote-connection-state.ts
@@ -5,7 +5,7 @@ import { resolveRemoteConfigPath, resolveRemoteConfigProfile } from './remote-co
 import { AppError } from './kernel/errors.ts';
 import { emitDiagnostic } from './utils/diagnostics.ts';
 import type { CliFlags } from './utils/cli-flags.ts';
-import type { LeaseBackend, SessionRuntimeHints } from './contracts.ts';
+import type { LeaseBackend, SessionRuntimeHints } from './kernel/contracts.ts';
 import {
   leaseScopeFromOptions,
   leaseScopeToCommandFlags,

--- a/src/utils/cli-flags.ts
+++ b/src/utils/cli-flags.ts
@@ -14,7 +14,7 @@ import {
   type ResponseLevel,
   type SessionRuntimeHints,
   type SessionIsolationMode,
-} from '../contracts.ts';
+} from '../kernel/contracts.ts';
 import type { RemoteConfigMetroOptions } from '../remote-config-schema.ts';
 import {
   SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS,

--- a/src/utils/install-source-config.ts
+++ b/src/utils/install-source-config.ts
@@ -1,4 +1,4 @@
-import type { DaemonInstallSource } from '../contracts.ts';
+import type { DaemonInstallSource } from '../kernel/contracts.ts';
 import { AppError } from '../kernel/errors.ts';
 
 export function parseGitHubActionsArtifactInstallSourceSpec(

--- a/src/utils/runtime-transport.ts
+++ b/src/utils/runtime-transport.ts
@@ -1,5 +1,5 @@
 import { URL } from 'node:url';
-import type { SessionRuntimeHints } from '../contracts.ts';
+import type { SessionRuntimeHints } from '../kernel/contracts.ts';
 import { AppError } from '../kernel/errors.ts';
 
 export type ResolvedRuntimeTransport = {


### PR DESCRIPTION
## What

Relocates the central `contracts.ts` barrel into the `src/kernel/` dependency sink, alongside `device.ts`/`errors.ts`/`redaction.ts`/`snapshot.ts` (moved in #940). Per [plans/perfect-shape.md §5.5](../blob/main/plans/perfect-shape.md), `kernel/` owns the pure domain types and is the bottom of the import DAG.

## Why

Phase 5 (layering): finishes seating the core contract types in the kernel sink so the eventual import-direction lint has a clean target. Pure path codemod — no behavior change.

## How

- `src/contracts.ts` → `src/kernel/contracts.ts` (git rename)
- Repoint all 44 internal importers to `…/kernel/contracts.ts`
- rslib entry keeps the key `contracts`, so the dist output stays `dist/src/contracts.js` and the public **`agent-device/contracts`** subpath is byte-identical (same pattern proven by the `metro` move in #947)
- Update `.fallowrc.json` entrypoint + `fallow-baselines/health.json` key to the new path

## Safety

- **Public API preserved:** `agent-device/contracts` resolves unchanged; verified by `build` producing `dist/src/contracts.{js,d.ts}` and `package-exports.test.ts` / `contracts-schema-public.test.ts` passing.
- typecheck ✅ · oxlint ✅ · build ✅ · fallow audit ✅ (no issues in 50 changed files) · targeted unit tests ✅ (42 passing)
- 49 files, +57/-57.

## Note

`kernel/contracts.ts` retains one type-only re-export from `../contracts/debug-symbols.ts` (the per-domain contract dir stays put per the plan's `contracts/ (KEEP)`). The layering-guard CI job is unaffected; the full import-direction lint is a later Phase 5 slice.