### PR TITLE
feat: expose daemon artifact inventory

### DIFF
--- a/src/__tests__/daemon-entrypoint.test.ts
+++ b/src/__tests__/daemon-entrypoint.test.ts
@@ -5,6 +5,10 @@ import path from 'node:path';
 import { test } from 'vitest';
 import { resolveDaemonPaths } from '../daemon/config.ts';
 import { startDaemonRuntime } from '../daemon/server/daemon-runtime.ts';
+import {
+  cleanupDownloadableArtifact,
+  trackDownloadableArtifact,
+} from '../daemon/artifact-tracking.ts';
 import { runCmdBackground } from '../utils/exec.ts';
 import { isProcessAlive, waitForProcessExit } from '../utils/process-identity.ts';
 import { waitForHttpOk } from './test-utils/index.ts';
@@ -58,6 +62,9 @@ function waitForStdoutLine(
 test('daemon runtime starts HTTP transport in-process and shuts down cleanly', async () => {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-daemon-runtime-'));
   const paths = resolveDaemonPaths(stateDir);
+  const artifactPath = path.join(stateDir, 'runtime-artifact.txt');
+  fs.writeFileSync(artifactPath, 'runtime-artifact');
+  const artifactId = trackDownloadableArtifact({ artifactPath, fileName: 'runtime-artifact.txt' });
   const stdout: string[] = [];
   const stderr: string[] = [];
   let exitCode: number | undefined;
@@ -68,6 +75,7 @@ test('daemon runtime starts HTTP transport in-process and shuts down cleanly', a
         ...process.env,
         AGENT_DEVICE_STATE_DIR: stateDir,
         AGENT_DEVICE_DAEMON_SERVER_MODE: 'http',
+        AGENT_DEVICE_RETAIN_ARTIFACTS: '1',
       },
       exit: (code) => {
         exitCode = code;
@@ -90,12 +98,21 @@ test('daemon runtime starts HTTP transport in-process and shuts down cleanly', a
     assert.ok(fs.existsSync(paths.lockPath), 'daemon lock should be held while runtime is active');
 
     await waitForHttpOk(`http://127.0.0.1:${runtime?.httpPort}/health`, 2_000);
+    const artifactResponse = await fetch(
+      `http://127.0.0.1:${runtime?.httpPort}/artifacts/${encodeURIComponent(artifactId)}`,
+      { headers: { authorization: `Bearer ${runtime?.token}` } },
+    );
+    assert.equal(artifactResponse.status, 200);
+    assert.equal(await artifactResponse.text(), 'runtime-artifact');
+    assert.equal(fs.existsSync(artifactPath), true);
+
     await runtime?.shutdown();
 
     assert.equal(exitCode, 0);
     assert.equal(fs.existsSync(paths.infoPath), false);
     assert.equal(fs.existsSync(paths.lockPath), false);
   } finally {
+    cleanupDownloadableArtifact(artifactId);
     fs.rmSync(stateDir, { recursive: true, force: true });
   }
 });

--- a/src/__tests__/daemon-proxy.test.ts
+++ b/src/__tests__/daemon-proxy.test.ts
@@ -10,6 +10,15 @@ import {
   skipWhenLoopbackUnavailable,
 } from './test-utils/index.ts';
 
+const PROXY_ARTIFACT_INVENTORY_ENTRY = {
+  id: 'shot-1',
+  filename: 'shot.png',
+  mimeType: 'image/png',
+  sizeBytes: 8,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  expiresAt: '2026-01-01T00:15:00.000Z',
+};
+
 test('daemon proxy forwards rpc requests with upstream daemon token', async (t) => {
   if (await skipWhenLoopbackUnavailable(t)) return;
 
@@ -163,63 +172,8 @@ test('daemon proxy leaves health endpoint unauthenticated', async (t) => {
 test('daemon proxy streams uploads and artifact downloads with upstream daemon token', async (t) => {
   if (await skipWhenLoopbackUnavailable(t)) return;
 
-  let uploadAuth = '';
-  let uploadTokenHeader = '';
-  let uploadArtifactType = '';
-  let uploadArtifactFilename = '';
-  let uploadBody = '';
-  let artifactListAuth = '';
-  let artifactListTokenHeader = '';
-  let artifactAuth = '';
-  let artifactTokenHeader = '';
-  const upstream = http.createServer((req, res) => {
-    if (req.method === 'POST' && req.url === '/upload') {
-      uploadAuth = String(req.headers.authorization ?? '');
-      uploadTokenHeader = String(req.headers['x-agent-device-token'] ?? '');
-      uploadArtifactType = String(req.headers['x-artifact-type'] ?? '');
-      uploadArtifactFilename = String(req.headers['x-artifact-filename'] ?? '');
-      req.setEncoding('utf8');
-      req.on('data', (chunk) => {
-        uploadBody += chunk;
-      });
-      req.on('end', () => {
-        res.setHeader('content-type', 'application/json');
-        res.end(JSON.stringify({ ok: true, uploadId: 'upload-1' }));
-      });
-      return;
-    }
-
-    if (req.method === 'GET' && req.url === '/artifacts') {
-      artifactListAuth = String(req.headers.authorization ?? '');
-      artifactListTokenHeader = String(req.headers['x-agent-device-token'] ?? '');
-      res.setHeader('content-type', 'application/json');
-      res.end(
-        JSON.stringify({
-          artifacts: [
-            {
-              id: 'shot-1',
-              filename: 'shot.png',
-              mimeType: 'image/png',
-              sizeBytes: 8,
-              createdAt: '2026-01-01T00:00:00.000Z',
-              expiresAt: '2026-01-01T00:15:00.000Z',
-            },
-          ],
-        }),
-      );
-      return;
-    }
-
-    assert.equal(req.method, 'GET');
-    assert.equal(req.url, '/artifacts/shot-1?download=1');
-    artifactAuth = String(req.headers.authorization ?? '');
-    artifactTokenHeader = String(req.headers['x-agent-device-token'] ?? '');
-    res.setHeader('content-type', 'image/png');
-    res.setHeader('content-disposition', 'attachment; filename="shot.png"');
-    res.setHeader('x-request-id', 'upstream-request-1');
-    res.write('png-');
-    res.end('body');
-  });
+  const capture: UploadAndArtifactProxyCapture = {};
+  const upstream = createUploadAndArtifactProxyUpstream(capture);
   const proxy = createDaemonProxyServer({
     upstreamBaseUrl: `http://127.0.0.1:${await listenOnLoopback(upstream)}`,
     upstreamToken: 'daemon-secret',
@@ -240,30 +194,25 @@ test('daemon proxy streams uploads and artifact downloads with upstream daemon t
     });
     assert.equal(upload.status, 200);
     assert.deepEqual(await upload.json(), { ok: true, uploadId: 'upload-1' });
-    assert.equal(uploadAuth, 'Bearer daemon-secret');
-    assert.equal(uploadTokenHeader, 'daemon-secret');
-    assert.equal(uploadArtifactType, 'file');
-    assert.equal(uploadArtifactFilename, 'demo.apk');
-    assert.equal(uploadBody, 'fake-apk');
+    assert.deepEqual(capture.upload, {
+      auth: 'Bearer daemon-secret',
+      token: 'daemon-secret',
+      artifactType: 'file',
+      artifactFilename: 'demo.apk',
+      body: 'fake-apk',
+    });
 
     const artifactList = await fetch(`http://127.0.0.1:${proxyPort}/agent-device/artifacts`, {
       headers: { authorization: 'Bearer proxy-secret' },
     });
     assert.equal(artifactList.status, 200);
     assert.deepEqual(await artifactList.json(), {
-      artifacts: [
-        {
-          id: 'shot-1',
-          filename: 'shot.png',
-          mimeType: 'image/png',
-          sizeBytes: 8,
-          createdAt: '2026-01-01T00:00:00.000Z',
-          expiresAt: '2026-01-01T00:15:00.000Z',
-        },
-      ],
+      artifacts: [PROXY_ARTIFACT_INVENTORY_ENTRY],
     });
-    assert.equal(artifactListAuth, 'Bearer daemon-secret');
-    assert.equal(artifactListTokenHeader, 'daemon-secret');
+    assert.deepEqual(capture.artifactList, {
+      auth: 'Bearer daemon-secret',
+      token: 'daemon-secret',
+    });
 
     const artifact = await fetch(
       `http://127.0.0.1:${proxyPort}/agent-device/artifacts/shot-1?download=1`,
@@ -274,13 +223,102 @@ test('daemon proxy streams uploads and artifact downloads with upstream daemon t
     assert.equal(artifact.headers.get('content-type'), 'image/png');
     assert.match(artifact.headers.get('content-disposition') ?? '', /shot\.png/);
     assert.equal(artifact.headers.get('x-request-id'), 'upstream-request-1');
-    assert.equal(artifactAuth, 'Bearer daemon-secret');
-    assert.equal(artifactTokenHeader, 'daemon-secret');
+    assert.deepEqual(capture.artifactDownload, {
+      auth: 'Bearer daemon-secret',
+      token: 'daemon-secret',
+    });
   } finally {
     await closeLoopbackServer(proxy);
     await closeLoopbackServer(upstream);
   }
 });
+
+type UploadAndArtifactProxyCapture = {
+  upload?: {
+    auth: string;
+    token: string;
+    artifactType: string;
+    artifactFilename: string;
+    body: string;
+  };
+  artifactList?: {
+    auth: string;
+    token: string;
+  };
+  artifactDownload?: {
+    auth: string;
+    token: string;
+  };
+};
+
+function createUploadAndArtifactProxyUpstream(capture: UploadAndArtifactProxyCapture): http.Server {
+  return http.createServer((req, res) => {
+    if (req.method === 'POST' && req.url === '/upload') {
+      handleUploadProxyRequest(req, res, capture);
+      return;
+    }
+    if (req.method === 'GET' && req.url === '/artifacts') {
+      handleArtifactListProxyRequest(req, res, capture);
+      return;
+    }
+    handleArtifactDownloadProxyRequest(req, res, capture);
+  });
+}
+
+function handleUploadProxyRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  capture: UploadAndArtifactProxyCapture,
+): void {
+  let body = '';
+  capture.upload = {
+    auth: String(req.headers.authorization ?? ''),
+    token: String(req.headers['x-agent-device-token'] ?? ''),
+    artifactType: String(req.headers['x-artifact-type'] ?? ''),
+    artifactFilename: String(req.headers['x-artifact-filename'] ?? ''),
+    body,
+  };
+  req.setEncoding('utf8');
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    capture.upload = { ...capture.upload!, body };
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ ok: true, uploadId: 'upload-1' }));
+  });
+}
+
+function handleArtifactListProxyRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  capture: UploadAndArtifactProxyCapture,
+): void {
+  capture.artifactList = {
+    auth: String(req.headers.authorization ?? ''),
+    token: String(req.headers['x-agent-device-token'] ?? ''),
+  };
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ artifacts: [PROXY_ARTIFACT_INVENTORY_ENTRY] }));
+}
+
+function handleArtifactDownloadProxyRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  capture: UploadAndArtifactProxyCapture,
+): void {
+  assert.equal(req.method, 'GET');
+  assert.equal(req.url, '/artifacts/shot-1?download=1');
+  capture.artifactDownload = {
+    auth: String(req.headers.authorization ?? ''),
+    token: String(req.headers['x-agent-device-token'] ?? ''),
+  };
+  res.setHeader('content-type', 'image/png');
+  res.setHeader('content-disposition', 'attachment; filename="shot.png"');
+  res.setHeader('x-request-id', 'upstream-request-1');
+  res.write('png-');
+  res.end('body');
+}
 
 test('daemon proxy forwards resumable upload routes and rewrites direct upload tickets', async (t) => {
   if (await skipWhenLoopbackUnavailable(t)) return;

--- a/src/__tests__/daemon-proxy.test.ts
+++ b/src/__tests__/daemon-proxy.test.ts
@@ -168,6 +168,8 @@ test('daemon proxy streams uploads and artifact downloads with upstream daemon t
   let uploadArtifactType = '';
   let uploadArtifactFilename = '';
   let uploadBody = '';
+  let artifactListAuth = '';
+  let artifactListTokenHeader = '';
   let artifactAuth = '';
   let artifactTokenHeader = '';
   const upstream = http.createServer((req, res) => {
@@ -184,6 +186,27 @@ test('daemon proxy streams uploads and artifact downloads with upstream daemon t
         res.setHeader('content-type', 'application/json');
         res.end(JSON.stringify({ ok: true, uploadId: 'upload-1' }));
       });
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/artifacts') {
+      artifactListAuth = String(req.headers.authorization ?? '');
+      artifactListTokenHeader = String(req.headers['x-agent-device-token'] ?? '');
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          artifacts: [
+            {
+              id: 'shot-1',
+              filename: 'shot.png',
+              mimeType: 'image/png',
+              sizeBytes: 8,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              expiresAt: '2026-01-01T00:15:00.000Z',
+            },
+          ],
+        }),
+      );
       return;
     }
 
