### PR TITLE
fix: exempt sdk/ public barrels from R3 platforms-seam — unblock red main

### DIFF
--- a/scripts/layering/check.ts
+++ b/scripts/layering/check.ts
@@ -89,6 +89,14 @@ function isDaemonServer(rel: string): boolean {
   return rel.startsWith('src/daemon/') && !rel.startsWith('src/daemon/client/');
 }
 
+// sdk/ are the package's PUBLIC re-export barrels (§5.5 "sdk = re-export barrels
+// only"). They legitimately re-export platform symbols as part of the public API,
+// and are OFF the CLI cold path (not imported by bin.ts/cli), so exempting them
+// from R3 does not regress cold-start — they sit above the internal DAG R3 governs.
+function isSdkBarrel(rel: string): boolean {
+  return rel.startsWith('src/sdk/');
+}
+
 // ── Import extraction ───────────────────────────────────────────────────────
 
 function scanDynamicImports(line: string, lineNo: number): ImportEdge[] {
@@ -180,7 +188,7 @@ function ruleCommandsFloor(ctx: EdgeContext): Violation | null {
 // daemon server; everywhere else use a dynamic import() or a type-only import.
 function rulePlatformsSeam(ctx: EdgeContext): Violation | null {
   if (ctx.toTop !== 'platforms' || ctx.imp.dynamic || ctx.imp.typeOnly) return null;
-  if (isCoreInteractor(ctx.file) || isDaemonServer(ctx.file)) return null;
+  if (isCoreInteractor(ctx.file) || isDaemonServer(ctx.file) || isSdkBarrel(ctx.file)) return null;
   return {
     rule: 'R3 platforms-seam',
     file: ctx.file,


### PR DESCRIPTION
## Urgent — `main` is RED (Layering Guard failing)

**Cause:** a Phase-5 merge-order self-inconsistency. #984 added the R3 platforms-seam layering rule; #986 moved the public SDK entry barrels into `src/sdk/`. Neither PR saw the other (the sdk agent ran before the lint existed on main), so once both merged, `scripts/layering/check.ts` flags the sdk barrels' static `platforms/` re-exports and the **Layering Guard job fails on every PR**.

**Fix:** exempt `src/sdk/` from R3, alongside `core/interactors/` and the daemon server. This is correct, not a waiver:
- sdk/ are the package's **public re-export barrels** (§5.5 "sdk = re-export barrels only") — they legitimately expose platform symbols (`android/manifest`, `install-source`, `android/logcat`, …) as part of the public API.
- They are **off the CLI cold path** (not imported by `bin.ts`/`cli`), so exempting them does **not** regress cold-start — the concern R3 protects.

**Verified:** `node scripts/layering/check.ts` → OK (635 files satisfy R1/R2/R3); oxfmt+oxlint clean. Docs-adjacent (one script file, ~9 lines).

Merge this to restore green main.