### PR TITLE
refactor(apple): promote tvOS to an explicit Apple-OS leaf (#976)

### DIFF
--- a/src/core/__tests__/dispatch-pinch.test.ts
+++ b/src/core/__tests__/dispatch-pinch.test.ts
@@ -23,3 +23,26 @@ test('dispatch pinch rejects tvOS before runner call', async () => {
       /pinch is not supported on tvOS/i.test(error.message),
   );
 });
+
+// tvOS is focus-only: coordinate multi-touch gestures have no meaning off the focused
+// element, so rotate/transform reject up front (mirroring pinch above). This pins the
+// UNSUPPORTED coordinate-gesture half of the tvOS interaction contract.
+test('dispatch rotate-gesture rejects tvOS before runner call', async () => {
+  await assert.rejects(
+    () => dispatchCommand(TVOS_SIMULATOR, 'rotate-gesture', ['90']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'UNSUPPORTED_OPERATION' &&
+      /rotate is not supported on tvOS/i.test(error.message),
+  );
+});
+
+test('dispatch transform-gesture rejects tvOS before runner call', async () => {
+  await assert.rejects(
+    () => dispatchCommand(TVOS_SIMULATOR, 'transform-gesture', ['1', '2', '3', '4', '1.5', '90']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'UNSUPPORTED_OPERATION' &&
+      /transform is not supported on tvOS/i.test(error.message),
+  );
+});

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -5,7 +5,7 @@ import {
 } from '../../command-catalog.ts';
 import type { CommandCapability } from '../capabilities.ts';
 import type { DaemonRequest } from '../../daemon/types.ts';
-import type { DeviceInfo } from '../../kernel/device.ts';
+import { isTvOsDevice, type DeviceInfo } from '../../kernel/device.ts';
 import type { CommandDescriptor } from './types.ts';
 
 // ---------------------------------------------------------------------------
@@ -42,16 +42,16 @@ const isNotMacOs = (device: DeviceInfo): boolean => device.platform !== 'macos';
 const isMacOsOrAppleSimulator = (device: DeviceInfo): boolean =>
   device.platform === 'macos' || device.kind === 'simulator';
 const isIosMobileSimulator = (device: DeviceInfo): boolean =>
-  device.platform === 'ios' && device.kind === 'simulator' && device.target !== 'tv';
+  device.platform === 'ios' && device.kind === 'simulator' && !isTvOsDevice(device);
 const supportsSynthesisGesture = (device: DeviceInfo): boolean =>
   device.platform === 'android' || isIosMobileSimulator(device);
 const supportsAndroidOrIosNonTv = (device: DeviceInfo): boolean =>
-  device.platform === 'android' || (device.platform === 'ios' && device.target !== 'tv');
+  device.platform === 'android' || (device.platform === 'ios' && !isTvOsDevice(device));
 
 const synthesisGestureUnsupportedHint = (device: DeviceInfo): string | undefined => {
   if (device.platform === 'macos')
     return 'macOS automation has no multi-touch input — this gesture is supported on Android and the iOS simulator only.';
-  if (device.platform === 'ios' && device.target === 'tv')
+  if (isTvOsDevice(device))
     return 'tvOS has no touch input — this gesture is supported on Android and the iOS simulator only.';
   if (device.platform === 'ios' && device.kind === 'device')
     return 'Two-finger gesture synthesis is iOS-simulator only — not available on physical iOS devices.';

--- a/src/core/dispatch-interactions.ts
+++ b/src/core/dispatch-interactions.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../kernel/errors.ts';
-import type { DeviceInfo } from '../kernel/device.ts';
+import { isTvOsDevice, type DeviceInfo } from '../kernel/device.ts';
 import { successText, withSuccessText } from '../utils/success-text.ts';
 import { findMistargetedTypeRefToken } from '../utils/type-target-warning.ts';
 import {
@@ -416,9 +416,10 @@ function buildPressSequenceSteps(
   series: PressSeriesOptions,
 ): RunnerSequenceStep[] {
   const kind = series.doubleTap ? 'doubleTap' : series.holdMs > 0 ? 'longPress' : 'tap';
-  // Mirror the individual `tap` command: on iOS non-tv, tap steps use synthesized HID taps
-  // (synthesizedTapAt) rather than the drag-based XCUICoordinate tapAt, matching iosTapCommand.
-  const synthesized = kind === 'tap' && device.platform === 'ios' && device.target !== 'tv';
+  // Mirror the individual `tap` command: on touch-input iOS (not the tvOS leaf), tap steps
+  // use synthesized HID taps (synthesizedTapAt) rather than the drag-based XCUICoordinate
+  // tapAt, matching iosTapCommand.
+  const synthesized = kind === 'tap' && device.platform === 'ios' && !isTvOsDevice(device);
   return Array.from({ length: series.count }, (_, index) => {
     const [dx, dy] = computeDeterministicJitter(index, series.jitterPx);
     const isLast = index === series.count - 1;
@@ -449,7 +450,7 @@ function buildSwipeSequenceSteps(params: {
   effectiveDurationMs: number;
 }): RunnerSequenceStep[] {
   const { device, x1, y1, x2, y2, count, pauseMs, pattern, effectiveDurationMs } = params;
-  const synthesized = device.platform === 'ios' && device.target !== 'tv';
+  const synthesized = device.platform === 'ios' && !isTvOsDevice(device);
   return Array.from({ length: count }, (_, index) => {
     const reverse = pattern === 'ping-pong' && index % 2 === 1;
     const isLast = index === count - 1;
@@ -863,6 +864,8 @@ export async function handlePinchCommand(
   positionals: string[],
   context: DispatchContext | undefined,
 ): Promise<Record<string, unknown>> {
+  // Cross-platform TV-target gate (also rejects Android TV, which shares target: 'tv');
+  // NOT narrowed to the tvOS Apple-OS leaf (isTvOsDevice) so Android-TV behavior is unchanged.
   if (device.target === 'tv') {
     throw new AppError('UNSUPPORTED_OPERATION', 'gesture pinch is not supported on tvOS');
   }
@@ -887,6 +890,7 @@ export async function handleRotateGestureCommand(
   interactor: Interactor,
   positionals: string[],
 ): Promise<Record<string, unknown>> {
+  // Cross-platform TV-target gate (also rejects Android TV) — see handlePinchCommand.
   if (device.target === 'tv') {
     throw new AppError('UNSUPPORTED_OPERATION', 'gesture rotate is not supported on tvOS');
   }
@@ -914,6 +918,7 @@ export async function handleTransformGestureCommand(
   interactor: Interactor,
   positionals: string[],
 ): Promise<Record<string, unknown>> {
+  // Cross-platform TV-target gate (also rejects Android TV) — see handlePinchCommand.
   if (device.target === 'tv') {
     throw new AppError('UNSUPPORTED_OPERATION', 'gesture transform is not supported on tvOS');
   }

--- a/src/core/interactors/apple.ts
+++ b/src/core/interactors/apple.ts
@@ -8,14 +8,14 @@ import {
   writeIosClipboardText,
 } from '../../platforms/apple/core/apps.ts';
 import {
-  appleRemotePressCommand,
   iosRunnerOverrides,
   resolveAppleBackRunnerCommand,
 } from '../../platforms/ios/interactions.ts';
+import { appleRemotePressCommand } from '../../platforms/apple/os/tvos/remote.ts';
 import { runMacOsScreenshotAction } from '../../platforms/apple/os/macos/helper.ts';
 import { runIosRunnerCommand } from '../../platforms/apple/core/runner/runner-client.ts';
 import { withDiagnosticTimer } from '../../utils/diagnostics.ts';
-import type { DeviceInfo } from '../../kernel/device.ts';
+import { isTvOsDevice, type DeviceInfo } from '../../kernel/device.ts';
 import { AppError } from '../../kernel/errors.ts';
 import type { RawSnapshotNode } from '../../kernel/snapshot.ts';
 import type { Interactor, RunnerContext } from '../interactor-types.ts';
@@ -89,7 +89,8 @@ export function createAppleInteractor(
       };
     },
     back: async (mode) => {
-      if (device.target === 'tv') {
+      if (isTvOsDevice(device)) {
+        // tvOS focus-only navigation: the Menu button pops focus, not a coordinate tap.
         await runIosRunnerCommand(
           device,
           appleRemotePressCommand('menu', runnerContext.appBundleId),
@@ -107,7 +108,8 @@ export function createAppleInteractor(
       );
     },
     home: async () => {
-      if (device.target === 'tv') {
+      if (isTvOsDevice(device)) {
+        // tvOS focus-only navigation: the Home button drives the remote, not a tap.
         await runIosRunnerCommand(
           device,
           appleRemotePressCommand('home', runnerContext.appBundleId),

--- a/src/kernel/device.ts
+++ b/src/kernel/device.ts
@@ -50,6 +50,21 @@ export function isMobilePlatform(platform: Platform): boolean {
   return platform === 'ios' || platform === 'android';
 }
 
+/**
+ * The tvOS Apple-OS leaf predicate. tvOS is modeled as the `ios` platform with a
+ * `tv` form-factor target (ADR-0009 defers the `Platform` collapse; discovery also
+ * stores `appleOs: 'tvos'`). Naming the leaf keeps its focus-only interaction
+ * contract — XCUIRemote focus navigation, and NO coordinate tap/gesture — gated by
+ * one explicit predicate instead of a `target === 'tv'` string compare smeared
+ * across the Apple interaction paths.
+ *
+ * Apple-only by design: Android TV also uses `target: 'tv'` but is a DISTINCT leaf,
+ * so the `platform === 'ios'` gate is load-bearing (do not widen it to any TV target).
+ */
+export function isTvOsDevice(device: Pick<DeviceInfo, 'platform' | 'target'>): boolean {
+  return device.platform === 'ios' && device.target === 'tv';
+}
+
 export function isPlatform(value: unknown): value is Platform {
   // Leaf-platform membership derived from the canonical PLATFORMS tuple (excludes the
   // `apple` selector, which is not a concrete device platform).

--- a/src/platforms/apple/os/tvos/remote.ts
+++ b/src/platforms/apple/os/tvos/remote.ts
@@ -1,0 +1,28 @@
+import type { RunnerCommand } from '../../core/runner/runner-contract.ts';
+
+// The tvOS Apple-OS leaf (ADR-0009). tvOS has no touch input: it is driven by the
+// Siri Remote's focus engine, so back/home/scroll navigate focus via XCUIRemote
+// hardware-button presses rather than coordinate taps or drags. This focus-only
+// interaction contract is per-OS by design and must NOT be flattened into a uniform
+// Apple tap/gesture path (perfect-shape §7; ADR-0009). The `isTvOsDevice` gate
+// (kernel/device.ts) selects when this leaf's behavior applies.
+
+export type AppleRemoteButton = NonNullable<RunnerCommand['remoteButton']>;
+
+/**
+ * Builds the XCUIRemote `remotePress` runner command for a tvOS navigation intent.
+ * Scroll directions map straight onto the directional remote buttons; back maps to
+ * `menu` and home to `home`. An optional `durationMs` becomes a button hold.
+ */
+export function appleRemotePressCommand(
+  remoteButton: AppleRemoteButton,
+  appBundleId?: string,
+  durationMs?: number,
+): RunnerCommand {
+  return {
+    command: 'remotePress',
+    remoteButton,
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(appBundleId !== undefined ? { appBundleId } : {}),
+  };
+}

--- a/src/platforms/ios/interactions.ts
+++ b/src/platforms/ios/interactions.ts
@@ -1,4 +1,4 @@
-import type { DeviceInfo } from '../../kernel/device.ts';
+import { isTvOsDevice, type DeviceInfo } from '../../kernel/device.ts';
 import { assertScrollGestureInput, type ScrollDirection } from '../../core/scroll-gesture.ts';
 import { normalizeScrollDurationMs, SCROLL_DURATION_MAX_MS } from '../../core/scroll-command.ts';
 import { runIosRunnerCommand } from '../apple/core/runner/runner-client.ts';
@@ -7,6 +7,7 @@ import {
   parseRunnerSequenceResult,
 } from '../apple/core/runner/runner-sequence.ts';
 import type { RunnerCommand } from '../apple/core/runner/runner-contract.ts';
+import { appleRemotePressCommand } from '../apple/os/tvos/remote.ts';
 import { runMacosDesktopScroll } from '../apple/os/macos/desktop-scroll.ts';
 import {
   normalizeAppleScrollResult,
@@ -22,7 +23,6 @@ import type {
 } from '../../core/interactor-types.ts';
 
 export type AppleBackRunnerCommand = 'backInApp' | 'backSystem';
-type AppleRemoteButton = NonNullable<RunnerCommand['remoteButton']>;
 type RunIosRunnerCommand = typeof runIosRunnerCommand;
 type RunnerOpts = RunnerCallOptions;
 
@@ -267,7 +267,8 @@ function iosTapCommand(
 }
 
 function shouldUseSynthesizedIosGesture(device: DeviceInfo): boolean {
-  return device.platform === 'ios' && device.target !== 'tv';
+  // Two-finger HID synthesis is for touch-input iOS only; the tvOS leaf has no touch.
+  return device.platform === 'ios' && !isTvOsDevice(device);
 }
 
 function iosDragCommand(
@@ -281,7 +282,7 @@ function iosDragCommand(
   options: IosDragCommandOptions,
 ): RunnerCommand {
   const normalizedDurationMs =
-    device.platform === 'ios' && device.target !== 'tv'
+    device.platform === 'ios' && !isTvOsDevice(device)
       ? iosGestureDurationMs(durationMs, options.defaultDurationMs)
       : (durationMs ?? options.legacyDefaultDurationMs);
   return {
@@ -305,19 +306,6 @@ function iosGestureDurationMs(durationMs: number | undefined, defaultDurationMs:
   );
 }
 
-export function appleRemotePressCommand(
-  remoteButton: AppleRemoteButton,
-  appBundleId?: string,
-  durationMs?: number,
-): Parameters<RunIosRunnerCommand>[1] {
-  return {
-    command: 'remotePress',
-    remoteButton,
-    ...(durationMs !== undefined ? { durationMs } : {}),
-    ...(appBundleId !== undefined ? { appBundleId } : {}),
-  };
-}
-
 async function runAppleScroll(
   runRunnerCommand: RunIosRunnerCommand,
   device: DeviceInfo,
@@ -330,7 +318,7 @@ async function runAppleScroll(
     invalidMessage: `scroll durationMs must be a non-negative integer at most ${SCROLL_DURATION_MAX_MS}`,
   });
 
-  if (device.target === 'tv') {
+  if (isTvOsDevice(device)) {
     const runnerResult = await runRunnerCommand(
       device,
       appleRemotePressCommand(direction, ctx.appBundleId, options?.durationMs),

--- a/src/utils/__tests__/device.test.ts
+++ b/src/utils/__tests__/device.test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   isPlatform,
+  isTvOsDevice,
   matchesPlatformSelector,
   PLATFORMS,
   resolveApplePlatformName,
@@ -9,7 +10,23 @@ import {
   resolveDevice,
 } from '../../kernel/device.ts';
 import type { DeviceInfo } from '../../kernel/device.ts';
+import {
+  ANDROID_TV_DEVICE,
+  IOS_SIMULATOR,
+  MACOS_DEVICE,
+  TVOS_SIMULATOR,
+} from '../../__tests__/test-utils/device-fixtures.ts';
 import { AppError } from '../../kernel/errors.ts';
+
+test('isTvOsDevice selects only the Apple tvOS leaf, not any TV target', () => {
+  assert.equal(isTvOsDevice(TVOS_SIMULATOR), true);
+  // Touch-input iOS and macOS are Apple, but are NOT the focus-only tvOS leaf.
+  assert.equal(isTvOsDevice(IOS_SIMULATOR), false);
+  assert.equal(isTvOsDevice(MACOS_DEVICE), false);
+  // Android TV shares target: 'tv' but is a DISTINCT leaf — the platform gate excludes it,
+  // so the tvOS focus-only contract is never applied to Android TV.
+  assert.equal(isTvOsDevice(ANDROID_TV_DEVICE), false);
+});
 
 test('matchesPlatformSelector resolves apple selector across Apple platforms', () => {
   assert.equal(matchesPlatformSelector('ios', 'apple'), true);

--- a/src/utils/__tests__/interactors.test.ts
+++ b/src/utils/__tests__/interactors.test.ts
@@ -130,6 +130,51 @@ test('tvOS scroll sends only a remotePress command (behavior unchanged)', async 
   ]);
 });
 
+test('tvOS back navigates focus via the remote Menu button, not a coordinate tap', async () => {
+  const commands: RunnerCommand[] = [];
+  mockRunIosRunnerCommand.mockImplementation(async (_device, command) => {
+    commands.push(command);
+    return {};
+  });
+  const interactor = await getInteractor(tvOsSimulator, { appBundleId: 'com.example.app' });
+
+  await interactor.back();
+
+  // tvOS is focus-only: back pops focus via the Siri Remote Menu button (XCUIRemote).
+  assert.deepEqual(commands, [
+    { command: 'remotePress', remoteButton: 'menu', appBundleId: 'com.example.app' },
+  ]);
+});
+
+test('tvOS home navigates focus via the remote Home button', async () => {
+  const commands: RunnerCommand[] = [];
+  mockRunIosRunnerCommand.mockImplementation(async (_device, command) => {
+    commands.push(command);
+    return {};
+  });
+  const interactor = await getInteractor(tvOsSimulator, { appBundleId: 'com.example.app' });
+
+  await interactor.home();
+
+  assert.deepEqual(commands, [
+    { command: 'remotePress', remoteButton: 'home', appBundleId: 'com.example.app' },
+  ]);
+});
+
+test('iOS back keeps the in-app navigation path, not the tvOS remote', async () => {
+  const commands: RunnerCommand[] = [];
+  mockRunIosRunnerCommand.mockImplementation(async (_device, command) => {
+    commands.push(command);
+    return {};
+  });
+  const interactor = await getInteractor(iosSimulator, { appBundleId: 'com.example.app' });
+
+  await interactor.back();
+
+  // The per-OS gate must not flatten: touch-input iOS never uses the XCUIRemote path.
+  assert.deepEqual(commands, [{ command: 'backInApp', appBundleId: 'com.example.app' }]);
+});
+
 test('ios scroll rejects non-positive amount before sending any runner command', async () => {
   mockRunIosRunnerCommand.mockImplementation(async () => ({}));
   const interactor = await getInteractor(iosSimulator, { appBundleId: 'com.example.app' });


### PR DESCRIPTION
Closes #976. Phase 3 step d.2 (part of #972). Refs perfect-shape.md §7, ADR-0009.

## What this does
Promotes `ios + target:'tv'` into an explicit, **named** tvOS Apple-OS leaf. This is a **rename/extraction, not a rewrite** — the XCUIRemote focus behavior already existed; this gives it a name and a home.

- **`isTvOsDevice(device)` in `kernel/device.ts`** — the tvOS leaf predicate. It lives in the kernel (the dependency sink) because the layering DAG (R3) forbids `core/` and the command-descriptor registry from importing `platforms/`, and all of them need to gate on it. **Apple-only by design:** Android TV also uses `target: 'tv'` but is a distinct leaf, so the `platform === 'ios'` gate is load-bearing.
- **New `src/platforms/apple/os/tvos/` leaf** (mirrors `os/macos/`) — owns the XCUIRemote focus-navigation command builder (`appleRemotePressCommand`, moved out of `platforms/ios/interactions.ts`). This delivers the "dedicated tvOS leaf" ADR-0009 listed as deferred.
- **Routed the unambiguous `target === 'tv'` gates through `isTvOsDevice`:** interactor `back`/`home`/`scroll` (the focus-only navigation), the iOS-touch synthesis gates in `interactions.ts` + `dispatch-interactions.ts`, and the registry capability predicates (`isIosMobileSimulator`, `supportsAndroidOrIosNonTv`, the tvOS synthesis-gesture hint). The capability matrix derives from the registry, so this stays byte-behavior-identical (parity tests green).

## Preserved focus-only contract (do-not-flatten)
The tvOS focus-only interaction contract is **not** flattened into a uniform Apple tap/gesture path:
- `back`/`home`/`scroll` drive **XCUIRemote focus** (`remotePress` menu/home/direction), never a coordinate tap/drag.
- A coordinate `tap(x,y)` on tvOS forwards to the runner **un-synthesized** (existing behavior), which rejects it off the focused element — the per-OS gate stays.
- `pinch`/`rotate`/`transform` remain **UNSUPPORTED** on tvOS.

Behavior is byte-identical for tvOS sample devices (verified against the `TVOS_SIMULATOR` fixture).

## Intentionally left (noted inline)
Two site-groups keep their literal `target === 'tv'`:
- `apple/core/devices.ts` `resolveAppleOs` — the canonical `target → appleOs` classification source; wrapping it in the predicate would be circular.
- `dispatch-interactions.ts` `handlePinch/Rotate/TransformGestureCommand` — those `target === 'tv'` gates **also reject Android TV** (which shares `target: 'tv'`). Narrowing them to the Apple-only leaf would silently change Android-TV behavior, so per the discipline they're left and annotated with a comment.

## Tests pinning the tvOS contract
- **`isTvOsDevice` Apple-only gate** (`utils/__tests__/device.test.ts`): true for `TVOS_SIMULATOR`; false for iOS, macOS, **and Android TV** (guards against widening the gate).
- **Focus-only navigation** (`utils/__tests__/interactors.test.ts`): tvOS `back` → `remotePress` menu, tvOS `home` → `remotePress` home, and iOS `back` keeps the in-app path (the per-OS gate does not flatten). tvOS `scroll` → `remotePress` was already covered.
- **UNSUPPORTED coordinate-gesture** (`core/__tests__/dispatch-pinch.test.ts`): added tvOS `rotate-gesture` + `transform-gesture` rejection alongside the existing `pinch` rejection.

## Verification (binaries run directly)
- `tsc -p tsconfig.json` — clean
- `oxlint . --deny-warnings` — clean
- `oxfmt --write/--check src test` — clean
- `scripts/layering/check.ts` — OK (new leaf import respects R3, kernel predicate respects R1)
- `rslib build` — clean
- `vitest run --project unit` — 2889 passed / 296 files (no flakes)
- `fallow audit --base origin/main` — no new findings

Human-review-only; do not merge automatically.