### PR TITLE
fix: stop retaining iOS runner for scoped and leased closes

### DIFF
--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -98,6 +98,7 @@ import {
   retainMaterializedPaths,
   cleanupRetainedMaterializedPathsForSession,
 } from '../../materialized-path-registry.ts';
+import { LeaseRegistry } from '../../lease-registry.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../../types.ts';
 import { AppError } from '../../../kernel/errors.ts';
@@ -3490,6 +3491,161 @@ test('close on macOS session stops runner and dismisses automation alert before 
     'dismiss-alert:dismiss:com.apple.systempreferences',
   ]);
   expect(sessionStore.get(sessionName)).toBe(undefined);
+});
+
+test('close on iOS simulator session retains runner and deletes the session', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-simulator-session';
+  sessionStore.set(sessionName, {
+    ...makeSession(sessionName, {
+      platform: 'apple',
+      id: 'sim-1',
+      name: 'iPhone 17 Pro',
+      kind: 'simulator',
+      booted: true,
+    }),
+    appName: 'com.example.app',
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: [],
+      flags: {},
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+  expect(mockStopIosRunner).not.toHaveBeenCalled();
+  expect(sessionStore.get(sessionName)).toBeUndefined();
+});
+
+test('close on iOS simulator with scoped simulator set stops runner before deleting session', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-scoped-simulator-session';
+  sessionStore.set(sessionName, {
+    ...makeSession(sessionName, {
+      platform: 'apple',
+      id: 'sim-1',
+      name: 'iPhone 17 Pro',
+      kind: 'simulator',
+      booted: true,
+      simulatorSetPath: '/tmp/tenant-a/simulator-set',
+    }),
+    appName: 'com.example.app',
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: [],
+      flags: {},
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+  expect(mockStopIosRunner).toHaveBeenCalledWith('sim-1');
+  expect(sessionStore.get(sessionName)).toBeUndefined();
+});
+
+test('close on leased iOS simulator session stops runner before deleting session', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-leased-simulator-session';
+  const leaseRegistry = new LeaseRegistry();
+  const lease = leaseRegistry.allocateLease({
+    tenantId: 'tenant-a',
+    runId: 'run-1',
+    leaseBackend: 'ios-simulator',
+    deviceKey: 'ios:sim-1',
+    clientId: 'client-a',
+  });
+  sessionStore.set(sessionName, {
+    ...makeSession(sessionName, {
+      platform: 'apple',
+      id: 'sim-1',
+      name: 'iPhone 17 Pro',
+      kind: 'simulator',
+      booted: true,
+    }),
+    appName: 'com.example.app',
+    lease: {
+      leaseId: lease.leaseId,
+      tenantId: lease.tenantId,
+      runId: lease.runId,
+      leaseBackend: lease.backend,
+      deviceKey: lease.deviceKey,
+      clientId: lease.clientId,
+      expiresAt: lease.expiresAt,
+    },
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: [],
+      flags: {},
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    leaseRegistry,
+    invoke: noopInvoke,
+  });
+
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+  expect(mockStopIosRunner).toHaveBeenCalledWith('sim-1');
+  expect(sessionStore.get(sessionName)).toBeUndefined();
+});
+
+test('close --shutdown on iOS simulator stops runner before deleting session', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'ios-simulator-shutdown-session';
+  sessionStore.set(sessionName, {
+    ...makeSession(sessionName, {
+      platform: 'apple',
+      id: 'sim-1',
+      name: 'iPhone 17 Pro',
+      kind: 'simulator',
+      booted: true,
+    }),
+    appName: 'com.example.app',
+  });
+
+  const response = await handleSessionCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'close',
+      positionals: [],
+      flags: { shutdown: true },
+    },
+    sessionName,
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    sessionStore,
+    invoke: noopInvoke,
+  });
+
+  expect(response).toBeTruthy();
+  expect(response?.ok).toBe(true);
+  expect(mockStopIosRunner).toHaveBeenCalledWith('sim-1');
+  expect(sessionStore.get(sessionName)).toBeUndefined();
 });
 
 test('close <app> on iOS stops runner before app close dispatch and performs final idempotent stop', async () => {

--- a/src/daemon/handlers/session-close.ts
+++ b/src/daemon/handlers/session-close.ts
@@ -43,7 +43,13 @@ async function maybeShutdownSessionTarget(params: {
 }
 
 function shouldRetainAppleRunnerAfterClose(req: DaemonRequest, session: SessionState): boolean {
-  return isIosSimulator(session.device) && !req.flags?.shutdown && !session.recording;
+  return (
+    isIosSimulator(session.device) &&
+    !req.flags?.shutdown &&
+    !session.recording &&
+    !session.lease &&
+    !session.device.simulatorSetPath
+  );
 }
 
 function shouldStopAppleRunnerBeforeTargetedClose(session: SessionState): boolean {


### PR DESCRIPTION
## Summary

Correct the iOS simulator close policy around cleanup-sensitive sessions.
Plain default-set simulator close already retained the runner; this PR narrows that retention so leased sessions and scoped simulator-set sessions stop the runner before the daemon deletes the session. Shutdown, recording, devices, and macOS remain on the full teardown path as before.

Closes #1013

2 files touched; scope stayed inside session close policy and its behavioral tests.

## Validation

`pnpm exec vitest run src/daemon/handlers/__tests__/session.test.ts src/daemon/handlers/__tests__/session-close-shutdown.test.ts` passed.
`pnpm format` passed.
`pnpm check:quick` passed.
CI is green, including Unit Tests, Integration Tests, Coverage, Lint & Format, Typecheck, Swift Runner Unit Compile, and iOS Runner Swift Compatibility.
Manual simulator verification on July 2, 2026 with `iPhone 17 Pro`: built `dist`, cleaned daemon state, opened `Settings` in session A, prepared the runner, closed the session, reopened `Settings` in session B on the same simulator, and `prepare ios-runner --json` reused the same device/artifact and returned in 243 ms.

Local `pnpm check:unit` hit unrelated Android `fillAndroid` failures under local CPU/process-spawn contention; the same PR head is green in CI.