### PR TITLE
refactor: absorb CLI parser into cli/parser/ — Phase 5

### DIFF
--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -529,7 +529,7 @@
         "count": 1
       }
     },
-    "src/utils/args.ts": {
+    "src/cli/parser/args.ts": {
       "complexity_critical": {
         "count": 2
       },
@@ -707,7 +707,7 @@
     "src/replay/script-utils.ts:high impact",
     "src/daemon/handlers/session-open-target.ts:high impact",
     "src/utils/selector-is-predicates.ts:high impact",
-    "src/utils/args.ts:high impact",
+    "src/cli/parser/args.ts:high impact",
     "src/daemon/snapshot-presentation/tree.ts:high impact",
     "src/utils/rect-center.ts:high impact",
     "src/utils/process-identity.ts:high impact",

--- a/scripts/integration-progress-model.ts
+++ b/scripts/integration-progress-model.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { PUBLIC_COMMANDS } from '../src/command-catalog.ts';
 import { listCommandMetadata } from '../src/commands/command-metadata.ts';
-import { getFlagDefinitions } from '../src/utils/cli-flags.ts';
+import { getFlagDefinitions } from '../src/cli/parser/cli-flags.ts';
 
 const EMPTY_COVERAGE_METRIC = { pct: 0 };
 const EMPTY_STATEMENT_COVERAGE = { covered: 0, pct: 0, total: 0 };

--- a/src/__tests__/cli-grammar.test.ts
+++ b/src/__tests__/cli-grammar.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { readInputFromCli } from '../commands/cli-grammar.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from '../cli/parser/cli-flags.ts';
 
 const BASE_FLAGS: CliFlags = {
   json: false,

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -32,7 +32,7 @@ function runVersionFastPath(argv: string[]): boolean {
 
 function runNoCommandFastPath(argv: string[]): boolean {
   if (argv.length !== 0) return false;
-  import('./utils/cli-help.ts')
+  import('./cli/parser/cli-help.ts')
     .then(({ buildUsageText }) => {
       process.stdout.write(`${buildUsageText()}\n`);
       process.exit(1);
@@ -45,7 +45,7 @@ function runHelpFastPath(argv: string[]): boolean {
   const helpTarget = resolveSimpleHelpTarget(argv);
   if (helpTarget === undefined) return false;
 
-  import('./utils/cli-help.ts')
+  import('./cli/parser/cli-help.ts')
     .then(({ buildCommandUsageText, buildUsageText }) => {
       if (helpTarget === null) {
         process.stdout.write(`${buildUsageText()}\n`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { parseRawArgs, usage, usageForCommand } from './utils/args.ts';
+import { parseRawArgs, usage, usageForCommand } from './cli/parser/args.ts';
 import { asAppError, AppError, normalizeError } from './kernel/errors.ts';
 import { printHumanError, printJson } from './utils/output.ts';
 import { readVersion } from './utils/version.ts';
@@ -33,7 +33,7 @@ import {
   type RemoteConnectionRequestMetadata,
 } from './remote/remote-connection-state.ts';
 import { resolveRemoteAuthForCli } from './cli/auth-session.ts';
-import type { CliFlags, FlagKey } from './utils/cli-flags.ts';
+import type { CliFlags, FlagKey } from './cli/parser/cli-flags.ts';
 import type { SessionRuntimeHints } from './kernel/contracts.ts';
 
 type CliDeps = {

--- a/src/cli/auth-session.ts
+++ b/src/cli/auth-session.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { runCmd } from '../utils/exec.ts';
 import { AppError } from '../kernel/errors.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from './parser/cli-flags.ts';
 import type { EnvMap } from '../utils/env-map.ts';
 import { readCloudJsonResponse } from './cloud-response.ts';
 

--- a/src/cli/batch-steps.ts
+++ b/src/cli/batch-steps.ts
@@ -3,7 +3,7 @@ import { type SessionRuntimeHints } from '../kernel/contracts.ts';
 import { parseBatchStepRuntime } from '../batch-contract.ts';
 import { readInputFromCli } from '../commands/cli-grammar.ts';
 import { isCommandName, type CommandName } from '../commands/command-metadata.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from './parser/cli-flags.ts';
 import { AppError } from '../kernel/errors.ts';
 import { isRecord } from '../utils/parsing.ts';
 

--- a/src/cli/cloud-connection-profile.ts
+++ b/src/cli/cloud-connection-profile.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import type { RemoteConfigProfile } from '../remote/remote-config-schema.ts';
 import { AppError } from '../kernel/errors.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from './parser/cli-flags.ts';
 import type { EnvMap } from '../utils/env-map.ts';
 import { resolveCloudAccessForConnect } from './auth-session.ts';
 import { readCloudJsonResponse } from './cloud-response.ts';

--- a/src/cli/commands/__tests__/generic.test.ts
+++ b/src/cli/commands/__tests__/generic.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { createAgentDeviceClient } from '../../../client.ts';
 import type { DaemonResponse } from '../../../kernel/contracts.ts';
-import type { CliFlags } from '../../../utils/cli-flags.ts';
+import type { CliFlags } from '../../parser/cli-flags.ts';
 import type { ClientBackedCliCommandName } from '../../../command-catalog.ts';
 import { runGenericClientBackedCommand } from '../generic.ts';
 

--- a/src/cli/commands/__tests__/screenshot.test.ts
+++ b/src/cli/commands/__tests__/screenshot.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { createAgentDeviceClient } from '../../../client.ts';
 import type { DaemonResponse } from '../../../kernel/contracts.ts';
-import type { CliFlags } from '../../../utils/cli-flags.ts';
+import type { CliFlags } from '../../parser/cli-flags.ts';
 import { screenshotCommand } from '../screenshot.ts';
 
 async function captureStdout(fn: () => Promise<unknown>): Promise<string> {

--- a/src/cli/commands/agent-cdp.ts
+++ b/src/cli/commands/agent-cdp.ts
@@ -2,7 +2,7 @@ import { runCmdStreaming } from '../../utils/exec.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { isRemoteBridgeBackend } from './remote-bridge.ts';
 import type { SessionRuntimeHints } from '../../kernel/contracts.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 
 const AGENT_CDP_VERSION = '1.6.0';
 export const AGENT_CDP_PACKAGE = `agent-cdp@${AGENT_CDP_VERSION}`;

--- a/src/cli/commands/connection-runtime.ts
+++ b/src/cli/commands/connection-runtime.ts
@@ -18,7 +18,7 @@ import { profileToCliFlags } from '../../utils/remote-config.ts';
 import type { BatchStep } from '../../client-types.ts';
 import { AppError } from '../../kernel/errors.ts';
 import type { LeaseBackend, SessionRuntimeHints } from '../../kernel/contracts.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import type { AgentDeviceClient, Lease } from '../../client.ts';
 import type { MetroPrepareKind } from '../../metro/client-metro.ts';
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';

--- a/src/cli/commands/connection.ts
+++ b/src/cli/commands/connection.ts
@@ -25,7 +25,7 @@ import {
 } from './connection-runtime.ts';
 import { writeCommandOutput } from './shared.ts';
 import type { LeaseBackend } from '../../kernel/contracts.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import type { ClientCommandHandler } from './router-types.ts';
 
 export const connectCommand: ClientCommandHandler = async ({ positionals, flags, client }) => {

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -4,7 +4,7 @@ import { runCliCommandWithOutput } from '../../commands/cli-runner.ts';
 import type { CommandName } from '../../commands/command-metadata.ts';
 import type { CliOutput } from '../../commands/command-contract.ts';
 import type { ReplaySuiteResult } from '../../daemon/types.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import { readCommandMessage } from '../../utils/success-text.ts';
 import { isNonDefaultResponseLevel } from '../../kernel/contracts.ts';
 import { writeCommandOutput } from './shared.ts';

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -4,7 +4,7 @@ import { buildDaemonHttpBaseUrl } from '../../daemon/http-contract.ts';
 import { ensureDaemon, resolveClientSettings } from '../../daemon-client-lifecycle.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { colorize, supportsColor } from '../../utils/output.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import { writeCommandOutput } from './shared.ts';
 import type { ClientCommandHandler } from './router-types.ts';
 

--- a/src/cli/commands/react-devtools.ts
+++ b/src/cli/commands/react-devtools.ts
@@ -5,7 +5,7 @@ import {
 } from '../../client-react-devtools-companion.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { isRemoteBridgeBackend } from './remote-bridge.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 
 const AGENT_REACT_DEVTOOLS_VERSION = '0.4.0';
 export const AGENT_REACT_DEVTOOLS_PACKAGE = `agent-react-devtools@${AGENT_REACT_DEVTOOLS_VERSION}`;

--- a/src/cli/commands/remote-bridge.ts
+++ b/src/cli/commands/remote-bridge.ts
@@ -1,4 +1,4 @@
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 
 export function isRemoteBridgeBackend(leaseBackend: CliFlags['leaseBackend']): boolean {
   return leaseBackend === 'android-instance' || leaseBackend === 'ios-instance';

--- a/src/cli/commands/router-types.ts
+++ b/src/cli/commands/router-types.ts
@@ -1,4 +1,4 @@
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import type { AgentDeviceClient } from '../../client.ts';
 import type { CliCommandName } from '../../command-catalog.ts';
 

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -1,4 +1,4 @@
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import type { AgentDeviceClient } from '../../client.ts';
 import {
   isClientBackedCliCommandName,

--- a/src/cli/commands/screenshot.ts
+++ b/src/cli/commands/screenshot.ts
@@ -7,7 +7,7 @@ import type { AgentDeviceClient, CaptureScreenshotResult } from '../../client.ts
 import { createLocalArtifactAdapter } from '../../io.ts';
 import { createAgentDevice, localCommandPolicy } from '../../runtime.ts';
 import { runCliCommand } from '../../commands/cli-runner.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import { writeCommandOutput } from './shared.ts';
 import type { ClientCommandHandler } from './router-types.ts';
 

--- a/src/cli/commands/shared.ts
+++ b/src/cli/commands/shared.ts
@@ -1,4 +1,4 @@
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import { printJson } from '../../utils/output.ts';
 
 export function writeCommandOutput(

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -4,7 +4,7 @@ import {
   type AgentBrowserToolStatus,
 } from '../../platforms/web/agent-browser-tool.ts';
 import { AppError } from '../../kernel/errors.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../parser/cli-flags.ts';
 import { printJson } from '../../utils/output.ts';
 
 type PublicAgentBrowserToolStatus = Omit<AgentBrowserToolStatus, 'socketDir'>;

--- a/src/cli/generated-remote-config.ts
+++ b/src/cli/generated-remote-config.ts
@@ -8,7 +8,7 @@ import type {
 } from '../remote/remote-config-schema.ts';
 import { AppError, asAppError } from '../kernel/errors.ts';
 import type { EnvMap } from '../utils/env-map.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from './parser/cli-flags.ts';
 import { profileToCliFlags } from '../utils/remote-config.ts';
 
 const GENERATED_REMOTE_CONFIG_SECRET_KEYS = new Set(['daemonAuthToken', 'metroBearerToken']);

--- a/src/cli/parser/args.ts
+++ b/src/cli/parser/args.ts
@@ -1,5 +1,5 @@
-import { AppError } from '../kernel/errors.ts';
-import { mergeDefinedFlags } from './merge-flags.ts';
+import { AppError } from '../../kernel/errors.ts';
+import { mergeDefinedFlags } from '../../utils/merge-flags.ts';
 import {
   applyCommandDefaults,
   getCommandSchema,
@@ -8,9 +8,9 @@ import {
   type CliFlags,
   type FlagDefinition,
   type FlagKey,
-} from './command-schema.ts';
+} from '../../utils/command-schema.ts';
 import { buildCommandUsageText, buildUsageText } from './cli-help.ts';
-import { isFlagSupportedForCommand } from './cli-option-schema.ts';
+import { isFlagSupportedForCommand } from '../../utils/cli-option-schema.ts';
 
 type ParsedArgs = {
   command: string | null;

--- a/src/cli/parser/cli-flags.ts
+++ b/src/cli/parser/cli-flags.ts
@@ -1,9 +1,13 @@
-import { SESSION_SURFACES, type SessionSurface } from '../core/session-surface.ts';
-import type { RecordingExportQuality } from '../core/recording-export-quality.ts';
-import type { BackMode } from '../core/back-mode.ts';
-import type { ClickButton } from '../core/click-button.ts';
-import type { SwipePattern } from '../core/scroll-gesture.ts';
-import { PLATFORM_SELECTORS, type DeviceTarget, type PlatformSelector } from '../kernel/device.ts';
+import { SESSION_SURFACES, type SessionSurface } from '../../core/session-surface.ts';
+import type { RecordingExportQuality } from '../../core/recording-export-quality.ts';
+import type { BackMode } from '../../core/back-mode.ts';
+import type { ClickButton } from '../../core/click-button.ts';
+import type { SwipePattern } from '../../core/scroll-gesture.ts';
+import {
+  PLATFORM_SELECTORS,
+  type DeviceTarget,
+  type PlatformSelector,
+} from '../../kernel/device.ts';
 import {
   type DaemonInstallSource,
   type DaemonServerMode,
@@ -14,17 +18,17 @@ import {
   type ResponseLevel,
   type SessionRuntimeHints,
   type SessionIsolationMode,
-} from '../kernel/contracts.ts';
-import type { RemoteConfigMetroOptions } from '../remote/remote-config-schema.ts';
+} from '../../kernel/contracts.ts';
+import type { RemoteConfigMetroOptions } from '../../remote/remote-config-schema.ts';
 import {
   SCREENSHOT_SPECIFIC_FLAG_DEFINITIONS,
   type ScreenshotRequestFlags,
-} from '../contracts/screenshot.ts';
-import { PERF_KIND_VALUES } from '../contracts/perf.ts';
+} from '../../contracts/screenshot.ts';
+import { PERF_KIND_VALUES } from '../../contracts/perf.ts';
 import {
   MAESTRO_COMPAT_TRACKER_URL,
   formatMaestroSupportedSubsetForCli,
-} from '../compat/maestro/support-matrix.ts';
+} from '../../compat/maestro/support-matrix.ts';
 
 export type CliFlags = RemoteConfigMetroOptions &
   ScreenshotRequestFlags & {

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -1,4 +1,4 @@
-import { listCliCommandNames } from '../command-catalog.ts';
+import { listCliCommandNames } from '../../command-catalog.ts';
 import {
   getCliCommandSchema,
   getCommandSchema,
@@ -7,7 +7,7 @@ import {
   type CommandSchema,
   type FlagDefinition,
   type FlagKey,
-} from './command-schema.ts';
+} from '../../utils/command-schema.ts';
 
 const AGENT_WORKFLOWS = [
   {

--- a/src/cli/proxy-connection-profile.ts
+++ b/src/cli/proxy-connection-profile.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import type { RemoteConfigProfile } from '../remote/remote-config-schema.ts';
 import { AppError } from '../kernel/errors.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from './parser/cli-flags.ts';
 import type { EnvMap } from '../utils/env-map.ts';
 import { persistAndResolveGeneratedProfile } from './generated-remote-config.ts';
 import { resolveRequestedLeaseBackend } from './commands/connection-runtime.ts';

--- a/src/commands/capture/diff.ts
+++ b/src/commands/capture/diff.ts
@@ -1,5 +1,5 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
-import { SNAPSHOT_FLAGS } from '../../utils/cli-flags.ts';
+import { SNAPSHOT_FLAGS } from '../../cli/parser/cli-flags.ts';
 import { AppError } from '../../kernel/errors.ts';
 import {
   booleanField,

--- a/src/commands/capture/index.test.ts
+++ b/src/commands/capture/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import {
   alertCliReader,
   alertDaemonWriter,

--- a/src/commands/capture/settings.ts
+++ b/src/commands/capture/settings.ts
@@ -2,7 +2,7 @@ import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { SettingsUpdateOptions } from '../../client-types.ts';
 import { SETTINGS_USAGE_OVERRIDE } from '../../core/settings-contract.ts';
 import type { CommandSchemaOverride } from '../../utils/cli-command-schema-types.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { readLocationCoordinate } from '../../utils/location-coordinates.ts';
 import { defineExecutableCommand } from '../command-contract.ts';

--- a/src/commands/capture/snapshot.ts
+++ b/src/commands/capture/snapshot.ts
@@ -1,5 +1,5 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
-import { SNAPSHOT_FLAGS } from '../../utils/cli-flags.ts';
+import { SNAPSHOT_FLAGS } from '../../cli/parser/cli-flags.ts';
 import { booleanField, integerField, stringField } from '../command-input.ts';
 import { defineExecutableCommand } from '../command-contract.ts';
 import { commonInputFromFlags, direct } from '../cli-grammar/common.ts';

--- a/src/commands/capture/wait.ts
+++ b/src/commands/capture/wait.ts
@@ -1,7 +1,7 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { WaitCommandOptions } from '../../client-types.ts';
 import { parseWaitPositionals } from '../../core/wait-positionals.ts';
-import { SELECTOR_SNAPSHOT_FLAGS, type CliFlags } from '../../utils/cli-flags.ts';
+import { SELECTOR_SNAPSHOT_FLAGS, type CliFlags } from '../../cli/parser/cli-flags.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { tryParseSelectorChain } from '../../utils/selectors-parse.ts';
 import {

--- a/src/commands/cli-grammar/common.ts
+++ b/src/commands/cli-grammar/common.ts
@@ -4,7 +4,7 @@ import type {
   InternalRequestOptions,
 } from '../../client-types.ts';
 import { splitSelectorFromArgs } from '../../utils/selectors-parse.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { compactRecord, type SelectorSnapshotInput } from '../command-input.ts';
 import type {

--- a/src/commands/cli-grammar/registry.ts
+++ b/src/commands/cli-grammar/registry.ts
@@ -1,4 +1,4 @@
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import type { CommandName } from '../command-metadata.ts';
 import { listCommandFamilyCliReaders } from '../family/registry.ts';
 

--- a/src/commands/cli-grammar/types.ts
+++ b/src/commands/cli-grammar/types.ts
@@ -1,6 +1,6 @@
 import type { InteractionTarget, InternalRequestOptions } from '../../client-types.ts';
 import type { CommandFlags } from '../../core/dispatch-context.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import type { ClickButton } from '../../core/click-button.ts';
 import type { DecodedFillTarget } from '../../core/interaction-positionals.ts';
 import type { WaitParsed } from '../../core/wait-positionals.ts';

--- a/src/commands/cli-runner.ts
+++ b/src/commands/cli-runner.ts
@@ -3,7 +3,7 @@ import { formatCliOutput } from './cli-output.ts';
 import { readInputFromCli } from './cli-grammar.ts';
 import { runCommand, type CommandName } from './command-surface.ts';
 import type { CliOutput } from './command-contract.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from '../cli/parser/cli-flags.ts';
 
 type CliRunOptions = {
   client: AgentDeviceClient;

--- a/src/commands/command-flags.ts
+++ b/src/commands/command-flags.ts
@@ -1,6 +1,6 @@
 import { buildFlags } from '../client-normalizers.ts';
 import type { CommandFlags } from '../core/dispatch-context.ts';
-import { getFlagDefinitions } from '../utils/cli-flags.ts';
+import { getFlagDefinitions } from '../cli/parser/cli-flags.ts';
 import type { InternalRequestOptions } from '../client-types.ts';
 import type { CommandMetadata } from './command-contract.ts';
 

--- a/src/commands/debugging/index.test.ts
+++ b/src/commands/debugging/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import { debugCliReader, debugCommandDefinition, debugCommandMetadata } from './index.ts';
 
 describe('debugging command interface', () => {

--- a/src/commands/interaction/gesture.test.ts
+++ b/src/commands/interaction/gesture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import type { CommandInput } from '../cli-grammar/types.ts';
 import { gestureCliReaders, gestureDaemonWriters } from './gesture.ts';
 

--- a/src/commands/interaction/gesture.ts
+++ b/src/commands/interaction/gesture.ts
@@ -1,6 +1,6 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { FlingOptions, RotateGestureOptions } from '../../client-types.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import { AppError } from '../../kernel/errors.ts';
 import {
   commonInputFromFlags,

--- a/src/commands/interaction/index.ts
+++ b/src/commands/interaction/index.ts
@@ -18,7 +18,7 @@ import type {
   TypeTextOptions,
 } from '../../client-types.ts';
 import type { CommandSchemaOverride } from '../../utils/cli-command-schema-types.ts';
-import { REPEATED_TOUCH_FLAGS, SELECTOR_SNAPSHOT_FLAGS } from '../../utils/cli-flags.ts';
+import { REPEATED_TOUCH_FLAGS, SELECTOR_SNAPSHOT_FLAGS } from '../../cli/parser/cli-flags.ts';
 import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/types.ts';
 import { defineExecutableCommand } from '../command-contract.ts';
 import {

--- a/src/commands/interaction/selectors.ts
+++ b/src/commands/interaction/selectors.ts
@@ -1,6 +1,6 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { FindOptions, IsOptions } from '../../client-types.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import { AppError } from '../../kernel/errors.ts';
 import {
   direct,

--- a/src/commands/management/install.ts
+++ b/src/commands/management/install.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { DaemonInstallSource } from '../../kernel/contracts.ts';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import type { CommandSchemaOverride } from '../../utils/cli-command-schema-types.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { parseGitHubActionsArtifactInstallSourceSpec } from '../../utils/install-source-config.ts';

--- a/src/commands/metro/index.test.ts
+++ b/src/commands/metro/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import { metroCliReader, metroCommandDefinition, metroCommandMetadata } from './index.ts';
 
 function flags(overrides: Partial<CliFlags> = {}): CliFlags {

--- a/src/commands/metro/index.ts
+++ b/src/commands/metro/index.ts
@@ -20,7 +20,7 @@ import { defineCommandFacet, defineCommandFamilyFromFacets } from '../family/typ
 import { defineExecutableCommand } from '../command-contract.ts';
 import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 import type { CliReader } from '../cli-grammar/types.ts';
-import { METRO_PREPARE_FLAGS, METRO_RELOAD_FLAGS } from '../../utils/cli-flags.ts';
+import { METRO_PREPARE_FLAGS, METRO_RELOAD_FLAGS } from '../../cli/parser/cli-flags.ts';
 import { metroCliOutputFormatters } from './output.ts';
 
 const METRO_COMMAND_NAME = 'metro';

--- a/src/commands/observability/index.test.ts
+++ b/src/commands/observability/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import {
   logsCliReader,
   logsCommandDefinition,

--- a/src/commands/perf/index.test.ts
+++ b/src/commands/perf/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import {
   perfCliReader,
   perfCommandDefinition,

--- a/src/commands/react-native/index.test.ts
+++ b/src/commands/react-native/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import {
   reactNativeCliReader,
   reactNativeCommandDefinition,

--- a/src/commands/recording/index.test.ts
+++ b/src/commands/recording/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import {
   recordCliReader,
   recordCommandDefinition,

--- a/src/commands/replay/index.test.ts
+++ b/src/commands/replay/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import {
   replayCliReader,
   replayCommandDefinition,

--- a/src/commands/replay/index.ts
+++ b/src/commands/replay/index.ts
@@ -16,7 +16,7 @@ import {
   requiredString,
 } from '../cli-grammar/common.ts';
 import type { CliReader, CommandInput, DaemonWriter } from '../cli-grammar/types.ts';
-import { REPLAY_FLAGS } from '../../utils/cli-flags.ts';
+import { REPLAY_FLAGS } from '../../cli/parser/cli-flags.ts';
 
 const REPLAY_COMMAND_NAME = 'replay';
 const TEST_COMMAND_NAME = 'test';

--- a/src/commands/system/index.test.ts
+++ b/src/commands/system/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { CliFlags } from '../../utils/cli-flags.ts';
+import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import {
   appStateCliReader,
   appStateDaemonWriter,

--- a/src/compat/maestro/__tests__/support-matrix.test.ts
+++ b/src/compat/maestro/__tests__/support-matrix.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { expect, test } from 'vitest';
-import { getFlagDefinitions } from '../../../utils/cli-flags.ts';
+import { getFlagDefinitions } from '../../../cli/parser/cli-flags.ts';
 import {
   MAESTRO_COMPAT_SUPPORTED_CAPABILITIES,
   MAESTRO_COMPAT_TRACKER_URL,

--- a/src/core/dispatch-context.ts
+++ b/src/core/dispatch-context.ts
@@ -1,4 +1,4 @@
-import type { CliFlags, DaemonExcludedCliFlag } from '../utils/cli-flags.ts';
+import type { CliFlags, DaemonExcludedCliFlag } from '../cli/parser/cli-flags.ts';
 import type { ScreenshotDispatchFlags } from '../contracts/screenshot.ts';
 import type { DaemonBatchStep } from './batch.ts';
 import type { BackMode } from './back-mode.ts';

--- a/src/core/dispatch-resolve.ts
+++ b/src/core/dispatch-resolve.ts
@@ -13,7 +13,7 @@ import {
   resolveAndroidSerialAllowlist,
   resolveIosSimulatorDeviceSetPath,
 } from '../utils/device-isolation.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from '../cli/parser/cli-flags.ts';
 import { listLocalDeviceInventory, type DeviceInventoryRequest } from './platform-inventory.ts';
 type ResolveDeviceFlags = Pick<
   CliFlags,

--- a/src/remote/remote-connection-state.ts
+++ b/src/remote/remote-connection-state.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { resolveRemoteConfigPath, resolveRemoteConfigProfile } from './remote-config-core.ts';
 import { AppError } from '../kernel/errors.ts';
 import { emitDiagnostic } from '../utils/diagnostics.ts';
-import type { CliFlags } from '../utils/cli-flags.ts';
+import type { CliFlags } from '../cli/parser/cli-flags.ts';
 import type { LeaseBackend, SessionRuntimeHints } from '../kernel/contracts.ts';
 import {
   leaseScopeFromOptions,

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { parseArgs, usage, usageForCommand } from '../args.ts';
+import { parseArgs, usage, usageForCommand } from '../../cli/parser/args.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { listCapabilityCommands } from '../../core/capabilities.ts';
 import { listCapabilityCheckedCommandNames, listCliCommandNames } from '../../command-catalog.ts';

--- a/src/utils/__tests__/cli-flags.test.ts
+++ b/src/utils/__tests__/cli-flags.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { getFlagDefinition } from '../cli-flags.ts';
+import { getFlagDefinition } from '../../cli/parser/cli-flags.ts';
 import { PLATFORM_SELECTORS } from '../../kernel/device.ts';
 
 test('--platform enumValues are derived from the canonical PLATFORM_SELECTORS tuple', () => {

--- a/src/utils/__tests__/perf-args.test.ts
+++ b/src/utils/__tests__/perf-args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { parseArgs, usageForCommand } from '../args.ts';
+import { parseArgs, usageForCommand } from '../../cli/parser/args.ts';
 
 test('parseArgs accepts perf area subcommands', () => {
   const metrics = parseArgs(['perf', 'metrics'], { strictFlags: true });

--- a/src/utils/cli-command-overrides.ts
+++ b/src/utils/cli-command-overrides.ts
@@ -2,7 +2,10 @@ import type { CommandName } from '../commands/command-metadata.ts';
 import { listCommandFamilyCliSchemas } from '../commands/family/registry.ts';
 import type { LocalCliCommandName } from '../command-catalog.ts';
 import type { CommandSchema, CommandSchemaOverride } from './cli-command-schema-types.ts';
-import { COMMON_COMMAND_SUPPORTED_FLAG_KEYS, METRO_PREPARE_FLAGS } from './cli-flags.ts';
+import {
+  COMMON_COMMAND_SUPPORTED_FLAG_KEYS,
+  METRO_PREPARE_FLAGS,
+} from '../cli/parser/cli-flags.ts';
 
 type SchemaOnlyCliCommandName = Exclude<LocalCliCommandName, CommandName>;
 

--- a/src/utils/cli-command-schema-types.ts
+++ b/src/utils/cli-command-schema-types.ts
@@ -1,4 +1,4 @@
-import type { CliFlags, FlagKey } from './cli-flags.ts';
+import type { CliFlags, FlagKey } from '../cli/parser/cli-flags.ts';
 
 export type CommandSchema = {
   helpDescription: string;

--- a/src/utils/cli-config.ts
+++ b/src/utils/cli-config.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { AppError } from '../kernel/errors.ts';
 import { mergeDefinedFlags } from './merge-flags.ts';
-import { type CliFlags, type FlagKey } from './cli-flags.ts';
+import { type CliFlags, type FlagKey } from '../cli/parser/cli-flags.ts';
 import { expandUserHomePath, resolveUserPath } from './path-resolution.ts';
 import {
   getConfigurableOptionSpecs,

--- a/src/utils/cli-options.ts
+++ b/src/utils/cli-options.ts
@@ -1,6 +1,6 @@
-import type { CliFlags } from './cli-flags.ts';
+import type { CliFlags } from '../cli/parser/cli-flags.ts';
 import { mergeDefinedFlags } from './merge-flags.ts';
-import { finalizeParsedArgs, parseRawArgs } from './args.ts';
+import { finalizeParsedArgs, parseRawArgs } from '../cli/parser/args.ts';
 import { resolveConfigBackedFlagDefaults } from './cli-config.ts';
 import { resolveRemoteConfigDefaults } from './remote-config.ts';
 import type { EnvMap } from './env-map.ts';

--- a/src/utils/command-schema.ts
+++ b/src/utils/command-schema.ts
@@ -11,7 +11,7 @@ import {
   type DaemonExcludedCliFlag,
   type FlagDefinition,
   type FlagKey,
-} from './cli-flags.ts';
+} from '../cli/parser/cli-flags.ts';
 
 export type { CliFlags, DaemonExcludedCliFlag, FlagDefinition, FlagKey };
 export type { CommandSchema, CommandSchemaOverride };

--- a/src/utils/remote-config.ts
+++ b/src/utils/remote-config.ts
@@ -1,4 +1,4 @@
-import type { CliFlags } from './cli-flags.ts';
+import type { CliFlags } from '../cli/parser/cli-flags.ts';
 import {
   REMOTE_CONFIG_FIELD_SPECS,
   type RemoteConfigProfile,

--- a/src/utils/session-binding.ts
+++ b/src/utils/session-binding.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../kernel/errors.ts';
-import type { CliFlags } from './cli-flags.ts';
+import type { CliFlags } from '../cli/parser/cli-flags.ts';
 import type { DaemonLockPolicy } from '../daemon/types.ts';
 
 export type BindingSettings = {


### PR DESCRIPTION
## What

Moves the CLI argument/flag/help parser out of `utils/` into a dedicated **`src/cli/parser/`** folder, per [plans/perfect-shape.md §5.5](../blob/main/plans/perfect-shape.md) (`utils/` hosts a ~3k-LOC CLI parser among its buried subsystems).

Files moved (3): `args`, `cli-flags`, `cli-help` (the `args → cli-help` intra-set import stays relative).

## How

- All 3 moved as git renames; **64 importers** repointed via the resolve-based codemod (staying `utils`/`kernel` deps recomputed to `../../`).
- **No public-export / rslib impact** (none were package entries).
- Updated the one non-src importer (`scripts/integration-progress-model.ts`, the CLI-flag classification guard) and `fallow-baselines/health.json` keys (`args` incl. its `:high impact` variant).

## Safety

typecheck ✅ · oxlint ✅ · format ✅ · build ✅ · fallow audit ✅ (no issues in 67 changed files) · targeted unit tests ✅ (141 passing) · the integration-progress model still runs. Behaviorless path codemod, 66 files. Independent of #955/#956 (they touch daemon/core, not cli files).