### PR TITLE
feat: add opt-in exec command diagnostics

### DIFF
--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -387,6 +387,7 @@ Alerts:
 
 Diagnostics and traces:
   Use --debug for CLI/daemon diagnostic ids and log paths.
+  Use AGENT_DEVICE_EXEC_TRACE=1 when you need host-tool spawn timing without full debug streaming; it flushes the full request diagnostics file on successful requests that spawn host tools.
   Open output includes Session state; JSON also includes runnerLogPath and requestLogPath.
   Session requests/<request-id>.ndjson holds daemon request diagnostics; session runner.log holds Apple runner/xcodebuild output.
   daemon.log is global daemon lifecycle evidence, not the primary per-run log.

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1655,6 +1655,10 @@ test('usageForCommand resolves debugging help topic', () => {
   assert.match(help, /resolved app executable/);
   assert.match(help, /--launch-console is only for direct iOS simulator app launches/);
   assert.match(help, /runnerLogPath and requestLogPath/);
+  assert.match(
+    help,
+    /AGENT_DEVICE_EXEC_TRACE=1 when you need host-tool spawn timing without full debug streaming/,
+  );
   assert.match(help, /requests\/<request-id>\.ndjson holds daemon request diagnostics/);
   assert.match(help, /daemon\.log is global daemon lifecycle evidence/);
   assert.match(help, /agent-device perf memory sample --json/);

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -100,58 +100,32 @@ test('runCmd writes stdin through pipeline', async () => {
 });
 
 test.sequential('runCmdBackground emits bounded exec_command diagnostics when AGENT_DEVICE_EXEC_TRACE is enabled', async () => {
-  const previousTraceEnv = process.env.AGENT_DEVICE_EXEC_TRACE;
-  process.env.AGENT_DEVICE_EXEC_TRACE = '1';
+  const diagnosticsPath = await withExecTraceEnv(
+    async () =>
+      await withDiagnosticsScope(
+        {
+          session: 'exec-trace',
+          requestId: 'exec-trace-1',
+          command: 'background',
+        },
+        async () => {
+          const { wait } = runCmdBackground(process.execPath, [
+            '-e',
+            'process.stdout.write("ok")',
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            'f',
+          ]);
+          await wait;
+          return flushDiagnosticsToSessionFile();
+        },
+      ),
+  );
 
-  try {
-    const diagnosticsPath = await withDiagnosticsScope(
-      {
-        session: 'exec-trace',
-        requestId: 'exec-trace-1',
-        command: 'background',
-      },
-      async () => {
-        const { wait } = runCmdBackground(process.execPath, [
-          '-e',
-          'process.stdout.write("ok")',
-          'a',
-          'b',
-          'c',
-          'd',
-          'e',
-          'f',
-        ]);
-        await wait;
-        return flushDiagnosticsToSessionFile();
-      },
-    );
-
-    const execEvents = readExecDiagnosticEvents(diagnosticsPath);
-    assert.equal(execEvents.length, 2);
-    const [spawnEvent, exitEvent] = execEvents;
-    assert.equal(spawnEvent?.phase, 'exec_command');
-    assert.equal(spawnEvent?.data?.command, process.execPath);
-    assert.equal(spawnEvent?.data?.event, 'spawn');
-    assert.equal(spawnEvent?.durationMs, undefined);
-    assert.deepEqual(spawnEvent?.data?.argsPrefix, [
-      '-e',
-      'process.stdout.write("ok")',
-      'a',
-      'b',
-      'c',
-      'd',
-    ]);
-    assert.equal(spawnEvent?.data?.omittedArgCount, 2);
-    assert.equal(exitEvent?.phase, 'exec_command');
-    assert.equal(exitEvent?.data?.event, 'exit');
-    assert.equal(typeof exitEvent?.durationMs, 'number');
-  } finally {
-    if (previousTraceEnv === undefined) {
-      delete process.env.AGENT_DEVICE_EXEC_TRACE;
-    } else {
-      process.env.AGENT_DEVICE_EXEC_TRACE = previousTraceEnv;
-    }
-  }
+  assertBackgroundExecTraceEvents(readExecDiagnosticEvents(diagnosticsPath));
 });
 
 test('runCmdBackground can leave output streams to the caller', async () => {
@@ -349,4 +323,65 @@ function readExecDiagnosticEvent(diagnosticsPath: string | null): {
   data?: Record<string, unknown>;
 } | null {
   return readExecDiagnosticEvents(diagnosticsPath)[0] ?? null;
+}
+
+async function withExecTraceEnv<T>(fn: () => Promise<T>): Promise<T> {
+  const previousTraceEnv = process.env.AGENT_DEVICE_EXEC_TRACE;
+  process.env.AGENT_DEVICE_EXEC_TRACE = '1';
+  try {
+    return await fn();
+  } finally {
+    restoreOptionalEnv('AGENT_DEVICE_EXEC_TRACE', previousTraceEnv);
+  }
+}
+
+function restoreOptionalEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
+
+function assertBackgroundExecTraceEvents(
+  execEvents: Array<{
+    level?: string;
+    phase?: string;
+    durationMs?: number;
+    data?: Record<string, unknown>;
+  }>,
+): void {
+  assert.deepEqual(execEvents.map(summarizeExecEvent), [
+    {
+      phase: 'exec_command',
+      command: process.execPath,
+      event: 'spawn',
+      durationType: 'undefined',
+      argsPrefix: ['-e', 'process.stdout.write("ok")', 'a', 'b', 'c', 'd'],
+      omittedArgCount: 2,
+    },
+    {
+      phase: 'exec_command',
+      command: process.execPath,
+      event: 'exit',
+      durationType: 'number',
+      argsPrefix: ['-e', 'process.stdout.write("ok")', 'a', 'b', 'c', 'd'],
+      omittedArgCount: 2,
+    },
+  ]);
+}
+
+function summarizeExecEvent(event: {
+  phase?: string;
+  durationMs?: number;
+  data?: Record<string, unknown>;
+}): Record<string, unknown> {
+  return {
+    phase: event.phase,
+    command: event.data?.command,
+    event: event.data?.event,
+    durationType: typeof event.durationMs,
+    argsPrefix: event.data?.argsPrefix,
+    omittedArgCount: event.data?.omittedArgCount,
+  };
 }

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -68,7 +68,7 @@ test('runCmd emits exec_command diagnostics when the scope is debug-enabled', as
     },
     async () => {
       await runCmd(process.execPath, ['-e', 'process.stdout.write("ok")']);
-      return flushDiagnosticsToSessionFile({ force: true });
+      return flushDiagnosticsToSessionFile();
     },
   );
 
@@ -122,7 +122,7 @@ test.sequential('runCmdBackground emits bounded exec_command diagnostics when AG
           'f',
         ]);
         await wait;
-        return flushDiagnosticsToSessionFile({ force: true });
+        return flushDiagnosticsToSessionFile();
       },
     );
 
