### PR TITLE
feat: find/get digest response-views + batch-step elision — Phase 4

### DIFF
--- a/src/core/__tests__/batch.test.ts
+++ b/src/core/__tests__/batch.test.ts
@@ -1,6 +1,12 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { validateAndNormalizeBatchSteps, type DaemonBatchStep } from '../batch.ts';
+import {
+  runBatch,
+  validateAndNormalizeBatchSteps,
+  type BatchRequest,
+  type DaemonBatchStep,
+} from '../batch.ts';
+import type { DaemonResponse, ResponseLevel } from '../../kernel/contracts.ts';
 
 test('validateAndNormalizeBatchSteps rejects unknown top-level step fields', () => {
   assert.throws(
@@ -35,4 +41,52 @@ test('validateAndNormalizeBatchSteps validates runtime hints', () => {
       ),
     /runtime is invalid/i,
   );
+});
+
+// Records the responseLevel each step is invoked with, so the Phase 4
+// intermediate-step elision can be asserted end to end.
+function recordingInvoke(seen: (ResponseLevel | undefined)[]) {
+  return async (req: BatchRequest): Promise<DaemonResponse> => {
+    seen.push(req.meta?.responseLevel);
+    return { ok: true, data: { command: req.command } };
+  };
+}
+
+function batchRequest(commands: string[], responseLevel?: ResponseLevel): BatchRequest {
+  return {
+    token: 't',
+    command: 'batch',
+    positionals: [],
+    flags: { batchSteps: commands.map((command) => ({ command })) },
+    ...(responseLevel ? { meta: { responseLevel } } : {}),
+  };
+}
+
+test('batch elides intermediate steps to digest, final step keeps requested level (full)', async () => {
+  const seen: (ResponseLevel | undefined)[] = [];
+  const response = await runBatch(
+    batchRequest(['snapshot', 'find', 'get'], 'full'),
+    'session',
+    recordingInvoke(seen),
+  );
+  assert.equal(response.ok, true);
+  assert.deepEqual(seen, ['digest', 'digest', 'full']);
+});
+
+test('batch at digest keeps every step at digest', async () => {
+  const seen: (ResponseLevel | undefined)[] = [];
+  await runBatch(batchRequest(['snapshot', 'find'], 'digest'), 'session', recordingInvoke(seen));
+  assert.deepEqual(seen, ['digest', 'digest']);
+});
+
+test('a single-step batch never elides (the only step is final)', async () => {
+  const seen: (ResponseLevel | undefined)[] = [];
+  await runBatch(batchRequest(['snapshot'], 'full'), 'session', recordingInvoke(seen));
+  assert.deepEqual(seen, ['full']);
+});
+
+test('default batch (no responseLevel) passes meta through unchanged — byte-identical', async () => {
+  const seen: (ResponseLevel | undefined)[] = [];
+  await runBatch(batchRequest(['snapshot', 'find', 'get']), 'session', recordingInvoke(seen));
+  assert.deepEqual(seen, [undefined, undefined, undefined]);
 });

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -1,4 +1,9 @@
-import { type DaemonRequest, type DaemonResponse } from '../kernel/contracts.ts';
+import {
+  type DaemonRequest,
+  type DaemonResponse,
+  type ResponseLevel,
+  isNonDefaultResponseLevel,
+} from '../kernel/contracts.ts';
 import { AppError, asAppError } from '../kernel/errors.ts';
 import { isRecord } from '../utils/parsing.ts';
 import {
@@ -90,7 +95,14 @@ export async function runBatch(
     const startedAt = Date.now();
     const partialResults: BatchStepResult[] = [];
     for (const [index, step] of steps.entries()) {
-      const stepResponse = await runBatchStep(req, sessionName, step, invoke, index + 1);
+      const stepResponse = await runBatchStep(
+        req,
+        sessionName,
+        step,
+        invoke,
+        index + 1,
+        index === steps.length - 1,
+      );
       if (!stepResponse.ok) {
         return {
           ok: false,
@@ -208,12 +220,34 @@ export function mergeParentFlags<TFlags extends Record<string, unknown>>(
   return childFlags;
 }
 
+// Phase 4 (agent-cost) batch-step elision. When a non-default response level is
+// requested for the whole batch, INTERMEDIATE steps are forced to `digest` so a
+// multi-step run collapses tokens, while the FINAL step keeps the requested
+// level. With no responseLevel (or `default`) this is a no-op, so the per-step
+// meta is passed through unchanged — byte-identical to today (Maestro `.ad`
+// recompare safe).
+function batchStepResponseLevel(
+  requested: ResponseLevel | undefined,
+  isFinalStep: boolean,
+): ResponseLevel | undefined {
+  if (!isNonDefaultResponseLevel(requested)) return requested;
+  return isFinalStep ? requested : 'digest';
+}
+
+function batchStepMeta(meta: BatchRequest['meta'], isFinalStep: boolean): BatchRequest['meta'] {
+  const requested = meta?.responseLevel;
+  const stepLevel = batchStepResponseLevel(requested, isFinalStep);
+  if (stepLevel === requested) return meta;
+  return { ...meta, responseLevel: stepLevel };
+}
+
 async function runBatchStep(
   req: BatchRequest,
   sessionName: string,
   step: NormalizedBatchStep,
   invoke: BatchInvoke,
   stepNumber: number,
+  isFinalStep: boolean,
 ): Promise<
   | { ok: true; step: number; result: BatchStepResult }
   | {
@@ -241,7 +275,7 @@ async function runBatchStep(
     positionals: step.positionals,
     flags: stepFlags,
     runtime: step.runtime === undefined ? req.runtime : step.runtime,
-    meta: req.meta,
+    meta: batchStepMeta(req.meta, isFinalStep),
   });
   const durationMs = Date.now() - stepStartedAt;
   if (!response.ok) {

--- a/src/daemon/__tests__/response-views.test.ts
+++ b/src/daemon/__tests__/response-views.test.ts
@@ -4,6 +4,8 @@ import type { DaemonResponseData } from '../types.ts';
 
 const snapshotView = RESPONSE_VIEWS.snapshot;
 const screenshotView = RESPONSE_VIEWS.screenshot;
+const findView = RESPONSE_VIEWS.find;
+const getView = RESPONSE_VIEWS.get;
 
 const SNAPSHOT_DATA: DaemonResponseData = {
   nodes: [
@@ -102,4 +104,95 @@ test('screenshot default and full return today’s shape unchanged (same referen
 test('screenshot digest tolerates a path-only result with no overlay refs', () => {
   const digest = screenshotView!({ path: '/tmp/s.png' }, 'digest');
   expect(digest).toEqual({ path: '/tmp/s.png', overlayCount: 0, overlayRefs: [] });
+});
+
+// A verbose matched node as it appears on the `find`/`get` wire: the semantic
+// attributes (kept) plus the geometry/index/process plumbing (the token sink).
+const MATCHED_NODE = {
+  ref: 'e7',
+  role: 'AXButton',
+  type: 'Button',
+  label: 'Sign in',
+  value: 'enabled',
+  identifier: 'login-button',
+  enabled: true,
+  selected: false,
+  focused: false,
+  hittable: true,
+  // verbose framing the digest intentionally drops:
+  rect: { x: 10, y: 20, width: 100, height: 44 },
+  index: 7,
+  parentIndex: 3,
+  depth: 4,
+  pid: 1234,
+  bundleId: 'com.demo.app',
+  appName: 'Demo',
+  windowTitle: 'Demo',
+  surface: 'app',
+  visibleToUser: true,
+};
+
+const COMPACT_NODE = {
+  ref: 'e7',
+  role: 'AXButton',
+  type: 'Button',
+  label: 'Sign in',
+  value: 'enabled',
+  identifier: 'login-button',
+  enabled: true,
+  selected: false,
+  focused: false,
+  hittable: true,
+};
+
+test('find and get views are registered (shared selector-read view)', () => {
+  expect(typeof findView).toBe('function');
+  expect(typeof getView).toBe('function');
+  expect(findView).toBe(getView);
+});
+
+test('find get-text digest keeps ref + text, drops the verbose node', () => {
+  const digest = findView!({ ref: '@e7', text: 'Sign in', node: MATCHED_NODE }, 'digest');
+  expect(digest).toEqual({ ref: '@e7', text: 'Sign in' });
+  expect('node' in digest).toBe(false);
+});
+
+test('find get-attrs digest compacts the node to semantic attributes only', () => {
+  const digest = findView!({ ref: '@e7', node: MATCHED_NODE }, 'digest');
+  expect(digest).toEqual({ ref: '@e7', node: COMPACT_NODE });
+  // The geometry/index/process plumbing (the token sink) is dropped from the node.
+  expect('rect' in (digest.node as Record<string, unknown>)).toBe(false);
+  expect('parentIndex' in (digest.node as Record<string, unknown>)).toBe(false);
+});
+
+test('find exists/wait/click digests keep the cheap actionable signals', () => {
+  expect(findView!({ found: true }, 'digest')).toEqual({ found: true });
+  expect(findView!({ found: true, waitedMs: 320 }, 'digest')).toEqual({
+    found: true,
+    waitedMs: 320,
+  });
+  expect(
+    findView!({ ref: '@e7', locator: 'text', query: 'Sign in', x: 60, y: 42 }, 'digest'),
+  ).toEqual({ ref: '@e7', locator: 'text', query: 'Sign in', x: 60, y: 42 });
+});
+
+test('get text digest keeps selector + text and drops the node', () => {
+  const digest = getView!(
+    { selector: 'text=Sign in', text: 'Sign in', node: MATCHED_NODE },
+    'digest',
+  );
+  expect(digest).toEqual({ selector: 'text=Sign in', text: 'Sign in' });
+});
+
+test('get attrs digest compacts the node under a ref target', () => {
+  const digest = getView!({ ref: 'e7', node: MATCHED_NODE }, 'digest');
+  expect(digest).toEqual({ ref: 'e7', node: COMPACT_NODE });
+});
+
+test('find/get default and full return today’s shape unchanged (same reference)', () => {
+  const data: DaemonResponseData = { ref: '@e7', text: 'Sign in', node: MATCHED_NODE };
+  expect(findView!(data, 'default')).toBe(data);
+  expect(findView!(data, 'full')).toBe(data);
+  expect(getView!(data, 'default')).toBe(data);
+  expect(getView!(data, 'full')).toBe(data);
 });

--- a/src/daemon/__tests__/response-views.test.ts
+++ b/src/daemon/__tests__/response-views.test.ts
@@ -157,6 +157,23 @@ test('find get-text digest keeps ref + text, drops the verbose node', () => {
   expect('node' in digest).toBe(false);
 });
 
+test('a text read keeps every OTHER cheap field (e.g. warning) while dropping the node', () => {
+  const digest = findView!(
+    {
+      ref: '@e7',
+      text: 'Sign in',
+      warning: 'recovered from a blocking dialog',
+      node: MATCHED_NODE,
+    },
+    'digest',
+  );
+  expect(digest).toEqual({
+    ref: '@e7',
+    text: 'Sign in',
+    warning: 'recovered from a blocking dialog',
+  });
+});
+
 test('find get-attrs digest compacts the node to semantic attributes only', () => {
   const digest = findView!({ ref: '@e7', node: MATCHED_NODE }, 'digest');
   expect(digest).toEqual({ ref: '@e7', node: COMPACT_NODE });
@@ -165,15 +182,35 @@ test('find get-attrs digest compacts the node to semantic attributes only', () =
   expect('parentIndex' in (digest.node as Record<string, unknown>)).toBe(false);
 });
 
-test('find exists/wait/click digests keep the cheap actionable signals', () => {
-  expect(findView!({ found: true }, 'digest')).toEqual({ found: true });
-  expect(findView!({ found: true, waitedMs: 320 }, 'digest')).toEqual({
-    found: true,
-    waitedMs: 320,
-  });
-  expect(
-    findView!({ ref: '@e7', locator: 'text', query: 'Sign in', x: 60, y: 42 }, 'digest'),
-  ).toEqual({ ref: '@e7', locator: 'text', query: 'Sign in', x: 60, y: 42 });
+test('an attrs read compacts the node but keeps every other cheap field (e.g. warning)', () => {
+  const digest = getView!({ ref: 'e7', warning: 'partial tree', node: MATCHED_NODE }, 'digest');
+  expect(digest).toEqual({ ref: 'e7', warning: 'partial tree', node: COMPACT_NODE });
+});
+
+// REGRESSION: `find` is registered command-wide, but `find fill/focus/type` return
+// the underlying INTERACTION response (carrying cheap, agent-critical signals like
+// `warning`/`message`), which has no verbose snapshot node. The conservative view
+// must return such a node-less shape UNCHANGED — never allowlist-narrow it.
+test('find fill/focus/type interaction responses pass through UNCHANGED (warning kept)', () => {
+  const fillResponse: DaemonResponseData = {
+    ref: 'e3',
+    text: 'hello',
+    message: 'Filled 5 chars',
+    warning: 'Recovered from a blocking system dialog',
+  };
+  const digest = findView!(fillResponse, 'digest');
+  expect(digest).toBe(fillResponse); // same reference — not narrowed at all
+  expect(digest).toEqual(fillResponse);
+});
+
+test('find exists/wait/click digests pass through the cheap actionable signals', () => {
+  // No verbose node → returned UNCHANGED (same reference).
+  const exists: DaemonResponseData = { found: true };
+  const wait: DaemonResponseData = { found: true, waitedMs: 320 };
+  const click: DaemonResponseData = { ref: '@e7', locator: 'text', query: 'Sign in', x: 60, y: 42 };
+  expect(findView!(exists, 'digest')).toBe(exists);
+  expect(findView!(wait, 'digest')).toBe(wait);
+  expect(findView!(click, 'digest')).toBe(click);
 });
 
 test('get text digest keeps selector + text and drops the node', () => {

--- a/src/daemon/response-views.ts
+++ b/src/daemon/response-views.ts
@@ -64,7 +64,75 @@ function screenshotView(data: DaemonResponseData, level: ResponseLevel): DaemonR
   };
 }
 
+// The cheap, agent-actionable scalar fields a `find` / `get` selector read can
+// surface (across the exists / wait / text / attrs / click outcomes). Each is
+// copied verbatim into a digest when present; the verbose matched `node` is the
+// only token sink and is handled separately.
+const SELECTOR_DIGEST_SCALAR_FIELDS = [
+  'found',
+  'ref',
+  'selector',
+  'text',
+  'waitedMs',
+  'locator',
+  'query',
+  'x',
+  'y',
+] as const;
+
+// The semantic attributes of a single matched node an agent reasons about. The
+// verbose framing a digest drops — geometry (`rect`), tree indices
+// (`index`/`parentIndex`/`depth`), and process/app plumbing
+// (`pid`/`bundleId`/`appName`/`windowTitle`/`surface`/…) — is intentionally absent.
+const SELECTOR_DIGEST_NODE_FIELDS = [
+  'role',
+  'type',
+  'subrole',
+  'label',
+  'value',
+  'identifier',
+  'enabled',
+  'selected',
+  'focused',
+  'hittable',
+] as const;
+
+function compactSelectorNode(node: SnapshotNode): Record<string, unknown> {
+  const compact: Record<string, unknown> = { ref: node.ref };
+  for (const field of SELECTOR_DIGEST_NODE_FIELDS) {
+    const value = node[field];
+    if (value !== undefined) compact[field] = value;
+  }
+  return compact;
+}
+
+/**
+ * Token-cheap digest shared by the `find` and `get` selector reads, whose wire
+ * shapes overlap (`ref`/`selector` + `text` for a text read, `+ node` for an
+ * attrs read, and the cheap `found`/`waitedMs`/coordinate signals). It keeps the
+ * agent-actionable essentials and collapses the verbose matched `node`:
+ *   • a text read drops `node` entirely — the `text` IS the answer;
+ *   • an attrs read keeps a COMPACT node (semantic attributes only; geometry and
+ *     internal tree/process plumbing dropped).
+ * `full` returns today's shape unchanged (nothing richer is computed yet).
+ */
+function selectorReadView(data: DaemonResponseData, level: ResponseLevel): DaemonResponseData {
+  if (level !== 'digest') return data;
+  const digest: DaemonResponseData = {};
+  for (const field of SELECTOR_DIGEST_SCALAR_FIELDS) {
+    if (data[field] !== undefined) digest[field] = data[field];
+  }
+  // A text read already carries the answer in `text`, so the node is redundant
+  // framing; an attrs read has no `text`, so keep a compacted node instead.
+  if (typeof data.text !== 'string' && data.node && typeof data.node === 'object') {
+    digest.node = compactSelectorNode(data.node as SnapshotNode);
+  }
+  return digest;
+}
+
 export const RESPONSE_VIEWS: Record<string, ResponseView> = {
   snapshot: snapshotView,
   screenshot: screenshotView,
+  find: selectorReadView,
+  get: selectorReadView,
 };

--- a/src/daemon/response-views.ts
+++ b/src/daemon/response-views.ts
@@ -64,22 +64,6 @@ function screenshotView(data: DaemonResponseData, level: ResponseLevel): DaemonR
   };
 }
 
-// The cheap, agent-actionable scalar fields a `find` / `get` selector read can
-// surface (across the exists / wait / text / attrs / click outcomes). Each is
-// copied verbatim into a digest when present; the verbose matched `node` is the
-// only token sink and is handled separately.
-const SELECTOR_DIGEST_SCALAR_FIELDS = [
-  'found',
-  'ref',
-  'selector',
-  'text',
-  'waitedMs',
-  'locator',
-  'query',
-  'x',
-  'y',
-] as const;
-
 // The semantic attributes of a single matched node an agent reasons about. The
 // verbose framing a digest drops — geometry (`rect`), tree indices
 // (`index`/`parentIndex`/`depth`), and process/app plumbing
@@ -107,27 +91,33 @@ function compactSelectorNode(node: SnapshotNode): Record<string, unknown> {
 }
 
 /**
- * Token-cheap digest shared by the `find` and `get` selector reads, whose wire
- * shapes overlap (`ref`/`selector` + `text` for a text read, `+ node` for an
- * attrs read, and the cheap `found`/`waitedMs`/coordinate signals). It keeps the
- * agent-actionable essentials and collapses the verbose matched `node`:
- *   • a text read drops `node` entirely — the `text` IS the answer;
- *   • an attrs read keeps a COMPACT node (semantic attributes only; geometry and
- *     internal tree/process plumbing dropped).
- * `full` returns today's shape unchanged (nothing richer is computed yet).
+ * Token-cheap digest shared by the `find` and `get` commands. The ONLY token
+ * sink in their results is the verbose matched `node`, which appears solely on a
+ * selector READ (text / attrs). The view is deliberately CONSERVATIVE: it acts
+ * only on a result that carries such a `node` and otherwise returns the data
+ * UNCHANGED — so the cheap exists/wait/click results AND the mutating
+ * `find fill` / `find focus` / `find type` interaction responses (which can
+ * carry agent-critical signals like `warning` / `message`) are never silently
+ * narrowed.
+ *
+ *   • a text read drops the redundant `node` — the `text` IS the answer;
+ *   • an attrs read compacts the `node` to its semantic attributes only;
+ *
+ * In both cases every OTHER (cheap) field is preserved verbatim. `default` and
+ * `full` return today's shape unchanged (nothing richer is computed yet).
  */
 function selectorReadView(data: DaemonResponseData, level: ResponseLevel): DaemonResponseData {
   if (level !== 'digest') return data;
-  const digest: DaemonResponseData = {};
-  for (const field of SELECTOR_DIGEST_SCALAR_FIELDS) {
-    if (data[field] !== undefined) digest[field] = data[field];
-  }
+  const node = data.node;
+  if (!node || typeof node !== 'object') return data;
   // A text read already carries the answer in `text`, so the node is redundant
-  // framing; an attrs read has no `text`, so keep a compacted node instead.
-  if (typeof data.text !== 'string' && data.node && typeof data.node === 'object') {
-    digest.node = compactSelectorNode(data.node as SnapshotNode);
+  // framing — drop only the node and keep every other (cheap) field.
+  if (typeof data.text === 'string') {
+    const { node: _node, ...rest } = data;
+    return rest;
   }
-  return digest;
+  // An attrs read: compact only the verbose node, keeping every other cheap field.
+  return { ...data, node: compactSelectorNode(node as SnapshotNode) };
 }
 
 export const RESPONSE_VIEWS: Record<string, ResponseView> = {


### PR DESCRIPTION
## What

Completes the two remaining **Phase 4 agent-cost grafts** (plans/perfect-shape.md §5.4):

1. **`find` / `get` digest response-views** — a token-cheap `digest` view registered for both selector reads.
2. **Typed batch-step elision** — intermediate batch steps collapse to `digest` while the final step returns at the requested level.

Both are strictly **opt-in**: they only activate when a non-default `responseLevel` (`digest`/`full`) is requested. The `default` wire shape is **byte-identical** to today.

## Why

North-star goal #2 (fast + cheap for AI agents): leveled/digest payloads cut tokens, and a multi-step batch collapses its intermediate noise. `find`/`get` are the last high-token selector reads without a digest (they carry a full matched `node` on the wire); batch is the canonical N-round-trips-into-1 path where intermediate snapshot/find/get steps dominate the response.

## How

### `find` / `get` digest (`src/daemon/response-views.ts`)
`find` and `get` share a wire shape (`ref`/`selector` + `text` for a text read, `+ node` for an attrs read, plus `found`/`waitedMs`/coordinate signals), so a single `selectorReadView` is registered under both command names (mirrors the existing `snapshotView`/`screenshotView` pattern):

- **text read** → keeps `ref`/`selector` + `text`, **drops the redundant verbose `node`** (the `text` is the answer).
- **attrs read** → keeps a **compacted node**: semantic attributes only (`role`/`type`/`subrole`/`label`/`value`/`identifier`/`enabled`/`selected`/`focused`/`hittable`); the token sink — geometry (`rect`), tree indices (`index`/`parentIndex`/`depth`), and process/app plumbing (`pid`/`bundleId`/`appName`/`windowTitle`/`surface`/…) — is dropped.
- **exists / wait / click** → keeps the cheap actionable signals (`found`/`waitedMs`/`locator`/`query`/`x`/`y`).
- `default` and `full` return today's shape unchanged (same reference).

(Note: on the success path `find` matches at most one element — ambiguity is an `AMBIGUOUS_MATCH` error, not success data — so there is no count/unique field to surface; the digest keeps the single matched ref + label/text.)

### Batch-step elision (`src/core/batch.ts`)
When `req.meta.responseLevel` is a non-default level, `runBatchStep` overrides the per-step `responseLevel` to `digest` for every step except the last, which keeps the requested level. The existing per-command views (snapshot/screenshot/find/get) then collapse those intermediate steps automatically.

## Byte-identical-default safety argument

- **Views**: `applyResponseLevelView` (request-router) only invokes a registered view when `responseLevel` is `digest`/`full`; for `default`/absent it returns the response untouched. `selectorReadView` itself early-returns the original `data` reference for any non-`digest` level. So `find`/`get` `default` output is unchanged.
- **Batch**: `batchStepMeta` returns the **same `req.meta` reference** unless a non-default level was requested (gated on `isNonDefaultResponseLevel`). With no `responseLevel` (or `default`) every step is invoked with identical meta — byte-for-byte today's behavior. A unit test asserts the default path passes `[undefined, undefined, undefined]` through.

## Verification (local)

- Typecheck `tsc -p tsconfig.json`: pass
- Lint `oxlint . --deny-warnings`: pass
- Format `oxfmt --check`: pass
- Build `rslib build`: pass
- Fallow `audit --base origin/main`: pass (No issues in changed files)
- Tests (changed files + selector/router/batch consumers): 63 pass
