### PR TITLE
test: relocate the 2 deferred Apple runner/recording tests (closes #980)

### DIFF
--- a/src/platforms/apple/core/__tests__/runner-client.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-client.test.ts
@@ -10,37 +10,38 @@ const { mockRunCmdStreaming, mockRepairMacOsRunnerProductsIfNeeded } = vi.hoiste
   mockRepairMacOsRunnerProductsIfNeeded: vi.fn(),
 }));
 
-vi.mock('../../../utils/exec.ts', async () => {
-  const actual =
-    await vi.importActual<typeof import('../../../utils/exec.ts')>('../../../utils/exec.ts');
+vi.mock('../../../../utils/exec.ts', async () => {
+  const actual = await vi.importActual<typeof import('../../../../utils/exec.ts')>(
+    '../../../../utils/exec.ts',
+  );
   return {
     ...actual,
     runCmdStreaming: mockRunCmdStreaming,
   };
 });
 
-vi.mock('../../apple/core/runner/runner-macos-products.ts', async () => {
-  const actual = await vi.importActual<
-    typeof import('../../apple/core/runner/runner-macos-products.ts')
-  >('../../apple/core/runner/runner-macos-products.ts');
+vi.mock('../runner/runner-macos-products.ts', async () => {
+  const actual = await vi.importActual<typeof import('../runner/runner-macos-products.ts')>(
+    '../runner/runner-macos-products.ts',
+  );
   return {
     ...actual,
     repairMacOsRunnerProductsIfNeeded: mockRepairMacOsRunnerProductsIfNeeded,
   };
 });
 
-import type { DeviceInfo } from '../../../kernel/device.ts';
+import type { DeviceInfo } from '../../../../kernel/device.ts';
 import {
   type RequestProgressEvent,
   withRequestProgressSink,
-} from '../../../daemon/request-progress.ts';
-import { flushDiagnosticsToSessionFile, withDiagnosticsScope } from '../../../utils/diagnostics.ts';
-import { AppError } from '../../../kernel/errors.ts';
-import { isReadOnlyRunnerCommand } from '../../apple/core/runner/runner-command-traits.ts';
+} from '../../../../daemon/request-progress.ts';
 import {
-  withRunnerCommandId,
-  type RunnerCommand,
-} from '../../apple/core/runner/runner-contract.ts';
+  flushDiagnosticsToSessionFile,
+  withDiagnosticsScope,
+} from '../../../../utils/diagnostics.ts';
+import { AppError } from '../../../../kernel/errors.ts';
+import { isReadOnlyRunnerCommand } from '../runner/runner-command-traits.ts';
+import { withRunnerCommandId, type RunnerCommand } from '../runner/runner-contract.ts';
 import {
   assertSafeDerivedCleanup,
   isRetryableRunnerError,
@@ -52,7 +53,7 @@ import {
   resolveRunnerMaxConcurrentDestinationsFlag,
   resolveRunnerSigningBuildSettings,
   shouldRetryRunnerConnectError,
-} from '../../apple/core/runner/runner-client.ts';
+} from '../runner/runner-client.ts';
 import {
   acquireRunnerXctestrunCacheLock,
   ensureXctestrunArtifact,
@@ -66,8 +67,8 @@ import {
   shouldDeleteRunnerDerivedRootEntry,
   writeRunnerCacheMetadata,
   xctestrunReferencesProjectRoot,
-} from '../../apple/core/runner/runner-xctestrun.ts';
-import { parseRunnerResponse } from '../../apple/core/runner/runner-session.ts';
+} from '../runner/runner-xctestrun.ts';
+import { parseRunnerResponse } from '../runner/runner-session.ts';
 
 const iosSimulator: DeviceInfo = {
   platform: 'ios',
@@ -180,7 +181,7 @@ const runnerProtocolCommandFixtures: Record<RunnerCommand['command'], RunnerComm
   shutdown: { command: 'shutdown' },
 };
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../');
 
 async function makeTmpDir(): Promise<string> {
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-xctestrun-'));

--- a/src/recording/__tests__/recording-scripts.test.ts
+++ b/src/recording/__tests__/recording-scripts.test.ts
@@ -2,15 +2,15 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runCmd } from '../../../utils/exec.ts';
-import { getRecordingOverlaySupportWarning } from '../../../recording/overlay.ts';
+import { runCmd } from '../../utils/exec.ts';
+import { getRecordingOverlaySupportWarning } from '../overlay.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const recordingScriptsDir = path.resolve(
   __dirname,
-  '../../../../ios-runner/AgentDeviceRunner/RecordingScripts',
+  '../../../ios-runner/AgentDeviceRunner/RecordingScripts',
 );
-const recordingTestSupportDir = path.resolve(__dirname, '../../../../test/integration/support');
+const recordingTestSupportDir = path.resolve(__dirname, '../../../test/integration/support');
 const SWIFT_TYPECHECK_TIMEOUT_MS = 60_000;
 
 async function assertSwiftScriptTypechecks(scriptPath: string): Promise<void> {


### PR DESCRIPTION
## Summary

Completes cleanup issue **#980** (follow-up to #983). #983 relocated 19/21 Apple-engine unit tests; the 2 deferred here compute runtime fs paths (`fileURLToPath`/`__dirname`), so they needed path-depth fixes in addition to import re-relativization.

- `runner-client.test.ts` → `src/platforms/apple/core/__tests__/` (joins the other Apple engine tests); `repoRoot` recomputed one level deeper (`../../../../` → `../../../../../`), `vi.mock`/`vi.importActual`/imports re-relativized.
- `recording-scripts.test.ts` → `src/recording/__tests__/` (beside the `overlay.ts` it tests); the `ios-runner/…/RecordingScripts` + `test/integration/support` `__dirname`-relative paths recomputed one level shallower.

`src/platforms/ios/__tests__/` is now **empty** — every Apple-engine test sits beside its source under `apple/core/` (and `src/recording/` for the recording-overlay test).

## Verification
Pure test relocation — no source/behavior change. Local: `tsc`, `oxlint --deny-warnings`, `oxfmt --check`, the layering guard, and `fallow audit` all clean; full unit suite passes (2883). The moved suites pass (64 tests) including the runtime-path assertions.

Closes #980.
