### PR TITLE
feat: gate watchOS as an explicit unsupported sentinel (closes #977)

### DIFF
--- a/src/core/interactors/__tests__/apple-watchos-sentinel.test.ts
+++ b/src/core/interactors/__tests__/apple-watchos-sentinel.test.ts
@@ -1,0 +1,50 @@
+import { test, expect } from 'vitest';
+import { createAppleInteractor } from '../apple.ts';
+import type { DeviceInfo } from '../../../kernel/device.ts';
+import type { RunnerContext } from '../../interactor-types.ts';
+import { AppError } from '../../../kernel/errors.ts';
+
+// watchOS is an explicit unsupported sentinel: XCUITest cannot drive watchOS UI,
+// so a `appleOs: 'watchos'` device must be rejected at interactor creation (the
+// admission seam) rather than silently falling through to the iOS runner.
+const watchOsDevice: DeviceInfo = {
+  platform: 'ios',
+  id: 'watch-1',
+  name: 'Apple Watch Series 10',
+  kind: 'device',
+  appleOs: 'watchos',
+};
+
+test('createAppleInteractor rejects a watchOS device as UNSUPPORTED_PLATFORM', () => {
+  // The guard throws before touching runnerContext, so an empty context is fine.
+  const create = () => createAppleInteractor(watchOsDevice, {} as RunnerContext);
+  expect(create).toThrow(AppError);
+  try {
+    create();
+    expect.unreachable('expected createAppleInteractor to throw for watchOS');
+  } catch (error) {
+    expect(error).toBeInstanceOf(AppError);
+    expect((error as AppError).code).toBe('UNSUPPORTED_PLATFORM');
+    expect((error as AppError).message).toMatch(/watchOS/i);
+  }
+});
+
+test('a non-watchOS appleOs does not trigger the watchOS sentinel', () => {
+  // A tvOS device must not throw the watchOS-specific rejection. (It may still
+  // fail later on the empty runner context, so we only assert it is not the
+  // watchOS sentinel error.)
+  const tvOsDevice: DeviceInfo = {
+    platform: 'ios',
+    id: 'tv-1',
+    name: 'Apple TV 4K',
+    kind: 'simulator',
+    target: 'tv',
+    appleOs: 'tvos',
+    booted: true,
+  };
+  try {
+    createAppleInteractor(tvOsDevice, {} as RunnerContext);
+  } catch (error) {
+    expect((error as AppError).message ?? '').not.toMatch(/watchOS/i);
+  }
+});

--- a/src/core/interactors/apple.ts
+++ b/src/core/interactors/apple.ts
@@ -28,6 +28,16 @@ export function createAppleInteractor(
   device: DeviceInfo,
   runnerContext: RunnerContext,
 ): Interactor {
+  // watchOS unsupported sentinel: XCUITest cannot drive watchOS UI (no
+  // XCUIApplication), so a watchOS device has no runner backend. Reject it
+  // explicitly here rather than letting `appleOs: 'watchos'` silently fall
+  // through to the iOS runner profile (see resolveRunnerPlatformNameForAppleOs).
+  if (device.appleOs === 'watchos') {
+    throw new AppError(
+      'UNSUPPORTED_PLATFORM',
+      'watchOS is not supported: XCUITest cannot drive watchOS UI, so this device has no runner backend.',
+    );
+  }
   const { overrides, runnerOpts } = iosRunnerOverrides(device, runnerContext);
   return {
     open: (app, options) =>


### PR DESCRIPTION
## Summary

Implements the **watchOS unsupported sentinel** (Phase 3 d.4, part of umbrella #972).

XCUITest cannot drive watchOS UI (no `XCUIApplication`), so a watchOS device has no runner backend. Today `appleOs: 'watchos'` **silently falls through to the iOS runner profile** (`resolveRunnerPlatformNameForAppleOs` in `kernel/device.ts`). This makes the case honest:

- `createAppleInteractor` (the admission seam where a device becomes a runner target) now rejects `appleOs === 'watchos'` with a clear `UNSUPPORTED_PLATFORM` error, before any runner work.

## Why this is safe
Discovery never produces watchOS today — `resolveAppleOs` (`platforms/apple/core/devices.ts`) only yields `ios`/`ipados`/`tvos`/`visionos`. So this changes **no real-device behavior**; it converts a silent wrong fallback into an explicit, declared "unsupported" sentinel (the whole point of the item per ADR-0009: "watchOS must be gated unsupported"). Per-`AppleOS` capability-table integration is deferred to **d.5 (#978)**.

## Tests
New `src/core/interactors/__tests__/apple-watchos-sentinel.test.ts`: asserts createAppleInteractor throws `UNSUPPORTED_PLATFORM` (with a watchOS message) for a watchOS device, and that a non-watchOS `appleOs` (tvOS) does not trigger the sentinel.

Local: `tsc`, `oxlint --deny-warnings`, `oxfmt --check`, layering guard, `fallow audit` all clean; full unit suite passes (2885).

Closes #977.
