### PR TITLE
feat: route recording + provider platform gates through PlatformPlugin facets

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,8 +73,9 @@ The refactor is substantively done; these follow-ups are intentionally deferred,
 - Phase 2c — narrow the ~15 remaining `Record`-typed client methods in
   `src/client/client-types.ts` to their existing typed contracts (a semver-relevant public-API
   narrowing; not yet done).
-- b.3 recording/providers facets — the two risky `PlatformPlugin` daemon facets (`providers`,
-  `recording`) remain on their daemon branch as source of truth (#974 closed).
+- b.3 perf sampling body — all four `PlatformPlugin` daemon facets now route through the plugin
+  (`appLog`, the `perf` support gate, `recording`, and `providers`; the last two via #1007). Only
+  the `perf` sampling body (`buildPerfResponseData`) still branches in the daemon.
 - Strict DAG back-edge inversion — the layering lint enforces the achievable subset; the full
   zero-back-edge DAG (e.g. `commands` → `cli`/`client`) is not done.
 - Legacy alias drops — ~175 LOC of legacy aliases/barrels remain, gated to the next major.

--- a/src/core/interactors/register-builtins.ts
+++ b/src/core/interactors/register-builtins.ts
@@ -32,6 +32,12 @@ const androidPlugin = {
   // Wraps the Android arm of `supportsPlatformPerfMetrics`: every Android device
   // reports perf-metrics support.
   perf: { supportsMetrics: () => true },
+  // Wraps the Android arm of `resolveRecordingBackendForDevice`: every Android device
+  // resolves to the android recording backend.
+  recording: { resolveBackendTag: () => 'android' },
+  // Declares the platform-gated request provider resolver the Android family owns (the
+  // adb provider, formerly gated by `device.platform === 'android'`).
+  providers: { platformGatedResolvers: ['androidAdbProvider'] },
   createInteractor: async (device: DeviceInfo) => {
     const { createAndroidInteractor } = await import('./android.ts');
     return createAndroidInteractor(device);
@@ -50,6 +56,11 @@ const linuxPlugin = {
   id: 'linux',
   platforms: ['linux'],
   capability: { bucket: 'linux' },
+  // No recording facet: linux historically fell through to the unsupported recording
+  // backend; the daemon lookup preserves that (`?? 'unsupported'`).
+  // Declares the platform-gated request provider resolver the linux family owns (the
+  // linux tool provider, formerly gated by `device.platform === 'linux'`).
+  providers: { platformGatedResolvers: ['linuxToolProvider'] },
   createInteractor: async () => {
     const { createLinuxInteractor } = await import('./linux.ts');
     return createLinuxInteractor();
@@ -64,6 +75,12 @@ const webPlugin = {
   id: 'web',
   platforms: ['web'],
   capability: { bucket: 'web' },
+  // Wraps the web arm of `resolveRecordingBackendForDevice`: the web device resolves to
+  // the web (agent-browser) recording backend.
+  recording: { resolveBackendTag: () => 'web' },
+  // Declares the platform-gated request provider resolver the web family owns (the web
+  // provider, formerly gated by `device.platform === 'web'`).
+  providers: { platformGatedResolvers: ['webProvider'] },
   createInteractor: async () => {
     const { createWebInteractor } = await import('./web.ts');
     return createWebInteractor();

--- a/src/core/platform-plugin/plugin.ts
+++ b/src/core/platform-plugin/plugin.ts
@@ -1,6 +1,8 @@
 import { AppError } from '../../kernel/errors.ts';
 import type { DeviceInfo, Platform, PlatformSelector } from '../../kernel/device.ts';
 import type { LogBackend } from '../../daemon/network-log.ts';
+import type { RecordingBackendTag } from '../../daemon/handlers/record-trace-recording-backends.ts';
+import type { PlatformGatedProviderResolverKey } from '../../daemon/request-platform-providers.ts';
 import type { Interactor, RunnerContext } from '../interactor-types.ts';
 import type { DeviceInventoryRequest } from '../platform-inventory.ts';
 import type { CapabilityBucket } from '../platform-descriptor/types.ts';
@@ -27,10 +29,15 @@ import type { CapabilityBucket } from '../platform-descriptor/types.ts';
  * (wraps `resolveLogBackend`, pinned by the daemon app-log routing parity test);
  * {@link PlatformPlugin.perf} carries the neutral perf-metrics support predicate
  * (wraps `supportsPlatformPerfMetrics`, pinned by the daemon perf routing parity
- * test). The remaining columns (`providers` / `recording`) — and the rest of the
- * `perf` facet (the sampling body `buildPerfResponseData` and the Android-only
- * native-collector gate) — stay on their daemon branch as the source of truth
- * until each clears the same gate. See
+ * test); {@link PlatformPlugin.recording} carries the neutral
+ * {@link RecordingBackendTag} resolver (wraps the per-platform branch of
+ * `resolveRecordingBackendForDevice`, pinned by the recording routing parity test);
+ * {@link PlatformPlugin.providers} carries the per-family platform-gated request
+ * provider resolver list (replaces the hand `device.platform === …` gate in
+ * `request-platform-providers.ts`, pinned by the providers routing parity test). The
+ * rest of the `perf` facet (the sampling body `buildPerfResponseData` and the
+ * Android-only native-collector gate) stays on its daemon branch as the source of
+ * truth until it clears the same gate. See
  * docs/adr/0009-apple-platform-consolidation.md (tracked in issue #974).
  */
 export type PlatformPlugin = {
@@ -92,6 +99,39 @@ export type PlatformPlugin = {
    */
   readonly perf?: {
     supportsMetrics(device: DeviceInfo): boolean;
+  };
+  /**
+   * The daemon recording facet (issue #974). `resolveBackendTag` wraps the
+   * per-platform branch of `resolveRecordingBackendForDevice`
+   * (src/daemon/handlers/record-trace-recording-backends.ts), returning the neutral
+   * {@link RecordingBackendTag} for `device` (a DATA-ONLY string, type-only in the
+   * plugin — exactly like {@link appLog}'s {@link LogBackend}). The daemon maps the tag
+   * back to its own {@link RecordingBackend} instance, so core/platforms never construct
+   * the daemon-owned backend objects. Present on families with a recording backend
+   * (Apple + Android + web); left `undefined` for linux, where the hand branch fell
+   * through to the unsupported backend — the daemon lookup preserves that fallthrough
+   * (`?? 'unsupported'`), and the recording routing parity test pins the equivalence.
+   */
+  readonly recording?: {
+    resolveBackendTag(device: DeviceInfo): RecordingBackendTag;
+  };
+  /**
+   * The daemon request-scope provider facet (issue #974). `platformGatedResolvers`
+   * declares which PLATFORM-GATED request provider resolvers apply to this family's
+   * devices — the DATA that replaces the hand `device.platform === …` gate formerly
+   * open-coded inside each descriptor's `resolve` in
+   * src/daemon/request-platform-providers.ts. The daemon still OWNS the resolver
+   * functions, their wrapper composition, and the request-scope concurrency isolation;
+   * this facet supplies only the per-family gate (a plain string list, the keys
+   * type-only in the plugin). The ungated resolvers (`appLogProvider` /
+   * `recordingProvider`, which apply on every platform) are intentionally NOT part of
+   * the facet and stay ungated in the daemon. Every family carries this facet (each
+   * owns at least one platform-specific resolver); a device on an unregistered platform
+   * resolves to no gated resolvers, matching the former hand gate. Pinned by the
+   * providers routing parity test.
+   */
+  readonly providers?: {
+    readonly platformGatedResolvers: readonly PlatformGatedProviderResolverKey[];
   };
 };
 

--- a/src/daemon/__tests__/providers-plugin-routing-parity.test.ts
+++ b/src/daemon/__tests__/providers-plugin-routing-parity.test.ts
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  isApplePlatform,
+  DEVICE_TARGETS,
+  PLATFORMS,
+  type DeviceInfo,
+  type DeviceKind,
+  type DeviceTarget,
+} from '../../kernel/device.ts';
+import {
+  ANDROID_EMULATOR,
+  ANDROID_TV_DEVICE,
+  IOS_DEVICE,
+  IOS_SIMULATOR,
+  IPADOS_SIMULATOR,
+  LINUX_DEVICE,
+  MACOS_DEVICE,
+  makeSession,
+  TVOS_SIMULATOR,
+  VISIONOS_SIMULATOR,
+  WEB_DESKTOP_DEVICE,
+} from '../../__tests__/test-utils/index.ts';
+import { getPlugin, tryGetPlugin } from '../../core/platform-plugin/plugin.ts';
+import { registerBuiltinPlatformPlugins } from '../../core/interactors/register-builtins.ts';
+import {
+  withRequestPlatformProviderScope,
+  type PlatformGatedProviderResolverKey,
+  type PlatformProviderResolvers,
+} from '../request-platform-providers.ts';
+import type { DaemonRequest } from '../types.ts';
+
+// Phase 3 step b.3 (issue #974) parity gate for the daemon request-scope provider
+// facet. The per-platform GATE that each descriptor in `request-platform-providers.ts`
+// open-coded (`device.platform === 'android'`, `isApplePlatform(...)`, etc.) now flows
+// through the PlatformPlugin `providers.platformGatedResolvers` facet. The daemon still
+// OWNS the resolver invocation, wrapper composition, and concurrency isolation — only
+// the gate moved to data. An INDEPENDENT verbatim copy of the former gates below is the
+// BEFORE oracle, checked at the facet level AND end-to-end through
+// `withRequestPlatformProviderScope`.
+
+registerBuiltinPlatformPlugins();
+
+// The platform-gated resolver keys, and the two ungated resolvers (no platform gate;
+// they apply on every platform and are NOT part of the facet).
+const GATED_KEYS: PlatformGatedProviderResolverKey[] = [
+  'androidAdbProvider',
+  'appleRunnerProvider',
+  'appleToolProvider',
+  'linuxToolProvider',
+  'webProvider',
+];
+const UNGATED_KEYS = ['appLogProvider', 'recordingProvider'] as const;
+
+// --- INDEPENDENT verbatim copy of the former per-descriptor platform gates ---
+function gatedResolversByHand(device: DeviceInfo): Set<PlatformGatedProviderResolverKey> {
+  const applies = new Set<PlatformGatedProviderResolverKey>();
+  if (device.platform === 'android') applies.add('androidAdbProvider'); // was `!== 'android'`
+  if (isApplePlatform(device.platform)) {
+    applies.add('appleRunnerProvider'); // was `!isApplePlatform(...)`
+    applies.add('appleToolProvider'); // was `!isApplePlatform(...)`
+  }
+  if (device.platform === 'linux') applies.add('linuxToolProvider'); // was `!== 'linux'`
+  if (device.platform === 'web') applies.add('webProvider'); // was `!== 'web'`
+  return applies;
+}
+
+// --- the exhaustive synthetic device matrix (every platform x kind x target) ---
+const DEVICE_KINDS_ALL: DeviceKind[] = ['simulator', 'emulator', 'device'];
+const DEVICE_TARGETS_ALL: (DeviceTarget | undefined)[] = [undefined, ...DEVICE_TARGETS];
+
+function buildDeviceMatrix(): DeviceInfo[] {
+  const devices: DeviceInfo[] = [];
+  for (const platform of PLATFORMS) {
+    for (const kind of DEVICE_KINDS_ALL) {
+      for (const target of DEVICE_TARGETS_ALL) {
+        devices.push({
+          platform,
+          id: `${platform}-${kind}-${target ?? 'none'}`,
+          name: `${platform} ${kind} ${target ?? 'none'}`,
+          kind,
+          ...(target ? { target } : {}),
+          booted: true,
+        });
+      }
+    }
+  }
+  return devices;
+}
+
+const SAMPLE_DEVICES: DeviceInfo[] = [
+  ANDROID_EMULATOR,
+  ANDROID_TV_DEVICE,
+  IOS_DEVICE,
+  IOS_SIMULATOR,
+  IPADOS_SIMULATOR,
+  LINUX_DEVICE,
+  MACOS_DEVICE,
+  TVOS_SIMULATOR,
+  VISIONOS_SIMULATOR,
+  WEB_DESKTOP_DEVICE,
+  ...buildDeviceMatrix(),
+];
+
+test('providers.platformGatedResolvers facet is byte-identical to the former hand gate', () => {
+  for (const device of SAMPLE_DEVICES) {
+    const facet = tryGetPlugin(device.platform)?.providers;
+    const expected = gatedResolversByHand(device);
+    for (const key of GATED_KEYS) {
+      const applies = facet?.platformGatedResolvers.includes(key) ?? false;
+      assert.equal(applies, expected.has(key), `gate for ${key} on ${device.id}`);
+    }
+  }
+});
+
+test('every family carries the providers facet with the resolvers it owns', () => {
+  // Apple owns ios + macos (SAME plugin instance). Unlike appLog/perf, EVERY family
+  // owns at least one platform-specific resolver, so all four carry the facet.
+  assert.equal(getPlugin('apple'), getPlugin('apple'));
+  assert.deepEqual([...getPlugin('apple').providers!.platformGatedResolvers].sort(), [
+    'appleRunnerProvider',
+    'appleToolProvider',
+  ]);
+  assert.deepEqual(
+    [...getPlugin('android').providers!.platformGatedResolvers],
+    ['androidAdbProvider'],
+  );
+  assert.deepEqual(
+    [...getPlugin('linux').providers!.platformGatedResolvers],
+    ['linuxToolProvider'],
+  );
+  assert.deepEqual([...getPlugin('web').providers!.platformGatedResolvers], ['webProvider']);
+});
+
+// End-to-end routing proof: drive the REAL `withRequestPlatformProviderScope` with a
+// spy for every resolver and assert exactly the gated resolvers the former hand gate
+// admitted are invoked (plus the two ungated resolvers, on every platform). Each spy
+// returns `undefined`, so no wrapper is composed — but the resolver is still called iff
+// its gate passed, which is precisely what the former `device.platform === …` branch
+// decided. Breaking the facet flips which resolvers run and fails this test.
+test('withRequestPlatformProviderScope invokes exactly the resolvers the former gate did', async () => {
+  for (const device of SAMPLE_DEVICES) {
+    const invoked = new Set<string>();
+    const spy = (key: string) => (): undefined => {
+      invoked.add(key);
+      return undefined;
+    };
+    const providers: PlatformProviderResolvers = {
+      androidAdbProvider: spy('androidAdbProvider'),
+      appleRunnerProvider: spy('appleRunnerProvider'),
+      appleToolProvider: spy('appleToolProvider'),
+      linuxToolProvider: spy('linuxToolProvider'),
+      webProvider: spy('webProvider'),
+      appLogProvider: spy('appLogProvider'),
+      recordingProvider: spy('recordingProvider'),
+    };
+
+    await withRequestPlatformProviderScope(
+      {
+        req: request('snapshot'),
+        existingSession: makeSession(`prov-${device.id}`, { device }),
+        providers,
+      },
+      async () => {},
+    );
+
+    const gatedInvoked = new Set(GATED_KEYS.filter((key) => invoked.has(key)));
+    assert.deepEqual(
+      [...gatedInvoked].sort(),
+      [...gatedResolversByHand(device)].sort(),
+      `gated resolvers invoked for ${device.id}`,
+    );
+    for (const key of UNGATED_KEYS) {
+      assert.ok(invoked.has(key), `ungated resolver ${key} must run for ${device.id}`);
+    }
+  }
+});
+
+function request(command: string): DaemonRequest {
+  return {
+    token: 'test-token',
+    session: 'default',
+    command,
+    positionals: [],
+    flags: {},
+    meta: { requestId: `req-${command}` },
+  };
+}

--- a/src/daemon/__tests__/recording-plugin-routing-parity.test.ts
+++ b/src/daemon/__tests__/recording-plugin-routing-parity.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  isIosFamily,
+  isMacOs,
+  DEVICE_TARGETS,
+  PLATFORMS,
+  type DeviceInfo,
+  type DeviceKind,
+  type DeviceTarget,
+} from '../../kernel/device.ts';
+import {
+  ANDROID_EMULATOR,
+  ANDROID_TV_DEVICE,
+  IOS_DEVICE,
+  IOS_SIMULATOR,
+  IPADOS_SIMULATOR,
+  LINUX_DEVICE,
+  MACOS_DEVICE,
+  TVOS_SIMULATOR,
+  VISIONOS_SIMULATOR,
+  WEB_DESKTOP_DEVICE,
+} from '../../__tests__/test-utils/index.ts';
+import { getPlugin, tryGetPlugin } from '../../core/platform-plugin/plugin.ts';
+import { registerBuiltinPlatformPlugins } from '../../core/interactors/register-builtins.ts';
+import {
+  resolveRecordingBackendForDevice,
+  type RecordingBackendTag,
+} from '../handlers/record-trace-recording-backends.ts';
+
+// Phase 3 step b.3 (issue #974) parity gate for the daemon recording facet. The
+// per-platform branch of `resolveRecordingBackendForDevice` now flows through the
+// PlatformPlugin `recording.resolveBackendTag` facet (mapped daemon-side back to the
+// concrete backend instance) instead of a hand branch. An INDEPENDENT verbatim copy
+// of the former branch below is the BEFORE oracle: a plugin-vs-branch disagreement on
+// any sample device fails this test. (Mirrors the verbatim-copy discipline in
+// daemon/__tests__/applog-plugin-routing-parity.test.ts.)
+
+registerBuiltinPlatformPlugins();
+
+// --- INDEPENDENT verbatim copy of the former `resolveRecordingBackendForDevice`
+// branch, expressed as the backend TAG each arm returned ---
+function recordingBackendTagByHand(device: DeviceInfo): RecordingBackendTag {
+  if (device.platform === 'web') return 'web';
+  if (device.platform === 'android') return 'android';
+  if (isMacOs(device)) return 'macos';
+  if (isIosFamily(device) && device.kind === 'device') return 'ios-device';
+  if (isIosFamily(device)) return 'ios-simulator';
+  return 'unsupported';
+}
+
+// --- the exhaustive synthetic device matrix (every platform x kind x target) ---
+const DEVICE_KINDS_ALL: DeviceKind[] = ['simulator', 'emulator', 'device'];
+const DEVICE_TARGETS_ALL: (DeviceTarget | undefined)[] = [undefined, ...DEVICE_TARGETS];
+
+function buildDeviceMatrix(): DeviceInfo[] {
+  const devices: DeviceInfo[] = [];
+  for (const platform of PLATFORMS) {
+    for (const kind of DEVICE_KINDS_ALL) {
+      for (const target of DEVICE_TARGETS_ALL) {
+        devices.push({
+          platform,
+          id: `${platform}-${kind}-${target ?? 'none'}`,
+          name: `${platform} ${kind} ${target ?? 'none'}`,
+          kind,
+          ...(target ? { target } : {}),
+          booted: true,
+        });
+      }
+    }
+  }
+  return devices;
+}
+
+// The hand-authored fixtures (the real discovery shapes, incl. macOS / iOS-device /
+// iOS-sim / tvOS / iPadOS / visionOS / android / web / linux) plus the exhaustive
+// synthetic cross-product, so every off-nominal combination is pinned too.
+const SAMPLE_DEVICES: DeviceInfo[] = [
+  ANDROID_EMULATOR,
+  ANDROID_TV_DEVICE,
+  IOS_DEVICE,
+  IOS_SIMULATOR,
+  IPADOS_SIMULATOR,
+  LINUX_DEVICE,
+  MACOS_DEVICE,
+  TVOS_SIMULATOR,
+  VISIONOS_SIMULATOR,
+  WEB_DESKTOP_DEVICE,
+  ...buildDeviceMatrix(),
+];
+
+test('recording.resolveBackendTag facet is byte-identical to the former hand branch tag', () => {
+  for (const device of SAMPLE_DEVICES) {
+    const facet = tryGetPlugin(device.platform)?.recording;
+    if (!facet) continue; // linux carries no facet; the fallthrough is asserted below
+    assert.equal(
+      facet.resolveBackendTag(device),
+      recordingBackendTagByHand(device),
+      `facet tag for ${device.id}`,
+    );
+  }
+});
+
+test('resolveRecordingBackendForDevice partitions devices identically to the former hand branch', () => {
+  // Table-equivalence WITHOUT exporting the module-private backend instances: two
+  // devices that hand-resolve to the SAME tag must route to the SAME backend instance,
+  // and distinct tags must route to distinct instances. Combined with the facet-tag
+  // parity above and the daemon's exhaustive tag->backend map, this pins the routed
+  // instance per device byte-for-byte.
+  const instanceByTag = new Map<
+    RecordingBackendTag,
+    ReturnType<typeof resolveRecordingBackendForDevice>
+  >();
+  for (const device of SAMPLE_DEVICES) {
+    const tag = recordingBackendTagByHand(device);
+    const backend = resolveRecordingBackendForDevice(device);
+    const seen = instanceByTag.get(tag);
+    if (seen) {
+      assert.equal(backend, seen, `same backend instance for tag '${tag}' (${device.id})`);
+    } else {
+      instanceByTag.set(tag, backend);
+    }
+  }
+  const instances = [...instanceByTag.values()];
+  assert.equal(
+    new Set(instances).size,
+    instances.length,
+    'each distinct tag maps to a distinct backend instance',
+  );
+});
+
+test('only families with a recording backend carry the recording facet', () => {
+  // Apple owns ios + macos (SAME plugin instance); Android + web carry their own.
+  assert.equal(getPlugin('apple'), getPlugin('apple'));
+  assert.ok(getPlugin('apple').recording, 'apple plugin exposes recording');
+  assert.ok(getPlugin('android').recording, 'android plugin exposes recording');
+  assert.ok(getPlugin('web').recording, 'web plugin exposes recording');
+  // linux historically fell through to the unsupported backend; it gets NO facet, and
+  // the daemon lookup preserves that fallthrough (asserted below).
+  assert.equal(getPlugin('linux').recording, undefined, 'linux plugin has no recording');
+});
+
+test('the factless family (linux) falls through to the unsupported backend', () => {
+  assert.equal(tryGetPlugin('linux')?.recording, undefined);
+  assert.equal(recordingBackendTagByHand(LINUX_DEVICE), 'unsupported');
+  const linuxBackend = resolveRecordingBackendForDevice(LINUX_DEVICE);
+  // The routed linux backend is distinct from every family-owned backend; since the
+  // daemon's tag->backend map is exhaustive over the 6 tags and the other 5 are proven
+  // above, the remaining distinct instance is necessarily `unsupportedRecordingBackend`.
+  for (const device of [
+    WEB_DESKTOP_DEVICE,
+    ANDROID_EMULATOR,
+    MACOS_DEVICE,
+    IOS_DEVICE,
+    IOS_SIMULATOR,
+  ]) {
+    assert.notEqual(
+      linuxBackend,
+      resolveRecordingBackendForDevice(device),
+      `linux (unsupported) backend must differ from ${device.id}`,
+    );
+  }
+});

--- a/src/daemon/handlers/record-trace-recording-backends.ts
+++ b/src/daemon/handlers/record-trace-recording-backends.ts
@@ -1,6 +1,7 @@
-import { isIosFamily, isMacOs } from '../../kernel/device.ts';
 import fs from 'node:fs';
 import path from 'node:path';
+import { tryGetPlugin } from '../../core/platform-plugin/plugin.ts';
+import { registerBuiltinPlatformPlugins } from '../../core/interactors/register-builtins.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import type { SessionStore } from '../session-store.ts';
 import {
@@ -23,6 +24,28 @@ import {
   stopIosSimulatorRecording,
 } from './record-trace-ios-simulator-recording.ts';
 import type { RecordTraceDeps, RecordingBase } from './record-trace-types.ts';
+
+// The plugin registry is consulted by `resolveRecordingBackendForDevice` below;
+// register the builtin plugins on load so the lookup is populated (idempotent,
+// mirrors src/daemon/app-log.ts and src/daemon/handlers/session-perf.ts).
+registerBuiltinPlatformPlugins();
+
+/**
+ * The daemon-owned recording-backend discriminant (issue #974). A PLATFORM-NEUTRAL
+ * string tag naming which recording backend a device resolves to; the daemon maps it
+ * back to the concrete {@link RecordingBackend} instance via `RECORDING_BACKENDS_BY_TAG`.
+ * The {@link PlatformPlugin.recording} facet returns this tag (type-only in the plugin,
+ * exactly like {@link LogBackend} for app-log), so core/platforms never construct the
+ * daemon-owned backend objects. `'unsupported'` is the fallthrough for families that
+ * carry no recording facet (linux) and any unregistered platform.
+ */
+export type RecordingBackendTag =
+  | 'web'
+  | 'android'
+  | 'macos'
+  | 'ios-device'
+  | 'ios-simulator'
+  | 'unsupported';
 
 type ActiveRecording = NonNullable<SessionState['recording']>;
 type RecordingPlatform = ActiveRecording['platform'];
@@ -74,12 +97,13 @@ type RecordingStartBackend = Omit<RecordingBackend, 'stop'>;
 export function resolveRecordingBackendForDevice(
   device: SessionState['device'],
 ): RecordingStartBackend {
-  if (device.platform === 'web') return webRecordingBackend;
-  if (device.platform === 'android') return androidRecordingBackend;
-  if (isMacOs(device)) return macOsRecordingBackend;
-  if (isIosFamily(device) && device.kind === 'device') return iosDeviceRecordingBackend;
-  if (isIosFamily(device)) return iosSimulatorRecordingBackend;
-  return unsupportedRecordingBackend;
+  // Routes the per-platform branch through the PlatformPlugin recording facet (issue
+  // #974): web/android/apple carry a `recording.resolveBackendTag`; linux (and any
+  // unregistered platform) fall through to `'unsupported'`, matching the former hand
+  // branch's default. The daemon owns the backend instances and maps the neutral tag
+  // back to them here. The recording-plugin routing parity test pins the equivalence.
+  const tag = tryGetPlugin(device.platform)?.recording?.resolveBackendTag(device) ?? 'unsupported';
+  return RECORDING_BACKENDS_BY_TAG[tag];
 }
 
 export function stopActiveRecording(context: RecordingStopContext): Promise<DaemonResponse | null> {
@@ -263,6 +287,19 @@ const unsupportedRecordingBackend: RecordingBackend = {
     errorResponse('UNSUPPORTED_OPERATION', 'record is not supported on this device'),
   stop: async () =>
     errorResponse('UNSUPPORTED_OPERATION', 'record is not supported on this device'),
+};
+
+// Maps the neutral {@link RecordingBackendTag} the plugin facet returns back to the
+// daemon-owned backend instance. Exhaustive over the tag union (a compile error if a
+// tag is added without a backend), so `resolveRecordingBackendForDevice` is a pure
+// data lookup with no platform branch of its own.
+const RECORDING_BACKENDS_BY_TAG: Record<RecordingBackendTag, RecordingStartBackend> = {
+  web: webRecordingBackend,
+  android: androidRecordingBackend,
+  macos: macOsRecordingBackend,
+  'ios-device': iosDeviceRecordingBackend,
+  'ios-simulator': iosSimulatorRecordingBackend,
+  unsupported: unsupportedRecordingBackend,
 };
 
 function webRecordingUnsupportedFlags(req: DaemonRequest): string[] {

--- a/src/daemon/request-platform-providers.ts
+++ b/src/daemon/request-platform-providers.ts
@@ -1,4 +1,6 @@
 import { resolveTargetDevice } from '../core/dispatch-resolve.ts';
+import { registerBuiltinPlatformPlugins } from '../core/interactors/register-builtins.ts';
+import { tryGetPlugin } from '../core/platform-plugin/plugin.ts';
 import type { AndroidAdbExecutor, AndroidAdbProvider } from '../platforms/android/adb-executor.ts';
 import type {
   AppleRunnerCommandExecutor,
@@ -10,7 +12,7 @@ import type {
 } from '../platforms/apple/core/tool-provider.ts';
 import type { LinuxToolProvider } from '../platforms/linux/tool-provider.ts';
 import type { WebProvider } from '../platforms/web/provider.ts';
-import { isApplePlatform, type DeviceInfo } from '../kernel/device.ts';
+import type { DeviceInfo } from '../kernel/device.ts';
 import type { AppLogProvider } from './app-log.ts';
 import { hasExplicitDeviceSelector } from './device-selector-intent.ts';
 import type { RecordingProvider } from './recording-provider.ts';
@@ -55,6 +57,51 @@ export type PlatformProviderResolvers = {
   appLogProvider?: AppLogProviderResolver;
   recordingProvider?: RecordingProviderResolver;
 };
+
+/**
+ * The request provider resolvers whose application is PLATFORM-GATED — each ran behind
+ * a hand `device.platform === …` predicate inside its descriptor's `resolve`. The
+ * PlatformPlugin `providers` facet (issue #974) declares, per family, which of these
+ * apply to that family's devices (data-only: a plain string list, type-only in the
+ * plugin), and `platformGatedResolverApplies` routes the gate through it. The daemon
+ * still OWNS the resolver invocation, wrapper composition, and request-scope
+ * concurrency isolation — only the platform GATE moved to data.
+ *
+ * `appLogProvider` / `recordingProvider` are deliberately ABSENT: they carry no
+ * platform gate (they apply on every platform), so they stay ungated in the daemon and
+ * are not part of the facet.
+ */
+export type PlatformGatedProviderResolverKey =
+  | 'androidAdbProvider'
+  | 'appleRunnerProvider'
+  | 'appleToolProvider'
+  | 'linuxToolProvider'
+  | 'webProvider';
+
+// Compile-time: every gated key is a real resolver key (so the facet can never name a
+// resolver the daemon does not compose).
+type AssertTrue<T extends true> = T;
+export type GatedKeysAreResolverKeys = AssertTrue<
+  [PlatformGatedProviderResolverKey] extends [keyof PlatformProviderResolvers] ? true : false
+>;
+
+// The plugin registry backs `platformGatedResolverApplies`; register the builtin
+// plugins on load so the lookup is populated (idempotent, mirrors app-log.ts).
+registerBuiltinPlatformPlugins();
+
+/**
+ * Whether the platform-gated resolver `key` applies to `device`, per the owning
+ * family's PlatformPlugin `providers` facet. A device on a platform with no plugin, or
+ * a family that does not list `key`, resolves to `false` — byte-identical to the former
+ * hand `device.platform === …` gate (which also excluded every other platform). Pinned
+ * by the providers-plugin routing parity test.
+ */
+function platformGatedResolverApplies(
+  key: PlatformGatedProviderResolverKey,
+  device: DeviceInfo,
+): boolean {
+  return tryGetPlugin(device.platform)?.providers?.platformGatedResolvers.includes(key) ?? false;
+}
 
 export type RequestPlatformProviderScope = {
   androidAdbExecutor?: AndroidAdbExecutor;
@@ -119,7 +166,11 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
     resolverKey: 'androidAdbProvider',
     resolve(providers, context) {
       const androidAdbProvider = providers.androidAdbProvider;
-      if (!androidAdbProvider || context.device.platform !== 'android') return {};
+      if (
+        !androidAdbProvider ||
+        !platformGatedResolverApplies('androidAdbProvider', context.device)
+      )
+        return {};
       const provider = androidAdbProvider(context);
       const executor = typeof provider === 'function' ? provider : provider?.exec;
       return { androidAdb: { provider, executor, serial: context.device.id } };
@@ -140,7 +191,11 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
     resolverKey: 'appleRunnerProvider',
     resolve(providers, context) {
       const appleRunnerProvider = providers.appleRunnerProvider;
-      if (!appleRunnerProvider || !isApplePlatform(context.device.platform)) return {};
+      if (
+        !appleRunnerProvider ||
+        !platformGatedResolverApplies('appleRunnerProvider', context.device)
+      )
+        return {};
       const provider = appleRunnerProvider(context);
       return {
         appleRunner: {
@@ -170,7 +225,8 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
     resolverKey: 'appleToolProvider',
     resolve(providers, context) {
       const appleToolProvider = providers.appleToolProvider;
-      if (!appleToolProvider || !isApplePlatform(context.device.platform)) return {};
+      if (!appleToolProvider || !platformGatedResolverApplies('appleToolProvider', context.device))
+        return {};
       return { appleTool: { provider: appleToolProvider(context) } };
     },
     async appendWrapper(scopedProviders, wrappers) {
@@ -183,7 +239,8 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
     resolverKey: 'linuxToolProvider',
     resolve(providers, context) {
       const linuxToolProvider = providers.linuxToolProvider;
-      if (!linuxToolProvider || context.device.platform !== 'linux') return {};
+      if (!linuxToolProvider || !platformGatedResolverApplies('linuxToolProvider', context.device))
+        return {};
       return { linuxTool: { provider: linuxToolProvider(context) } };
     },
     async appendWrapper(scopedProviders, wrappers) {
@@ -196,7 +253,7 @@ const REQUEST_PLATFORM_PROVIDER_DESCRIPTORS = [
     resolverKey: 'webProvider',
     resolve(providers, context) {
       const webProvider = providers.webProvider;
-      if (!webProvider || context.device.platform !== 'web') return {};
+      if (!webProvider || !platformGatedResolverApplies('webProvider', context.device)) return {};
       return { web: { provider: webProvider(context) } };
     },
     async appendWrapper(scopedProviders, wrappers) {

--- a/src/platforms/apple/plugin.ts
+++ b/src/platforms/apple/plugin.ts
@@ -138,6 +138,16 @@ export const applePlugin = {
   // Wraps the Apple arm of `supportsPlatformPerfMetrics`: every Apple device
   // (ios/macos, any kind/target) reports perf-metrics support.
   perf: { supportsMetrics: () => true },
+  // Wraps the Apple arm of `resolveRecordingBackendForDevice` verbatim: macOS ->
+  // 'macos'; an iOS `device` -> 'ios-device'; every other iOS kind (simulator, incl.
+  // tvOS/iPadOS/visionOS) -> 'ios-simulator'. Mirrors the appLog resolveBackend shape.
+  recording: {
+    resolveBackendTag: (device: DeviceInfo) =>
+      isMacOs(device) ? 'macos' : device.kind === 'device' ? 'ios-device' : 'ios-simulator',
+  },
+  // Declares the platform-gated request provider resolvers the Apple family owns: the
+  // runner + tool providers (formerly gated by `isApplePlatform(device.platform)`).
+  providers: { platformGatedResolvers: ['appleRunnerProvider', 'appleToolProvider'] },
   createInteractor: async (device: DeviceInfo, runner: RunnerContext) => {
     const { createAppleInteractor } = await import('./interactor.ts');
     return createAppleInteractor(device, runner);


### PR DESCRIPTION
## Summary

Phase 3 step b.3 (issue #974): lands the two **deferred** daemon-owned `PlatformPlugin` facets — `recording` and `providers` — as **DATA-ONLY** seams, mirroring the shipped `appLog`/`perf` templates. Both facets are type-only in the plugin (R3-clean, exactly like `LogBackend`), so there is no `platforms/`→`daemon/` value edge and no CLI cold-start regression.

**Both facets landed.** Neither had to be deferred.

## `recording` facet — LANDED

- New neutral discriminant `RecordingBackendTag = 'web' | 'android' | 'macos' | 'ios-device' | 'ios-simulator' | 'unsupported'` (daemon-owned, in `record-trace-recording-backends.ts`; type-only in the plugin).
- `PlatformPlugin.recording.resolveBackendTag(device)` returns the tag. Populated on apple (macOS→`macos`, iOS device→`ios-device`, iOS other→`ios-simulator` — mirrors the `appLog` shape), android (`android`), web (`web`); linux left `undefined`.
- `resolveRecordingBackendForDevice` routes through `tryGetPlugin(device.platform)?.recording?.resolveBackendTag(device) ?? 'unsupported'` and maps the tag back to the existing daemon-owned backend instance via an exhaustive `RECORDING_BACKENDS_BY_TAG` map. **The backend instances + `RecordingBackend` type stay in the daemon, unchanged.** No renames (kept behaviorless).

## `providers` facet — LANDED

The load-bearing request-scope orchestration seam. The **only** thing moved to data is the per-platform GATE (the hand `device.platform === 'android'` / `isApplePlatform(...)` / `!== 'linux'` / `!== 'web'` predicates that lived inside each descriptor's `resolve`). The daemon still **OWNS** resolver invocation, per-request wrapper composition, and request-scope concurrency isolation — none of that moved.

- New daemon-owned key union `PlatformGatedProviderResolverKey` (`androidAdbProvider | appleRunnerProvider | appleToolProvider | linuxToolProvider | webProvider`) + a compile-time assertion that every gated key is a real `keyof PlatformProviderResolvers`. Type-only in the plugin.
- `PlatformPlugin.providers.platformGatedResolvers` declares, per family, which gated resolvers apply: apple→`[appleRunnerProvider, appleToolProvider]`, android→`[androidAdbProvider]`, linux→`[linuxToolProvider]`, web→`[webProvider]`.
- The two **ungated** resolvers (`appLogProvider`, `recordingProvider`) apply on every platform, carry no gate, and are deliberately NOT part of the facet — they stay ungated in the daemon.
- Each descriptor's gate now calls `platformGatedResolverApplies(key, device)` → `tryGetPlugin(device.platform)?.providers?.platformGatedResolvers.includes(key) ?? false`. Byte-identical to the former gate (an unregistered platform admits no gated resolver, exactly as the old `=== X` predicates did).

## Why this was safe (the deferral rationale, resolved)

The HARD CONSTRAINT was that a facet cannot return/construct daemon-owned instances (`RecordingBackend` objects, provider-resolver functions) because R3 forbids `platforms/`→`daemon/` value imports. Both facets return **data only** (a string tag; a list of string keys) with type-only daemon imports; the daemon maps data→its own implementation. The providers gate is a pure, static per-platform predicate, so lifting it to data does not touch the orchestration/concurrency-isolation machinery.

## Parity tests (independent verbatim oracle, full matrix)

- `src/daemon/__tests__/recording-plugin-routing-parity.test.ts` — verbatim hand-branch tag oracle; facet-tag equivalence across the real fixtures (incl. macOS / iOS-device / iOS-sim / tvOS / iPadOS / visionOS / android / web / linux) + exhaustive platform×kind×target matrix; instance-partition equivalence of `resolveRecordingBackendForDevice` (same tag ⇒ same backend instance, distinct tags ⇒ distinct instances) without exporting private instances; facet-presence; linux→unsupported fallthrough.
- `src/daemon/__tests__/providers-plugin-routing-parity.test.ts` — verbatim hand-gate oracle; facet-set equivalence per key across the full matrix; exact per-family facet sets; **end-to-end** proof through the real `withRequestPlatformProviderScope` (spy per resolver, asserts exactly the gated resolvers the old gate admitted are invoked, plus the two ungated ones on every platform).

## Verification (full CI set, final tree)

- `tsc -p tsconfig.json` — PASS
- `oxlint . --deny-warnings` — PASS
- `oxfmt --write src test && --check src test` — PASS
- `node --experimental-strip-types scripts/layering/check.ts` — **PASS** (679 files; R1/R2/R3 green — the whole point)
- `rslib build` — PASS
- `CI=true vitest run --project unit` — PASS (only the known `fillAndroid` CPU-contention flake times out under load; **confirmed 92/92 in isolation** and green in the serial coverage run)
- `CI=true vitest run --project provider-integration` — **PASS** (26 files, 85 tests, incl. the apple-platform-output-guard — recording/providers responses do not leak `apple`)
- `CI=true vitest run --coverage` — **PASS** run serially (334 files; statements 84.84 ≥ 78, lines 86.99 ≥ 80)
- `fallow audit --base origin/main` — PASS (no issues in changed files)

## Files

5 modified, 2 new tests (the `node_modules` symlink is intentionally NOT committed):
`src/core/platform-plugin/plugin.ts`, `src/platforms/apple/plugin.ts`, `src/core/interactors/register-builtins.ts`, `src/daemon/handlers/record-trace-recording-backends.ts`, `src/daemon/request-platform-providers.ts` + the two parity tests.

Human-review-only — please do not auto-merge.
