### PR TITLE
fix: surface open timing in debug diagnostics

### DIFF
--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -389,6 +389,7 @@ Diagnostics and traces:
   Use --debug for CLI/daemon diagnostic ids and log paths.
   Use AGENT_DEVICE_EXEC_TRACE=1 when you need host-tool spawn timing without full debug streaming; it flushes the full request diagnostics file on successful requests that spawn host tools.
   Open output includes Session state; JSON also includes runnerLogPath and requestLogPath.
+  For open timing under --debug, run open --debug --json and inspect requestLogPath for the open_timing event.
   Session requests/<request-id>.ndjson holds daemon request diagnostics; session runner.log holds Apple runner/xcodebuild output.
   daemon.log is global daemon lifecycle evidence, not the primary per-run log.
   Use trace for low-level session diagnostics around one repro:

--- a/src/commands/management/output.test.ts
+++ b/src/commands/management/output.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { doctorCliOutput, managementCliOutputFormatters, openCliOutput } from './output.ts';
 import { markDoctorProgressRendered } from '../../cli-doctor-output.ts';
 import { withNoColor } from '../../__tests__/test-utils/index.ts';
+import type { AppOpenResult } from '../../client/client-types.ts';
 
 describe('openCliOutput', () => {
   test('prints session state directory on a second line', () => {
@@ -18,6 +19,18 @@ describe('openCliOutput', () => {
       session: 'default',
       sessionStateDir: '/tmp/agent-device/sessions/cwd_123_default',
     });
+  });
+
+  test('keeps internal open timing out of public output data', () => {
+    const result: AppOpenResult & { timing: { totalDurationMs: number } } = {
+      session: 'default',
+      sessionStateDir: '/tmp/agent-device/sessions/cwd_123_default',
+      identifiers: { session: 'default' },
+      timing: { totalDurationMs: 42 },
+    };
+    const output = openCliOutput(result);
+
+    expect(output.data).not.toHaveProperty('timing');
   });
 });
 

--- a/src/daemon/__tests__/request-router-open.test.ts
+++ b/src/daemon/__tests__/request-router-open.test.ts
@@ -94,6 +94,40 @@ test('open returns and creates the session state directory', async () => {
   }
 });
 
+test('open --debug writes bounded open timing diagnostics to requestLogPath', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-open-');
+  const device = makeIosDevice('SIM-DEBUG');
+  mockResolveTargetDevice.mockResolvedValue(device);
+
+  const handler = createOpenHandler(sessionStore);
+
+  const response = await handler(
+    openRequest('session-debug', { platform: 'ios', verbose: true }, 'req-open-debug', {
+      debug: true,
+    }),
+  );
+
+  expect(response.ok).toBe(true);
+  if (response.ok) {
+    const requestLogPath = String(response.data?.requestLogPath);
+    expect(fs.existsSync(requestLogPath)).toBe(true);
+    const rows = fs
+      .readFileSync(requestLogPath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const timingEvent = rows.find((row) => row.phase === 'open_timing');
+    expect(timingEvent).toMatchObject({
+      level: 'info',
+      phase: 'open_timing',
+      durationMs: expect.any(Number),
+      data: {
+        totalDurationMs: expect.any(Number),
+      },
+    });
+  }
+});
+
 test('open stores admitted lease metadata on the session', async () => {
   const sessionStore = makeSessionStore('agent-device-router-open-');
   const leaseRegistry = new LeaseRegistry({ now: () => 1_000 });

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -32,7 +32,7 @@ import { buildNextOpenSession, buildOpenResult } from './session-open-surface.ts
 import { markAndroidSnapshotFreshness } from '../android-snapshot-freshness.ts';
 import { resetAndroidFramePerfStats } from '../../platforms/android/perf.ts';
 import { withKeyedLock } from '../../utils/keyed-lock.ts';
-import { getDiagnosticsMeta } from '../../utils/diagnostics.ts';
+import { emitDiagnostic, getDiagnosticsMeta } from '../../utils/diagnostics.ts';
 import { inferAndroidPackageAfterOpen } from './session-open-target.ts';
 import {
   invalidOpenArgs,
@@ -319,6 +319,12 @@ async function completeOpenCommand(params: {
     req.meta?.requestId ?? getDiagnosticsMeta().requestId,
   );
   timing.totalDurationMs = Math.max(0, Date.now() - openCommandStartedAtMs);
+  emitDiagnostic({
+    level: 'info',
+    phase: 'open_timing',
+    durationMs: timing.totalDurationMs,
+    data: timing,
+  });
   const openResult = buildOpenResult({
     sessionName: nextSession.name,
     sessionStateDir,

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1659,6 +1659,8 @@ test('usageForCommand resolves debugging help topic', () => {
     help,
     /AGENT_DEVICE_EXEC_TRACE=1 when you need host-tool spawn timing without full debug streaming/,
   );
+  assert.match(help, /open --debug --json/);
+  assert.match(help, /open_timing event/);
   assert.match(help, /requests\/<request-id>\.ndjson holds daemon request diagnostics/);
   assert.match(help, /daemon\.log is global daemon lifecycle evidence/);
   assert.match(help, /agent-device perf memory sample --json/);


### PR DESCRIPTION
## Summary

Surface `open` timing through the existing debug diagnostics path instead of changing the public success JSON.

The daemon now emits a bounded `open_timing` event into the request log under `--debug`, keeps internal timing out of `AppOpenResult`/CLI output, and documents how to find that evidence from `open --debug --json` via `requestLogPath`.

Closes #1015

## Validation

Focused validation on the rebased branch:
- `./node_modules/.bin/tsc -p tsconfig.json`
- `./node_modules/.bin/oxlint . --deny-warnings`
- `./node_modules/.bin/vitest run src/daemon/__tests__/request-router-open.test.ts -t "open --debug writes bounded open timing diagnostics to requestLogPath"`
- `./node_modules/.bin/vitest run src/commands/management/output.test.ts -t "keeps internal open timing out of public output data"`
- `./node_modules/.bin/vitest run src/utils/__tests__/args.test.ts -t "usageForCommand resolves debugging help topic"`
