### PR TITLE
fix: pin agent-cdp 1.6.1

### DIFF
--- a/src/__tests__/cli-agent-cdp.test.ts
+++ b/src/__tests__/cli-agent-cdp.test.ts
@@ -19,14 +19,14 @@ afterEach(() => {
 });
 
 test('cdp wrapper pins agent-cdp package version', () => {
-  assert.equal(AGENT_CDP_PACKAGE, 'agent-cdp@1.6.0');
+  assert.equal(AGENT_CDP_PACKAGE, 'agent-cdp@1.6.1');
   assert.deepEqual(
     buildAgentCdpNpmExecArgs(['memory', 'usage', 'sample', '--label', 'baseline', '--gc']),
     [
       'exec',
       '--yes',
       '--package',
-      'agent-cdp@1.6.0',
+      'agent-cdp@1.6.1',
       '--',
       'agent-cdp',
       'memory',
@@ -81,7 +81,7 @@ test('cdp wrapper streams through npm exec and returns downstream exit code', as
     'exec',
     '--yes',
     '--package',
-    'agent-cdp@1.6.0',
+    'agent-cdp@1.6.1',
     '--',
     'agent-cdp',
     'target',
@@ -175,7 +175,7 @@ test('cdp passes injected remote target url to npm exec', async () => {
     'exec',
     '--yes',
     '--package',
-    'agent-cdp@1.6.0',
+    'agent-cdp@1.6.1',
     '--',
     'agent-cdp',
     'target',

--- a/src/cli/commands/agent-cdp.ts
+++ b/src/cli/commands/agent-cdp.ts
@@ -4,7 +4,7 @@ import { isRemoteBridgeBackend } from './remote-bridge.ts';
 import type { SessionRuntimeHints } from '../../kernel/contracts.ts';
 import type { CliFlags } from '../parser/cli-flags.ts';
 
-const AGENT_CDP_VERSION = '1.6.0';
+const AGENT_CDP_VERSION = '1.6.1';
 export const AGENT_CDP_PACKAGE = `agent-cdp@${AGENT_CDP_VERSION}`;
 const AGENT_CDP_BIN = 'agent-cdp';
 


### PR DESCRIPTION
## Summary

Pin the CDP helper wrapper to the published `agent-cdp@1.6.1` package so `agent-device cdp ...` works from standard installs again.

Closes #994

Touched files: 2

## Validation

Verified `agent-cdp@1.6.1` is published with `npm view agent-cdp@1.6.1 version`. Ran the focused CDP wrapper tests, formatter, and quick static gate: `pnpm exec vitest run src/__tests__/cli-agent-cdp.test.ts --project unit`, `pnpm format`, and `pnpm check:quick`.