@@ -222,6 +245,25 @@ test('daemon proxy streams uploads and artifact downloads with upstream daemon t
     assert.equal(uploadArtifactType, 'file');
     assert.equal(uploadArtifactFilename, 'demo.apk');
     assert.equal(uploadBody, 'fake-apk');
+
+    const artifactList = await fetch(`http://127.0.0.1:${proxyPort}/agent-device/artifacts`, {
+      headers: { authorization: 'Bearer proxy-secret' },
+    });
+    assert.equal(artifactList.status, 200);
+    assert.deepEqual(await artifactList.json(), {
+      artifacts: [
+        {
+          id: 'shot-1',
+          filename: 'shot.png',
+          mimeType: 'image/png',
+          sizeBytes: 8,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          expiresAt: '2026-01-01T00:15:00.000Z',
+        },
+      ],
+    });
+    assert.equal(artifactListAuth, 'Bearer daemon-secret');
+    assert.equal(artifactListTokenHeader, 'daemon-secret');
 
     const artifact = await fetch(
       `http://127.0.0.1:${proxyPort}/agent-device/artifacts/shot-1?download=1`,

--- a/src/daemon/__tests__/http-server-artifacts.test.ts
+++ b/src/daemon/__tests__/http-server-artifacts.test.ts
@@ -1,0 +1,322 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDaemonHttpServer } from '../server/http-server.ts';
+import {
+  cleanupDownloadableArtifact,
+  listDownloadableArtifacts,
+  trackDownloadableArtifact,
+} from '../artifact-tracking.ts';
+import type { DaemonResponse } from '../types.ts';
+import { runCmdSync, withCommandExecutorOverride } from '../../utils/exec.ts';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  skipWhenLoopbackUnavailable,
+} from '../../__tests__/test-utils/index.ts';
+
+type ArtifactInventoryResponse = {
+  artifacts: Array<{
+    id: string;
+    filename: string;
+    mimeType: string;
+    sizeBytes: number;
+    createdAt: string;
+    expiresAt: string;
+  }>;
+};
+
+test('downloadable artifact inventory is filtered by tenant', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-artifacts-tenants-'));
+  const publicPath = path.join(tempDir, 'public.txt');
+  const tenantAPath = path.join(tempDir, 'tenant-a.txt');
+  const tenantBPath = path.join(tempDir, 'tenant-b.txt');
+  fs.writeFileSync(publicPath, 'public');
+  fs.writeFileSync(tenantAPath, 'tenant-a');
+  fs.writeFileSync(tenantBPath, 'tenant-b');
+  const artifactIds = [
+    trackDownloadableArtifact({ artifactPath: publicPath, fileName: 'public.txt' }),
+    trackDownloadableArtifact({
+      artifactPath: tenantAPath,
+      tenantId: 'tenant-a',
+      fileName: 'tenant-a.txt',
+    }),
+    trackDownloadableArtifact({
+      artifactPath: tenantBPath,
+      tenantId: 'tenant-b',
+      fileName: 'tenant-b.txt',
+    }),
+  ];
+
+  try {
+    assert.deepEqual(
+      (await listDownloadableArtifacts()).map((artifact) => artifact.filename),
+      ['public.txt'],
+    );
+    assert.deepEqual(
+      (await listDownloadableArtifacts('tenant-a')).map((artifact) => artifact.filename),
+      ['public.txt', 'tenant-a.txt'],
+    );
+    assert.deepEqual(
+      (await listDownloadableArtifacts('tenant-b')).map((artifact) => artifact.filename),
+      ['public.txt', 'tenant-b.txt'],
+    );
+  } finally {
+    for (const artifactId of artifactIds) {
+      cleanupDownloadableArtifact(artifactId);
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('downloadable artifact inventory skips directory artifacts that fail to archive', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-artifacts-archive-error-'));
+  const filePath = path.join(tempDir, 'report.json');
+  const tracePath = path.join(tempDir, '--profile.trace');
+  fs.writeFileSync(filePath, '{}\n');
+  fs.mkdirSync(tracePath, { recursive: true });
+  fs.writeFileSync(path.join(tracePath, 'metadata.json'), '{}\n');
+  const artifactIds = [
+    trackDownloadableArtifact({ artifactPath: filePath, fileName: 'report.json' }),
+    trackDownloadableArtifact({ artifactPath: tracePath, fileName: 'profile.trace' }),
+  ];
+
+  try {
+    const artifacts = await withCommandExecutorOverride(
+      (cmd) => {
+        if (cmd !== 'tar') return undefined;
+        throw new Error('tar unavailable');
+      },
+      async () => await listDownloadableArtifacts(),
+    );
+    assert.deepEqual(
+      artifacts.map((artifact) => artifact.filename),
+      ['report.json'],
+    );
+  } finally {
+    for (const artifactId of artifactIds) {
+      cleanupDownloadableArtifact(artifactId);
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('daemon artifact inventory exposes directory artifacts as tar.gz downloads', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-artifacts-directory-'));
+  const tracePath = path.join(tempDir, '--profile.trace');
+  fs.mkdirSync(tracePath, { recursive: true });
+  fs.writeFileSync(path.join(tracePath, 'metadata.json'), '{"ok":true}\n');
+  const artifactId = trackDownloadableArtifact({
+    artifactPath: tracePath,
+    fileName: 'profile.trace',
+  });
+  const server = await createDaemonHttpServer({
+    token: 'daemon-secret',
+    handleRequest: async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+  });
+
+  try {
+    const port = await listenOnLoopback(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const auth = { authorization: 'Bearer daemon-secret' };
+
+    const inventory = await fetch(`${baseUrl}/artifacts`, { headers: auth });
+    assert.equal(inventory.status, 200);
+    const body = (await inventory.json()) as ArtifactInventoryResponse;
+    const artifact = body.artifacts.find((entry) => entry.id === artifactId);
+    assert.ok(artifact, `expected ${artifactId} in artifact inventory`);
+    assert.equal(artifact.filename, 'profile.trace.tar.gz');
+    assert.equal(artifact.mimeType, 'application/gzip');
+    assert.ok(artifact.sizeBytes > 0);
+
+    const consumingDownload = await fetch(
+      `${baseUrl}/artifacts/${encodeURIComponent(artifactId)}?download=1`,
+      {
+        headers: auth,
+      },
+    );
+    assert.equal(consumingDownload.status, 200);
+    assert.equal(consumingDownload.headers.get('content-type'), 'application/gzip');
+    assert.equal(consumingDownload.headers.get('content-length'), String(artifact.sizeBytes));
+    assert.match(
+      consumingDownload.headers.get('content-disposition') ?? '',
+      /profile\.trace\.tar\.gz/,
+    );
+    const archivePath = path.join(tempDir, 'downloaded.tar.gz');
+    fs.writeFileSync(archivePath, Buffer.from(await consumingDownload.arrayBuffer()));
+    const entries = runCmdSync('tar', ['-tzf', archivePath]).stdout;
+    assert.match(entries, /--profile\.trace\/metadata\.json/);
+
+    await waitFor(() => !fs.existsSync(tracePath));
+    assert.equal(fs.existsSync(tracePath), false);
+    const inventoryAfterConsume = await fetch(`${baseUrl}/artifacts`, { headers: auth });
+    const consumedBody = (await inventoryAfterConsume.json()) as ArtifactInventoryResponse;
+    assert.equal(
+      consumedBody.artifacts.some((entry) => entry.id === artifactId),
+      false,
+    );
+  } finally {
+    cleanupDownloadableArtifact(artifactId);
+    await closeLoopbackServer(server);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('daemon artifact inventory lists artifacts and downloads consume them', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-artifacts-http-'));
+  const artifactPath = path.join(tempDir, 'shot.png');
+  fs.writeFileSync(artifactPath, 'png-body');
+  const artifactId = trackDownloadableArtifact({
+    artifactPath,
+    fileName: 'shot.png',
+  });
+  const server = await createDaemonHttpServer({
+    token: 'daemon-secret',
+    handleRequest: async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+  });
+
+  try {
+    const port = await listenOnLoopback(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const auth = { authorization: 'Bearer daemon-secret' };
+
+    const inventory = await fetch(`${baseUrl}/artifacts`, { headers: auth });
+    assert.equal(inventory.status, 200);
+    const body = (await inventory.json()) as ArtifactInventoryResponse;
+    const artifact = body.artifacts.find((entry) => entry.id === artifactId);
+    assert.ok(artifact, `expected ${artifactId} in artifact inventory`);
+    assert.equal(artifact.filename, 'shot.png');
+    assert.equal(artifact.mimeType, 'application/octet-stream');
+    assert.equal(artifact.sizeBytes, 'png-body'.length);
+    assert.ok(Date.parse(artifact.createdAt));
+    assert.ok(Date.parse(artifact.expiresAt));
+
+    const consumingDownload = await fetch(
+      `${baseUrl}/artifacts/${encodeURIComponent(artifactId)}`,
+      {
+        headers: auth,
+      },
+    );
+    assert.equal(consumingDownload.status, 200);
+    assert.equal(await consumingDownload.text(), 'png-body');
+    await waitFor(() => !fs.existsSync(artifactPath));
+
+    const inventoryAfterConsume = await fetch(`${baseUrl}/artifacts`, { headers: auth });
+    const consumedBody = (await inventoryAfterConsume.json()) as ArtifactInventoryResponse;
+    assert.equal(
+      consumedBody.artifacts.some((entry) => entry.id === artifactId),
+      false,
+    );
+  } finally {
+    cleanupDownloadableArtifact(artifactId);
+    await closeLoopbackServer(server);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('daemon artifact downloads can keep the source file while consuming the inventory entry', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-artifacts-retain-file-'));
+  const artifactPath = path.join(tempDir, 'runner-output.txt');
+  fs.writeFileSync(artifactPath, 'runner-output');
+  const artifactId = trackDownloadableArtifact({
+    artifactPath,
+    fileName: 'runner-output.txt',
+    deleteAfterDownload: false,
+  });
+  const server = await createDaemonHttpServer({
+    token: 'daemon-secret',
+    handleRequest: async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+  });
+
+  try {
+    const port = await listenOnLoopback(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const auth = { authorization: 'Bearer daemon-secret' };
+
+    const inventory = await fetch(`${baseUrl}/artifacts`, { headers: auth });
+    assert.equal(inventory.status, 200);
+    const body = (await inventory.json()) as ArtifactInventoryResponse;
+    assert.ok(body.artifacts.some((entry) => entry.id === artifactId));
+
+    const consumingDownload = await fetch(
+      `${baseUrl}/artifacts/${encodeURIComponent(artifactId)}`,
+      {
+        headers: auth,
+      },
+    );
+    assert.equal(consumingDownload.status, 200);
+    assert.equal(await consumingDownload.text(), 'runner-output');
+    assert.equal(fs.existsSync(artifactPath), true);
+
+    const inventoryAfterConsume = await fetch(`${baseUrl}/artifacts`, { headers: auth });
+    const consumedBody = (await inventoryAfterConsume.json()) as ArtifactInventoryResponse;
+    assert.equal(
+      consumedBody.artifacts.some((entry) => entry.id === artifactId),
+      false,
+    );
+  } finally {
+    cleanupDownloadableArtifact(artifactId);
+    await closeLoopbackServer(server);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('daemon artifact downloads can be forced retained by server option', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t)) return;
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-artifacts-retain-all-'));
+  const artifactPath = path.join(tempDir, 'session-log.txt');
+  fs.writeFileSync(artifactPath, 'log-body');
+  const artifactId = trackDownloadableArtifact({
+    artifactPath,
+    fileName: 'session-log.txt',
+  });
+  const server = await createDaemonHttpServer({
+    token: 'daemon-secret',
+    retainArtifacts: true,
+    handleRequest: async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+  });
+
+  try {
+    const port = await listenOnLoopback(server);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const auth = { authorization: 'Bearer daemon-secret' };
+
+    const bareDownload = await fetch(`${baseUrl}/artifacts/${encodeURIComponent(artifactId)}`, {
+      headers: auth,
+    });
+    assert.equal(bareDownload.status, 200);
+    assert.equal(await bareDownload.text(), 'log-body');
+    assert.equal(fs.existsSync(artifactPath), true);
+
+    const secondDownload = await fetch(`${baseUrl}/artifacts/${encodeURIComponent(artifactId)}`, {
+      headers: auth,
+    });
+    assert.equal(secondDownload.status, 200);
+    assert.equal(await secondDownload.text(), 'log-body');
+    assert.equal(fs.existsSync(artifactPath), true);
+
+    const inventoryAfterDownloads = await fetch(`${baseUrl}/artifacts`, { headers: auth });
+    const body = (await inventoryAfterDownloads.json()) as ArtifactInventoryResponse;
+    assert.ok(body.artifacts.some((entry) => entry.id === artifactId));
+  } finally {
+    cleanupDownloadableArtifact(artifactId);
+    await closeLoopbackServer(server);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/src/daemon/artifact-tracking.ts
+++ b/src/daemon/artifact-tracking.ts
@@ -1,20 +1,51 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { AppError } from '../kernel/errors.ts';
+import { runCmd } from '../utils/exec.ts';
 
 // --- Downloadable artifact tracking ---
 
 const ARTIFACT_CLEANUP_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_DOWNLOAD_MIME_TYPE = 'application/octet-stream';
+const DIRECTORY_ARCHIVE_MIME_TYPE = 'application/gzip';
+
+type DirectoryArchive = {
+  archivePath: string;
+  tempDir: string;
+  fileName: string;
+  sizeBytes: number;
+};
 
 type ArtifactEntry = {
   artifactPath: string;
   tenantId?: string;
   fileName?: string;
   deleteAfterDownload: boolean;
+  createdAt: number;
+  directoryArchive?: DirectoryArchive;
+  directoryArchivePromise?: Promise<DirectoryArchive>;
   timer: ReturnType<typeof setTimeout>;
 };
 
 const pendingArtifacts = new Map<string, ArtifactEntry>();
+
+export type DownloadableArtifactInventoryEntry = {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  expiresAt: string;
+};
+
+export type PreparedDownloadableArtifact = {
+  artifactPath: string;
+  fileName?: string;
+  mimeType: string;
+  sizeBytes: number;
+};
 
 export function trackDownloadableArtifact(params: {
   artifactPath: string;
@@ -23,6 +54,7 @@ export function trackDownloadableArtifact(params: {
   deleteAfterDownload?: boolean;
 }): string {
   const artifactId = crypto.randomUUID();
+  const createdAt = Date.now();
   const timer = setTimeout(() => {
     cleanupDownloadableArtifact(artifactId);
   }, ARTIFACT_CLEANUP_TIMEOUT_MS);
@@ -32,15 +64,71 @@ export function trackDownloadableArtifact(params: {
     tenantId: params.tenantId,
     fileName: params.fileName,
     deleteAfterDownload: params.deleteAfterDownload !== false,
+    createdAt,
     timer,
   });
   return artifactId;
 }
 
-export function prepareDownloadableArtifact(
+export async function prepareDownloadableArtifact(
   artifactId: string,
   tenantId?: string,
-): { artifactPath: string; fileName?: string; deleteAfterDownload: boolean } {
+): Promise<PreparedDownloadableArtifact> {
+  const { entry, stat } = readDownloadableArtifactEntry(artifactId, tenantId);
+  const payload = await prepareArtifactPayload(artifactId, entry, stat);
+  if (!payload) {
+    throw new AppError(
+      'COMMAND_FAILED',
+      `Artifact path is not a regular file or directory: ${entry.artifactPath}`,
+    );
+  }
+  return payload;
+}
+
+export async function listDownloadableArtifacts(
+  tenantId?: string,
+): Promise<DownloadableArtifactInventoryEntry[]> {
+  const artifacts: DownloadableArtifactInventoryEntry[] = [];
+  for (const [id, entry] of pendingArtifacts) {
+    if (!canReadArtifact(entry, tenantId)) continue;
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(entry.artifactPath);
+    } catch {
+      cleanupDownloadableArtifact(id);
+      continue;
+    }
+    const payload = await prepareArtifactPayloadForInventory(id, entry, stat);
+    if (!payload) continue;
+    artifacts.push({
+      id,
+      filename: payload.fileName ?? id,
+      mimeType: payload.mimeType,
+      sizeBytes: payload.sizeBytes,
+      createdAt: new Date(entry.createdAt).toISOString(),
+      expiresAt: new Date(entry.createdAt + ARTIFACT_CLEANUP_TIMEOUT_MS).toISOString(),
+    });
+  }
+  return artifacts;
+}
+
+async function prepareArtifactPayloadForInventory(
+  artifactId: string,
+  entry: ArtifactEntry,
+  stat: fs.Stats,
+): Promise<PreparedDownloadableArtifact | null> {
+  try {
+    return await prepareArtifactPayload(artifactId, entry, stat);
+  } catch {
+    // Inventory is best-effort; direct downloads still surface artifact-specific errors.
+    return null;
+  }
+}
+
+function readDownloadableArtifactEntry(
+  artifactId: string,
+  tenantId: string | undefined,
+): { entry: ArtifactEntry; stat: fs.Stats } {
   const entry = pendingArtifacts.get(artifactId);
   if (!entry) {
     throw new AppError('INVALID_ARGS', `Artifact not found: ${artifactId}`);
@@ -48,15 +136,144 @@ export function prepareDownloadableArtifact(
   if (entry.tenantId && entry.tenantId !== tenantId) {
     throw new AppError('UNAUTHORIZED', 'Artifact belongs to a different tenant');
   }
-  if (!fs.existsSync(entry.artifactPath)) {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(entry.artifactPath);
+  } catch {
     cleanupDownloadableArtifact(artifactId);
     throw new AppError('COMMAND_FAILED', `Artifact file is missing: ${entry.artifactPath}`);
   }
+  return { entry, stat };
+}
+
+async function prepareArtifactPayload(
+  artifactId: string,
+  entry: ArtifactEntry,
+  stat: fs.Stats,
+): Promise<PreparedDownloadableArtifact | null> {
+  if (stat.isFile()) {
+    return {
+      artifactPath: entry.artifactPath,
+      fileName: safeArtifactFilename(entry.fileName, artifactId),
+      mimeType: DEFAULT_DOWNLOAD_MIME_TYPE,
+      sizeBytes: stat.size,
+    };
+  }
+  if (!stat.isDirectory()) return null;
+
+  const directoryArchive = await ensureDirectoryArchive(artifactId, entry);
   return {
-    artifactPath: entry.artifactPath,
-    fileName: entry.fileName,
-    deleteAfterDownload: entry.deleteAfterDownload,
+    artifactPath: directoryArchive.archivePath,
+    fileName: directoryArchive.fileName,
+    mimeType: DIRECTORY_ARCHIVE_MIME_TYPE,
+    sizeBytes: directoryArchive.sizeBytes,
   };
+}
+
+async function ensureDirectoryArchive(
+  artifactId: string,
+  entry: ArtifactEntry,
+): Promise<DirectoryArchive> {
+  if (entry.directoryArchive && fs.existsSync(entry.directoryArchive.archivePath)) {
+    return entry.directoryArchive;
+  }
+  if (entry.directoryArchivePromise) {
+    return await entry.directoryArchivePromise;
+  }
+
+  const archivePromise = createDirectoryArchive(artifactId, entry);
+  entry.directoryArchivePromise = archivePromise;
+  try {
+    return await archivePromise;
+  } finally {
+    if (entry.directoryArchivePromise === archivePromise) {
+      entry.directoryArchivePromise = undefined;
+    }
+  }
+}
+
+async function createDirectoryArchive(
+  artifactId: string,
+  entry: ArtifactEntry,
+): Promise<DirectoryArchive> {
+  cleanupDirectoryArchive(entry);
+
+  const sourceName = safeArtifactFilename(
+    entry.fileName,
+    path.basename(entry.artifactPath) || artifactId,
+  );
+  const fileName = archiveFilename(sourceName);
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `agent-device-download-${crypto.randomUUID()}-`),
+  );
+  const archivePath = path.join(tempDir, fileName);
+  try {
+    await runCmd(
+      'tar',
+      [
+        'czf',
+        archivePath,
+        '-C',
+        path.dirname(entry.artifactPath),
+        '--',
+        path.basename(entry.artifactPath),
+      ],
+      {
+        env: {
+          ...process.env,
+          COPYFILE_DISABLE: '1',
+        },
+      },
+    );
+    const archive = {
+      archivePath,
+      tempDir,
+      fileName,
+      sizeBytes: fs.statSync(archivePath).size,
+    };
+    // The artifact may be consumed or expire while tar is still archiving.
+    if (pendingArtifacts.get(artifactId) !== entry) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      throw new AppError('INVALID_ARGS', `Artifact not found: ${artifactId}`);
+    }
+    entry.directoryArchive = archive;
+    return archive;
+  } catch (error) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    if (error instanceof AppError) throw error;
+    throw new AppError(
+      'COMMAND_FAILED',
+      `Failed to archive downloadable artifact: ${entry.artifactPath}`,
+      { artifactPath: entry.artifactPath },
+      error instanceof Error ? error : undefined,
+    );
+  }
+}
+
+function archiveFilename(fileName: string): string {
+  const lowered = fileName.toLowerCase();
+  if (lowered.endsWith('.tar.gz') || lowered.endsWith('.tgz')) return fileName;
+  return `${fileName}.tar.gz`;
+}
+
+function canReadArtifact(entry: ArtifactEntry, tenantId: string | undefined): boolean {
+  if (!entry.tenantId) return true;
+  return entry.tenantId === tenantId;
+}
+
+function safeArtifactFilename(fileName: string | undefined, fallback: string): string {
+  const cleaned = fileName?.trim();
+  return cleaned && !hasUnsafeFilenameCharacter(cleaned) ? cleaned : fallback;
+}
+
+function hasUnsafeFilenameCharacter(fileName: string): boolean {
+  return (
+    fileName.includes('/') ||
+    fileName.includes('\\') ||
+    fileName.includes('\0') ||
+    fileName.includes('\r') ||
+    fileName.includes('\n')
+  );
 }
 
 export function cleanupDownloadableArtifact(artifactId: string): void {
@@ -64,11 +281,23 @@ export function cleanupDownloadableArtifact(artifactId: string): void {
   if (!entry) return;
   clearTimeout(entry.timer);
   pendingArtifacts.delete(artifactId);
+  cleanupDirectoryArchive(entry);
   if (!entry.deleteAfterDownload) return;
   try {
-    fs.rmSync(entry.artifactPath, { force: true });
+    fs.rmSync(entry.artifactPath, { recursive: true, force: true });
   } catch {
     // best-effort cleanup only
+  }
+}
+
+function cleanupDirectoryArchive(entry: ArtifactEntry): void {
+  if (!entry.directoryArchive) return;
+  try {
+    fs.rmSync(entry.directoryArchive.tempDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup only
+  } finally {
+    entry.directoryArchive = undefined;
   }
 }
 

--- a/src/daemon/downloadable-artifact-http.ts
+++ b/src/daemon/downloadable-artifact-http.ts
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import { normalizeError } from '../kernel/errors.ts';
+import type { DaemonRequest } from './types.ts';
+import {
+  cleanupDownloadableArtifact,
+  listDownloadableArtifacts,
+  prepareDownloadableArtifact,
+} from './artifact-tracking.ts';
+import { sendRestJsonError, statusCodeForNormalizedError } from './http-errors.ts';
+
+type DownloadableArtifactHttpRoute =
+  | { kind: 'inventory' }
+  | { kind: 'download'; artifactId: string };
+
+type DownloadableArtifactHttpAuthorizer = (params: {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  daemonRequest: Pick<DaemonRequest, 'command' | 'positionals'>;
+}) => Promise<{ tenantId?: string } | null>;
+
+export function tryHandleDownloadableArtifactHttpRoute(params: {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  authorize: DownloadableArtifactHttpAuthorizer;
+  retainArtifacts?: boolean;
+}): boolean {
+  const { req, res, authorize, retainArtifacts } = params;
+  const route = resolveDownloadableArtifactHttpRoute(req);
+  if (route === null) return false;
+
+  void handleDownloadableArtifactHttpRoute(route, req, res, authorize, { retainArtifacts });
+  return true;
+}
+
+async function handleDownloadableArtifactHttpRoute(
+  route: DownloadableArtifactHttpRoute,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  authorize: DownloadableArtifactHttpAuthorizer,
+  options: { retainArtifacts?: boolean },
+): Promise<void> {
+  switch (route.kind) {
+    case 'inventory':
+      await handleArtifactInventory(req, res, authorize);
+      return;
+    case 'download':
+      await handleArtifactDownload(route.artifactId, req, res, authorize, options);
+      return;
+  }
+}
+
+function resolveDownloadableArtifactHttpRoute(
+  req: http.IncomingMessage,
+): DownloadableArtifactHttpRoute | null {
+  if (req.method !== 'GET') return null;
+  const pathname = readRequestPathname(req.url);
+  if (pathname === '/artifacts' || pathname === '/artifacts/') {
+    return { kind: 'inventory' };
+  }
+  if (!pathname.startsWith('/artifacts/')) return null;
+  return { kind: 'download', artifactId: readArtifactId(pathname) };
+}
+
+async function handleArtifactDownload(
+  artifactId: string,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  authorize: DownloadableArtifactHttpAuthorizer,
+  options: { retainArtifacts?: boolean },
+): Promise<void> {
+  if (!artifactId) {
+    res.statusCode = 400;
+    res.end('Missing artifact id');
+    return;
+  }
+
+  try {
+    const auth = await authorize({
+      req,
+      res,
+      daemonRequest: {
+        command: 'download_artifact',
+        positionals: [artifactId],
+      },
+    });
+    if (!auth) return;
+
+    const artifact = await prepareDownloadableArtifact(artifactId, auth.tenantId);
+    const retainArtifactAfterDownload = options.retainArtifacts === true;
+    const stream = fs.createReadStream(artifact.artifactPath);
+    res.statusCode = 200;
+    res.setHeader('content-type', artifact.mimeType);
+    res.setHeader('content-length', String(artifact.sizeBytes));
+    if (artifact.fileName) {
+      res.setHeader(
+        'content-disposition',
+        `attachment; filename="${artifact.fileName.replace(/"/g, '')}"`,
+      );
+    }
+    stream.on('error', (error) => {
+      if (!res.headersSent) {
+        const normalized = normalizeError(error);
+        res.statusCode = statusCodeForNormalizedError(normalized.code);
+        res.end(normalized.message);
+      } else {
+        res.destroy(error as Error);
+      }
+    });
+    let didCleanupArtifact = false;
+    const cleanupCompletedDownload = () => {
+      if (didCleanupArtifact || retainArtifactAfterDownload) return;
+      didCleanupArtifact = true;
+      cleanupDownloadableArtifact(artifactId);
+    };
+    res.on('finish', cleanupCompletedDownload);
+    res.on('close', () => {
+      if (res.writableFinished) {
+        cleanupCompletedDownload();
+      }
+    });
+    stream.pipe(res);
+  } catch (error) {
+    sendRestJsonError(res, normalizeError(error));
+  }
+}
+
+async function handleArtifactInventory(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  authorize: DownloadableArtifactHttpAuthorizer,
+): Promise<void> {
+  try {
+    const auth = await authorize({
+      req,
+      res,
+      daemonRequest: {
+        command: 'list_artifacts',
+        positionals: [],
+      },
+    });
+    if (!auth) return;
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ artifacts: await listDownloadableArtifacts(auth.tenantId) }));
+  } catch (error) {
+    sendRestJsonError(res, normalizeError(error));
+  }
+}
+
+function readArtifactId(pathname: string): string {
+  const encoded = pathname.slice('/artifacts/'.length);
+  if (!encoded || encoded.includes('/')) return '';
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return '';
+  }
+}
+
+function readRequestPathname(requestUrl: string | undefined): string {
+  const requestTarget = requestUrl || '/';
+  const queryIndex = requestTarget.indexOf('?');
+  return queryIndex >= 0 ? requestTarget.slice(0, queryIndex) || '/' : requestTarget;
+}

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -21,6 +21,7 @@ import {
   flushDiagnosticsToSessionFile,
   withDiagnosticsScope,
 } from '../../utils/diagnostics.ts';
+import { isEnvTruthy } from '../../utils/retry.ts';
 import {
   acquireDaemonLock,
   parseIntegerEnv,
@@ -73,6 +74,7 @@ export async function startDaemonRuntime(
   const daemonPaths = resolveDaemonPaths(env.AGENT_DEVICE_STATE_DIR);
   const { baseDir, infoPath, lockPath, logPath, sessionsDir } = daemonPaths;
   const daemonServerMode = resolveDaemonServerMode(env.AGENT_DEVICE_DAEMON_SERVER_MODE);
+  const retainArtifacts = isEnvTruthy(env.AGENT_DEVICE_RETAIN_ARTIFACTS);
   setRunnerLeaseOwnerStateDir(baseDir);
 
   cleanupStaleAppLogProcesses(sessionsDir);
@@ -165,7 +167,11 @@ export async function startDaemonRuntime(
     }
 
     if (startHttpServer) {
-      const httpServer = await createDaemonHttpServer({ handleRequest, token });
+      const httpServer = await createDaemonHttpServer({
+        handleRequest,
+        token,
+        retainArtifacts,
+      });
       servers.push(httpServer);
       httpPort = await listenHttpServer(httpServer);
     }

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -1,5 +1,4 @@
 import http, { type IncomingHttpHeaders } from 'node:http';
-import fs from 'node:fs';
 import { AppError, normalizeError, toAppErrorCode } from '../../kernel/errors.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
 import { timingSafeStringEqual } from '../../utils/timing-safe-equal.ts';
@@ -22,11 +21,6 @@ import {
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { sleep } from '../../utils/timeouts.ts';
-import {
-  cleanupDownloadableArtifact,
-  listDownloadableArtifacts,
-  prepareDownloadableArtifact,
-} from '../artifact-tracking.ts';
 import { type RequestProgressEvent, withRequestProgressSink } from '../request-progress.ts';
 import {
   serializeDaemonProgressEnvelope,
@@ -36,6 +30,7 @@ import {
 import { buildDaemonHealthPayload } from '../http-health.ts';
 import { sendRestJsonError, statusCodeForNormalizedError } from '../http-errors.ts';
 import { tryHandleUploadHttpRoute } from '../upload-http.ts';
+import { tryHandleDownloadableArtifactHttpRoute } from '../downloadable-artifact-http.ts';
 
 type JsonRpcRequest = JsonRpcRequestEnvelope;
 
@@ -548,13 +543,21 @@ export async function createDaemonHttpServer(options: {
       return;
     }
 
-    if (req.method === 'GET' && isArtifactInventoryRoute(req.url)) {
-      void handleArtifactInventory(req, res, authHook, token);
-      return;
-    }
-
-    if (req.method === 'GET' && isArtifactDownloadRoute(req.url)) {
-      void handleArtifactDownload(req, res, authHook, token, { retainArtifacts });
+    if (
+      tryHandleDownloadableArtifactHttpRoute({
+        req,
+        res,
+        retainArtifacts,
+        authorize: async (request) =>
+          await authorizeAuxiliaryHttpRequest({
+            req: request.req,
+            res: request.res,
+            authHook,
+            expectedToken: token,
+            daemonRequest: request.daemonRequest,
+          }),
+      })
+    ) {
       return;
     }
 
@@ -740,124 +743,6 @@ export async function createDaemonHttpServer(options: {
       }
     });
   });
-}
-
-async function handleArtifactDownload(
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-  authHook: HttpAuthHook | null,
-  expectedToken?: string,
-  options: { retainArtifacts?: boolean } = {},
-): Promise<void> {
-  const artifactId = readArtifactId(req.url);
-  if (!artifactId) {
-    res.statusCode = 400;
-    res.end('Missing artifact id');
-    return;
-  }
-  try {
-    const auth = await authorizeAuxiliaryHttpRequest({
-      req,
-      res,
-      authHook,
-      expectedToken,
-      daemonRequest: {
-        command: 'download_artifact',
-        positionals: [artifactId],
-      },
-    });
-    if (!auth) return;
-
-    const artifact = await prepareDownloadableArtifact(artifactId, auth.tenantId);
-    const retainArtifactAfterDownload = options.retainArtifacts === true;
-    const stream = fs.createReadStream(artifact.artifactPath);
-    res.statusCode = 200;
-    res.setHeader('content-type', artifact.mimeType);
-    res.setHeader('content-length', String(artifact.sizeBytes));
-    if (artifact.fileName) {
-      res.setHeader(
-        'content-disposition',
-        `attachment; filename="${artifact.fileName.replace(/"/g, '')}"`,
-      );
-    }
-    stream.on('error', (error) => {
-      if (!res.headersSent) {
-        const normalized = normalizeError(error);
-        res.statusCode = statusCodeForNormalizedError(normalized.code);
-        res.end(normalized.message);
-      } else {
-        res.destroy(error as Error);
-      }
-    });
-    let didCleanupArtifact = false;
-    const cleanupCompletedDownload = () => {
-      if (didCleanupArtifact || retainArtifactAfterDownload) return;
-      didCleanupArtifact = true;
-      cleanupDownloadableArtifact(artifactId);
-    };
-    res.on('close', () => {
-      if (res.writableFinished) {
-        cleanupCompletedDownload();
-      }
-    });
-    stream.pipe(res);
-  } catch (error) {
-    const normalized = normalizeError(error);
-    sendRestJsonError(res, normalized);
-  }
-}
-
-async function handleArtifactInventory(
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-  authHook: HttpAuthHook | null,
-  expectedToken?: string,
-): Promise<void> {
-  try {
-    const auth = await authorizeAuxiliaryHttpRequest({
-      req,
-      res,
-      authHook,
-      expectedToken,
-      daemonRequest: {
-        command: 'list_artifacts',
-        positionals: [],
-      },
-    });
-    if (!auth) return;
-
-    res.statusCode = 200;
-    res.setHeader('content-type', 'application/json');
-    res.end(JSON.stringify({ artifacts: await listDownloadableArtifacts(auth.tenantId) }));
-  } catch (error) {
-    const normalized = normalizeError(error);
-    sendRestJsonError(res, normalized);
-  }
-}
-
-function isArtifactInventoryRoute(requestUrl: string | undefined): boolean {
-  const pathname = readRequestPathname(requestUrl);
-  return pathname === '/artifacts' || pathname === '/artifacts/';
-}
-
-function isArtifactDownloadRoute(requestUrl: string | undefined): boolean {
-  return readRequestPathname(requestUrl).startsWith('/artifacts/');
-}
-
-function readArtifactId(requestUrl: string | undefined): string {
-  const encoded = readRequestPathname(requestUrl).slice('/artifacts/'.length);
-  if (!encoded || encoded.includes('/')) return '';
-  try {
-    return decodeURIComponent(encoded);
-  } catch {
-    return '';
-  }
-}
-
-function readRequestPathname(requestUrl: string | undefined): string {
-  const requestTarget = requestUrl || '/';
-  const queryIndex = requestTarget.indexOf('?');
-  return queryIndex >= 0 ? requestTarget.slice(0, queryIndex) || '/' : requestTarget;
 }
 
 async function abortInFlightIosRunnerSessionsWhileDisconnected(

--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -22,7 +22,11 @@ import {
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { sleep } from '../../utils/timeouts.ts';
-import { cleanupDownloadableArtifact, prepareDownloadableArtifact } from '../artifact-tracking.ts';
+import {
+  cleanupDownloadableArtifact,
+  listDownloadableArtifacts,
+  prepareDownloadableArtifact,
+} from '../artifact-tracking.ts';
 import { type RequestProgressEvent, withRequestProgressSink } from '../request-progress.ts';
 import {
   serializeDaemonProgressEnvelope,
@@ -514,9 +518,10 @@ async function loadHttpAuthHook(): Promise<HttpAuthHook | null> {
 export async function createDaemonHttpServer(options: {
   handleRequest: DaemonInvokeFn;
   token?: string;
+  retainArtifacts?: boolean;
 }): Promise<http.Server> {
   const authHook = await loadHttpAuthHook();
-  const { handleRequest, token } = options;
+  const { handleRequest, token, retainArtifacts = false } = options;
   return http.createServer((req, res) => {
     if (req.method === 'GET' && req.url === '/health') {
       res.statusCode = 200;
@@ -543,8 +548,13 @@ export async function createDaemonHttpServer(options: {
       return;
     }
 
-    if (req.method === 'GET' && req.url?.startsWith('/artifacts/')) {
-      void handleArtifactDownload(req, res, authHook, token);
+    if (req.method === 'GET' && isArtifactInventoryRoute(req.url)) {
+      void handleArtifactInventory(req, res, authHook, token);
+      return;
+    }
+
+    if (req.method === 'GET' && isArtifactDownloadRoute(req.url)) {
+      void handleArtifactDownload(req, res, authHook, token, { retainArtifacts });
       return;
     }
 
@@ -737,8 +747,9 @@ async function handleArtifactDownload(
   res: http.ServerResponse,
   authHook: HttpAuthHook | null,
   expectedToken?: string,
+  options: { retainArtifacts?: boolean } = {},
 ): Promise<void> {
-  const artifactId = req.url?.slice('/artifacts/'.length) ?? '';
+  const artifactId = readArtifactId(req.url);
   if (!artifactId) {
     res.statusCode = 400;
     res.end('Missing artifact id');
@@ -757,10 +768,12 @@ async function handleArtifactDownload(
     });
     if (!auth) return;
 
-    const artifact = prepareDownloadableArtifact(artifactId, auth.tenantId);
+    const artifact = await prepareDownloadableArtifact(artifactId, auth.tenantId);
+    const retainArtifactAfterDownload = options.retainArtifacts === true;
     const stream = fs.createReadStream(artifact.artifactPath);
     res.statusCode = 200;
-    res.setHeader('content-type', 'application/octet-stream');
+    res.setHeader('content-type', artifact.mimeType);
+    res.setHeader('content-length', String(artifact.sizeBytes));
     if (artifact.fileName) {
       res.setHeader(
         'content-disposition',
@@ -776,9 +789,15 @@ async function handleArtifactDownload(
         res.destroy(error as Error);
       }
     });
+    let didCleanupArtifact = false;
+    const cleanupCompletedDownload = () => {
+      if (didCleanupArtifact || retainArtifactAfterDownload) return;
+      didCleanupArtifact = true;
+      cleanupDownloadableArtifact(artifactId);
+    };
     res.on('close', () => {
       if (res.writableFinished) {
-        cleanupDownloadableArtifact(artifactId);
+        cleanupCompletedDownload();
       }
     });
     stream.pipe(res);
@@ -786,6 +805,59 @@ async function handleArtifactDownload(
     const normalized = normalizeError(error);
     sendRestJsonError(res, normalized);
   }
+}
+
+async function handleArtifactInventory(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  authHook: HttpAuthHook | null,
+  expectedToken?: string,
+): Promise<void> {
+  try {
+    const auth = await authorizeAuxiliaryHttpRequest({
+      req,
+      res,
+      authHook,
+      expectedToken,
+      daemonRequest: {
+        command: 'list_artifacts',
+        positionals: [],
+      },
+    });
+    if (!auth) return;
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ artifacts: await listDownloadableArtifacts(auth.tenantId) }));
+  } catch (error) {
+    const normalized = normalizeError(error);
+    sendRestJsonError(res, normalized);
+  }
+}
+
+function isArtifactInventoryRoute(requestUrl: string | undefined): boolean {
+  const pathname = readRequestPathname(requestUrl);
+  return pathname === '/artifacts' || pathname === '/artifacts/';
+}
+
+function isArtifactDownloadRoute(requestUrl: string | undefined): boolean {
+  return readRequestPathname(requestUrl).startsWith('/artifacts/');
+}
+
+function readArtifactId(requestUrl: string | undefined): string {
+  const encoded = readRequestPathname(requestUrl).slice('/artifacts/'.length);
+  if (!encoded || encoded.includes('/')) return '';
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return '';
+  }
+}
+
+function readRequestPathname(requestUrl: string | undefined): string {
+  const requestTarget = requestUrl || '/';
+  const queryIndex = requestTarget.indexOf('?');
+  return queryIndex >= 0 ? requestTarget.slice(0, queryIndex) || '/' : requestTarget;
 }
 
 async function abortInFlightIosRunnerSessionsWhileDisconnected(

--- a/src/remote/daemon-artifacts.ts
+++ b/src/remote/daemon-artifacts.ts
@@ -335,14 +335,16 @@ function resolveMaterializedArtifactPath(artifact: DaemonArtifact, req: DaemonRe
   return path.resolve(req.meta?.cwd ?? process.cwd(), fallbackName);
 }
 
-export async function downloadRemoteArtifact(params: {
+type DownloadRemoteArtifactParams = {
   baseUrl: string;
   token: string;
   artifactId: string;
   destinationPath: string;
   requestId?: string;
   timeoutMs?: number;
-}): Promise<void> {
+};
+
+export async function downloadRemoteArtifact(params: DownloadRemoteArtifactParams): Promise<void> {
   const artifactUrl = new URL(buildDaemonArtifactUrl(params.baseUrl, params.artifactId));
   const transport = artifactUrl.protocol === 'https:' ? https : http;
   await fs.promises.mkdir(path.dirname(params.destinationPath), { recursive: true });

--- a/src/remote/daemon-proxy.ts
+++ b/src/remote/daemon-proxy.ts
@@ -285,6 +285,7 @@ function resolveProxyRoute(requestUrl: string): string {
 function isSupportedDaemonRoute(route: string, method: string | undefined): boolean {
   if (route === '/rpc') return method === 'POST';
   if (isSupportedUploadRoute(route, method)) return true;
+  if (route === '/artifacts' || route === '/artifacts/') return method === 'GET';
   if (route.startsWith('/artifacts/')) return method === 'GET';
   return false;
 }

--- a/src/utils/__tests__/daemon-client.test.ts
+++ b/src/utils/__tests__/daemon-client.test.ts
@@ -1315,6 +1315,40 @@ test('sendToDaemon preserves install_source payload metadata for remote HTTP RPC
   }
 });
 
+test('downloadRemoteArtifact downloads daemon artifact URL', async (t) => {
+  if (!(await supportsLoopbackBind())) {
+    t.skip('loopback listeners are not permitted in this environment');
+    return;
+  }
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-remote-artifact-'));
+  const destinationPath = path.join(tempRoot, 'artifacts', 'screen.png');
+  let seenUrl = '';
+  let seenAuth = '';
+  const server = http.createServer((req, res) => {
+    seenUrl = req.url ?? '';
+    seenAuth = String(req.headers.authorization ?? '');
+    res.statusCode = 200;
+    res.end('png-body');
+  });
+  const port = await listenOnLoopback(server);
+
+  try {
+    await downloadRemoteArtifact({
+      baseUrl: `http://127.0.0.1:${port}/agent-device`,
+      token: 'remote-secret',
+      artifactId: 'artifact-download',
+      destinationPath,
+      requestId: 'req-remote-artifact-download',
+    });
+    assert.equal(seenUrl, '/agent-device/artifacts/artifact-download');
+    assert.equal(seenAuth, 'Bearer remote-secret');
+    assert.equal(fs.readFileSync(destinationPath, 'utf8'), 'png-body');
+  } finally {
+    await closeLoopbackServer(server);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('downloadRemoteArtifact times out stalled artifact responses and removes partial files', async (t) => {
   if (!(await supportsLoopbackBind())) {
     t.skip('loopback listeners are not permitted in this environment');

--- a/src/utils/cli-command-overrides.ts
+++ b/src/utils/cli-command-overrides.ts
@@ -97,7 +97,7 @@ const SCHEMA_ONLY_CLI_COMMAND_SCHEMAS = {
 
 Run this on the host that has access to simulators/devices, expose the printed local proxy URL through a tunnel, then point another machine at the tunnel URL with connect proxy.
 
-The proxy starts or reuses a local HTTP daemon, accepts /health, /rpc, /upload and resumable /upload/* routes, and /artifacts/*, and also accepts the same routes under /agent-device/*. Health is unauthenticated for reachability probes. Other routes require the generated bearer token printed at startup, or the explicit --daemon-auth-token value when provided. The proxy rewrites authorized client requests to the upstream daemon token instead of exposing the local daemon token.
+The proxy starts or reuses a local HTTP daemon, accepts /health, /rpc, /upload and resumable /upload/* routes, and /artifacts plus /artifacts/*, and also accepts the same routes under /agent-device/*. Health is unauthenticated for reachability probes. Other routes require the generated bearer token printed at startup, or the explicit --daemon-auth-token value when provided. The proxy rewrites authorized client requests to the upstream daemon token instead of exposing the local daemon token.
 
 Use the /agent-device base path when connecting through cloudflared, ngrok, or another shared origin. Treat the bearer token as a secret; anyone with it can control the proxied daemon. This direct proxy flow does not use agent-device auth.
 


### PR DESCRIPTION
## Summary

- add an authenticated `GET /artifacts` daemon endpoint that lists pending downloadable artifacts with filename, MIME type, size, creation time, and expiry time
- support hosted-session retained artifacts via `AGENT_DEVICE_RETAIN_ARTIFACTS=1`
- archive directory artifacts as `.tar.gz` downloads, including `.trace` bundles, while preserving the existing one-shot consume behavior for normal downloads
- allow the daemon proxy to forward artifact inventory requests and downloads

## Details

The inventory endpoint is tenant-filtered and best-effort: missing artifacts are cleaned up, and directory artifacts that fail to archive are skipped from inventory without blocking other artifacts. Direct downloads still surface artifact-specific errors.

Directory archives are cached per tracked artifact and concurrent callers share the same in-flight archive operation. Cached archives are cleaned up with the tracked artifact.

Normal downloads still consume their artifact inventory entry even when the tracked source path was registered with `deleteAfterDownload: false`; that flag only controls whether cleanup removes the backing path. When the daemon starts with `AGENT_DEVICE_RETAIN_ARTIFACTS=1`, every direct `GET /artifacts/:id` download stays retained instead. This lets EAS-style hosted sessions keep tunneling the raw daemon port while preventing user downloads from consuming artifacts before a live upload poller can upload them.

## Test plan

- `pnpm vitest run --project unit src/daemon/__tests__/http-server-artifacts.test.ts src/__tests__/daemon-entrypoint.test.ts src/__tests__/daemon-proxy.test.ts src/utils/__tests__/args.test.ts src/utils/__tests__/daemon-client.test.ts`
- `pnpm vitest run --project provider-integration test/integration/provider-scenarios/daemon-http-server.test.ts test/integration/provider-scenarios/remote-daemon-client.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
