### PR TITLE
feat: route daemon app-log backend through PlatformPlugin appLog facet (#974)

### DIFF
--- a/src/core/platform-plugin/plugin.ts
+++ b/src/core/platform-plugin/plugin.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../../kernel/errors.ts';
 import type { DeviceInfo, Platform, PlatformSelector } from '../../kernel/device.ts';
+import type { LogBackend } from '../../daemon/network-log.ts';
 import type { Interactor, RunnerContext } from '../interactor-types.ts';
 import type { DeviceInventoryRequest } from '../platform-inventory.ts';
 import type { CapabilityBucket } from '../platform-descriptor/types.ts';
@@ -18,11 +19,14 @@ import type { CapabilityBucket } from '../platform-descriptor/types.ts';
  * `import()` inside `createInteractor` / `discoverDevices`, preserving the
  * CLI cold-start laziness that today's `getInteractor` switch relies on.
  *
- * Step-a scope: this contract intentionally contains ONLY the facets this slice
- * genuinely implements and parity-tests. The daemon-owned columns
- * (`providers` / `recording` / `appLog` / `perf`) are NOT declared here — they
- * arrive in step (b), typed against PLATFORM-NEUTRAL, daemon-owned wrappers
- * (not the iOS-simulator-shaped provider seam). See
+ * Daemon-owned columns (step b.3, issue #974): each is declared ONLY once it is
+ * populated by wrapping the existing daemon branch AND pinned by a table-equivalence
+ * parity test before a real call-site routes through it. A facet's type stays
+ * PLATFORM-NEUTRAL and daemon-owned (never the iOS-simulator-shaped provider seam):
+ * {@link PlatformPlugin.appLog} carries the neutral {@link LogBackend} resolver
+ * (wraps `resolveLogBackend`, pinned by the daemon app-log routing parity test).
+ * The remaining columns (`providers` / `recording` / `perf`) stay on their daemon
+ * branch as the source of truth until they clear the same gate. See
  * docs/adr/0009-apple-platform-consolidation.md (tracked in issue #974).
  */
 export type PlatformPlugin = {
@@ -46,6 +50,17 @@ export type PlatformPlugin = {
   readonly capability: {
     readonly bucket: CapabilityBucket;
     supportsByDefault?(device: DeviceInfo): boolean;
+  };
+  /**
+   * The daemon app-log facet (issue #974). `resolveBackend` wraps the platform
+   * branch of `src/daemon/app-log.ts`'s `resolveLogBackend`, returning the neutral
+   * {@link LogBackend} tag for `device`. Present only on families that have an
+   * app-log backend (Apple + Android); left `undefined` for linux/web, where the
+   * hand branch historically fell through to the `'android'` default — the daemon
+   * lookup preserves that fallthrough, and the parity test pins the equivalence.
+   */
+  readonly appLog?: {
+    resolveBackend(device: DeviceInfo): LogBackend;
   };
 };
 

--- a/src/core/platform-plugin/register-builtins.ts
+++ b/src/core/platform-plugin/register-builtins.ts
@@ -18,6 +18,16 @@ const applePlugin = {
   platforms: ['ios', 'macos'],
   familySelector: 'apple',
   capability: { bucket: 'apple' },
+  // Wraps the Apple arm of `resolveLogBackend` verbatim: macOS -> 'macos';
+  // an iOS `device` -> 'ios-device'; every other iOS kind -> 'ios-simulator'.
+  appLog: {
+    resolveBackend: (device: DeviceInfo) =>
+      device.platform === 'macos'
+        ? 'macos'
+        : device.kind === 'device'
+          ? 'ios-device'
+          : 'ios-simulator',
+  },
   createInteractor: async (device: DeviceInfo, runner: RunnerContext) => {
     const { createAppleInteractor } = await import('../interactors/apple.ts');
     return createAppleInteractor(device, runner);
@@ -41,6 +51,8 @@ const androidPlugin = {
   id: 'android',
   platforms: ['android'],
   capability: { bucket: 'android' },
+  // Wraps the Android arm of `resolveLogBackend`: every Android device -> 'android'.
+  appLog: { resolveBackend: () => 'android' },
   createInteractor: async (device: DeviceInfo) => {
     const { createAndroidInteractor } = await import('../interactors/android.ts');
     return createAndroidInteractor(device);

--- a/src/daemon/__tests__/applog-plugin-routing-parity.test.ts
+++ b/src/daemon/__tests__/applog-plugin-routing-parity.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  DEVICE_TARGETS,
+  PLATFORMS,
+  type DeviceInfo,
+  type DeviceKind,
+  type DeviceTarget,
+} from '../../kernel/device.ts';
+import {
+  ANDROID_EMULATOR,
+  ANDROID_TV_DEVICE,
+  IOS_DEVICE,
+  IOS_SIMULATOR,
+  LINUX_DEVICE,
+  MACOS_DEVICE,
+  TVOS_SIMULATOR,
+  WEB_DESKTOP_DEVICE,
+} from '../../__tests__/test-utils/index.ts';
+import { getPlugin } from '../../core/platform-plugin/plugin.ts';
+import { registerBuiltinPlatformPlugins } from '../../core/platform-plugin/register-builtins.ts';
+import { resolveLogBackend } from '../app-log.ts';
+import type { LogBackend } from '../network-log.ts';
+
+// Phase 3 step b.3 (issue #974) parity gate for the daemon app-log facet. The
+// per-platform branch of `resolveLogBackend` now flows through the PlatformPlugin
+// `appLog.resolveBackend` facet instead of a hand switch. An INDEPENDENT verbatim
+// copy of the former branch below is the BEFORE oracle: a plugin-vs-branch
+// disagreement on any sample device fails this test. (Mirrors the verbatim-copy
+// discipline in core/__tests__/capability-plugin-routing-parity.test.ts.)
+
+registerBuiltinPlatformPlugins();
+
+// --- INDEPENDENT verbatim copy of the former `resolveLogBackend` hand branch ---
+function resolveLogBackendByHand(device: DeviceInfo): LogBackend {
+  if (device.platform === 'macos') return 'macos';
+  if (device.platform === 'ios') {
+    return device.kind === 'device' ? 'ios-device' : 'ios-simulator';
+  }
+  return 'android';
+}
+
+// --- the exhaustive synthetic device matrix (every platform x kind x target) ---
+const DEVICE_KINDS_ALL: DeviceKind[] = ['simulator', 'emulator', 'device'];
+const DEVICE_TARGETS_ALL: (DeviceTarget | undefined)[] = [undefined, ...DEVICE_TARGETS];
+
+function buildDeviceMatrix(): DeviceInfo[] {
+  const devices: DeviceInfo[] = [];
+  for (const platform of PLATFORMS) {
+    for (const kind of DEVICE_KINDS_ALL) {
+      for (const target of DEVICE_TARGETS_ALL) {
+        devices.push({
+          platform,
+          id: `${platform}-${kind}-${target ?? 'none'}`,
+          name: `${platform} ${kind} ${target ?? 'none'}`,
+          kind,
+          ...(target ? { target } : {}),
+          booted: true,
+        });
+      }
+    }
+  }
+  return devices;
+}
+
+// The hand-authored fixtures (the real discovery shapes) plus the exhaustive
+// synthetic cross-product, so every off-nominal combination is pinned too.
+const SAMPLE_DEVICES: DeviceInfo[] = [
+  ANDROID_EMULATOR,
+  ANDROID_TV_DEVICE,
+  IOS_DEVICE,
+  IOS_SIMULATOR,
+  LINUX_DEVICE,
+  MACOS_DEVICE,
+  TVOS_SIMULATOR,
+  WEB_DESKTOP_DEVICE,
+  ...buildDeviceMatrix(),
+];
+
+test('resolveLogBackend routed through the plugin is byte-identical to the former hand branch', () => {
+  for (const device of SAMPLE_DEVICES) {
+    assert.equal(
+      resolveLogBackend(device),
+      resolveLogBackendByHand(device),
+      `backend for ${device.id}`,
+    );
+  }
+});
+
+test('only families with an app-log backend carry the appLog facet', () => {
+  // Apple owns ios + macos (SAME plugin instance); Android carries its own.
+  assert.equal(getPlugin('ios'), getPlugin('macos'));
+  assert.ok(getPlugin('ios').appLog, 'apple plugin exposes appLog');
+  assert.ok(getPlugin('android').appLog, 'android plugin exposes appLog');
+  // linux/web historically fell through to the `'android'` default; they get NO
+  // facet, and the daemon lookup preserves that fallthrough (asserted below).
+  assert.equal(getPlugin('linux').appLog, undefined, 'linux plugin has no appLog');
+  assert.equal(getPlugin('web').appLog, undefined, 'web plugin has no appLog');
+});
+
+test('each populated appLog facet resolves the backend its family owns', () => {
+  for (const device of SAMPLE_DEVICES.filter(
+    (d) => d.platform === 'ios' || d.platform === 'macos' || d.platform === 'android',
+  )) {
+    assert.equal(
+      getPlugin(device.platform).appLog?.resolveBackend(device),
+      resolveLogBackendByHand(device),
+      `facet backend for ${device.id}`,
+    );
+  }
+});
+
+test('the factless families fall through to the historical default', () => {
+  for (const device of SAMPLE_DEVICES.filter(
+    (d) => d.platform === 'linux' || d.platform === 'web',
+  )) {
+    assert.equal(getPlugin(device.platform).appLog, undefined);
+    assert.equal(resolveLogBackend(device), 'android', `fallthrough for ${device.id}`);
+  }
+});

--- a/src/daemon/app-log.ts
+++ b/src/daemon/app-log.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { DeviceInfo } from '../kernel/device.ts';
 import { AppError } from '../kernel/errors.ts';
+import { tryGetPlugin } from '../core/platform-plugin/plugin.ts';
+import { registerBuiltinPlatformPlugins } from '../core/platform-plugin/register-builtins.ts';
 import { runCmd } from '../utils/exec.ts';
 import { runXcrun } from '../platforms/apple/core/tool-provider.ts';
 import { runAndroidAdb } from '../platforms/android/adb.ts';
@@ -29,6 +31,12 @@ import {
   type NetworkIncludeMode,
   type LogBackend,
 } from './network-log.ts';
+
+// Populate the PlatformPlugin registry once at module load (idempotent; registers
+// only lazy closures, so no leaf code is imported and CLI cold-start is unaffected
+// — mirrors the same call in `core/capabilities.ts`). `resolveLogBackend` reads the
+// per-platform app-log facet from this registry, so it must be populated first.
+registerBuiltinPlatformPlugins();
 
 export type { AppLogResult } from './app-log-process.ts';
 export type { AppLogState } from './app-log-process.ts';
@@ -177,11 +185,11 @@ export function getAppLogPathMetadata(outPath: string): {
 }
 
 export function resolveLogBackend(device: DeviceInfo): LogBackend {
-  if (device.platform === 'macos') return 'macos';
-  if (device.platform === 'ios') {
-    return device.kind === 'device' ? 'ios-device' : 'ios-simulator';
-  }
-  return 'android';
+  // Routes the platform branch through the PlatformPlugin app-log facet (issue
+  // #974). Apple/Android carry a `resolveBackend`; linux/web (and any unregistered
+  // platform) fall through to the historical `'android'` default. The daemon
+  // app-log routing parity test pins this against the former hand branch.
+  return tryGetPlugin(device.platform)?.appLog?.resolveBackend(device) ?? 'android';
 }
 
 export async function readSessionNetworkCapture(params: {


### PR DESCRIPTION
## Phase 3 b.3 — platform-neutral daemon facets on `PlatformPlugin`

Implements the lowest-risk column of #974: the daemon **app-log** facet. Adds it to `PlatformPlugin` typed against a **platform-neutral, daemon-owned** wrapper, populates it by wrapping the existing daemon branch verbatim, pins it with a table-equivalence parity test, then routes the daemon lookup through the plugin.

### Facet landed: `appLog`

- **Neutral wrapper type:** `PlatformPlugin.appLog?.resolveBackend(device: DeviceInfo): LogBackend`, where `LogBackend = 'ios-simulator' | 'ios-device' | 'android' | 'macos'` — a plain daemon-owned string union, **not** the iOS-simulator-shaped provider seam. `plugin.ts` imports `LogBackend` **type-only** (layering guard stays green; core→daemon type edge only).
- **Optional facet:** present only on families that actually have an app-log backend — Apple (owns both `ios` + `macos`, resolves internally) and Android. `linux`/`web` omit it; the daemon lookup preserves the historical `'android'` fallthrough those platforms hit.
- **Populate = wrap the branch verbatim** (`src/core/platform-plugin/register-builtins.ts`): Apple mirrors `resolveLogBackend`'s Apple arm (`macos` → `'macos'`, iOS `device` → `'ios-device'`, else → `'ios-simulator'`); Android → `'android'`.
- **Route through `getPlugin`** (`src/daemon/app-log.ts`): `resolveLogBackend` now returns `tryGetPlugin(device.platform)?.appLog?.resolveBackend(device) ?? 'android'`. The registry is populated at module load (idempotent, lazy — mirrors `core/capabilities.ts`), so no leaf code is imported and CLI cold-start is unaffected.

### Parity gate

`src/daemon/__tests__/applog-plugin-routing-parity.test.ts` pins the routed `resolveLogBackend` **byte-for-byte** against an *independent verbatim copy* of the former hand branch, across the hand device fixtures (`src/__tests__/test-utils/device-fixtures.ts`) **plus** the exhaustive `platform × kind × target` synthetic matrix. It also asserts facet presence (Apple/Android carry it; linux/web don't) and the fallthrough. Follows the verbatim-copy discipline of `capability-plugin-routing-parity.test.ts`.

### Deferred (kept as the daemon branch's source of truth — NOT added to the contract)

- **`providers`** — the `REQUEST_PLATFORM_PROVIDER_DESCRIPTORS` seam is load-bearing scope orchestration (per-request wrapper composition + concurrency isolation) and the `() => Partial<PlatformProviderResolvers>` wrapper is under-specified; refactoring it safely is a larger change than a "smaller, fully-correct" slice allows.
- **`recording`** — needs the de-iOS-naming start/stop-context redesign the issue calls for (`startIosSimulatorRecording` → neutral start context); larger surface, deferred.
- **`perf`** — `buildPerfResponseData` is a heavy internal response-builder whose routing can't be directly pinned without broadening the module surface; the `supportsPlatformPerfMetrics` predicate alone would be a partial slice of that row.

Each deferred facet stays the daemon branch's source of truth per the issue's gate ("until each facet is populated AND a real call-site routed through it with a passing parity test, the daemon branch stays the source of truth and the facet is NOT added to the contract").

### Verification

- `tsc -p tsconfig.json` ✅
- `oxlint . --deny-warnings` ✅
- `oxfmt --write && --check src test` ✅
- `layering/check.ts` ✅ (635 files, R1/R2/R3)
- `rslib build` ✅
- `fallow audit --base origin/main` ✅ no new findings
- `vitest run --project unit` ✅ except the known `fillAndroid` timeout flake under CPU contention (android suite passes 92/92 in isolation)

Refs: perfect-shape.md §6; ADR-0009. Part of #972. Closes part of #974.

🤖 Human-review-only — do not merge.