### PR TITLE
fix: reduce iOS runner keepalive log noise

### DIFF
--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -46,7 +46,8 @@ final class RunnerTests: XCTestCase {
   let firstInteractionAfterActivateDelay: TimeInterval = 0.25
   let scrollInteractionIdleTimeoutDefault: TimeInterval = 1.0
   let tvRemoteDoublePressDelayDefault: TimeInterval = 0.0
-  let xctestIdleKeepaliveInterval: TimeInterval = 5.0
+  // Keep a periodic XCTest liveness marker in runner.log without flooding long-lived sessions.
+  let xctestIdleKeepaliveInterval: TimeInterval = 60.0
   let minRecordingFps = 1
   let maxRecordingFps = 120
   var needsPostSnapshotInteractionDelay = false


### PR DESCRIPTION
## Summary

Cuts the XCTest idle keepalive cadence from every 5 seconds to every 60 seconds so long-lived runner sessions stop flooding runner.log while still emitting periodic liveness markers.
Keeps daemon readiness diagnostics unchanged, so actionable readiness failures still surface through the existing debug diagnostics and runner errors.
Closes #1016
Touched files: 1. Scope stayed within the iOS runner UITest entrypoint.

## Validation

`pnpm build:xcuitest` passed, including the iOS and macOS XCTest runner builds. No screen behavior changed; this only reduces idle runner log volume during long-lived sessions.