@@ -185,7 +185,7 @@ test.sequential('runCmd stays silent when exec tracing is not enabled', async ()
       },
       async () => {
         await runCmd(process.execPath, ['-e', 'process.stdout.write("ok")']);
-        return flushDiagnosticsToSessionFile({ force: true });
+        return flushDiagnosticsToSessionFile();
       },
     );
 

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { flushDiagnosticsToSessionFile, withDiagnosticsScope } from '../diagnostics.ts';
 import {
   runCmd,
   runCmdBackground,
@@ -52,6 +53,34 @@ test('runCmd abort keeps cancellation details while writing stdin', async () => 
   await assertRejectsRequestCanceled(promise);
 });
 
+test('runCmd emits exec_command diagnostics when the scope is debug-enabled', async () => {
+  const logPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-exec-debug-')),
+    'diag.ndjson',
+  );
+  const diagnosticsPath = await withDiagnosticsScope(
+    {
+      session: 'exec-debug',
+      requestId: 'exec-debug-1',
+      command: 'debug',
+      debug: true,
+      logPath,
+    },
+    async () => {
+      await runCmd(process.execPath, ['-e', 'process.stdout.write("ok")']);
+      return flushDiagnosticsToSessionFile({ force: true });
+    },
+  );
+
+  const execEvent = readExecDiagnosticEvent(diagnosticsPath);
+  assert.equal(execEvent?.level, 'debug');
+  assert.equal(execEvent?.phase, 'exec_command');
+  assert.equal(execEvent?.data?.command, process.execPath);
+  assert.deepEqual(execEvent?.data?.argsPrefix, ['-e', 'process.stdout.write("ok")']);
+  assert.equal(execEvent?.data?.omittedArgCount, undefined);
+  assert.equal(typeof execEvent?.durationMs, 'number');
+});
+
 test('runCmd writes stdin through pipeline', async () => {
   const stdin = Buffer.alloc(256_000, 'a');
   const result = await runCmd(
@@ -68,6 +97,54 @@ test('runCmd writes stdin through pipeline', async () => {
   );
 
   assert.equal(result.stdout, String(stdin.length));
+});
+
+test.sequential('runCmdBackground emits bounded exec_command diagnostics when AGENT_DEVICE_EXEC_TRACE is enabled', async () => {
+  const previousTraceEnv = process.env.AGENT_DEVICE_EXEC_TRACE;
+  process.env.AGENT_DEVICE_EXEC_TRACE = '1';
+
+  try {
+    const diagnosticsPath = await withDiagnosticsScope(
+      {
+        session: 'exec-trace',
+        requestId: 'exec-trace-1',
+        command: 'background',
+      },
+      async () => {
+        const { wait } = runCmdBackground(process.execPath, [
+          '-e',
+          'process.stdout.write("ok")',
+          'a',
+          'b',
+          'c',
+          'd',
+          'e',
+          'f',
+        ]);
+        await wait;
+        return flushDiagnosticsToSessionFile({ force: true });
+      },
+    );
+
+    const execEvent = readExecDiagnosticEvent(diagnosticsPath);
+    assert.equal(execEvent?.phase, 'exec_command');
+    assert.equal(execEvent?.data?.command, process.execPath);
+    assert.deepEqual(execEvent?.data?.argsPrefix, [
+      '-e',
+      'process.stdout.write("ok")',
+      'a',
+      'b',
+      'c',
+      'd',
+    ]);
+    assert.equal(execEvent?.data?.omittedArgCount, 2);
+  } finally {
+    if (previousTraceEnv === undefined) {
+      delete process.env.AGENT_DEVICE_EXEC_TRACE;
+    } else {
+      process.env.AGENT_DEVICE_EXEC_TRACE = previousTraceEnv;
+    }
+  }
 });
 
 test('runCmdBackground can leave output streams to the caller', async () => {
@@ -93,6 +170,31 @@ test('runCmdBackground can leave output streams to the caller', async () => {
   assert.equal(result.stderr, '');
   assert.equal(stdout, 'out');
   assert.equal(stderr, 'err');
+});
+
+test.sequential('runCmd stays silent when exec tracing is not enabled', async () => {
+  const previousTraceEnv = process.env.AGENT_DEVICE_EXEC_TRACE;
+  delete process.env.AGENT_DEVICE_EXEC_TRACE;
+
+  try {
+    const diagnosticsPath = await withDiagnosticsScope(
+      {
+        session: 'exec-silent',
+        requestId: 'exec-silent-1',
+        command: 'home',
+      },
+      async () => {
+        await runCmd(process.execPath, ['-e', 'process.stdout.write("ok")']);
+        return flushDiagnosticsToSessionFile({ force: true });
+      },
+    );
+
+    assert.equal(diagnosticsPath, null);
+  } finally {
+    if (previousTraceEnv !== undefined) {
+      process.env.AGENT_DEVICE_EXEC_TRACE = previousTraceEnv;
+    }
+  }
 });
 
 test('runCmdBackground aborts with request cancellation details', async () => {
@@ -209,3 +311,29 @@ test.sequential('whichCmd ignores directories that match a command name in PATH'
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+function readExecDiagnosticEvent(diagnosticsPath: string | null): {
+  level?: string;
+  phase?: string;
+  durationMs?: number;
+  data?: Record<string, unknown>;
+} | null {
+  if (!diagnosticsPath) return null;
+  const rows = fs
+    .readFileSync(diagnosticsPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as { phase?: string });
+  return (
+    rows.find(
+      (
+        row,
+      ): row is {
+        level?: string;
+        phase?: string;
+        durationMs?: number;
+        data?: Record<string, unknown>;
+      } => row.phase === 'exec_command',
+    ) ?? null
+  );
+}

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -126,10 +126,14 @@ test.sequential('runCmdBackground emits bounded exec_command diagnostics when AG
       },
     );
 
-    const execEvent = readExecDiagnosticEvent(diagnosticsPath);
-    assert.equal(execEvent?.phase, 'exec_command');
-    assert.equal(execEvent?.data?.command, process.execPath);
-    assert.deepEqual(execEvent?.data?.argsPrefix, [
+    const execEvents = readExecDiagnosticEvents(diagnosticsPath);
+    assert.equal(execEvents.length, 2);
+    const [spawnEvent, exitEvent] = execEvents;
+    assert.equal(spawnEvent?.phase, 'exec_command');
+    assert.equal(spawnEvent?.data?.command, process.execPath);
+    assert.equal(spawnEvent?.data?.event, 'spawn');
+    assert.equal(spawnEvent?.durationMs, undefined);
+    assert.deepEqual(spawnEvent?.data?.argsPrefix, [
       '-e',
       'process.stdout.write("ok")',
       'a',
@@ -137,7 +141,10 @@ test.sequential('runCmdBackground emits bounded exec_command diagnostics when AG
       'c',
       'd',
     ]);
-    assert.equal(execEvent?.data?.omittedArgCount, 2);
+    assert.equal(spawnEvent?.data?.omittedArgCount, 2);
+    assert.equal(exitEvent?.phase, 'exec_command');
+    assert.equal(exitEvent?.data?.event, 'exit');
+    assert.equal(typeof exitEvent?.durationMs, 'number');
   } finally {
     if (previousTraceEnv === undefined) {
       delete process.env.AGENT_DEVICE_EXEC_TRACE;
@@ -312,28 +319,34 @@ test.sequential('whichCmd ignores directories that match a command name in PATH'
   }
 });
 
+function readExecDiagnosticEvents(diagnosticsPath: string | null): Array<{
+  level?: string;
+  phase?: string;
+  durationMs?: number;
+  data?: Record<string, unknown>;
+}> {
+  if (!diagnosticsPath) return [];
+  const rows = fs
+    .readFileSync(diagnosticsPath, 'utf8')
+    .trim()
+    .split('\n')
+    .map(
+      (line) =>
+        JSON.parse(line) as {
+          level?: string;
+          phase?: string;
+          durationMs?: number;
+          data?: Record<string, unknown>;
+        },
+    );
+  return rows.filter((row) => row.phase === 'exec_command');
+}
+
 function readExecDiagnosticEvent(diagnosticsPath: string | null): {
   level?: string;
   phase?: string;
   durationMs?: number;
   data?: Record<string, unknown>;
 } | null {
-  if (!diagnosticsPath) return null;
-  const rows = fs
-    .readFileSync(diagnosticsPath, 'utf8')
-    .trim()
-    .split('\n')
-    .map((line) => JSON.parse(line) as { phase?: string });
-  return (
-    rows.find(
-      (
-        row,
-      ): row is {
-        level?: string;
-        phase?: string;
-        durationMs?: number;
-        data?: Record<string, unknown>;
-      } => row.phase === 'exec_command',
-    ) ?? null
-  );
+  return readExecDiagnosticEvents(diagnosticsPath)[0] ?? null;
 }

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -23,6 +23,7 @@ type DiagnosticsScopeOptions = {
   requestId?: string;
   command?: string;
   debug?: boolean;
+  flushOnSuccess?: boolean;
   logPath?: string;
   traceLogPath?: string;
 };
@@ -172,7 +173,7 @@ export async function withDiagnosticTimer<T>(
 export function flushDiagnosticsToSessionFile(options: { force?: boolean } = {}): string | null {
   const scope = diagnosticsStorage.getStore();
   if (!scope) return null;
-  if (!options.force && !scope.debug) return null;
+  if (!options.force && !scope.debug && !scope.flushOnSuccess) return null;
   if (scope.events.length === 0) return null;
 
   try {

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -75,6 +75,7 @@ export function getDiagnosticsMeta(): {
   session?: string;
   command?: string;
   debug?: boolean;
+  flushOnSuccess?: boolean;
 } {
   const scope = diagnosticsStorage.getStore();
   if (!scope) return {};
@@ -84,6 +85,7 @@ export function getDiagnosticsMeta(): {
     session: scope.session,
     command: scope.command,
     debug: scope.debug,
+    flushOnSuccess: scope.flushOnSuccess,
   };
 }
 

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -6,6 +6,7 @@ import { spawn, spawnSync, type ChildProcess, type StdioOptions } from 'node:chi
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '../kernel/errors.ts';
+import { emitDiagnostic, getDiagnosticsMeta } from './diagnostics.ts';
 
 export type ExecResult = {
   stdout: string;
@@ -65,6 +66,7 @@ export type ExecBackgroundOptions = ExecOptions & {
 
 const BARE_COMMAND_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
 const WINDOWS_PATH_EXTENSIONS = ['.com', '.exe', '.bat', '.cmd'];
+const EXEC_DIAGNOSTIC_ARG_LIMIT = 6;
 export type CommandExecutorOverride = (
   cmd: string,
   args: string[],
@@ -112,6 +114,7 @@ function runSpawnedCommand(
   options: ExecStreamOptions = {},
 ): Promise<ExecResult> {
   const executable = normalizeExecutableCommand(cmd);
+  const execTrace = createExecTraceContext();
   return new Promise((resolve, reject) => {
     const child = spawn(executable, args, {
       cwd: options.cwd,
@@ -127,6 +130,7 @@ function runSpawnedCommand(
     const stdoutChunks: Buffer[] | undefined = options.binaryStdout ? [] : undefined;
     let stderr = '';
     let didTimeout = false;
+    let didEmitExecDiagnostic = false;
     const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
     const timeoutHandle = timeoutMs
       ? setTimeout(() => {
@@ -165,12 +169,22 @@ function runSpawnedCommand(
     child.on('error', (err) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
       abort.dispose();
+      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
+        if (didEmitExecDiagnostic) return false;
+        didEmitExecDiagnostic = true;
+        return true;
+      });
       reject(spawnRejectionError(abort, executable, cmd, args, err));
     });
 
     child.on('close', (code) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
       abort.dispose();
+      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
+        if (didEmitExecDiagnostic) return false;
+        didEmitExecDiagnostic = true;
+        return true;
+      });
       const exitCode = code ?? 1;
       if (!abort.didAbort && didTimeout && timeoutMs) {
         reject(createTimeoutError(executable, cmd, args, timeoutMs, exitCode, stdout, stderr));
@@ -356,6 +370,7 @@ export function runCmdBackground(
   options: ExecBackgroundOptions = {},
 ): ExecBackgroundResult {
   const executable = normalizeExecutableCommand(cmd);
+  const execTrace = createExecTraceContext();
   const child = spawn(executable, args, {
     cwd: options.cwd,
     env: options.env,
@@ -369,6 +384,7 @@ export function runCmdBackground(
   let stderr = '';
   const captureOutput = options.captureOutput ?? true;
   const abort = watchCommandAbort(child, options);
+  let didEmitExecDiagnostic = false;
 
   if (captureOutput) {
     child.stdout?.setEncoding('utf8');
@@ -385,10 +401,20 @@ export function runCmdBackground(
   const wait = new Promise<ExecResult>((resolve, reject) => {
     child.on('error', (err) => {
       abort.dispose();
+      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
+        if (didEmitExecDiagnostic) return false;
+        didEmitExecDiagnostic = true;
+        return true;
+      });
       reject(spawnRejectionError(abort, executable, cmd, args, err));
     });
     child.on('close', (code) => {
       abort.dispose();
+      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
+        if (didEmitExecDiagnostic) return false;
+        didEmitExecDiagnostic = true;
+        return true;
+      });
       const exitCode = code ?? 1;
       const failure = commandCloseFailure(
         abort,
@@ -409,6 +435,37 @@ export function runCmdBackground(
   });
 
   return { child, wait };
+}
+
+function createExecTraceContext(): { enabled: boolean; startedAtMs?: number } {
+  const diagnosticsDebugEnabled = getDiagnosticsMeta().debug === true;
+  const envTraceEnabled = isTruthyEnvValue(process.env.AGENT_DEVICE_EXEC_TRACE);
+  if (!diagnosticsDebugEnabled && !envTraceEnabled) {
+    return { enabled: false };
+  }
+  return { enabled: true, startedAtMs: Date.now() };
+}
+
+function emitExecCommandDiagnostic(
+  context: { enabled: boolean; startedAtMs?: number },
+  cmd: string,
+  args: string[],
+  markEmitted: () => boolean,
+): void {
+  if (!context.enabled || context.startedAtMs === undefined || !markEmitted()) return;
+  const argsPrefix = args.slice(0, EXEC_DIAGNOSTIC_ARG_LIMIT);
+  emitDiagnostic({
+    level: 'debug',
+    phase: 'exec_command',
+    durationMs: Math.max(0, Date.now() - context.startedAtMs),
+    data: {
+      command: cmd,
+      argsPrefix,
+      ...(args.length > argsPrefix.length
+        ? { omittedArgCount: args.length - argsPrefix.length }
+        : {}),
+    },
+  });
 }
 
 function normalizeExecutableCommand(cmd: string): string {
@@ -660,4 +717,8 @@ function isEpipeError(error: unknown): boolean {
   return (
     error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'EPIPE'
   );
+}
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase());
 }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -7,6 +7,7 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '../kernel/errors.ts';
 import { emitDiagnostic, getDiagnosticsMeta, updateDiagnosticsScope } from './diagnostics.ts';
+import { parseBooleanLiteral } from './source-value.ts';
 
 export type ExecResult = {
   stdout: string;
@@ -130,7 +131,6 @@ function runSpawnedCommand(
     const stdoutChunks: Buffer[] | undefined = options.binaryStdout ? [] : undefined;
     let stderr = '';
     let didTimeout = false;
-    let didEmitExecDiagnostic = false;
     const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
     const timeoutHandle = timeoutMs
       ? setTimeout(() => {
@@ -169,22 +169,14 @@ function runSpawnedCommand(
     child.on('error', (err) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
       abort.dispose();
-      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
-        if (didEmitExecDiagnostic) return false;
-        didEmitExecDiagnostic = true;
-        return true;
-      });
+      execTrace.emitForegroundCompletion(cmd, args);
       reject(spawnRejectionError(abort, executable, cmd, args, err));
     });
 
     child.on('close', (code) => {
       if (timeoutHandle) clearTimeout(timeoutHandle);
       abort.dispose();
-      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
-        if (didEmitExecDiagnostic) return false;
-        didEmitExecDiagnostic = true;
-        return true;
-      });
+      execTrace.emitForegroundCompletion(cmd, args);
       const exitCode = code ?? 1;
       if (!abort.didAbort && didTimeout && timeoutMs) {
         reject(createTimeoutError(executable, cmd, args, timeoutMs, exitCode, stdout, stderr));
@@ -379,12 +371,12 @@ export function runCmdBackground(
     windowsHide: true,
     shell: false,
   });
+  execTrace.emitBackgroundSpawn(cmd, args);
 
   let stdout = '';
   let stderr = '';
   const captureOutput = options.captureOutput ?? true;
   const abort = watchCommandAbort(child, options);
-  let didEmitExecDiagnostic = false;
 
   if (captureOutput) {
     child.stdout?.setEncoding('utf8');
@@ -401,20 +393,12 @@ export function runCmdBackground(
   const wait = new Promise<ExecResult>((resolve, reject) => {
     child.on('error', (err) => {
       abort.dispose();
-      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
-        if (didEmitExecDiagnostic) return false;
-        didEmitExecDiagnostic = true;
-        return true;
-      });
+      execTrace.emitBackgroundCompletion(cmd, args, 'error');
       reject(spawnRejectionError(abort, executable, cmd, args, err));
     });
     child.on('close', (code) => {
       abort.dispose();
-      emitExecCommandDiagnostic(execTrace, cmd, args, () => {
-        if (didEmitExecDiagnostic) return false;
-        didEmitExecDiagnostic = true;
-        return true;
-      });
+      execTrace.emitBackgroundCompletion(cmd, args, 'exit');
       const exitCode = code ?? 1;
       const failure = commandCloseFailure(
         abort,
@@ -437,36 +421,81 @@ export function runCmdBackground(
   return { child, wait };
 }
 
-function createExecTraceContext(): { enabled: boolean; startedAtMs?: number } {
-  const diagnosticsDebugEnabled = getDiagnosticsMeta().debug === true;
-  const envTraceEnabled = isTruthyEnvValue(process.env.AGENT_DEVICE_EXEC_TRACE);
+type ExecTraceContext = {
+  emitBackgroundCompletion: (cmd: string, args: string[], event: 'error' | 'exit') => void;
+  emitBackgroundSpawn: (cmd: string, args: string[]) => void;
+  emitForegroundCompletion: (cmd: string, args: string[]) => void;
+};
+
+function createExecTraceContext(): ExecTraceContext {
+  const diagnosticsMeta = getDiagnosticsMeta();
+  const diagnosticsDebugEnabled = diagnosticsMeta.debug === true;
+  const envTraceEnabled = parseBooleanLiteral(process.env.AGENT_DEVICE_EXEC_TRACE ?? '') === true;
   if (!diagnosticsDebugEnabled && !envTraceEnabled) {
-    return { enabled: false };
+    return createDisabledExecTraceContext();
   }
-  if (envTraceEnabled) {
+  if (envTraceEnabled && diagnosticsMeta.flushOnSuccess !== true) {
     updateDiagnosticsScope({ flushOnSuccess: true });
   }
-  return { enabled: true, startedAtMs: Date.now() };
+  const startedAtMs = Date.now();
+  let completionEmitted = false;
+  return {
+    emitForegroundCompletion: (cmd, args) => {
+      if (completionEmitted) return;
+      completionEmitted = true;
+      emitExecCommandDiagnostic({
+        cmd,
+        args,
+        startedAtMs,
+      });
+    },
+    emitBackgroundSpawn: (cmd, args) => {
+      emitExecCommandDiagnostic({
+        cmd,
+        args,
+        data: { event: 'spawn' },
+      });
+    },
+    emitBackgroundCompletion: (cmd, args, event) => {
+      if (completionEmitted) return;
+      completionEmitted = true;
+      emitExecCommandDiagnostic({
+        cmd,
+        args,
+        startedAtMs,
+        data: { event },
+      });
+    },
+  };
 }
 
-function emitExecCommandDiagnostic(
-  context: { enabled: boolean; startedAtMs?: number },
-  cmd: string,
-  args: string[],
-  markEmitted: () => boolean,
-): void {
-  if (!context.enabled || context.startedAtMs === undefined || !markEmitted()) return;
-  const argsPrefix = args.slice(0, EXEC_DIAGNOSTIC_ARG_LIMIT);
+function createDisabledExecTraceContext(): ExecTraceContext {
+  return {
+    emitForegroundCompletion: () => {},
+    emitBackgroundSpawn: () => {},
+    emitBackgroundCompletion: () => {},
+  };
+}
+
+function emitExecCommandDiagnostic(params: {
+  cmd: string;
+  args: string[];
+  startedAtMs?: number;
+  data?: Record<string, unknown>;
+}): void {
+  const argsPrefix = params.args.slice(0, EXEC_DIAGNOSTIC_ARG_LIMIT);
   emitDiagnostic({
     level: 'debug',
     phase: 'exec_command',
-    durationMs: Math.max(0, Date.now() - context.startedAtMs),
+    durationMs:
+      params.startedAtMs === undefined ? undefined : Math.max(0, Date.now() - params.startedAtMs),
     data: {
-      command: cmd,
+      command: params.cmd,
       argsPrefix,
-      ...(args.length > argsPrefix.length
-        ? { omittedArgCount: args.length - argsPrefix.length }
+      ...(params.args.length > argsPrefix.length
+        ? { omittedArgCount: params.args.length - argsPrefix.length }
         : {}),
+      ...(params.data ?? {}),
     },
   });
 }
@@ -720,8 +749,4 @@ function isEpipeError(error: unknown): boolean {
   return (
     error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'EPIPE'
   );
-}
-
-function isTruthyEnvValue(value: string | undefined): boolean {
-  return ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase());
 }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -6,7 +6,7 @@ import { spawn, spawnSync, type ChildProcess, type StdioOptions } from 'node:chi
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '../kernel/errors.ts';
-import { emitDiagnostic, getDiagnosticsMeta } from './diagnostics.ts';
+import { emitDiagnostic, getDiagnosticsMeta, updateDiagnosticsScope } from './diagnostics.ts';
 
 export type ExecResult = {
   stdout: string;
@@ -442,6 +442,9 @@ function createExecTraceContext(): { enabled: boolean; startedAtMs?: number } {
   const envTraceEnabled = isTruthyEnvValue(process.env.AGENT_DEVICE_EXEC_TRACE);
   if (!diagnosticsDebugEnabled && !envTraceEnabled) {
     return { enabled: false };
+  }
+  if (envTraceEnabled) {
+    updateDiagnosticsScope({ flushOnSuccess: true });
   }
   return { enabled: true, startedAtMs: Date.now() };
 }

--- a/src/utils/source-value.ts
+++ b/src/utils/source-value.ts
@@ -108,7 +108,7 @@ function parseBooleanValue(value: unknown, sourceLabel: string, rawKey: string):
   );
 }
 
-function parseBooleanLiteral(value: string): boolean | undefined {
+export function parseBooleanLiteral(value: string): boolean | undefined {
   const normalized = value.trim().toLowerCase();
   if (BOOLEAN_TRUE_VALUES.has(normalized)) return true;
   if (BOOLEAN_FALSE_VALUES.has(normalized)) return false;


### PR DESCRIPTION
## Summary

Add opt-in exec command diagnostics for async spawn helpers.
Emit bounded `exec_command` debug diagnostics when `AGENT_DEVICE_EXEC_TRACE=1` or the active diagnostics scope already runs in debug mode, while keeping default runs silent.
Add focused exec-helper tests for debug-scope emission, env-enabled emission, and non-opt-in silence.

Closes #1012.

## Validation

Ran `pnpm format`, `pnpm check:quick`, `pnpm test:unit`, `pnpm build`, and `pnpm test:smoke`.
The first `pnpm check:unit` smoke pass failed only because this worktree was missing a fresh `dist` build; after `pnpm build`, the smoke suite passed cleanly.
