### PR TITLE
fix: project doctor output platform to the public leaf after the Platform collapse

### DIFF
--- a/src/daemon/handlers/session-doctor-app.ts
+++ b/src/daemon/handlers/session-doctor-app.ts
@@ -43,7 +43,7 @@ export async function appendAppChecks(
       status: 'fail',
       summary: `Target app check failed: ${normalized.message}`,
       hint: normalized.hint ?? 'Install the app or pass an exact package/bundle id or app name.',
-      command: `agent-device apps --platform ${device.platform} --all`,
+      command: `agent-device apps --platform ${publicPlatformString(device)} --all`,
       evidence: { code: normalized.code, message: normalized.message },
     });
   }

--- a/src/daemon/handlers/session-doctor-device.ts
+++ b/src/daemon/handlers/session-doctor-device.ts
@@ -13,8 +13,8 @@ import {
   publicPlatformString,
   type DeviceInfo,
   type DeviceTarget,
-  type Platform,
   type PlatformSelector,
+  type PublicPlatform,
 } from '../../kernel/device.ts';
 import { normalizeError } from '../../kernel/errors.ts';
 import type { DaemonRequest, SessionState } from '../types.ts';
@@ -267,12 +267,16 @@ function deviceInventoryEvidence(
   devices: DeviceInfo[],
   failures: DoctorInventoryFailure[],
 ): Record<string, unknown> {
-  const byPlatform = new Map<Platform, { available: number; booted: number }>();
+  // Key by the PUBLIC leaf platform (ios/macos/android/...), never the internal
+  // collapsed `apple`, so the doctor breakdown stays a machine-stable output and
+  // Apple devices split into ios vs macos.
+  const byPlatform = new Map<PublicPlatform, { available: number; booted: number }>();
   for (const device of devices) {
-    const entry = byPlatform.get(device.platform) ?? { available: 0, booted: 0 };
+    const key = publicPlatformString(device);
+    const entry = byPlatform.get(key) ?? { available: 0, booted: 0 };
     entry.available += 1;
     if (device.booted === true) entry.booted += 1;
-    byPlatform.set(device.platform, entry);
+    byPlatform.set(key, entry);
   }
   return {
     available: devices.length,

--- a/src/daemon/handlers/session-doctor-options.ts
+++ b/src/daemon/handlers/session-doctor-options.ts
@@ -1,4 +1,5 @@
 import { detectProjectRuntimeKind } from '../../utils/project-runtime.ts';
+import { publicPlatformString } from '../../kernel/device.ts';
 import type { SessionStore } from '../session-store.ts';
 import type { DaemonRequest, SessionState } from '../types.ts';
 import type { DoctorCheck, DoctorKind, DoctorOptions } from './session-doctor-types.ts';
@@ -116,7 +117,7 @@ export function sessionChecks(
           : undefined,
       command:
         sameDeviceSessions.length > 0
-          ? `agent-device close --session ${sameDeviceSessions[0]} --platform ${session.device.platform}`
+          ? `agent-device close --session ${sameDeviceSessions[0]} --platform ${publicPlatformString(session.device)}`
           : undefined,
       evidence: {
         session: session.name,


### PR DESCRIPTION
## Summary

Follow-up to the Platform collapse (#1002) — you were right to double-check `doctor` (added recently in #883, concurrent with the refactor). It was **mostly** converted but had one real output leak the collapse's guard didn't cover.

### The gap (fixed)
`session-doctor-device.ts` `deviceInventoryEvidence` built the `byPlatform` breakdown keyed by the **raw internal `device.platform`**, so an Apple session's `doctor` device-inventory check emitted `byPlatform: { apple: {...} }` — a machine-facing `apple` leak, contrary to approach (b) (output stays leaf `ios`/`macos`).

- Now keyed by `publicPlatformString(device)` → `Map<PublicPlatform, …>`, so an `apple` key is **compile-impossible**, and Apple devices split into `ios` vs `macos` in the breakdown (more useful).
- Also projected two `doctor` command-**suggestion** strings (`apps --platform …`, `close --platform …`) to the leaf — `--platform apple` was valid but broader than the session's actual device.

### What was already correct (verified, not changed)
- `doctor` is in the command catalog + command-descriptor registry; it routes via the descriptor `daemon` block (`route:'session'`, `sessionKind:'inventory'`) — no `daemon-command-registry` entry needed.
- No platform-specific `supports`/capability gate (doctor is platform-agnostic) → correctly absent from the Apple `supportsByDefault` map.
- `appendToolchainChecks` already handles `'apple'` (so `session-doctor.ts` toolchain routing works); `:111` platform is an internal device-inventory **selector**, not output.

## Verification
tsc · oxlint --deny-warnings · oxfmt --check · layering guard · fallow (no new findings) · **provider-integration 82/82**; full unit green except the known android `fillAndroid` contention flake (passes 92/92 in isolation). The fix is type-guaranteed (leaf keys) and `publicPlatformString` is already parity-tested.
