### PR TITLE
test: relocate remaining Apple-engine unit tests to apple/core (#980)

### DIFF
--- a/src/platforms/apple/core/__tests__/recording-scripts.test.ts
+++ b/src/platforms/apple/core/__tests__/recording-scripts.test.ts
@@ -2,15 +2,15 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runCmd } from '../../../utils/exec.ts';
-import { getRecordingOverlaySupportWarning } from '../../../recording/overlay.ts';
+import { runCmd } from '../../../../utils/exec.ts';
+import { getRecordingOverlaySupportWarning } from '../../../../recording/overlay.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const recordingScriptsDir = path.resolve(
   __dirname,
-  '../../../../ios-runner/AgentDeviceRunner/RecordingScripts',
+  '../../../../../ios-runner/AgentDeviceRunner/RecordingScripts',
 );
-const recordingTestSupportDir = path.resolve(__dirname, '../../../../test/integration/support');
+const recordingTestSupportDir = path.resolve(__dirname, '../../../../../test/integration/support');
 const SWIFT_TYPECHECK_TIMEOUT_MS = 60_000;
 
 async function assertSwiftScriptTypechecks(scriptPath: string): Promise<void> {

--- a/src/platforms/apple/core/__tests__/runner-client.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-client.test.ts
@@ -10,37 +10,38 @@ const { mockRunCmdStreaming, mockRepairMacOsRunnerProductsIfNeeded } = vi.hoiste
   mockRepairMacOsRunnerProductsIfNeeded: vi.fn(),
 }));
 
-vi.mock('../../../utils/exec.ts', async () => {
-  const actual =
-    await vi.importActual<typeof import('../../../utils/exec.ts')>('../../../utils/exec.ts');
+vi.mock('../../../../utils/exec.ts', async () => {
+  const actual = await vi.importActual<typeof import('../../../../utils/exec.ts')>(
+    '../../../../utils/exec.ts',
+  );
   return {
     ...actual,
     runCmdStreaming: mockRunCmdStreaming,
   };
 });
 
-vi.mock('../../apple/core/runner/runner-macos-products.ts', async () => {
-  const actual = await vi.importActual<
-    typeof import('../../apple/core/runner/runner-macos-products.ts')
-  >('../../apple/core/runner/runner-macos-products.ts');
+vi.mock('../runner/runner-macos-products.ts', async () => {
+  const actual = await vi.importActual<typeof import('../runner/runner-macos-products.ts')>(
+    '../runner/runner-macos-products.ts',
+  );
   return {
     ...actual,
     repairMacOsRunnerProductsIfNeeded: mockRepairMacOsRunnerProductsIfNeeded,
   };
 });
 
-import type { DeviceInfo } from '../../../kernel/device.ts';
+import type { DeviceInfo } from '../../../../kernel/device.ts';
 import {
   type RequestProgressEvent,
   withRequestProgressSink,
-} from '../../../daemon/request-progress.ts';
-import { flushDiagnosticsToSessionFile, withDiagnosticsScope } from '../../../utils/diagnostics.ts';
-import { AppError } from '../../../kernel/errors.ts';
-import { isReadOnlyRunnerCommand } from '../../apple/core/runner/runner-command-traits.ts';
+} from '../../../../daemon/request-progress.ts';
 import {
-  withRunnerCommandId,
-  type RunnerCommand,
-} from '../../apple/core/runner/runner-contract.ts';
+  flushDiagnosticsToSessionFile,
+  withDiagnosticsScope,
+} from '../../../../utils/diagnostics.ts';
+import { AppError } from '../../../../kernel/errors.ts';
+import { isReadOnlyRunnerCommand } from '../runner/runner-command-traits.ts';
+import { withRunnerCommandId, type RunnerCommand } from '../runner/runner-contract.ts';
 import {
   assertSafeDerivedCleanup,
   isRetryableRunnerError,
@@ -52,7 +53,7 @@ import {
   resolveRunnerMaxConcurrentDestinationsFlag,
   resolveRunnerSigningBuildSettings,
   shouldRetryRunnerConnectError,
-} from '../../apple/core/runner/runner-client.ts';
+} from '../runner/runner-client.ts';
 import {
   acquireRunnerXctestrunCacheLock,
   ensureXctestrunArtifact,
@@ -66,8 +67,8 @@ import {
   shouldDeleteRunnerDerivedRootEntry,
   writeRunnerCacheMetadata,
   xctestrunReferencesProjectRoot,
-} from '../../apple/core/runner/runner-xctestrun.ts';
-import { parseRunnerResponse } from '../../apple/core/runner/runner-session.ts';
+} from '../runner/runner-xctestrun.ts';
+import { parseRunnerResponse } from '../runner/runner-session.ts';
 
 const iosSimulator: DeviceInfo = {
   platform: 'ios',
@@ -180,7 +181,7 @@ const runnerProtocolCommandFixtures: Record<RunnerCommand['command'], RunnerComm
   shutdown: { command: 'shutdown' },
 };
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../');
 
 async function makeTmpDir(): Promise<string> {
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-xctestrun-'));


### PR DESCRIPTION
## What

Finishes the Apple-engine unit-test relocation under Phase-3 umbrella #972. PR #983 moved 19 tests from `src/platforms/ios/__tests__/` into `src/platforms/apple/core/__tests__/` but **deferred 2 files** because they compute runtime fs paths to native runner artifacts (not just import re-relativization). This PR moves the last two:

- `recording-scripts.test.ts`
- `runner-client.test.ts`

## Path fixes made

Both files moved one directory level deeper (`platforms/ios/__tests__` → `platforms/apple/core/__tests__`), so **both** relative import specifiers and repo-root-relative runtime fs paths gained one `../` level.

Import re-relativization:
- `../../../<src-dir>/…` → `../../../../<src-dir>/…` (utils, kernel, daemon, recording)
- `../../apple/core/runner/…` → `../runner/…` (sibling runner modules)

Runtime fs path fixes (the reason these were deferred): the native `ios-runner/` Xcode project and `test/integration/support/` still live at the **repo root** — #968 only consolidated the TypeScript engine into `platforms/apple/`, not the Swift runner sources. So the repo-root-relative paths needed one extra `../`:
- `recording-scripts.test.ts`: `recordingScriptsDir` and `recordingTestSupportDir` (`../../../../` → `../../../../../`) → resolve to `ios-runner/AgentDeviceRunner/RecordingScripts` and `test/integration/support`.
- `runner-client.test.ts`: `repoRoot` (`../../../../` → `../../../../../`), which feeds the project `.tmp` dir and the `ios-runner/AgentDeviceRunner/AgentDeviceRunner.xcodeproj` path. All other `ios-runner` string occurrences in this file are synthetic temp-dir fixtures / regex assertions and were left untouched.

Behaviorless move — no test logic changed (oxfmt reflowed the import wrapping).

## Verification

- `tsc -p tsconfig.json --noEmit` — clean
- `vitest run` both moved files — 2 files, **64 tests pass**
- `scripts/layering/check.ts` — OK (635 files satisfy the DAG)
- `oxfmt --write` + `oxlint --deny-warnings` on changed — clean
- `fallow audit --base origin/main` — no issues in changed files

closes #980