### PR TITLE
docs: fix stale platforms/ios paths after Apple consolidation (#968) + remaining-work plan

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -62,14 +62,6 @@
       "exports": ["installAndroidInstallablePath"]
     },
     {
-      "file": "src/platforms/ios/apps.ts",
-      "exports": ["listSimulatorApps", "uninstallIosApp"]
-    },
-    {
-      "file": "src/platforms/ios/index.ts",
-      "exports": ["listSimulatorApps", "uninstallIosApp"]
-    },
-    {
       "file": "src/platforms/apple/core/apps.ts",
       "exports": ["listSimulatorApps", "uninstallIosApp"]
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Single-context repo. Read `CONTEXT.md` for domain language and testing/architect
 ## Exploration & Token Use
 - Prefer these first-pass commands over broad reads:
   - `rg -n "<symbol|command|flag>" src test`
-  - `rg --files src/daemon/handlers src/platforms/ios src/platforms/android`
+  - `rg --files src/daemon/handlers src/platforms/apple src/platforms/ios src/platforms/android`
   - `git diff -- <path>` for active-branch context
   - read `.oxlintrc.json` before treating lint output as source-level bugs
 - For files over 500 LOC, search for the relevant type/function/section first, then read a bounded range.
@@ -105,17 +105,17 @@ Single-context repo. Read `CONTEXT.md` for domain language and testing/architect
 - `open/close/replay/apps/appstate`: `src/daemon/handlers/session.ts` -> `src/daemon/session-store.ts` -> `src/daemon/handlers/__tests__/session.test.ts`
 - `click/fill/get/is`: `src/daemon/handlers/interaction.ts` -> `src/daemon/selectors.ts` -> `src/daemon/handlers/__tests__/interaction.test.ts`
 - `snapshot/wait/settings/alert`: `src/daemon/handlers/snapshot.ts` -> `src/daemon/snapshot-processing.ts` -> `src/daemon/handlers/__tests__/snapshot-handler.test.ts`
-- `record/trace`: `src/daemon/handlers/record-trace.ts` -> `src/platforms/ios/runner-client.ts` -> `src/daemon/handlers/__tests__/record-trace.test.ts`
+- `record/trace`: `src/daemon/handlers/record-trace.ts` -> `src/platforms/apple/core/runner/runner-client.ts` -> `src/daemon/handlers/__tests__/record-trace.test.ts`
 
-## iOS Runner Seams
-- Keep dependency direction clean:
+## Apple Runner Seams
+- The OS-agnostic Apple XCTest runner lives under `src/platforms/apple/core/runner/`. Keep dependency direction clean:
   - `runner-client.ts`: command execution + retry behavior
   - `runner-transport.ts`: connection/probing/HTTP transport
   - `runner-contract.ts`: shared `RunnerCommand` type and runner connect/error helpers
   - `runner-session.ts`: session lifecycle and request/response execution
   - `runner-xctestrun.ts`: xctestrun preparation/build/cache logic
 - `runner-transport.ts` must not import back from `runner-client.ts`.
-- If changing runner connect errors, retry policy, or command typing, start in `src/platforms/ios/runner-contract.ts` before touching client/transport files.
+- If changing runner connect errors, retry policy, or command typing, start in `src/platforms/apple/core/runner/runner-contract.ts` before touching client/transport files.
 
 ## Adding a New CLI Flag
 
@@ -139,7 +139,7 @@ Command-only flags (like `find --first`) that do not flow to the platform layer 
 - Use `keyboard dismiss` for iOS keyboard dismissal; it may tap safe native controls such as `Done` but must not fall back to system back navigation.
 - Do not remove shared snapshot/session model behavior without full migration.
 - Command/device support must come from `src/core/capabilities.ts`.
-- Apple-family target changes must keep `src/kernel/device.ts`, `src/core/capabilities.ts`, `src/core/dispatch-resolve.ts`, `src/platforms/ios/devices.ts`, and `src/platforms/ios/runner-xctestrun.ts` in sync.
+- Apple-family target changes must keep `src/kernel/device.ts`, `src/core/capabilities.ts`, `src/core/dispatch-resolve.ts`, `src/platforms/apple/core/devices.ts`, and `src/platforms/apple/core/runner/runner-xctestrun.ts` in sync.
 - iOS simulator-set scoping is iOS-specific: do not let `iosSimulatorDeviceSet` hide the host macOS desktop target when `--platform macos` or `--target desktop` is requested.
 - If Swift runner code changes, run `pnpm build:xcuitest`.
 - Use `inferFillText` and `uniqueStrings` from `src/daemon/action-utils.ts`.
@@ -243,7 +243,7 @@ Command-only flags (like `find --first`) that do not flow to the platform layer 
 - Inlining `is` predicate logic in handlers.
 - Returning non-normalized user-facing errors.
 - Duplicating logs backend logic in handlers instead of `src/daemon/app-log.ts`.
-- Growing `src/daemon/handlers/session.ts` or `src/platforms/ios/apps.ts` further without extracting Apple-family/macOS-specific helpers first.
+- Growing `src/daemon/handlers/session.ts` or `src/platforms/apple/core/apps.ts` further without extracting Apple-family/macOS-specific helpers first.
 - Reintroducing an npm lockfile or assuming ESLint/Prettier still exist in this repo.
 - Changing `tsconfig.lib.json`/build tooling without running `pnpm check:tooling`; declaration generation is stricter than `tsc --noEmit`.
 
@@ -280,7 +280,7 @@ Command-only flags (like `find --first`) that do not flow to the platform layer 
 - Command identity + command surface: `src/command-catalog.ts`, `src/commands/command-surface.ts`, `src/commands/command-contract.ts`, `src/commands/client-command-contracts.ts`
 - CLI grammar: `src/commands/cli-grammar.ts`, `src/commands/cli-grammar/*`
 - Daemon request projection: `src/commands/command-projection.ts`
-- Platform backends: `src/platforms/ios/*`, `ios-runner/*`, `src/platforms/android/*`
+- Platform backends: `src/platforms/apple/*`, `src/platforms/ios/*`, `ios-runner/*`, `src/platforms/android/*`
 
 ## Pull Requests
 - Before opening PR: ensure no conflict markers/unmerged paths.

--- a/ios-runner/README.md
+++ b/ios-runner/README.md
@@ -15,7 +15,7 @@ Current internal runner for iOS, tvOS, and macOS desktop automation.
 Protocol and maintenance references:
 
 - Protocol overview: [`RUNNER_PROTOCOL.md`](RUNNER_PROTOCOL.md)
-- TypeScript client: [`../src/platforms/ios/runner-client.ts`](../src/platforms/ios/runner-client.ts)
+- TypeScript client: [`../src/platforms/apple/core/runner/runner-client.ts`](../src/platforms/apple/core/runner/runner-client.ts)
 - Swift wire models: [`AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift`](AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift)
 
 ## UITest Runner File Map

--- a/ios-runner/RUNNER_PROTOCOL.md
+++ b/ios-runner/RUNNER_PROTOCOL.md
@@ -41,7 +41,7 @@ Examples:
 
 The current command names are defined in:
 
-- [`../src/platforms/ios/runner-client.ts`](../src/platforms/ios/runner-client.ts)
+- [`../src/platforms/apple/core/runner/runner-client.ts`](../src/platforms/apple/core/runner/runner-client.ts)
 - [`AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift`](AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Models.swift)
 
 ## Response Shape


### PR DESCRIPTION
## Summary

Post-#968 (Apple platform consolidation) follow-up: **doc/config path fixes**, **live runner validation**, and the **decomposed plan for the remaining Phase 3 work**.

### 1. Stale path fixes (the code change here)
#968 moved the OS-agnostic Apple runner engine from `src/platforms/ios/` to `src/platforms/apple/core/`, but several docs/config still pointed at the old locations (actively misleading to agents grepping those paths):
- **AGENTS.md** — repointed the runner-seam map, the Apple-family sync rule, the `record/trace` seam, the search-roots hint, and the platform-backends list at `src/platforms/apple/core/...`; renamed "iOS Runner Seams" → "Apple Runner Seams".
- **.fallowrc.json** — dropped the two stale `ignoreExports` entries for the removed `src/platforms/ios/{apps,index}.ts` (the live `src/platforms/apple/core/apps.ts` entry already covers those test-only exports).
- **ios-runner/{README,RUNNER_PROTOCOL}.md** — pointed the TypeScript-client links at `src/platforms/apple/core/runner/runner-client.ts`.

Docs/config only; no behavior change. `fallow audit`, `tsc`, `oxlint --deny-warnings`, and `rslib build` stay green.

### 2. Live runner validation
Ran the full iOS simulator replay suite on a booted **iPhone 17 Pro** (building the runner fresh): **6/6 passed in 160s** — `01-settings`, `02-deep-navigation`, `03-scroll-discovery`, `04-text-input-keyboard`, `05-app-lifecycle`, `06-swipe-gestures`. Confirms the consolidated Apple runner works live across tap/scroll/type/swipe/lifecycle. (This is the live smoke replay the plan now relies on after the request-count CI gate was removed.)

### 3. My #968 review follow-ups — already resolved in the merge
Items 3–5 from the review are addressed in the merged #968: the existing iOS/tvOS/macOS `disallowed` SDK lists do **not** contain `xros`/`xrsimulator` (only the new visionOS row does); the `device.ts` visionOS comment is accurate; and `apple/core` no longer imports backward through `ios/` shims (the shims are deleted, imports point at siblings).

## Remaining Phase 3 work (plan — needs issues filed)

The remaining work from `plans/phase3-platform-plugin-progress.md` decomposes into the units below. I have full agent-ready bodies for each but **could not auto-file them as GitHub issues** (blocked by the external-write guard — needs your OK). Once filed, `plans/phase3-platform-plugin-progress.md` can be removed (its content lives in the issues + `perfect-shape.md` §5–7 + ADR-0009).

Sequencing (→ = blocked by):
```
b.2 ─┬─> d.5
b.3 ─┴─> d.1 ──┐
d.2 ───────────┤
d.4 ───────────┼─> d.3 (LAST: public Platform collapse ios/macos→apple)
d.5 ───────────┘
cleanup-tests / cosmetic-rename  (independent)
```

| Unit | Summary | Label | Blocked by |
|---|---|---|---|
| **b.2** | Relocate `supports()`/`unsupportedHint()` Apple closures onto `plugin.capability.supportsByDefault` (parity-gated) | ready-for-agent | — |
| **b.3** | Platform-neutral daemon facets `providers`/`recording`/`appLog`/`perf` (4-way fan-out, each parity-gated) | ready-for-agent | — |
| **d.1** | Relocate plugin + interactor + `interactions.ts` under `platforms/apple` | ready-for-agent | b.3 |
| **d.2** | Promote tvOS to an explicit Apple-OS leaf (preserve focus-only/UNSUPPORTED-tap) | ready-for-agent | — |
| **d.4** | watchOS unsupported sentinel | ready-for-agent | — |
| **d.5** | Per-`AppleOS` capability tables | ready-for-agent | b.2 |
| **d.3** | Final public `Platform` collapse `ios`/`macos` → `apple` (~59 macOS + 47 `isApplePlatform` sites) | ready-for-human | b.2,b.3,d.1,d.2,d.5 |
| **cleanup** | Relocate the 18 Apple unit tests out of `platforms/ios/__tests__` (+ split `index.test.ts`, move `recording-scripts.test.ts`) | ready-for-agent | — |
| **cosmetic** | Rename `ios-runner` → `apple-runner` + `runIosRunnerCommand`/`createIosRunnerCachePrewarmOnColdBoot` | backlog | — |

**Discipline (perfect-shape §7):** every derived table/closure is pinned by a table-/closure-equivalence parity test across `src/__tests__/test-utils/device-fixtures.ts` before any hand site is deleted; do not flatten the leaves (two-finger XCTest synthesis, tvOS focus-only, AppKit macOS helper).
