### PR TITLE
refactor: split daemon client driver into daemon/client/ — Phase 5

### DIFF
--- a/fallow-baselines/health.json
+++ b/fallow-baselines/health.json
@@ -156,25 +156,25 @@
         "count": 2
       }
     },
-    "src/daemon-client-lifecycle.ts": {
-      "complexity_moderate": {
+    "src/daemon/client/daemon-client-lifecycle.ts": {
+      "complexity_high": {
         "count": 1
       },
-      "crap_moderate": {
+      "crap_high": {
         "count": 1
       }
     },
-    "src/daemon-client-metadata.ts": {
+    "src/daemon/client/daemon-client-metadata.ts": {
       "complexity_moderate": {
         "count": 1
       }
     },
-    "src/daemon-client-rpc.ts": {
+    "src/daemon/client/daemon-client-rpc.ts": {
       "crap_moderate": {
         "count": 2
       }
     },
-    "src/daemon-client.ts": {
+    "src/daemon/client/daemon-client.ts": {
       "complexity_moderate": {
         "count": 2
       }

--- a/src/__tests__/cli-agent-cdp-session.test.ts
+++ b/src/__tests__/cli-agent-cdp-session.test.ts
@@ -19,7 +19,7 @@ import {
   hashRemoteConfigFile,
   writeRemoteConnectionState,
 } from '../remote/remote-connection-state.ts';
-import type { DaemonResponse } from '../daemon-client.ts';
+import type { DaemonResponse } from '../daemon/client/daemon-client.ts';
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/src/__tests__/cli-capture.ts
+++ b/src/__tests__/cli-capture.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { runCli } from '../cli.ts';
-import type { DaemonRequest, DaemonResponse } from '../daemon-client.ts';
+import type { DaemonRequest, DaemonResponse } from '../daemon/client/daemon-client.ts';
 import { installIsolatedCliTestEnv } from './cli-test-env.ts';
 
 class ExitSignal extends Error {

--- a/src/__tests__/cli-diagnostics.test.ts
+++ b/src/__tests__/cli-diagnostics.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { DaemonResponse } from '../daemon-client.ts';
+import type { DaemonResponse } from '../daemon/client/daemon-client.ts';
 import { resolveDaemonPaths } from '../daemon/config.ts';
 import {
   runCliCapture as captureCli,

--- a/src/__tests__/cli-diff.test.ts
+++ b/src/__tests__/cli-diff.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { PNG } from '../utils/png.ts';
-import type { DaemonResponse } from '../daemon-client.ts';
+import type { DaemonResponse } from '../daemon/client/daemon-client.ts';
 import {
   runCliCapture as captureCli,
   type CapturedCliRun,

--- a/src/__tests__/cli-react-devtools-session.test.ts
+++ b/src/__tests__/cli-react-devtools-session.test.ts
@@ -15,7 +15,7 @@ import {
   hashRemoteConfigFile,
   writeRemoteConnectionState,
 } from '../remote/remote-connection-state.ts';
-import type { DaemonResponse } from '../daemon-client.ts';
+import type { DaemonResponse } from '../daemon/client/daemon-client.ts';
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/src/__tests__/daemon-client-progress.test.ts
+++ b/src/__tests__/daemon-client-progress.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events';
 import type { Socket } from 'node:net';
 import { test } from 'vitest';
 import type { DaemonRequest, DaemonResponse } from '../daemon/types.ts';
-import { readDaemonSocketProgressResponse } from '../daemon-client-progress.ts';
+import { readDaemonSocketProgressResponse } from '../daemon/client/daemon-client-progress.ts';
 import { AppError } from '../kernel/errors.ts';
 
 type MockSocket = EventEmitter & {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { asAppError, AppError, normalizeError } from './kernel/errors.ts';
 import { printHumanError, printJson } from './utils/output.ts';
 import { readVersion } from './utils/version.ts';
 import { pathToFileURL } from 'node:url';
-import { sendToDaemon } from './daemon-client.ts';
+import { sendToDaemon } from './daemon/client/daemon-client.ts';
 import fs from 'node:fs';
 import type { BatchStep } from './client/client-types.ts';
 import {

--- a/src/cli/commands/proxy.ts
+++ b/src/cli/commands/proxy.ts
@@ -1,7 +1,10 @@
 import { randomBytes } from 'node:crypto';
 import { createDaemonProxyServer } from '../../remote/daemon-proxy.ts';
 import { buildDaemonHttpBaseUrl } from '../../daemon/http-contract.ts';
-import { ensureDaemon, resolveClientSettings } from '../../daemon-client-lifecycle.ts';
+import {
+  ensureDaemon,
+  resolveClientSettings,
+} from '../../daemon/client/daemon-client-lifecycle.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { colorize, supportsColor } from '../../utils/output.ts';
 import type { CliFlags } from '../parser/cli-flags.ts';

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,4 +1,4 @@
-import { sendToDaemon } from '../daemon-client.ts';
+import { sendToDaemon } from '../daemon/client/daemon-client.ts';
 import { prepareMetroRuntime, reloadMetro } from '../metro/client-metro.ts';
 import { resolveDaemonPaths } from '../daemon/config.ts';
 import { symbolicateCrashArtifact } from '../platforms/ios/debug-symbols.ts';

--- a/src/commands/batch/cli.test.ts
+++ b/src/commands/batch/cli.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { DaemonResponse } from '../../daemon-client.ts';
+import type { DaemonResponse } from '../../daemon/client/daemon-client.ts';
 import {
   runCliCapture as captureCli,
   type CapturedCliRun,

--- a/src/daemon/client/daemon-client-lifecycle.ts
+++ b/src/daemon/client/daemon-client-lifecycle.ts
@@ -2,11 +2,11 @@ import fs from 'node:fs';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { AppError } from './kernel/errors.ts';
-import type { DaemonRequest } from './daemon/types.ts';
-import { runCmdDetachedMonitored, type ExecDetachedExit } from './utils/exec.ts';
-import { findProjectRoot, readVersion } from './utils/version.ts';
-import { emitDiagnostic } from './utils/diagnostics.ts';
+import { AppError } from '../../kernel/errors.ts';
+import type { DaemonRequest } from '../types.ts';
+import { runCmdDetachedMonitored, type ExecDetachedExit } from '../../utils/exec.ts';
+import { findProjectRoot, readVersion } from '../../utils/version.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import {
   resolveDaemonPaths,
   resolveDaemonServerMode,
@@ -14,10 +14,10 @@ import {
   type DaemonPaths,
   type DaemonServerMode,
   type DaemonTransportPreference,
-} from './daemon/config.ts';
-import { computeDaemonCodeSignature } from './daemon/code-signature.ts';
-import { PUBLIC_COMMANDS } from './command-catalog.ts';
-import { sleep } from './utils/timeouts.ts';
+} from '../config.ts';
+import { computeDaemonCodeSignature } from '../code-signature.ts';
+import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
+import { sleep } from '../../utils/timeouts.ts';
 import {
   cleanupFailedDaemonStartupMetadata,
   cleanupStaleDaemonLockIfSafe,

--- a/src/daemon/client/daemon-client-metadata.ts
+++ b/src/daemon/client/daemon-client-metadata.ts
@@ -1,8 +1,11 @@
 import fs from 'node:fs';
-import { emitDiagnostic } from './utils/diagnostics.ts';
-import { isAgentDeviceDaemonProcess, stopProcessForTakeover } from './utils/process-identity.ts';
-import { shellQuote } from './utils/shell-quote.ts';
-import { resolveDaemonPaths, type DaemonPaths, type DaemonServerMode } from './daemon/config.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import {
+  isAgentDeviceDaemonProcess,
+  stopProcessForTakeover,
+} from '../../utils/process-identity.ts';
+import { shellQuote } from '../../utils/shell-quote.ts';
+import { resolveDaemonPaths, type DaemonPaths, type DaemonServerMode } from '../config.ts';
 
 export type DaemonInfo = {
   port?: number;

--- a/src/daemon/client/daemon-client-progress.ts
+++ b/src/daemon/client/daemon-client-progress.ts
@@ -1,18 +1,18 @@
 import http from 'node:http';
 import type { Socket } from 'node:net';
-import { AppError } from './kernel/errors.ts';
-import type { DaemonRequest, DaemonResponse } from './daemon/types.ts';
-import type { RequestProgressEvent } from './daemon/request-progress.ts';
-import { consumeTextLines } from './utils/line-stream.ts';
+import { AppError } from '../../kernel/errors.ts';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import type { RequestProgressEvent } from '../request-progress.ts';
+import { consumeTextLines } from '../../utils/line-stream.ts';
 import {
   createReplayTestProgressRenderer,
   type ReplayTestProgressRender,
-} from './cli-test-progress.ts';
+} from '../../cli-test-progress.ts';
 import {
   isDaemonProgressEnvelope,
   isDaemonResponseEnvelope,
   shouldStreamRequestProgress,
-} from './daemon/request-progress-protocol.ts';
+} from '../request-progress-protocol.ts';
 
 type RequestProgressRenderer = {
   render(event: RequestProgressEvent): ReplayTestProgressRender | undefined;

--- a/src/daemon/client/daemon-client-rpc.ts
+++ b/src/daemon/client/daemon-client-rpc.ts
@@ -1,13 +1,13 @@
-import { AppError, toAppErrorCode } from './kernel/errors.ts';
-import { createRequestId } from './utils/diagnostics.ts';
-import type { DaemonRequest, DaemonResponse } from './daemon/types.ts';
-import { materializeRemoteArtifacts } from './remote/daemon-artifacts.ts';
+import { AppError, toAppErrorCode } from '../../kernel/errors.ts';
+import { createRequestId } from '../../utils/diagnostics.ts';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import { materializeRemoteArtifacts } from '../../remote/daemon-artifacts.ts';
 import type { DaemonInfo } from './daemon-client-metadata.ts';
 import {
   leaseScopeFromRequest,
   leaseScopeToLeaseRpcParams,
   type LeaseRpcCommand,
-} from './core/lease-scope.ts';
+} from '../../core/lease-scope.ts';
 
 export function handleDaemonHttpResponseBody(
   body: string,

--- a/src/daemon/client/daemon-client-timeout.ts
+++ b/src/daemon/client/daemon-client-timeout.ts
@@ -1,9 +1,9 @@
-import { AppError } from './kernel/errors.ts';
-import { runCmdSync } from './utils/exec.ts';
-import { emitDiagnostic } from './utils/diagnostics.ts';
-import { isAgentDeviceDaemonProcess } from './utils/process-identity.ts';
-import { PUBLIC_COMMANDS } from './command-catalog.ts';
-import type { DaemonPaths } from './daemon/config.ts';
+import { AppError } from '../../kernel/errors.ts';
+import { runCmdSync } from '../../utils/exec.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import { isAgentDeviceDaemonProcess } from '../../utils/process-identity.ts';
+import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
+import type { DaemonPaths } from '../config.ts';
 import {
   removeDaemonInfo,
   removeDaemonLock,

--- a/src/daemon/client/daemon-client-transport.ts
+++ b/src/daemon/client/daemon-client-transport.ts
@@ -1,22 +1,22 @@
 import net from 'node:net';
 import http from 'node:http';
 import https from 'node:https';
-import { AppError } from './kernel/errors.ts';
-import { readNodeHttpResponseBody } from './utils/node-http.ts';
-import type { DaemonRequest, DaemonResponse } from './daemon/types.ts';
-import { emitDiagnostic } from './utils/diagnostics.ts';
-import type { DaemonPaths, DaemonTransportPreference } from './daemon/config.ts';
+import { AppError } from '../../kernel/errors.ts';
+import { readNodeHttpResponseBody } from '../../utils/node-http.ts';
+import type { DaemonRequest, DaemonResponse } from '../types.ts';
+import { emitDiagnostic } from '../../utils/diagnostics.ts';
+import type { DaemonPaths, DaemonTransportPreference } from '../config.ts';
 import {
   readDaemonHttpProgressResponse,
   readDaemonSocketProgressResponse,
   shouldReadDaemonProgressStream,
 } from './daemon-client-progress.ts';
-import { buildDaemonHttpAuthHeaders, buildDaemonHttpUrl } from './daemon/http-contract.ts';
+import { buildDaemonHttpAuthHeaders, buildDaemonHttpUrl } from '../http-contract.ts';
 import { buildHttpRpcPayload, handleDaemonHttpResponseBody } from './daemon-client-rpc.ts';
 import { handleRequestTimeout } from './daemon-client-timeout.ts';
 import { isRemoteDaemon, type DaemonInfo } from './daemon-client-metadata.ts';
-import { DAEMON_RPC_PROTOCOL_VERSION } from './daemon/http-health.ts';
-import { readVersion } from './utils/version.ts';
+import { DAEMON_RPC_PROTOCOL_VERSION } from '../http-health.ts';
+import { readVersion } from '../../utils/version.ts';
 
 type ResolvedDaemonTransport = 'socket' | 'http';
 

--- a/src/daemon/client/daemon-client.ts
+++ b/src/daemon/client/daemon-client.ts
@@ -1,10 +1,10 @@
 import type {
   DaemonRequest as SharedDaemonRequest,
   DaemonResponse as SharedDaemonResponse,
-} from './daemon/types.ts';
-import { createRequestId, emitDiagnostic, withDiagnosticTimer } from './utils/diagnostics.ts';
-import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from './command-catalog.ts';
-import { prepareRemoteRequestArtifacts } from './remote/daemon-artifacts.ts';
+} from '../types.ts';
+import { createRequestId, emitDiagnostic, withDiagnosticTimer } from '../../utils/diagnostics.ts';
+import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../../command-catalog.ts';
+import { prepareRemoteRequestArtifacts } from '../../remote/daemon-artifacts.ts';
 import {
   cleanupDaemonAfterRequest,
   ensureDaemon,
@@ -12,8 +12,8 @@ import {
 } from './daemon-client-lifecycle.ts';
 import { sendRequest } from './daemon-client-transport.ts';
 
-export { computeDaemonCodeSignature } from './daemon/code-signature.ts';
-export { downloadRemoteArtifact } from './remote/daemon-artifacts.ts';
+export { computeDaemonCodeSignature } from '../code-signature.ts';
+export { downloadRemoteArtifact } from '../../remote/daemon-artifacts.ts';
 export {
   cleanupFailedDaemonStartupMetadata,
   resolveDaemonStartupHint,

--- a/src/utils/__tests__/daemon-client-lifecycle.test.ts
+++ b/src/utils/__tests__/daemon-client-lifecycle.test.ts
@@ -27,8 +27,8 @@ import {
   computeDaemonCodeSignature,
   sendToDaemon,
   type DaemonRequest,
-} from '../../daemon-client.ts';
-import { sendRequest } from '../../daemon-client-transport.ts';
+} from '../../daemon/client/daemon-client.ts';
+import { sendRequest } from '../../daemon/client/daemon-client-transport.ts';
 import {
   closeLoopbackServer,
   listenOnLoopback,

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -21,7 +21,7 @@ import {
   resolveDaemonStartupHint,
   sendToDaemon,
   shouldResetDaemonAfterRequestTimeout,
-} from '../../daemon-client.ts';
+} from '../../daemon/client/daemon-client.ts';
 import { resolveDaemonPaths } from '../../daemon/config.ts';
 import {
   isProcessAlive,


### PR DESCRIPTION
## What

Moves the daemon **client driver** (the in-process side that sends requests to a running daemon) out of the `src/` root into **`src/daemon/client/`**, per [plans/perfect-shape.md §5.5](../blob/main/plans/perfect-shape.md) ("the `daemon-` prefix co-locates client driver + server bootstrap + proxy" at src root).

Files moved (7): `daemon-client`, `daemon-client-lifecycle`, `daemon-client-metadata`, `daemon-client-progress`, `daemon-client-rpc`, `daemon-client-timeout`, `daemon-client-transport`.

## How

- git renames; **19 importers** repointed via the resolve-based codemod (intra-set stays `./`, `kernel` → `../../`, daemon/remote deps recomputed).
- **Layering Guard verified**: none of these import `src/commands/*`, so they're safe now that they live under `src/daemon/`.
- Not a public export; no rslib impact.
- `fallow-baselines/health.json`: rekeyed the 4 moved-file entries, and bumped `daemon-client-lifecycle.ts` from `*_moderate` → `*_high` — the move brought `startLocalDaemon` into audit scope and surfaced that its **pre-existing** complexity (unchanged by this move; 17 cyclomatic / 33 cognitive) had a **stale** baseline entry. Scoped to just this file (no full-baseline regen, which would have swept in unrelated drift).

## Safety

typecheck ✅ · oxlint ✅ · format ✅ · build ✅ · fallow audit ✅ (no issues in 21 changed files) · daemon-client unit tests ✅ (44 passing). Behaviorless path codemod, 20 files.

## Scope note

`backend.ts` and the daemon **server** bootstrap remain at root; the `daemon/server/` split is a separate follow-up.