### PR TITLE
fix: respect prepare timeout for runner health checks

### DIFF
--- a/src/daemon/client/daemon-client.ts
+++ b/src/daemon/client/daemon-client.ts
@@ -11,6 +11,11 @@ import {
   resolveClientSettings,
 } from './daemon-client-lifecycle.ts';
 import { sendRequest } from './daemon-client-transport.ts';
+import {
+  DAEMON_REQUEST_TIMEOUT_MS,
+  INSTALL_REQUEST_TIMEOUT_MS,
+  PREPARE_REQUEST_TIMEOUT_MS,
+} from '../request-timeouts.ts';
 
 export { computeDaemonCodeSignature } from '../code-signature.ts';
 export { downloadRemoteArtifact } from '../../remote/daemon-artifacts.ts';
@@ -22,12 +27,6 @@ export { canConnectSocket } from './daemon-client-transport.ts';
 export { shouldResetDaemonAfterRequestTimeout } from './daemon-client-timeout.ts';
 export type DaemonRequest = SharedDaemonRequest;
 export type DaemonResponse = SharedDaemonResponse;
-
-const REQUEST_TIMEOUT_MS = 90_000;
-const PREPARE_REQUEST_TIMEOUT_MS = 240_000;
-// Keep this above the longest platform install subprocess timeout so the client
-// envelope does not abort a still-progressing device install first.
-const INSTALL_REQUEST_TIMEOUT_MS = 180_000;
 
 export async function sendToDaemon(req: Omit<DaemonRequest, 'token'>): Promise<DaemonResponse> {
   const requestId = req.meta?.requestId ?? createRequestId();
@@ -123,7 +122,7 @@ export function resolveDaemonRequestTimeoutMs(
   }
   if (req.command === PUBLIC_COMMANDS.prepare) return PREPARE_REQUEST_TIMEOUT_MS;
   if (isInstallLikeCommand(req.command)) return INSTALL_REQUEST_TIMEOUT_MS;
-  return REQUEST_TIMEOUT_MS;
+  return DAEMON_REQUEST_TIMEOUT_MS;
 }
 
 function isExplicitTimeoutCommand(command: string | undefined): boolean {

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -2509,7 +2509,7 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
     expect.objectContaining({
       cleanStaleBundles: true,
       buildTimeoutMs: 240000,
-      healthTimeoutMs: 90000,
+      healthTimeoutMs: 120000,
       logPath: expect.stringMatching(/daemon\.log$/),
       requestId: 'prepare-request',
       startupTimeoutMs: 240000,
@@ -2562,7 +2562,7 @@ test('prepare ios-runner starts the XCTest runner on an explicit macOS selector'
     expect.objectContaining({ platform: 'macos', id: 'host-macos-local' }),
     expect.objectContaining({
       buildTimeoutMs: 240000,
-      healthTimeoutMs: 90000,
+      healthTimeoutMs: 120000,
       requestId: 'prepare-macos-request',
     }),
   );

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -2509,8 +2509,13 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
     expect.objectContaining({
       cleanStaleBundles: true,
       buildTimeoutMs: 240000,
-      healthTimeoutMs: 120000,
+      healthTimeoutMs: 240000,
       logPath: expect.stringMatching(/daemon\.log$/),
+      prepareDeadline: expect.objectContaining({
+        elapsedMs: expect.any(Function),
+        isExpired: expect.any(Function),
+        remainingMs: expect.any(Function),
+      }),
       requestId: 'prepare-request',
       startupTimeoutMs: 240000,
     }),
@@ -2562,7 +2567,12 @@ test('prepare ios-runner starts the XCTest runner on an explicit macOS selector'
     expect.objectContaining({ platform: 'macos', id: 'host-macos-local' }),
     expect.objectContaining({
       buildTimeoutMs: 240000,
-      healthTimeoutMs: 120000,
+      healthTimeoutMs: 240000,
+      prepareDeadline: expect.objectContaining({
+        elapsedMs: expect.any(Function),
+        isExpired: expect.any(Function),
+        remainingMs: expect.any(Function),
+      }),
       requestId: 'prepare-macos-request',
     }),
   );

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -42,6 +42,7 @@ import { LeaseRegistry } from '../lease-registry.ts';
 const PREPARE_IOS_RUNNER_MIN_STARTUP_TIMEOUT_MS = 45_000;
 const PREPARE_IOS_RUNNER_DEFAULT_BUILD_TIMEOUT_MS = 5 * 60_000;
 const PREPARE_IOS_RUNNER_HEALTH_TIMEOUT_MS = 90_000;
+const PREPARE_IOS_RUNNER_MAX_HEALTH_TIMEOUT_MS = 3 * 60_000;
 
 async function handlePrepareCommand(params: {
   req: DaemonRequest;
@@ -99,7 +100,7 @@ function buildPrepareIosRunnerOptions(
     cleanStaleBundles: true,
     startupTimeoutMs: resolvePrepareIosRunnerStartupTimeoutMs(req.flags?.timeoutMs),
     buildTimeoutMs,
-    healthTimeoutMs: Math.min(buildTimeoutMs, PREPARE_IOS_RUNNER_HEALTH_TIMEOUT_MS),
+    healthTimeoutMs: resolvePrepareIosRunnerHealthTimeoutMs(req.flags?.timeoutMs, buildTimeoutMs),
   };
 }
 
@@ -115,6 +116,24 @@ function readPrepareIosRunnerBuildTimeoutMs(req: DaemonRequest): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? value
     : PREPARE_IOS_RUNNER_DEFAULT_BUILD_TIMEOUT_MS;
+}
+
+function resolvePrepareIosRunnerHealthTimeoutMs(
+  timeoutMs: unknown,
+  buildTimeoutMs: number,
+): number {
+  const configuredTimeout =
+    typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? Math.floor(timeoutMs)
+      : undefined;
+  if (!configuredTimeout) {
+    return Math.min(buildTimeoutMs, PREPARE_IOS_RUNNER_HEALTH_TIMEOUT_MS);
+  }
+  return Math.min(
+    buildTimeoutMs,
+    PREPARE_IOS_RUNNER_MAX_HEALTH_TIMEOUT_MS,
+    Math.max(PREPARE_IOS_RUNNER_HEALTH_TIMEOUT_MS, Math.floor(configuredTimeout / 2)),
+  );
 }
 
 function prepareIosRunnerResponseData(

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -38,11 +38,8 @@ import { handleSessionObservabilityCommands } from './session-observability.ts';
 import { handleSessionReplayCommands } from './session-replay.ts';
 import { getSessionCommandKind } from '../daemon-command-registry.ts';
 import { LeaseRegistry } from '../lease-registry.ts';
-
-const PREPARE_IOS_RUNNER_MIN_STARTUP_TIMEOUT_MS = 45_000;
-const PREPARE_IOS_RUNNER_DEFAULT_BUILD_TIMEOUT_MS = 5 * 60_000;
-const PREPARE_IOS_RUNNER_HEALTH_TIMEOUT_MS = 90_000;
-const PREPARE_IOS_RUNNER_MAX_HEALTH_TIMEOUT_MS = 3 * 60_000;
+import { PREPARE_REQUEST_TIMEOUT_MS } from '../request-timeouts.ts';
+import { Deadline } from '../../utils/retry.ts';
 
 async function handlePrepareCommand(params: {
   req: DaemonRequest;
@@ -76,7 +73,7 @@ async function handlePrepareCommand(params: {
   const startedAtMs = Date.now();
   const result = await prepareIosRunner(
     device,
-    buildPrepareIosRunnerOptions(req, session, logPath),
+    buildPrepareIosRunnerOptions(req, session, logPath, startedAtMs),
   );
   const durationMs = Math.max(0, Date.now() - startedAtMs);
   return {
@@ -89,8 +86,9 @@ function buildPrepareIosRunnerOptions(
   req: DaemonRequest,
   session: SessionState | undefined,
   logPath: string,
+  startedAtMs: number,
 ): Parameters<typeof prepareIosRunner>[1] {
-  const buildTimeoutMs = readPrepareIosRunnerBuildTimeoutMs(req);
+  const timeoutMs = readPrepareIosRunnerTimeoutMs(req);
   return {
     ...buildAppleRunnerRequestOptions({
       req,
@@ -98,42 +96,18 @@ function buildPrepareIosRunnerOptions(
       traceLogPath: session?.trace?.outPath,
     }),
     cleanStaleBundles: true,
-    startupTimeoutMs: resolvePrepareIosRunnerStartupTimeoutMs(req.flags?.timeoutMs),
-    buildTimeoutMs,
-    healthTimeoutMs: resolvePrepareIosRunnerHealthTimeoutMs(req.flags?.timeoutMs, buildTimeoutMs),
+    buildTimeoutMs: timeoutMs,
+    healthTimeoutMs: timeoutMs,
+    prepareDeadline: Deadline.fromTimeoutMs(timeoutMs, startedAtMs),
+    startupTimeoutMs: timeoutMs,
   };
 }
 
-function resolvePrepareIosRunnerStartupTimeoutMs(timeoutMs: unknown): number | undefined {
-  if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return undefined;
-  }
-  return Math.max(PREPARE_IOS_RUNNER_MIN_STARTUP_TIMEOUT_MS, Math.floor(timeoutMs));
-}
-
-function readPrepareIosRunnerBuildTimeoutMs(req: DaemonRequest): number {
+function readPrepareIosRunnerTimeoutMs(req: DaemonRequest): number {
   const value = req.flags?.timeoutMs;
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? value
-    : PREPARE_IOS_RUNNER_DEFAULT_BUILD_TIMEOUT_MS;
-}
-
-function resolvePrepareIosRunnerHealthTimeoutMs(
-  timeoutMs: unknown,
-  buildTimeoutMs: number,
-): number {
-  const configuredTimeout =
-    typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
-      ? Math.floor(timeoutMs)
-      : undefined;
-  if (!configuredTimeout) {
-    return Math.min(buildTimeoutMs, PREPARE_IOS_RUNNER_HEALTH_TIMEOUT_MS);
-  }
-  return Math.min(
-    buildTimeoutMs,
-    PREPARE_IOS_RUNNER_MAX_HEALTH_TIMEOUT_MS,
-    Math.max(PREPARE_IOS_RUNNER_HEALTH_TIMEOUT_MS, Math.floor(configuredTimeout / 2)),
-  );
+    : PREPARE_REQUEST_TIMEOUT_MS;
 }
 
 function prepareIosRunnerResponseData(

--- a/src/daemon/request-timeouts.ts
+++ b/src/daemon/request-timeouts.ts
@@ -1,0 +1,6 @@
+export const DAEMON_REQUEST_TIMEOUT_MS = 90_000;
+export const PREPARE_REQUEST_TIMEOUT_MS = 240_000;
+
+// Keep this above the longest platform install subprocess timeout so the client
+// envelope does not abort a still-progressing device install first.
+export const INSTALL_REQUEST_TIMEOUT_MS = 180_000;

--- a/src/platforms/ios/__tests__/runner-command-retry.test.ts
+++ b/src/platforms/ios/__tests__/runner-command-retry.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { IOS_SIMULATOR } from '../../../__tests__/test-utils/index.ts';
 import { clearRequestCanceled, markRequestCanceled } from '../../../daemon/request-cancel.ts';
 import { AppError } from '../../../kernel/errors.ts';
+import { Deadline } from '../../../utils/retry.ts';
 import type { RunnerSession } from '../runner-session-types.ts';
 
 const {
@@ -172,6 +173,35 @@ test('prepareIosRunner retries a fresh launch session when the health check cann
       reason: 'Runner did not accept connection',
     },
   );
+});
+
+test('prepareIosRunner spends one shared deadline across setup and health check', async () => {
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(1_000);
+    const session = makeRunnerSession({ port: 8100 });
+    const prepareDeadline = Deadline.fromTimeoutMs(100_000);
+
+    mockEnsureRunnerSession.mockImplementationOnce(async () => {
+      vi.setSystemTime(31_000);
+      return session;
+    });
+    mockExecuteRunnerCommandWithSession.mockResolvedValueOnce({ uptimeMs: 42 });
+
+    const result = await prepareIosRunner(IOS_SIMULATOR, {
+      buildTimeoutMs: 100_000,
+      healthTimeoutMs: 100_000,
+      prepareDeadline,
+      startupTimeoutMs: 100_000,
+    });
+
+    assert.deepEqual(result.runner, { uptimeMs: 42 });
+    assert.equal(mockEnsureRunnerSession.mock.calls[0]?.[1]?.buildTimeoutMs, 100_000);
+    assert.equal(mockEnsureRunnerSession.mock.calls[0]?.[1]?.startupTimeoutMs, 100_000);
+    assert.equal(mockExecuteRunnerCommandWithSession.mock.calls[0]?.[4], 70_000);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('prewarmIosRunnerSession proves cached runner health with uptime', async () => {

--- a/src/platforms/ios/runner-lifecycle.ts
+++ b/src/platforms/ios/runner-lifecycle.ts
@@ -30,6 +30,10 @@ export type PrepareIosRunnerResult = AppleRunnerPrepareResult;
 
 const PREPARE_RUNNER_HEALTH_MAX_SESSION_ATTEMPTS = 2;
 
+type PrepareDeadlinePhaseTimeouts = Partial<
+  Pick<PrepareIosRunnerOptions, 'buildTimeoutMs' | 'startupTimeoutMs'>
+>;
+
 export async function prepareLocalIosRunner(
   device: DeviceInfo,
   options: PrepareIosRunnerOptions,
@@ -72,6 +76,7 @@ async function runPrepareAttempt(params: {
   const session = await ensureRunnerSession(device, {
     ...options,
     cleanStaleBundles: attempt > 1 ? true : options.cleanStaleBundles,
+    ...readPrepareDeadlinePhaseTimeouts(options, 'runner_session'),
   });
   const connectMs = Date.now() - connectStartedAt;
   try {
@@ -169,6 +174,7 @@ async function recoverBadCachedRunnerArtifact(params: {
     ...options,
     cleanStaleBundles: true,
     forceRunnerXctestrunRebuild: true,
+    ...readPrepareDeadlinePhaseTimeouts(options, 'runner_rebuild'),
   });
   const connectMs = Date.now() - connectStartedAt;
   try {
@@ -364,12 +370,17 @@ async function runPrepareHealthCheck(
   reason?: { recoveryReason?: string; failureReason?: string },
 ): Promise<PrepareIosRunnerResult> {
   const healthStartedAt = Date.now();
+  const timeoutMs = readPreparePhaseTimeoutMs(
+    options.prepareDeadline,
+    options.healthTimeoutMs,
+    'runner_health',
+  );
   const runner = await executeRunnerCommandWithSession(
     device,
     session,
     command,
     options.logPath,
-    options.healthTimeoutMs,
+    timeoutMs,
     signal,
   );
   return buildPrepareIosRunnerResult(
@@ -379,6 +390,35 @@ async function runPrepareHealthCheck(
     Date.now() - healthStartedAt,
     reason,
   );
+}
+
+function readPrepareDeadlinePhaseTimeouts(
+  options: PrepareIosRunnerOptions,
+  phase: string,
+): PrepareDeadlinePhaseTimeouts {
+  if (!options.prepareDeadline) return {};
+  const timeoutMs = readPreparePhaseTimeoutMs(
+    options.prepareDeadline,
+    options.buildTimeoutMs,
+    phase,
+  );
+  return { buildTimeoutMs: timeoutMs, startupTimeoutMs: timeoutMs };
+}
+
+function readPreparePhaseTimeoutMs(
+  deadline: PrepareIosRunnerOptions['prepareDeadline'],
+  fallbackTimeoutMs: number | undefined,
+  phase: string,
+): number {
+  if (!deadline) return fallbackTimeoutMs ?? RUNNER_STARTUP_TIMEOUT_MS;
+  const remainingMs = Math.floor(deadline.remainingMs());
+  if (remainingMs <= 0) {
+    throw new AppError('COMMAND_FAILED', 'prepare ios-runner timed out', {
+      phase,
+      reason: 'prepare_deadline_expired',
+    });
+  }
+  return remainingMs;
 }
 
 function shouldRecoverBadCachedRunnerArtifact(

--- a/src/platforms/ios/runner-provider.ts
+++ b/src/platforms/ios/runner-provider.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { RunnerLogicalLeaseContext } from '../../core/runner-lease-context.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
+import type { Deadline } from '../../utils/retry.ts';
 import type { RunnerCommand } from './runner-contract.ts';
 import type {
   RunnerXctestrunArtifactState,
@@ -27,6 +28,7 @@ export type AppleRunnerPrewarmOptions = AppleRunnerLifecycleOptions;
 
 export type AppleRunnerPrepareOptions = AppleRunnerLifecycleOptions & {
   healthTimeoutMs: number;
+  prepareDeadline?: Deadline;
 };
 
 export type AppleRunnerPrepareResult = {


### PR DESCRIPTION
## Summary

Make `prepare ios-runner --timeout` extend the runner health-readiness window instead of keeping it hard-capped at 90s.
<details>

The failing iOS smoke job passed `--timeout 420000`, but only build/startup used that budget. On slow hosted macOS/Xcode runners, the rebuilt XCTest runner could still be starting when the fixed 90s health probe expired. The health timeout now derives from the explicit prepare timeout, capped at 3 minutes; default behavior remains 90s.

</details>

## Validation

Focused prepare-handler test passed: `pnpm exec vitest run src/daemon/handlers/__tests__/session.test.ts --testNamePattern "prepare ios-runner"`.

Static and formatting gates passed: `pnpm typecheck`, `pnpm format`.