### PR TITLE
feat: add session event timeline

### DIFF
--- a/src/__tests__/cli-client-commands.test.ts
+++ b/src/__tests__/cli-client-commands.test.ts
@@ -379,6 +379,53 @@ test('metro reload forwards host, port, bundle URL, and timeout to client.metro.
   assert.equal(stdout, 'Reloaded React Native apps via http://127.0.0.1:9090/reload\n');
 });
 
+test('events prints a parsed session timeline from the generic CLI route', async () => {
+  let observed: Parameters<AgentDeviceClient['observability']['events']>[0] | undefined;
+  const client = createStubClient({
+    installFromSource: async () => {
+      throw new Error('unexpected install call');
+    },
+    events: async (options) => {
+      observed = options;
+      return {
+        path: '/tmp/session/events.ndjson',
+        cursor: '0',
+        limit: 100,
+        events: [
+          {
+            version: 1,
+            ts: '2026-07-02T12:00:00.000Z',
+            session: 'default',
+            kind: 'action.recorded',
+            command: 'click',
+            summary: 'Tapped @e14',
+            details: { ref: '@e14' },
+          },
+        ],
+      };
+    },
+  });
+
+  const output = await captureOutput(async () => {
+    const handled = await tryRunClientBackedCommand({
+      command: 'events',
+      positionals: [],
+      flags: {
+        json: false,
+        help: false,
+        version: false,
+      },
+      client,
+    });
+    assert.equal(handled, true);
+  });
+
+  assert.equal(observed?.limit, undefined);
+  assert.equal(observed?.cursor, undefined);
+  assert.match(output.stdout, /action click\s+Tapped @e14/);
+  assert.match(output.stderr, /path=\/tmp\/session\/events\.ndjson/);
+});
+
 test('screenshot forwards --overlay-refs to the client capture API', async () => {
   let observed:
     | {
@@ -1074,6 +1121,7 @@ async function captureOutput(
 function createStubClient(params: {
   installFromSource: AgentDeviceClient['apps']['installFromSource'];
   listApps?: AgentDeviceClient['apps']['list'];
+  events?: AgentDeviceClient['observability']['events'];
   prepareMetro?: AgentDeviceClient['metro']['prepare'];
   reloadMetro?: AgentDeviceClient['metro']['reload'];
   open?: AgentDeviceClient['apps']['open'];
@@ -1198,7 +1246,10 @@ function createStubClient(params: {
     interactions: createThrowingMethodGroup<AgentDeviceClient['interactions']>(),
     replay: createThrowingMethodGroup<AgentDeviceClient['replay']>(),
     batch: createThrowingMethodGroup<AgentDeviceClient['batch']>(),
-    observability: createThrowingMethodGroup<AgentDeviceClient['observability']>(),
+    observability: {
+      ...createThrowingMethodGroup<AgentDeviceClient['observability']>(),
+      events: params.events ?? unexpectedCommandCall,
+    },
     debug: createThrowingMethodGroup<AgentDeviceClient['debug']>(),
     recording: createThrowingMethodGroup<AgentDeviceClient['recording']>(),
     settings: {

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -464,6 +464,12 @@ Logs:
     agent-device open MyApp --platform ios --relaunch --launch-console ./artifacts/app.console.log
   --launch-console is only for direct iOS simulator app launches, not URL opens.
 
+Events:
+  Use events for a compact session timeline without dumping full app logs.
+    agent-device events
+    agent-device events 50 100
+  Events preserve command names, status, durations, paths, session/device/app identifiers, refs/selectors, and coordinates. Typed text, clipboard writes, push/event payloads, raw unknown command arguments, and matching raw message fragments are replaced with length-only placeholders. --no-record suppresses action.recorded entries, but request start/finish entries still record command, status, and timing.
+
 Network:
   Use network dump for recent session HTTP traffic parsed from app logs.
     agent-device network dump --include headers

--- a/src/client/client-shared.ts
+++ b/src/client/client-shared.ts
@@ -150,6 +150,7 @@ export function serializeOpenResult(result: AppOpenResult): Record<string, unkno
       ...(result.sessionStateDir ? { sessionStateDir: result.sessionStateDir } : {}),
       ...(result.runnerLogPath ? { runnerLogPath: result.runnerLogPath } : {}),
       ...(result.requestLogPath ? { requestLogPath: result.requestLogPath } : {}),
+      ...(result.eventLogPath ? { eventLogPath: result.eventLogPath } : {}),
       ...(result.appName ? { appName: result.appName } : {}),
       ...(result.appBundleId ? { appBundleId: result.appBundleId } : {}),
       ...(result.startup ? { startup: result.startup } : {}),

--- a/src/client/client-types.ts
+++ b/src/client/client-types.ts
@@ -282,6 +282,7 @@ export type AppOpenResult = {
   sessionStateDir?: string;
   runnerLogPath?: string;
   requestLogPath?: string;
+  eventLogPath?: string;
   appName?: string;
   appBundleId?: string;
   appId?: string;
@@ -857,6 +858,11 @@ export type LogsOptions = AgentDeviceRequestOverrides & {
   restart?: boolean;
 };
 
+export type EventsOptions = AgentDeviceRequestOverrides & {
+  cursor?: string;
+  limit?: number;
+};
+
 export type NetworkOptions = AgentDeviceRequestOverrides & {
   action?: 'dump' | 'log';
   limit?: number;
@@ -1105,6 +1111,7 @@ export type AgentDeviceClient = {
   observability: {
     perf: (options?: PerfOptions) => Promise<CommandRequestResult>;
     logs: (options?: LogsOptions) => Promise<CommandRequestResult>;
+    events: (options?: EventsOptions) => Promise<CommandRequestResult>;
     network: (options?: NetworkOptions) => Promise<CommandRequestResult>;
     audio: (options?: AudioOptions) => Promise<CommandRequestResult>;
   };

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -200,6 +200,7 @@ export function createAgentDeviceClient(
         return {
           session,
           sessionStateDir: readOptionalString(data, 'sessionStateDir'),
+          eventLogPath: readOptionalString(data, 'eventLogPath'),
           appName: readOptionalString(data, 'appName'),
           appBundleId,
           appId,
@@ -350,6 +351,7 @@ export function createAgentDeviceClient(
     observability: {
       perf: async (options = {}) => await executeCommand('perf', options),
       logs: async (options = {}) => await executeCommand('logs', options),
+      events: async (options = {}) => await executeCommand('events', options),
       network: async (options = {}) => await executeCommand('network', options),
       audio: async (options = {}) => await executeCommand('audio', options),
     },

--- a/src/commands/observability/index.test.ts
+++ b/src/commands/observability/index.test.ts
@@ -80,9 +80,17 @@ describe('observability command interface', () => {
       limit: 25,
       cursor: '100',
     });
+    expect(eventsCliReader(['', '100'], NO_FLAGS)).toEqual({
+      limit: undefined,
+      cursor: '100',
+    });
     expect(eventsDaemonWriter({ limit: 25, cursor: '100' })).toMatchObject({
       command: 'events',
       positionals: ['25', '100'],
+    });
+    expect(eventsDaemonWriter({ cursor: '100' })).toMatchObject({
+      command: 'events',
+      positionals: ['', '100'],
     });
   });
 

--- a/src/commands/observability/index.test.ts
+++ b/src/commands/observability/index.test.ts
@@ -5,6 +5,10 @@ import {
   audioCommandDefinition,
   audioCommandMetadata,
   audioDaemonWriter,
+  eventsCliReader,
+  eventsCommandDefinition,
+  eventsCommandMetadata,
+  eventsDaemonWriter,
   logsCliReader,
   logsCommandDefinition,
   logsCommandMetadata,
@@ -14,6 +18,7 @@ import {
   networkCommandMetadata,
   networkDaemonWriter,
 } from './index.ts';
+import { observabilityCliOutputFormatters } from './output.ts';
 
 const NO_FLAGS = {} as CliFlags;
 
@@ -30,6 +35,8 @@ describe('observability command interface', () => {
   test('owns logs and network public metadata', () => {
     expect(audioCommandMetadata.name).toBe('audio');
     expect(audioCommandDefinition.name).toBe('audio');
+    expect(eventsCommandMetadata.name).toBe('events');
+    expect(eventsCommandDefinition.name).toBe('events');
     expect(logsCommandMetadata.name).toBe('logs');
     expect(logsCommandDefinition.name).toBe('logs');
     expect(networkCommandMetadata.name).toBe('network');
@@ -66,6 +73,73 @@ describe('observability command interface', () => {
       command: 'logs',
       positionals: ['mark', 'checkout started'],
     });
+  });
+
+  test('reads events pagination as compact daemon positionals', () => {
+    expect(eventsCliReader(['25', '100'], NO_FLAGS)).toEqual({
+      limit: 25,
+      cursor: '100',
+    });
+    expect(eventsDaemonWriter({ limit: 25, cursor: '100' })).toMatchObject({
+      command: 'events',
+      positionals: ['25', '100'],
+    });
+  });
+
+  test('formats events as a compact human timeline', () => {
+    const output = observabilityCliOutputFormatters.events({
+      input: {},
+      result: {
+        path: '/tmp/session/events.ndjson',
+        cursor: '0',
+        limit: 100,
+        events: [
+          {
+            version: 1,
+            ts: '2026-07-02T12:00:00.000Z',
+            session: 'default',
+            kind: 'request.started',
+            command: 'open',
+            summary: 'Started open',
+          },
+          {
+            version: 1,
+            ts: '2026-07-02T12:00:00.250Z',
+            session: 'default',
+            kind: 'request.finished',
+            command: 'open',
+            status: 'ok',
+            summary: 'Finished open',
+            details: { durationMs: 250 },
+          },
+          {
+            version: 1,
+            ts: '2026-07-02T12:00:01.000Z',
+            session: 'default',
+            kind: 'action.recorded',
+            command: 'fill',
+            summary: 'Filled @e14',
+            details: { ref: '@e14', textLength: 8 },
+          },
+        ],
+      },
+    });
+
+    expect(output.text).toContain('2026-07-02 12:00:00.000Z  start open');
+    expect(output.text).toContain('2026-07-02 12:00:00.250Z  ok open 250ms');
+    expect(output.text).toContain('2026-07-02 12:00:01.000Z  action fill');
+    expect(output.text).toContain('Filled @e14 (text=8 chars)');
+    expect(output.stderr).toContain('path=/tmp/session/events.ndjson');
+  });
+
+  test('formats empty events page with a readable message', () => {
+    const output = observabilityCliOutputFormatters.events({
+      input: {},
+      result: { path: '/tmp/session/events.ndjson', cursor: '0', limit: 100, events: [] },
+    });
+
+    expect(output.text).toBe('No session events found.');
+    expect(output.stderr).toContain('cursor=0');
   });
 
   test('reads network include from flag or positional', () => {

--- a/src/commands/observability/index.ts
+++ b/src/commands/observability/index.ts
@@ -1,4 +1,9 @@
-import type { AudioOptions, LogsOptions, NetworkOptions } from '../../client/client-types.ts';
+import type {
+  AudioOptions,
+  EventsOptions,
+  LogsOptions,
+  NetworkOptions,
+} from '../../client/client-types.ts';
 import { NETWORK_INCLUDE_MODES, type NetworkIncludeMode } from '../../kernel/contracts.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { parseStringMember } from '../../utils/string-enum.ts';
@@ -20,6 +25,7 @@ import type { CliReader, DaemonWriter } from '../cli-grammar/types.ts';
 import { observabilityCliOutputFormatters } from './output.ts';
 
 const LOGS_COMMAND_NAME = 'logs';
+const EVENTS_COMMAND_NAME = 'events';
 const NETWORK_COMMAND_NAME = 'network';
 const AUDIO_COMMAND_NAME = 'audio';
 const NETWORK_ACTION_VALUES = ['dump', 'log'] as const;
@@ -27,6 +33,7 @@ const AUDIO_ACTION_VALUES = ['probe'] as const;
 const AUDIO_PROBE_ACTION_VALUES = ['start', 'status', 'stop'] as const;
 
 const logsCommandDescription = 'Manage session app logs.';
+const eventsCommandDescription = 'Read the session event timeline.';
 const networkCommandDescription = 'Show recent HTTP traffic.';
 const audioCommandDescription = 'Probe audio levels.';
 
@@ -37,6 +44,15 @@ export const logsCommandMetadata = defineFieldCommandMetadata(
     action: enumField(LOG_ACTION_VALUES),
     message: stringField(),
     restart: booleanField(),
+  },
+);
+
+export const eventsCommandMetadata = defineFieldCommandMetadata(
+  EVENTS_COMMAND_NAME,
+  eventsCommandDescription,
+  {
+    limit: integerField(),
+    cursor: stringField(),
   },
 );
 
@@ -65,6 +81,11 @@ export const logsCommandDefinition = defineExecutableCommand(logsCommandMetadata
   client.observability.logs(input),
 );
 
+export const eventsCommandDefinition = defineExecutableCommand(
+  eventsCommandMetadata,
+  (client, input) => client.observability.events(input),
+);
+
 export const networkCommandDefinition = defineExecutableCommand(
   networkCommandMetadata,
   (client, input) => client.observability.network(input),
@@ -83,6 +104,14 @@ const logsCliSchema = {
   positionalArgs: ['path|start|stop|clear|doctor|mark', 'message?'],
   allowsExtraPositionals: true,
   allowedFlags: ['restart'],
+} as const satisfies CommandSchemaOverride;
+
+const eventsCliSchema = {
+  usageOverride: 'events [limit] [cursor]',
+  listUsageOverride: 'events',
+  helpDescription: 'Read the daemon-owned session event timeline as paged JSON-friendly entries',
+  summary: 'Read session event timeline',
+  positionalArgs: ['limit?', 'cursor?'],
 } as const satisfies CommandSchemaOverride;
 
 const networkCliSchema = {
@@ -113,6 +142,12 @@ export const logsCliReader: CliReader = (positionals, flags) => ({
   restart: flags.restart,
 });
 
+export const eventsCliReader: CliReader = (positionals, flags) => ({
+  ...commonInputFromFlags(flags),
+  limit: optionalCliNumber(positionals[0]),
+  cursor: positionals[1],
+});
+
 export const networkCliReader: CliReader = (positionals, flags) => ({
   ...commonInputFromFlags(flags),
   action: readNetworkAction(positionals[0]),
@@ -132,6 +167,9 @@ export const logsDaemonWriter: DaemonWriter = direct(LOGS_COMMAND_NAME, (input) 
   logsPositionals(input as LogsOptions),
 );
 
+export const eventsDaemonWriter: DaemonWriter = (input) =>
+  request(EVENTS_COMMAND_NAME, eventsPositionals(input as EventsOptions), input);
+
 export const networkDaemonWriter: DaemonWriter = (input) =>
   request(NETWORK_COMMAND_NAME, networkPositionals(input as NetworkOptions), {
     ...input,
@@ -149,6 +187,16 @@ const logsCommandFacet = defineCommandFacet({
   cliReader: logsCliReader,
   daemonWriter: logsDaemonWriter,
   cliOutputFormatter: observabilityCliOutputFormatters.logs,
+});
+
+const eventsCommandFacet = defineCommandFacet({
+  name: EVENTS_COMMAND_NAME,
+  metadata: eventsCommandMetadata,
+  definition: eventsCommandDefinition,
+  cliSchema: eventsCliSchema,
+  cliReader: eventsCliReader,
+  daemonWriter: eventsDaemonWriter,
+  cliOutputFormatter: observabilityCliOutputFormatters.events,
 });
 
 const networkCommandFacet = defineCommandFacet({
@@ -173,11 +221,15 @@ const audioCommandFacet = defineCommandFacet({
 
 export const observabilityCommandFamily = defineCommandFamilyFromFacets({
   name: 'observability',
-  commands: [logsCommandFacet, networkCommandFacet, audioCommandFacet],
+  commands: [logsCommandFacet, eventsCommandFacet, networkCommandFacet, audioCommandFacet],
 });
 
 function logsPositionals(input: { action?: string; message?: string }): string[] {
   return [input.action ?? 'path', ...optionalString(input.message)];
+}
+
+function eventsPositionals(input: EventsOptions): string[] {
+  return [...optionalNumber(input.limit), ...optionalString(input.cursor)];
 }
 
 function networkPositionals(input: NetworkOptions): string[] {

--- a/src/commands/observability/index.ts
+++ b/src/commands/observability/index.ts
@@ -144,7 +144,7 @@ export const logsCliReader: CliReader = (positionals, flags) => ({
 
 export const eventsCliReader: CliReader = (positionals, flags) => ({
   ...commonInputFromFlags(flags),
-  limit: optionalCliNumber(positionals[0]),
+  limit: optionalEventsLimit(positionals[0]),
   cursor: positionals[1],
 });
 
@@ -229,11 +229,16 @@ function logsPositionals(input: { action?: string; message?: string }): string[]
 }
 
 function eventsPositionals(input: EventsOptions): string[] {
-  return [...optionalNumber(input.limit), ...optionalString(input.cursor)];
+  if (input.cursor === undefined) return optionalNumber(input.limit);
+  return [input.limit === undefined ? '' : String(input.limit), input.cursor];
 }
 
 function networkPositionals(input: NetworkOptions): string[] {
   return [...(input.action ? [input.action] : []), ...optionalNumber(input.limit)];
+}
+
+function optionalEventsLimit(value: string | undefined): number | undefined {
+  return value === undefined || value.trim() === '' ? undefined : optionalCliNumber(value);
 }
 
 function audioPositionals(input: AudioOptions): string[] {

--- a/src/commands/observability/index.ts
+++ b/src/commands/observability/index.ts
@@ -144,7 +144,7 @@ export const logsCliReader: CliReader = (positionals, flags) => ({
 
 export const eventsCliReader: CliReader = (positionals, flags) => ({
   ...commonInputFromFlags(flags),
-  limit: optionalEventsLimit(positionals[0]),
+  limit: positionals[0]?.trim() ? optionalCliNumber(positionals[0]) : undefined,
   cursor: positionals[1],
 });
 
@@ -235,10 +235,6 @@ function eventsPositionals(input: EventsOptions): string[] {
 
 function networkPositionals(input: NetworkOptions): string[] {
   return [...(input.action ? [input.action] : []), ...optionalNumber(input.limit)];
-}
-
-function optionalEventsLimit(value: string | undefined): number | undefined {
-  return value === undefined || value.trim() === '' ? undefined : optionalCliNumber(value);
 }
 
 function audioPositionals(input: AudioOptions): string[] {

--- a/src/commands/observability/output.ts
+++ b/src/commands/observability/output.ts
@@ -23,6 +23,24 @@ type LogsCliResult = LogsActionFields & {
   notes?: readonly string[];
 };
 
+type EventsCliEntry = {
+  ts?: string;
+  kind?: string;
+  requestId?: string;
+  command?: string;
+  status?: string;
+  summary?: string;
+  details?: Record<string, unknown>;
+};
+
+type EventsCliResult = {
+  path?: string;
+  cursor?: string;
+  nextCursor?: string;
+  limit?: number;
+  events?: readonly EventsCliEntry[];
+};
+
 const LOG_ACTION_FIELD_KEYS = [
   'started',
   'stopped',
@@ -76,6 +94,17 @@ function logsCliOutput(data: LogsCliResult): CliOutput {
       formatActionFields(data),
       data.hint,
       formatNotes(data.notes),
+    ]),
+  };
+}
+
+function eventsCliOutput(data: EventsCliResult): CliOutput {
+  const events = data.events ?? [];
+  return {
+    data,
+    text: events.length > 0 ? formatEventEntries(events) : 'No session events found.',
+    stderr: joinDefinedLines([
+      formatKeyValueFields(data, ['path', 'cursor', 'nextCursor', 'limit'] as const),
     ]),
   };
 }
@@ -136,9 +165,111 @@ function audioCliOutput(data: AudioCliResult): CliOutput {
 
 export const observabilityCliOutputFormatters = {
   logs: resultOutput<LogsCliResult>(logsCliOutput),
+  events: resultOutput<EventsCliResult>(eventsCliOutput),
   network: resultOutput<NetworkCliResult>(networkCliOutput),
   audio: resultOutput<AudioCliResult>(audioCliOutput),
 } as const satisfies Record<string, CliOutputFormatter>;
+
+function formatEventEntries(entries: readonly EventsCliEntry[]): string {
+  const rows = entries.map(formatEventRow);
+  const labelWidth = Math.min(Math.max(...rows.map((row) => row.label.length), 'event'.length), 32);
+  return rows.map((row) => formatEventRowLine(row, labelWidth)).join('\n');
+}
+
+function formatEventRow(entry: EventsCliEntry): {
+  timestamp: string;
+  label: string;
+  summary: string;
+} {
+  return {
+    timestamp: formatEventTimestamp(entry.ts),
+    label: formatEventLabel(entry),
+    summary: formatEventSummary(entry),
+  };
+}
+
+function formatEventRowLine(
+  row: { timestamp: string; label: string; summary: string },
+  labelWidth: number,
+): string {
+  const label = row.label.padEnd(labelWidth);
+  const prefix = row.timestamp ? `${row.timestamp}  ${label}` : label.trimEnd();
+  return row.summary ? `${prefix}  ${row.summary}` : prefix.trimEnd();
+}
+
+function formatEventTimestamp(value: string | undefined): string {
+  if (!value) return '';
+  const match = value.match(
+    /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?)(Z|[+-]\d{2}:\d{2})?$/,
+  );
+  return match ? `${match[1]} ${match[2]}${match[3] ?? ''}` : value;
+}
+
+function formatEventLabel(entry: EventsCliEntry): string {
+  const command = entry.command ?? 'command';
+  switch (entry.kind) {
+    case 'request.started':
+      return `start ${command}`;
+    case 'request.finished':
+      return joinDefinedWords([
+        entry.status === 'error' ? 'error' : 'ok',
+        command,
+        formatDuration(readNumber(entry.details?.durationMs)),
+      ]);
+    case 'action.recorded':
+      return `action ${command}`;
+    default:
+      return joinDefinedWords([entry.kind ?? 'event', entry.command]);
+  }
+}
+
+function formatEventSummary(entry: EventsCliEntry): string {
+  const summary = compactDefaultSummary(entry.summary, entry);
+  const hints = formatEventHints(entry, summary);
+  return `${summary}${hints}`.trim();
+}
+
+function compactDefaultSummary(summary: string | undefined, entry: EventsCliEntry): string {
+  const text = summary?.trim() ?? '';
+  const command = entry.command ?? '';
+  if (entry.kind === 'request.started' && text === `Started ${command}`) return '';
+  if (entry.kind === 'request.finished' && text === `Finished ${command}`) return '';
+  return text;
+}
+
+function formatEventHints(entry: EventsCliEntry, summary: string): string {
+  if (entry.kind !== 'action.recorded') return '';
+  const details = entry.details;
+  if (!details) return '';
+  const hints = [
+    formatActionTargetHint(details, summary),
+    formatTextLengthHint(readNumber(details.textLength)),
+  ].filter((hint): hint is string => Boolean(hint));
+  return hints.length > 0 ? ` (${hints.join(', ')})` : '';
+}
+
+function formatActionTargetHint(
+  details: Record<string, unknown>,
+  summary: string,
+): string | undefined {
+  const target = readString(details.ref) ?? readString(details.selector) ?? formatPoint(details);
+  if (!target || summary.includes(target)) return undefined;
+  return `target=${target}`;
+}
+
+function formatPoint(details: Record<string, unknown>): string | undefined {
+  const x = readNumber(details.x);
+  const y = readNumber(details.y);
+  return x === undefined || y === undefined ? undefined : `(${x}, ${y})`;
+}
+
+function formatTextLengthHint(length: number | undefined): string | undefined {
+  return length === undefined ? undefined : `text=${length} chars`;
+}
+
+function formatDuration(durationMs: number | undefined): string | undefined {
+  return durationMs === undefined ? undefined : `${Math.round(durationMs)}ms`;
+}
 
 function formatAudioArray(label: string, value: readonly number[] | undefined): string | undefined {
   if (!Array.isArray(value)) return undefined;
@@ -158,6 +289,18 @@ function formatActionFields(data: LogsActionFields): string | undefined {
 
 function formatActionField(key: string, value: true | number | null | undefined): string {
   return value == null ? '' : `${key}=${value}`;
+}
+
+function joinDefinedWords(words: Array<string | undefined>): string {
+  return words.filter((word): word is string => Boolean(word)).join(' ');
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function formatNetworkEntry(entry: NetworkCliEntry): string[] {

--- a/src/commands/observability/output.ts
+++ b/src/commands/observability/output.ts
@@ -199,10 +199,7 @@ function formatEventRowLine(
 
 function formatEventTimestamp(value: string | undefined): string {
   if (!value) return '';
-  const match = value.match(
-    /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?)(Z|[+-]\d{2}:\d{2})?$/,
-  );
-  return match ? `${match[1]} ${match[2]}${match[3] ?? ''}` : value;
+  return value.replace('T', ' ');
 }
 
 function formatEventLabel(entry: EventsCliEntry): string {

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -46,6 +46,7 @@ const NO_CAPABILITY_PUBLIC_COMMANDS = new Set<string>([
   PUBLIC_COMMANDS.capabilities,
   PUBLIC_COMMANDS.devices,
   PUBLIC_COMMANDS.doctor,
+  PUBLIC_COMMANDS.events,
   PUBLIC_COMMANDS.gesture,
   PUBLIC_COMMANDS.prepare,
   PUBLIC_COMMANDS.replay,

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -337,6 +337,18 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
+    name: 'events',
+    catalog: { group: 'public' },
+    daemon: {
+      route: 'session',
+      sessionKind: 'observability',
+      allowInvalidRecording: true,
+      ...REQUEST_EXECUTION_EXEMPT,
+    },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+  },
+  {
     name: 'network',
     catalog: { group: 'public' },
     daemon: { route: 'session', sessionKind: 'observability' },

--- a/src/daemon/__tests__/request-router-events.test.ts
+++ b/src/daemon/__tests__/request-router-events.test.ts
@@ -47,6 +47,49 @@ test('events reads the daemon-owned session timeline without appending poll nois
   expect(fs.readFileSync(eventLogPath, 'utf8').trim().split('\n')).toHaveLength(1);
 });
 
+test('events accepts a blank limit placeholder for cursor-only reads', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-events-cursor-');
+  sessionStore.recordEvent('events-session', {
+    kind: 'action.recorded',
+    command: 'open',
+    summary: 'Opened session',
+  });
+  sessionStore.recordEvent('events-session', {
+    kind: 'action.recorded',
+    command: 'click',
+    summary: 'Tapped @14',
+  });
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'events-session',
+    command: 'events',
+    positionals: ['', '1'],
+    flags: {},
+    meta: { requestId: 'req-events-cursor' },
+  });
+
+  expect(response.ok).toBe(true);
+  if (!response.ok) return;
+  expect(response.data?.cursor).toBe('1');
+  expect(response.data?.limit).toBe(100);
+  expect(response.data?.events).toEqual([
+    expect.objectContaining({
+      kind: 'action.recorded',
+      command: 'click',
+      summary: 'Tapped @14',
+    }),
+  ]);
+});
+
 test('request timeline records thrown request failures after scope creation', async () => {
   const sessionStore = makeSessionStore('agent-device-router-events-throws-');
   sessionStore.set('events-session', makeIosSession('events-session'));

--- a/src/daemon/__tests__/request-router-events.test.ts
+++ b/src/daemon/__tests__/request-router-events.test.ts
@@ -90,6 +90,84 @@ test('events accepts a blank limit placeholder for cursor-only reads', async () 
   ]);
 });
 
+test('events returns structured errors for invalid limit and cursor', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-events-invalid-');
+  sessionStore.recordEvent('events-session', {
+    kind: 'action.recorded',
+    command: 'open',
+    summary: 'Opened session',
+  });
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const invalidLimit = await handler({
+    token: 'test-token',
+    session: 'events-session',
+    command: 'events',
+    positionals: ['0'],
+    flags: {},
+    meta: { requestId: 'req-events-limit' },
+  });
+  const invalidCursor = await handler({
+    token: 'test-token',
+    session: 'events-session',
+    command: 'events',
+    positionals: ['10', 'abc'],
+    flags: {},
+    meta: { requestId: 'req-events-cursor' },
+  });
+
+  expect(invalidLimit).toMatchObject({
+    ok: false,
+    error: { code: 'INVALID_ARGS', message: 'events limit must be between 1 and 500.' },
+  });
+  expect(invalidCursor).toMatchObject({
+    ok: false,
+    error: {
+      code: 'INVALID_ARGS',
+      message: 'events cursor must be a non-negative integer string.',
+    },
+  });
+});
+
+test('events flushes pending event writes before reading', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-events-flush-');
+  sessionStore.recordEvent('events-session', {
+    kind: 'action.recorded',
+    command: 'open',
+    summary: 'Opened session',
+  });
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'events-session',
+    command: 'events',
+    positionals: ['10'],
+    flags: {},
+    meta: { requestId: 'req-events-flush' },
+  });
+
+  expect(response.ok).toBe(true);
+  if (!response.ok) return;
+  expect(response.data?.events).toEqual([
+    expect.objectContaining({ kind: 'action.recorded', summary: 'Opened session' }),
+  ]);
+});
+
 test('request timeline records thrown request failures after scope creation', async () => {
   const sessionStore = makeSessionStore('agent-device-router-events-throws-');
   sessionStore.set('events-session', makeIosSession('events-session'));
@@ -112,6 +190,7 @@ test('request timeline records thrown request failures after scope creation', as
   });
 
   expect(response.ok).toBe(false);
+  await sessionStore.flushEvents('events-session');
   const page = sessionStore.readEvents('events-session');
   expect(page.events).toEqual([
     expect.objectContaining({
@@ -149,6 +228,7 @@ test('request timeline records setup failures after start is appended', async ()
   });
 
   expect(response.ok).toBe(false);
+  await sessionStore.flushEvents('default');
   const page = sessionStore.readEvents('default');
   expect(page.events).toEqual([
     expect.objectContaining({

--- a/src/daemon/__tests__/request-router-events.test.ts
+++ b/src/daemon/__tests__/request-router-events.test.ts
@@ -1,0 +1,123 @@
+import { test, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequestHandler } from '../request-router.ts';
+import { LeaseRegistry } from '../lease-registry.ts';
+import { makeSessionStore } from '../../__tests__/test-utils/store-factory.ts';
+import { makeIosSession } from '../../__tests__/test-utils/index.ts';
+
+test('events reads the daemon-owned session timeline without appending poll noise', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-events-');
+  sessionStore.recordEvent('events-session', {
+    kind: 'action.recorded',
+    command: 'click',
+    summary: 'Tapped @14 (10, 20)',
+    details: { ref: '14', x: 10, y: 20 },
+  });
+  const eventLogPath = sessionStore.resolveEventLogPath('events-session');
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'events-session',
+    command: 'events',
+    positionals: ['10'],
+    flags: {},
+    meta: { requestId: 'req-events' },
+  });
+
+  expect(response.ok).toBe(true);
+  if (!response.ok) return;
+  expect(response.data?.path).toBe(eventLogPath);
+  expect(response.data?.events).toEqual([
+    expect.objectContaining({
+      kind: 'action.recorded',
+      command: 'click',
+      summary: 'Tapped @14 (10, 20)',
+    }),
+  ]);
+  expect(fs.readFileSync(eventLogPath, 'utf8').trim().split('\n')).toHaveLength(1);
+});
+
+test('request timeline records thrown request failures after scope creation', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-events-throws-');
+  sessionStore.set('events-session', makeIosSession('events-session'));
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'events-session',
+    command: 'click',
+    positionals: ['10', '20'],
+    flags: { platform: 'android' },
+    meta: { requestId: 'req-selector-conflict' },
+  });
+
+  expect(response.ok).toBe(false);
+  const page = sessionStore.readEvents('events-session');
+  expect(page.events).toEqual([
+    expect.objectContaining({
+      kind: 'request.started',
+      command: 'click',
+      requestId: 'req-selector-conflict',
+    }),
+    expect.objectContaining({
+      kind: 'request.finished',
+      command: 'click',
+      requestId: 'req-selector-conflict',
+      status: 'error',
+    }),
+  ]);
+});
+
+test('request timeline records setup failures after start is appended', async () => {
+  const sessionStore = makeSessionStore('agent-device-router-events-setup-failure-');
+
+  const handler = createRequestHandler({
+    logPath: path.join(os.tmpdir(), 'daemon.log'),
+    token: 'test-token',
+    sessionStore,
+    leaseRegistry: new LeaseRegistry(),
+    trackDownloadableArtifact: () => 'artifact-id',
+  });
+
+  const response = await handler({
+    token: 'test-token',
+    session: 'default',
+    command: 'open',
+    positionals: ['Expo Go'],
+    flags: {},
+    meta: { requestId: 'req-proxy-open', leaseProvider: 'proxy' },
+  });
+
+  expect(response.ok).toBe(false);
+  const page = sessionStore.readEvents('default');
+  expect(page.events).toEqual([
+    expect.objectContaining({
+      kind: 'request.started',
+      command: 'open',
+      requestId: 'req-proxy-open',
+    }),
+    expect.objectContaining({
+      kind: 'request.finished',
+      command: 'open',
+      requestId: 'req-proxy-open',
+      status: 'error',
+    }),
+  ]);
+});

--- a/src/daemon/__tests__/request-router-open.test.ts
+++ b/src/daemon/__tests__/request-router-open.test.ts
@@ -90,7 +90,11 @@ test('open returns and creates the session state directory', async () => {
     expect(response.data?.requestLogPath).toEqual(
       path.join(String(response.data?.sessionStateDir), 'requests', 'req-open-state.ndjson'),
     );
+    expect(response.data?.eventLogPath).toEqual(
+      path.join(String(response.data?.sessionStateDir), 'events.ndjson'),
+    );
     expect(fs.existsSync(String(response.data?.sessionStateDir))).toBe(true);
+    expect(fs.existsSync(String(response.data?.eventLogPath))).toBe(true);
   }
 });
 

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -229,6 +229,34 @@ test('recordAction event log redacts payload-bearing and unknown positionals', (
   assert.equal(page.events[3]?.details?.message, 'Ran <arg:19 chars>');
 });
 
+test('recordAction event log redacts overlapping unknown positionals in one pass', () => {
+  const { store, session } = makeFixture('agent-device-session-events-overlap-redaction-');
+
+  store.recordAction(session, {
+    command: 'future-command',
+    positionals: ['token', 'my-token-123'],
+    flags: {},
+    result: { message: 'Ran my-token-123 after token' },
+  });
+  store.recordAction(session, {
+    command: 'future-command',
+    positionals: ['arg', 'my-arg-123'],
+    flags: {},
+    result: { message: 'Ran my-arg-123 after arg' },
+  });
+
+  const page = store.readEvents(session.name);
+  const serialized = JSON.stringify(page.events);
+  assert.equal(serialized.includes('my-token-123'), false);
+  assert.equal(serialized.includes('token'), false);
+  assert.equal(serialized.includes('my-arg-123'), false);
+  assert.equal(page.events[0]?.summary, 'Ran <arg:12 chars> after <arg:5 chars>');
+  assert.equal(page.events[0]?.details?.message, 'Ran <arg:12 chars> after <arg:5 chars>');
+  assert.deepEqual(page.events[0]?.details?.positionals, ['<arg:5 chars>', '<arg:12 chars>']);
+  assert.equal(page.events[1]?.summary, 'Ran <arg:10 chars> after <arg:3 chars>');
+  assert.equal(page.events[1]?.details?.message, 'Ran <arg:10 chars> after <arg:3 chars>');
+});
+
 test('saveScript path writes session log to custom location', () => {
   const { root, store, session } = makeFixture('agent-device-session-log-custom-path-', 'sessions');
   const customPath = path.join(root, 'workflows', 'my-flow.ad');

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -171,12 +171,14 @@ test('recordAction event log redacts typed text from display positionals', () =>
     command: 'fill',
     positionals: ['@14', 'super-secret-token'],
     flags: {},
-    result: { ref: '14', text: 'super-secret-token', message: 'Filled 18 chars' },
+    result: { ref: '14', text: 'super-secret-token', message: 'Filled super-secret-token' },
   });
 
   const page = store.readEvents(session.name);
   const serialized = JSON.stringify(page.events);
   assert.equal(serialized.includes('super-secret-token'), false);
+  assert.equal(page.events[0]?.summary, 'Filled <text:18 chars>');
+  assert.equal(page.events[0]?.details?.message, 'Filled <text:18 chars>');
   assert.deepEqual(page.events[0]?.details?.positionals, ['@14', '<text:18 chars>']);
   assert.equal(page.events[0]?.details?.textLength, 18);
 });
@@ -210,7 +212,7 @@ test('recordAction event log redacts payload-bearing and unknown positionals', (
     command: 'future-command',
     positionals: ['public-ish', futurePayload],
     flags: {},
-    result: {},
+    result: { message: `Ran ${futurePayload}` },
   });
 
   const page = store.readEvents(session.name);
@@ -223,6 +225,8 @@ test('recordAction event log redacts payload-bearing and unknown positionals', (
   assert.deepEqual(page.events[1]?.details?.positionals, ['com.example.app', '<payload:29 chars>']);
   assert.deepEqual(page.events[2]?.details?.positionals, ['checkout', '<payload:30 chars>']);
   assert.deepEqual(page.events[3]?.details?.positionals, ['<arg:10 chars>', '<arg:19 chars>']);
+  assert.equal(page.events[3]?.summary, 'Ran <arg:19 chars>');
+  assert.equal(page.events[3]?.details?.message, 'Ran <arg:19 chars>');
 });
 
 test('saveScript path writes session log to custom location', () => {

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -181,6 +181,50 @@ test('recordAction event log redacts typed text from display positionals', () =>
   assert.equal(page.events[0]?.details?.textLength, 18);
 });
 
+test('recordAction event log redacts payload-bearing and unknown positionals', () => {
+  const { store, session } = makeFixture('agent-device-session-events-payload-redaction-');
+  const clipboardText = 'super-secret-token';
+  const pushPayload = '{"token":"push-secret-token"}';
+  const eventPayload = '{"token":"event-secret-token"}';
+  const futurePayload = 'future-secret-token';
+
+  store.recordAction(session, {
+    command: 'clipboard',
+    positionals: ['write', clipboardText],
+    flags: {},
+    result: { action: 'write', textLength: Array.from(clipboardText).length },
+  });
+  store.recordAction(session, {
+    command: 'push',
+    positionals: ['com.example.app', pushPayload],
+    flags: {},
+    result: { message: 'Pushed notification to com.example.app' },
+  });
+  store.recordAction(session, {
+    command: 'trigger-app-event',
+    positionals: ['checkout', eventPayload],
+    flags: {},
+    result: { message: 'Triggered app event checkout' },
+  });
+  store.recordAction(session, {
+    command: 'future-command',
+    positionals: ['public-ish', futurePayload],
+    flags: {},
+    result: {},
+  });
+
+  const page = store.readEvents(session.name);
+  const serialized = JSON.stringify(page.events);
+  assert.equal(serialized.includes(clipboardText), false);
+  assert.equal(serialized.includes(pushPayload), false);
+  assert.equal(serialized.includes(eventPayload), false);
+  assert.equal(serialized.includes(futurePayload), false);
+  assert.deepEqual(page.events[0]?.details?.positionals, ['write', '<text:18 chars>']);
+  assert.deepEqual(page.events[1]?.details?.positionals, ['com.example.app', '<payload:29 chars>']);
+  assert.deepEqual(page.events[2]?.details?.positionals, ['checkout', '<payload:30 chars>']);
+  assert.deepEqual(page.events[3]?.details?.positionals, ['<arg:10 chars>', '<arg:19 chars>']);
+});
+
 test('saveScript path writes session log to custom location', () => {
   const { root, store, session } = makeFixture('agent-device-session-log-custom-path-', 'sessions');
   const customPath = path.join(root, 'workflows', 'my-flow.ad');

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -143,6 +143,44 @@ test('saveScript flag enables .ad session log writing', () => {
   assert.equal(listSessionScriptFiles(root).length, 1);
 });
 
+test('recordAction writes a paged session event log', () => {
+  const { store, session } = makeFixture('agent-device-session-events-');
+  recordOpen(store, session, { platform: 'ios' });
+  store.recordAction(session, {
+    command: 'click',
+    positionals: ['@14', 'Checkout'],
+    flags: { platform: 'ios' },
+    result: { ref: '14', refLabel: 'Checkout', x: 120, y: 240, message: 'Tapped @14 (120, 240)' },
+  });
+
+  const eventLogPath = store.resolveEventLogPath(session.name);
+  assert.equal(fs.existsSync(eventLogPath), true);
+  const firstPage = store.readEvents(session.name, { limit: 1 });
+  assert.equal(firstPage.events.length, 1);
+  assert.equal(firstPage.events[0]?.kind, 'action.recorded');
+  assert.equal(firstPage.nextCursor, '1');
+
+  const secondPage = store.readEvents(session.name, { cursor: firstPage.nextCursor, limit: 1 });
+  assert.equal(secondPage.events[0]?.summary, 'Tapped @14 (120, 240)');
+  assert.equal(secondPage.nextCursor, undefined);
+});
+
+test('recordAction event log redacts typed text from display positionals', () => {
+  const { store, session } = makeFixture('agent-device-session-events-redaction-');
+  store.recordAction(session, {
+    command: 'fill',
+    positionals: ['@14', 'super-secret-token'],
+    flags: {},
+    result: { ref: '14', text: 'super-secret-token', message: 'Filled 18 chars' },
+  });
+
+  const page = store.readEvents(session.name);
+  const serialized = JSON.stringify(page.events);
+  assert.equal(serialized.includes('super-secret-token'), false);
+  assert.deepEqual(page.events[0]?.details?.positionals, ['@14', '<text:18 chars>']);
+  assert.equal(page.events[0]?.details?.textLength, 18);
+});
+
 test('saveScript path writes session log to custom location', () => {
   const { root, store, session } = makeFixture('agent-device-session-log-custom-path-', 'sessions');
   const customPath = path.join(root, 'workflows', 'my-flow.ad');
@@ -151,7 +189,7 @@ test('saveScript path writes session log to custom location', () => {
 
   store.writeSessionLog(session);
   assert.equal(fs.existsSync(customPath), true);
-  assert.equal(fs.existsSync(path.join(root, 'sessions')), false);
+  assert.equal(fs.existsSync(store.resolveEventLogPath(session.name)), true);
 });
 
 test('writeSessionLog persists open --relaunch in script output', () => {

--- a/src/daemon/__tests__/session-store.test.ts
+++ b/src/daemon/__tests__/session-store.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { SessionStore } from '../session-store.ts';
 import type { SessionState } from '../types.ts';
+import { buildRequestFinishedEvent } from '../session-event-log.ts';
 
 type RecordActionEntry = Parameters<SessionStore['recordAction']>[1];
 
@@ -143,7 +144,7 @@ test('saveScript flag enables .ad session log writing', () => {
   assert.equal(listSessionScriptFiles(root).length, 1);
 });
 
-test('recordAction writes a paged session event log', () => {
+test('recordAction writes a paged session event log', async () => {
   const { store, session } = makeFixture('agent-device-session-events-');
   recordOpen(store, session, { platform: 'ios' });
   store.recordAction(session, {
@@ -152,6 +153,7 @@ test('recordAction writes a paged session event log', () => {
     flags: { platform: 'ios' },
     result: { ref: '14', refLabel: 'Checkout', x: 120, y: 240, message: 'Tapped @14 (120, 240)' },
   });
+  await store.flushEvents(session.name);
 
   const eventLogPath = store.resolveEventLogPath(session.name);
   assert.equal(fs.existsSync(eventLogPath), true);
@@ -161,11 +163,11 @@ test('recordAction writes a paged session event log', () => {
   assert.equal(firstPage.nextCursor, '1');
 
   const secondPage = store.readEvents(session.name, { cursor: firstPage.nextCursor, limit: 1 });
-  assert.equal(secondPage.events[0]?.summary, 'Tapped @14 (120, 240)');
+  assert.equal(secondPage.events[0]?.summary, 'Tapped @14');
   assert.equal(secondPage.nextCursor, undefined);
 });
 
-test('recordAction event log redacts typed text from display positionals', () => {
+test('recordAction event log redacts typed text from display positionals', async () => {
   const { store, session } = makeFixture('agent-device-session-events-redaction-');
   store.recordAction(session, {
     command: 'fill',
@@ -173,17 +175,18 @@ test('recordAction event log redacts typed text from display positionals', () =>
     flags: {},
     result: { ref: '14', text: 'super-secret-token', message: 'Filled super-secret-token' },
   });
+  await store.flushEvents(session.name);
 
   const page = store.readEvents(session.name);
   const serialized = JSON.stringify(page.events);
   assert.equal(serialized.includes('super-secret-token'), false);
-  assert.equal(page.events[0]?.summary, 'Filled <text:18 chars>');
-  assert.equal(page.events[0]?.details?.message, 'Filled <text:18 chars>');
+  assert.equal(page.events[0]?.summary, 'Filled @14');
+  assert.equal(page.events[0]?.details?.message, undefined);
   assert.deepEqual(page.events[0]?.details?.positionals, ['@14', '<text:18 chars>']);
   assert.equal(page.events[0]?.details?.textLength, 18);
 });
 
-test('recordAction event log redacts payload-bearing and unknown positionals', () => {
+test('recordAction event log redacts payload-bearing and unknown positionals', async () => {
   const { store, session } = makeFixture('agent-device-session-events-payload-redaction-');
   const clipboardText = 'super-secret-token';
   const pushPayload = '{"token":"push-secret-token"}';
@@ -214,6 +217,7 @@ test('recordAction event log redacts payload-bearing and unknown positionals', (
     flags: {},
     result: { message: `Ran ${futurePayload}` },
   });
+  await store.flushEvents(session.name);
 
   const page = store.readEvents(session.name);
   const serialized = JSON.stringify(page.events);
@@ -225,11 +229,11 @@ test('recordAction event log redacts payload-bearing and unknown positionals', (
   assert.deepEqual(page.events[1]?.details?.positionals, ['com.example.app', '<payload:29 chars>']);
   assert.deepEqual(page.events[2]?.details?.positionals, ['checkout', '<payload:30 chars>']);
   assert.deepEqual(page.events[3]?.details?.positionals, ['<arg:10 chars>', '<arg:19 chars>']);
-  assert.equal(page.events[3]?.summary, 'Ran <arg:19 chars>');
-  assert.equal(page.events[3]?.details?.message, 'Ran <arg:19 chars>');
+  assert.equal(page.events[3]?.summary, 'Ran future-command');
+  assert.equal(page.events[3]?.details?.message, undefined);
 });
 
-test('recordAction event log redacts overlapping unknown positionals in one pass', () => {
+test('recordAction event log omits transformed messages for redacted positionals', async () => {
   const { store, session } = makeFixture('agent-device-session-events-overlap-redaction-');
 
   store.recordAction(session, {
@@ -244,26 +248,106 @@ test('recordAction event log redacts overlapping unknown positionals in one pass
     flags: {},
     result: { message: 'Ran my-arg-123 after arg' },
   });
+  await store.flushEvents(session.name);
 
   const page = store.readEvents(session.name);
   const serialized = JSON.stringify(page.events);
   assert.equal(serialized.includes('my-token-123'), false);
   assert.equal(serialized.includes('token'), false);
   assert.equal(serialized.includes('my-arg-123'), false);
-  assert.equal(page.events[0]?.summary, 'Ran <arg:12 chars> after <arg:5 chars>');
-  assert.equal(page.events[0]?.details?.message, 'Ran <arg:12 chars> after <arg:5 chars>');
+  assert.equal(page.events[0]?.summary, 'Ran future-command');
+  assert.equal(page.events[0]?.details?.message, undefined);
   assert.deepEqual(page.events[0]?.details?.positionals, ['<arg:5 chars>', '<arg:12 chars>']);
-  assert.equal(page.events[1]?.summary, 'Ran <arg:10 chars> after <arg:3 chars>');
-  assert.equal(page.events[1]?.details?.message, 'Ran <arg:10 chars> after <arg:3 chars>');
+  assert.equal(page.events[1]?.summary, 'Ran future-command');
+  assert.equal(page.events[1]?.details?.message, undefined);
 });
 
-test('saveScript path writes session log to custom location', () => {
+test('recordAction event log does not leak short typed text through message replacement', async () => {
+  const { store, session } = makeFixture('agent-device-session-events-short-text-');
+  store.recordAction(session, {
+    command: 'type',
+    positionals: ['e'],
+    flags: {},
+    result: { text: 'e', message: 'Typed 1 chars' },
+  });
+  await store.flushEvents(session.name);
+
+  const page = store.readEvents(session.name);
+  const serialized = JSON.stringify(page.events);
+  assert.equal(serialized.includes('"e"'), false);
+  assert.equal(page.events[0]?.summary, 'Typed <text:1 chars>');
+  assert.equal(page.events[0]?.details?.message, undefined);
+  assert.deepEqual(page.events[0]?.details?.positionals, ['<text:1 chars>']);
+});
+
+test('recordAction event log omits value-bearing selector details', async () => {
+  const { store, session } = makeFixture('agent-device-session-events-selector-redaction-');
+  store.recordAction(session, {
+    command: 'click',
+    positionals: ['value=123456'],
+    flags: {},
+    result: {
+      refLabel: '123456',
+      selector: 'value="123456"',
+      selectorChain: ['value="123456" editable=true'],
+      message: 'Tapped 123456',
+    },
+  });
+  await store.flushEvents(session.name);
+
+  const page = store.readEvents(session.name);
+  const serialized = JSON.stringify(page.events);
+  assert.equal(serialized.includes('123456'), false);
+  assert.equal(page.events[0]?.summary, 'Tapped target');
+  assert.equal(page.events[0]?.details?.message, undefined);
+  assert.equal(page.events[0]?.details?.refLabel, undefined);
+  assert.equal(page.events[0]?.details?.selector, undefined);
+  assert.equal(page.events[0]?.details?.selectorChain, undefined);
+  assert.equal(page.events[0]?.details?.selectorChainLength, 1);
+});
+
+test('request failure event log omits raw error message and hint', async () => {
+  const { store, session } = makeFixture('agent-device-session-events-error-redaction-');
+  const secretPayload = '{"ssn":"123-45-6789"';
+  store.recordEvent(
+    session.name,
+    buildRequestFinishedEvent({
+      req: {
+        token: 'test-token',
+        session: session.name,
+        command: 'trigger-app-event',
+        positionals: ['login', secretPayload],
+        meta: { requestId: 'req-secret-error' },
+      },
+      response: {
+        ok: false,
+        error: {
+          code: 'INVALID_ARGS',
+          message: `Invalid trigger-app-event payload JSON: ${secretPayload}`,
+          hint: `Fix payload ${secretPayload}`,
+        },
+      },
+      durationMs: 12,
+    }),
+  );
+  await store.flushEvents(session.name);
+
+  const page = store.readEvents(session.name);
+  const serialized = JSON.stringify(page.events);
+  assert.equal(serialized.includes(secretPayload), false);
+  assert.equal(page.events[0]?.summary, 'Failed trigger-app-event: INVALID_ARGS');
+  assert.equal(page.events[0]?.details?.message, undefined);
+  assert.equal(page.events[0]?.details?.hint, undefined);
+});
+
+test('saveScript path writes session log to custom location', async () => {
   const { root, store, session } = makeFixture('agent-device-session-log-custom-path-', 'sessions');
   const customPath = path.join(root, 'workflows', 'my-flow.ad');
   recordOpen(store, session, { platform: 'ios', saveScript: customPath });
   recordClose(store, session);
 
   store.writeSessionLog(session);
+  await store.flushEvents(session.name);
   assert.equal(fs.existsSync(customPath), true);
   assert.equal(fs.existsSync(store.resolveEventLogPath(session.name)), true);
 });

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -195,7 +195,7 @@ export async function handleSessionObservabilityCommands(
     return handleLogsCommand(params);
   }
   if (req.command === 'events') {
-    return handleEventsCommand(params);
+    return await handleEventsCommand(params);
   }
   if (req.command === 'network') {
     return handleNetworkCommand(params);
@@ -207,24 +207,20 @@ export async function handleSessionObservabilityCommands(
   return null;
 }
 
-function handleEventsCommand(params: ObservabilityParams): DaemonResponse {
+async function handleEventsCommand(params: ObservabilityParams): Promise<DaemonResponse> {
   const { req, sessionName, sessionStore } = params;
-  const limit = readOptionalEventLimit(req.positionals?.[0]);
-  if (limit instanceof AppError) return { ok: false, error: normalizeError(limit) };
-  return {
-    ok: true,
-    data: sessionStore.readEvents(sessionName, {
-      limit,
-      cursor: req.positionals?.[1],
-    }),
-  };
-}
-
-function readOptionalEventLimit(value: string | undefined): number | undefined | AppError {
-  if (value === undefined || value.trim() === '') return undefined;
-  const parsed = Number(value);
-  if (Number.isInteger(parsed)) return parsed;
-  return new AppError('INVALID_ARGS', 'events limit must be an integer.');
+  try {
+    await sessionStore.flushEvents(sessionName);
+    return {
+      ok: true,
+      data: sessionStore.readEvents(sessionName, {
+        limit: req.positionals?.[0],
+        cursor: req.positionals?.[1],
+      }),
+    };
+  } catch (error) {
+    return { ok: false, error: normalizeError(error) };
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -221,7 +221,7 @@ function handleEventsCommand(params: ObservabilityParams): DaemonResponse {
 }
 
 function readOptionalEventLimit(value: string | undefined): number | undefined | AppError {
-  if (value === undefined) return undefined;
+  if (value === undefined || value.trim() === '') return undefined;
   const parsed = Number(value);
   if (Number.isInteger(parsed)) return parsed;
   return new AppError('INVALID_ARGS', 'events limit must be an integer.');

--- a/src/daemon/handlers/session-observability.ts
+++ b/src/daemon/handlers/session-observability.ts
@@ -194,6 +194,9 @@ export async function handleSessionObservabilityCommands(
   if (req.command === 'logs') {
     return handleLogsCommand(params);
   }
+  if (req.command === 'events') {
+    return handleEventsCommand(params);
+  }
   if (req.command === 'network') {
     return handleNetworkCommand(params);
   }
@@ -202,6 +205,26 @@ export async function handleSessionObservabilityCommands(
   }
 
   return null;
+}
+
+function handleEventsCommand(params: ObservabilityParams): DaemonResponse {
+  const { req, sessionName, sessionStore } = params;
+  const limit = readOptionalEventLimit(req.positionals?.[0]);
+  if (limit instanceof AppError) return { ok: false, error: normalizeError(limit) };
+  return {
+    ok: true,
+    data: sessionStore.readEvents(sessionName, {
+      limit,
+      cursor: req.positionals?.[1],
+    }),
+  };
+}
+
+function readOptionalEventLimit(value: string | undefined): number | undefined | AppError {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (Number.isInteger(parsed)) return parsed;
+  return new AppError('INVALID_ARGS', 'events limit must be an integer.');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/handlers/session-open-surface.ts
+++ b/src/daemon/handlers/session-open-surface.ts
@@ -16,6 +16,7 @@ export function buildOpenResult(params: {
   sessionStateDir: string;
   runnerLogPath: string;
   requestLogPath: string;
+  eventLogPath: string;
   appName?: string;
   appBundleId?: string;
   surface: SessionSurface;
@@ -30,6 +31,7 @@ export function buildOpenResult(params: {
     sessionStateDir,
     runnerLogPath,
     requestLogPath,
+    eventLogPath,
     appName,
     appBundleId,
     surface,
@@ -45,6 +47,7 @@ export function buildOpenResult(params: {
     sessionStateDir,
     runnerLogPath,
     requestLogPath,
+    eventLogPath,
   };
   if (appName) result.appName = appName;
   if (appBundleId) result.appBundleId = appBundleId;

--- a/src/daemon/handlers/session-open.ts
+++ b/src/daemon/handlers/session-open.ts
@@ -344,6 +344,7 @@ async function completeOpenCommand(params: {
     sessionStateDir,
     runnerLogPath: resolveSessionRunnerLogPath(sessionStateDir),
     requestLogPath,
+    eventLogPath: sessionStore.resolveEventLogPath(sessionName),
     appName,
     appBundleId: sessionAppBundleId,
     surface,
@@ -353,6 +354,7 @@ async function completeOpenCommand(params: {
     runtime,
     runtimeHintCount: countConfiguredRuntimeHints,
   });
+  sessionStore.set(sessionName, nextSession);
   sessionStore.recordAction(nextSession, {
     command: 'open',
     positionals: openPositionals,
@@ -360,7 +362,6 @@ async function completeOpenCommand(params: {
     runtime: req.runtime !== undefined ? runtime : undefined,
     result: openResult,
   });
-  sessionStore.set(sessionName, nextSession);
   return { ok: true, data: openResult };
 }
 

--- a/src/daemon/request-execution-scope.ts
+++ b/src/daemon/request-execution-scope.ts
@@ -7,6 +7,7 @@ import {
   updateDiagnosticsScope,
 } from '../utils/diagnostics.ts';
 import { applyCommandDefaults } from '../utils/command-schema.ts';
+import { normalizeError } from '../kernel/errors.ts';
 import type { DaemonCommandContext } from './context.ts';
 import { contextFromFlags as contextFromFlagsWithLog } from './context.ts';
 import { assertSessionSelectorMatches } from './session-selector.ts';
@@ -30,6 +31,11 @@ import {
   shouldLockSessionExecution,
   shouldValidateSessionSelector,
 } from './daemon-command-registry.ts';
+import {
+  buildRequestFinishedEvent,
+  buildRequestStartedEvent,
+  shouldRecordEventForRequest,
+} from './session-event-log.ts';
 import type { LeaseRegistry } from './lease-registry.ts';
 import {
   resolveSessionRequestLogPath,
@@ -49,6 +55,7 @@ export type RequestExecutionScope = {
   sessionName: string;
   requestLogPath: string;
   runnerLogPath: string;
+  startedAtMs: number;
   runAdmitted<T>(task: () => Promise<T>): Promise<T>;
   runLocked<T>(task: () => Promise<T>): Promise<T>;
   throwIfCanceled(): void;
@@ -85,6 +92,7 @@ export async function createRequestExecutionScope(params: {
   let scopedReq = applyRequestCommandDefaults(scopeRequestSession(params.req));
 
   const command = scopedReq.command;
+  const startedAtMs = Date.now();
   const sessionName = resolveEffectiveSessionName(scopedReq, sessionStore);
   const diagnosticsMeta = getDiagnosticsMeta();
   const sessionDir = sessionStore.resolveSessionDir(sessionName);
@@ -110,47 +118,80 @@ export async function createRequestExecutionScope(params: {
       runnerLogPath,
     },
   });
-  assertLockedLeaseAdmissionPreflight(scopedReq);
-  const executionLockKeys = shouldLockSessionExecution(command)
-    ? await resolveRequestExecutionLockKeys({ req: scopedReq, sessionName, sessionStore })
-    : [];
-  const executionLocks = getLeaseRegistryExecutionLocks(leaseRegistry);
-
-  const scope: RequestExecutionScope = {
-    req: scopedReq,
-    command,
-    sessionName,
-    requestLogPath,
-    runnerLogPath,
-    throwIfCanceled: () => throwIfRequestCanceled(scopedReq.meta?.requestId),
-    runAdmitted: async (task) => {
-      throwIfRequestCanceled(scopedReq.meta?.requestId);
-      await cleanupExpiredLeasedSession({
-        sessionName,
-        sessionStore,
-        leaseRegistry,
-        teardownSession: teardownSessionResources,
-      });
-      scopedReq = admitRequestLeaseForLockedScope({
+  const shouldRecordRequestEvents = shouldRecordEventForRequest(scopedReq);
+  if (shouldRecordRequestEvents) {
+    sessionStore.recordEvent(
+      sessionName,
+      buildRequestStartedEvent({
         req: scopedReq,
         sessionName,
-        sessionStore,
-        leaseRegistry,
-      });
-      scope.req = scopedReq;
-      return await task();
-    },
-    runLocked: async (task) => {
-      throwIfRequestCanceled(scopedReq.meta?.requestId);
-      if (executionLockKeys.length === 0) return await scope.runAdmitted(task);
-      return await withRequestExecutionLocks(
-        executionLocks,
-        executionLockKeys,
-        async () => await scope.runAdmitted(task),
+        requestLogPath,
+        runnerLogPath,
+      }),
+    );
+  }
+  try {
+    assertLockedLeaseAdmissionPreflight(scopedReq);
+    const executionLockKeys = shouldLockSessionExecution(command)
+      ? await resolveRequestExecutionLockKeys({ req: scopedReq, sessionName, sessionStore })
+      : [];
+    const executionLocks = getLeaseRegistryExecutionLocks(leaseRegistry);
+
+    const scope: RequestExecutionScope = {
+      req: scopedReq,
+      command,
+      sessionName,
+      requestLogPath,
+      runnerLogPath,
+      startedAtMs,
+      throwIfCanceled: () => throwIfRequestCanceled(scopedReq.meta?.requestId),
+      runAdmitted: async (task) => {
+        throwIfRequestCanceled(scopedReq.meta?.requestId);
+        await cleanupExpiredLeasedSession({
+          sessionName,
+          sessionStore,
+          leaseRegistry,
+          teardownSession: teardownSessionResources,
+        });
+        scopedReq = admitRequestLeaseForLockedScope({
+          req: scopedReq,
+          sessionName,
+          sessionStore,
+          leaseRegistry,
+        });
+        scope.req = scopedReq;
+        return await task();
+      },
+      runLocked: async (task) => {
+        throwIfRequestCanceled(scopedReq.meta?.requestId);
+        if (executionLockKeys.length === 0) return await scope.runAdmitted(task);
+        return await withRequestExecutionLocks(
+          executionLocks,
+          executionLockKeys,
+          async () => await scope.runAdmitted(task),
+        );
+      },
+    };
+    return scope;
+  } catch (error) {
+    if (shouldRecordRequestEvents) {
+      sessionStore.recordEvent(
+        sessionName,
+        buildRequestFinishedEvent({
+          req: scopedReq,
+          response: {
+            ok: false,
+            error: normalizeError(error, {
+              diagnosticId: getDiagnosticsMeta().diagnosticId,
+              logPath: requestLogPath,
+            }),
+          },
+          durationMs: Math.max(0, Date.now() - startedAtMs),
+        }),
       );
-    },
-  };
-  return scope;
+    }
+    throw error;
+  }
 }
 
 async function withRequestExecutionLocks<T>(
@@ -203,8 +244,20 @@ export function prepareLockedRequestScope(params: {
   });
   const lockedReq = binding.req;
   existingSession = binding.existingSession;
-  const finalize = (response: DaemonResponse): DaemonResponse =>
-    finalizeDaemonResponse(lockedReq, response, trackDownloadableArtifact);
+  const finalize = (response: DaemonResponse): DaemonResponse => {
+    const finalized = finalizeDaemonResponse(lockedReq, response, trackDownloadableArtifact);
+    if (shouldRecordEventForRequest(lockedReq)) {
+      sessionStore.recordEvent(
+        scope.sessionName,
+        buildRequestFinishedEvent({
+          req: lockedReq,
+          response: finalized,
+          durationMs: Math.max(0, Date.now() - scope.startedAtMs),
+        }),
+      );
+    }
+    return finalized;
+  };
 
   if (
     existingSession?.recording?.invalidatedReason &&

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -42,6 +42,7 @@ import { buildRequestFinishedEvent, shouldRecordEventForRequest } from './sessio
 import { canRunReplayScopedAction } from './daemon-command-registry.ts';
 import { createAgentBrowserWebProvider } from '../platforms/web/agent-browser-provider.ts';
 import type { LeaseLifecycleProvider } from './handlers/lease.ts';
+import { openWebSessionNames } from './web-session-names.ts';
 
 // ---------------------------------------------------------------------------
 // Request handler API
@@ -261,13 +262,6 @@ const createDefaultWebProvider =
 
 function shouldUseDefaultWebProvider(scope: LockedRequestScope): boolean {
   return scope.existingSession?.device.platform === 'web' || scope.req.flags?.platform === 'web';
-}
-
-function openWebSessionNames(sessionStore: SessionStore): string[] {
-  return sessionStore
-    .toArray()
-    .filter((session) => session.device.platform === 'web')
-    .map((session) => session.name);
 }
 
 function unauthorizedResponse(): DaemonResponse {

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -239,7 +239,7 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
         childScope = await createRequestExecutionScope({ req, sessionStore, leaseRegistry });
         return childScope.sessionName === parentScope.sessionName
           ? await executeRequestScope(childScope, providerScope)
-          : await handleRequest(req);
+          : await executeRequestScope(childScope);
       } catch (error) {
         const response = finalizeThrownRequestError(error);
         recordThrownRequestEvent(sessionStore, childScope, response);

--- a/src/daemon/request-router.ts
+++ b/src/daemon/request-router.ts
@@ -38,6 +38,7 @@ import {
   prepareLockedRequestScope,
   type RequestExecutionScope,
 } from './request-execution-scope.ts';
+import { buildRequestFinishedEvent, shouldRecordEventForRequest } from './session-event-log.ts';
 import { canRunReplayScopedAction } from './daemon-command-registry.ts';
 import { createAgentBrowserWebProvider } from '../platforms/web/agent-browser-provider.ts';
 import type { LeaseLifecycleProvider } from './handlers/lease.ts';
@@ -124,9 +125,10 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
       return unauthorizedResponse();
     }
 
+    let scope: RequestExecutionScope | undefined;
     try {
       return await withTargetDeviceResolutionScope(deviceInventoryProvider, async () => {
-        const scope = await createRequestExecutionScope({
+        scope = await createRequestExecutionScope({
           req,
           sessionStore,
           leaseRegistry,
@@ -134,7 +136,9 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
         return await executeRequestScope(scope);
       });
     } catch (error) {
-      return finalizeThrownRequestError(error);
+      const response = finalizeThrownRequestError(error);
+      recordThrownRequestEvent(sessionStore, scope, response);
+      return response;
     }
   }
 
@@ -229,13 +233,16 @@ export function createRequestHandler(deps: RequestRouterDeps): DaemonInvokeFn {
         return unauthorizedResponse();
       }
 
+      let childScope: RequestExecutionScope | undefined;
       try {
-        const childScope = await createRequestExecutionScope({ req, sessionStore, leaseRegistry });
+        childScope = await createRequestExecutionScope({ req, sessionStore, leaseRegistry });
         return childScope.sessionName === parentScope.sessionName
           ? await executeRequestScope(childScope, providerScope)
           : await handleRequest(req);
       } catch (error) {
-        return finalizeThrownRequestError(error);
+        const response = finalizeThrownRequestError(error);
+        recordThrownRequestEvent(sessionStore, childScope, response);
+        return response;
       }
     };
   }
@@ -314,6 +321,22 @@ function finalizeThrownRequestError(error: unknown): DaemonResponse {
     logPath: logPathOnFailure,
   });
   return { ok: false, error: normalizedError };
+}
+
+function recordThrownRequestEvent(
+  sessionStore: SessionStore,
+  scope: RequestExecutionScope | undefined,
+  response: DaemonResponse,
+): void {
+  if (!scope || !shouldRecordEventForRequest(scope.req)) return;
+  sessionStore.recordEvent(
+    scope.sessionName,
+    buildRequestFinishedEvent({
+      req: scope.req,
+      response,
+      durationMs: Math.max(0, Date.now() - scope.startedAtMs),
+    }),
+  );
 }
 
 // Phase 2 typed-error graft: add machine-readable signals to an error response.

--- a/src/daemon/server/daemon-runtime.ts
+++ b/src/daemon/server/daemon-runtime.ts
@@ -43,6 +43,7 @@ import { sleep } from '../../utils/timeouts.ts';
 import { setRunnerLeaseOwnerStateDir } from '../../platforms/apple/core/runner/runner-lease.ts';
 import { cleanupManagedAgentBrowserOrphans } from '../../platforms/web/agent-browser-lifecycle.ts';
 import { getManagedAgentBrowserStatus } from '../../platforms/web/agent-browser-tool.ts';
+import { openWebSessionNames } from '../web-session-names.ts';
 
 const DAEMON_SESSION_TEARDOWN_TIMEOUT_MS = 5_000;
 const DAEMON_PNG_WORKER_TERMINATE_TIMEOUT_MS = 1_000;
@@ -320,11 +321,4 @@ export async function cleanupWebBrowserOrphansForDaemonStartup(params: {
       data: { error: error instanceof Error ? error.message : String(error) },
     });
   }
-}
-
-function openWebSessionNames(sessionStore: SessionStore): string[] {
-  return sessionStore
-    .toArray()
-    .filter((session) => session.device.platform === 'web')
-    .map((session) => session.name);
 }

--- a/src/daemon/session-action-recorder.ts
+++ b/src/daemon/session-action-recorder.ts
@@ -12,22 +12,26 @@ export type RecordActionEntry = {
   result?: Record<string, unknown>;
 };
 
-export function recordActionEntry(session: SessionState, entry: RecordActionEntry): void {
-  if (entry.flags?.noRecord) return;
+export function recordActionEntry(
+  session: SessionState,
+  entry: RecordActionEntry,
+): SessionAction | undefined {
+  if (entry.flags?.noRecord) return undefined;
   if (entry.flags?.saveScript) {
     session.recordSession = true;
     if (typeof entry.flags.saveScript === 'string') {
       session.saveScriptPath = expandSessionPath(entry.flags.saveScript);
     }
   }
-  session.actions.push({
+  const action: SessionAction = {
     ts: Date.now(),
     command: entry.command,
     positionals: entry.positionals,
     runtime: entry.runtime,
     flags: sanitizeFlags(entry.flags),
     result: entry.result,
-  });
+  };
+  session.actions.push(action);
   emitDiagnostic({
     level: 'debug',
     phase: 'record_action',
@@ -36,6 +40,7 @@ export function recordActionEntry(session: SessionState, entry: RecordActionEntr
       session: session.name,
     },
   });
+  return action;
 }
 
 const SANITIZED_FLAG_KEYS = [

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -2,7 +2,7 @@ import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../command-catalog.ts';
 import type { SessionAction } from './types.ts';
 
 export function buildActionSummary(action: SessionAction): string {
-  const message = readString(action.result?.message);
+  const message = readSanitizedActionMessage(action);
   if (message) return message;
   switch (action.command) {
     case PUBLIC_COMMANDS.open:
@@ -32,7 +32,7 @@ export function buildActionDetails(action: SessionAction): Record<string, unknow
     positionals: buildDisplayPositionals(action),
     flags: action.flags,
     action: result.action,
-    message: result.message,
+    message: readSanitizedActionMessage(action),
     ref: result.ref,
     refLabel: result.refLabel,
     selector: result.selector,
@@ -61,6 +61,29 @@ export function buildActionDetails(action: SessionAction): Record<string, unknow
     textLength: typeof result.text === 'string' ? Array.from(result.text).length : undefined,
     nodeCount: Array.isArray(result.nodes) ? result.nodes.length : undefined,
   };
+}
+
+function readSanitizedActionMessage(action: SessionAction): string | undefined {
+  const message = readString(action.result?.message);
+  if (!message) return undefined;
+  return sanitizeActionDisplayText(action, message);
+}
+
+function sanitizeActionDisplayText(action: SessionAction, value: string): string {
+  let sanitized = value;
+  const displayPositionals = buildDisplayPositionals(action) ?? [];
+  for (const [index, positional] of action.positionals.entries()) {
+    if (!positional) continue;
+    const replacement = displayPositionals[index] ?? redactDisplayPositional(positional);
+    if (replacement !== positional) {
+      sanitized = sanitized.split(positional).join(replacement);
+    }
+  }
+  const resultText = action.result?.text;
+  if (typeof resultText === 'string' && resultText.length > 0) {
+    sanitized = sanitized.split(resultText).join(hiddenValue('text', resultText));
+  }
+  return sanitized;
 }
 
 function readActionTargetLabel(action: SessionAction): string | undefined {

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -1,0 +1,154 @@
+import { PUBLIC_COMMANDS } from '../command-catalog.ts';
+import type { SessionAction } from './types.ts';
+
+export function buildActionSummary(action: SessionAction): string {
+  const message = readString(action.result?.message);
+  if (message) return message;
+  switch (action.command) {
+    case PUBLIC_COMMANDS.open:
+      return `Opened ${readActionTargetLabel(action) ?? 'session'}`;
+    case PUBLIC_COMMANDS.close:
+      return `Closed ${readString(action.result?.session) ?? 'session'}`;
+    case PUBLIC_COMMANDS.click:
+    case PUBLIC_COMMANDS.press:
+      return `Tapped ${readActionTargetLabel(action) ?? 'target'}`;
+    case PUBLIC_COMMANDS.longPress:
+      return `Long pressed ${readActionTargetLabel(action) ?? 'target'}`;
+    case PUBLIC_COMMANDS.fill:
+      return `Filled ${readActionTargetLabel(action) ?? 'target'}`;
+    case PUBLIC_COMMANDS.install:
+    case PUBLIC_COMMANDS.reinstall:
+    case 'install_source':
+      return `Installed ${readActionTargetLabel(action) ?? 'app'}`;
+    default:
+      return `Ran ${action.command}`;
+  }
+}
+
+export function buildActionDetails(action: SessionAction): Record<string, unknown> {
+  const result = action.result ?? {};
+  return compactDetails({
+    command: action.command,
+    positionals: buildDisplayPositionals(action),
+    flags: action.flags,
+    action: result.action,
+    message: result.message,
+    ref: result.ref,
+    refLabel: result.refLabel,
+    selector: result.selector,
+    selectorChain: readStringArray(result.selectorChain),
+    x: result.x,
+    y: result.y,
+    x2: result.x2,
+    y2: result.y2,
+    durationMs: result.durationMs,
+    waitedMs: result.waitedMs,
+    found: result.found,
+    path: result.path,
+    outPath: result.outPath,
+    telemetryPath: result.telemetryPath,
+    sessionStateDir: result.sessionStateDir,
+    requestLogPath: result.requestLogPath,
+    runnerLogPath: result.runnerLogPath,
+    platform: result.platform,
+    target: result.target,
+    device: result.device,
+    appName: result.appName,
+    appBundleId: result.appBundleId,
+    bundleId: result.bundleId,
+    packageName: result.packageName,
+    launchTarget: result.launchTarget,
+    textLength: typeof result.text === 'string' ? Array.from(result.text).length : undefined,
+    nodeCount: Array.isArray(result.nodes) ? result.nodes.length : undefined,
+  });
+}
+
+function readActionTargetLabel(action: SessionAction): string | undefined {
+  const result = action.result ?? {};
+  const ref = readString(result.ref);
+  if (ref) return ref.startsWith('@') ? ref : `@${ref}`;
+  const selector = readString(result.selector);
+  if (selector) return selector;
+  const refLabel = readString(result.refLabel);
+  if (refLabel) return refLabel;
+  const x = readNumber(result.x);
+  const y = readNumber(result.y);
+  if (x !== undefined && y !== undefined) return `(${x}, ${y})`;
+  return (
+    readString(result.appName) ??
+    readString(result.appBundleId) ??
+    readString(result.bundleId) ??
+    readString(result.packageName) ??
+    action.positionals[0]
+  );
+}
+
+function buildDisplayPositionals(action: SessionAction): string[] | undefined {
+  if (action.command === PUBLIC_COMMANDS.type) {
+    return [`<text:${readActionTextLength(action)} chars>`];
+  }
+  if (action.command === PUBLIC_COMMANDS.fill) {
+    return buildFillDisplayPositionals(action);
+  }
+  if (action.command === PUBLIC_COMMANDS.find) {
+    return buildFindDisplayPositionals(action);
+  }
+  return action.positionals.length > 0 ? action.positionals : undefined;
+}
+
+function buildFillDisplayPositionals(action: SessionAction): string[] {
+  const textPlaceholder = `<text:${readActionTextLength(action)} chars>`;
+  const result = action.result ?? {};
+  const ref = readString(result.ref);
+  if (ref) return [ref.startsWith('@') ? ref : `@${ref}`, textPlaceholder];
+  const selector = readString(result.selector);
+  if (selector) return [selector, textPlaceholder];
+  const x = readNumber(result.x);
+  const y = readNumber(result.y);
+  if (x !== undefined && y !== undefined) return [String(x), String(y), textPlaceholder];
+  return [textPlaceholder];
+}
+
+function buildFindDisplayPositionals(action: SessionAction): string[] | undefined {
+  const sensitiveActionIndex = action.positionals.findIndex(
+    (value) => value === 'fill' || value === 'type',
+  );
+  if (sensitiveActionIndex < 0) {
+    return action.positionals.length > 0 ? action.positionals : undefined;
+  }
+  return [
+    ...action.positionals.slice(0, sensitiveActionIndex + 1),
+    `<text:${readActionTextLength(action)} chars>`,
+  ];
+}
+
+function readActionTextLength(action: SessionAction): number {
+  const resultText = action.result?.text;
+  if (typeof resultText === 'string') return Array.from(resultText).length;
+  if (action.command === PUBLIC_COMMANDS.type) {
+    return Array.from(action.positionals.join(' ')).length;
+  }
+  return 0;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+    ? value
+    : undefined;
+}
+
+function compactDetails(record: Record<string, unknown>): Record<string, unknown> {
+  const compact: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (value !== undefined) compact[key] = value;
+  }
+  return compact;
+}

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -4,8 +4,6 @@ import type { SessionAction } from './types.ts';
 type ActionTextReplacement = { raw: string; display: string };
 
 export function buildActionSummary(action: SessionAction): string {
-  const message = readSanitizedActionMessage(action);
-  if (message) return message;
   switch (action.command) {
     case PUBLIC_COMMANDS.open:
       return `Opened ${readActionTargetLabel(action) ?? 'session'}`;
@@ -18,12 +16,14 @@ export function buildActionSummary(action: SessionAction): string {
       return `Long pressed ${readActionTargetLabel(action) ?? 'target'}`;
     case PUBLIC_COMMANDS.fill:
       return `Filled ${readActionTargetLabel(action) ?? 'target'}`;
+    case PUBLIC_COMMANDS.type:
+      return `Typed ${hiddenValueFromLength('text', readActionTextLength(action))}`;
     case PUBLIC_COMMANDS.install:
     case PUBLIC_COMMANDS.reinstall:
     case INTERNAL_COMMANDS.installSource:
       return `Installed ${readActionTargetLabel(action) ?? 'app'}`;
     default:
-      return `Ran ${action.command}`;
+      return readSafeActionMessage(action) ?? `Ran ${action.command}`;
   }
 }
 
@@ -34,11 +34,10 @@ export function buildActionDetails(action: SessionAction): Record<string, unknow
     positionals: buildDisplayPositionals(action),
     flags: action.flags,
     action: result.action,
-    message: readSanitizedActionMessage(action),
+    message: readSafeActionMessage(action),
     ref: result.ref,
-    refLabel: result.refLabel,
-    selector: result.selector,
-    selectorChain: readStringArray(result.selectorChain),
+    targetLabel: readActionTargetLabel(action),
+    selectorChainLength: readStringArray(result.selectorChain)?.length,
     x: result.x,
     y: result.y,
     x2: result.x2,
@@ -65,18 +64,25 @@ export function buildActionDetails(action: SessionAction): Record<string, unknow
   };
 }
 
-function readSanitizedActionMessage(action: SessionAction): string | undefined {
+function readSafeActionMessage(action: SessionAction): string | undefined {
   const message = readString(action.result?.message);
   if (!message) return undefined;
-  return sanitizeActionDisplayText(action, message);
+  if (hasRedactedActionInput(action) || hasValueBearingTargetDetails(action.result ?? {})) {
+    return undefined;
+  }
+  return message;
 }
 
-function sanitizeActionDisplayText(action: SessionAction, value: string): string {
-  const replacements = buildActionTextReplacements(action);
-  if (replacements.length === 0) return value;
-  const replacementByRaw = new Map(replacements.map(({ raw, display }) => [raw, display]));
-  const pattern = replacements.map(({ raw }) => escapeRegExp(raw)).join('|');
-  return value.replace(new RegExp(pattern, 'g'), (raw) => replacementByRaw.get(raw) ?? raw);
+function hasRedactedActionInput(action: SessionAction): boolean {
+  return buildActionTextReplacements(action).length > 0;
+}
+
+function hasValueBearingTargetDetails(result: Record<string, unknown>): boolean {
+  return (
+    readString(result.refLabel) !== undefined ||
+    readString(result.selector) !== undefined ||
+    readStringArray(result.selectorChain) !== undefined
+  );
 }
 
 function buildActionTextReplacements(action: SessionAction): ActionTextReplacement[] {
@@ -121,10 +127,6 @@ function uniqueActionTextReplacements(
   return replacements;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function readActionTargetLabel(action: SessionAction): string | undefined {
   const result = action.result ?? {};
   return (
@@ -138,9 +140,7 @@ function readActionTargetLabel(action: SessionAction): string | undefined {
 function readElementTargetLabel(result: Record<string, unknown>): string | undefined {
   const ref = readString(result.ref);
   if (ref) return ref.startsWith('@') ? ref : `@${ref}`;
-  const selector = readString(result.selector);
-  if (selector) return selector;
-  return readString(result.refLabel);
+  return undefined;
 }
 
 function readPointTargetLabel(result: Record<string, unknown>): string | undefined {
@@ -188,7 +188,7 @@ function buildFillDisplayPositionals(action: SessionAction): string[] {
   const ref = readString(result.ref);
   if (ref) return [ref.startsWith('@') ? ref : `@${ref}`, textPlaceholder];
   const selector = readString(result.selector);
-  if (selector) return [selector, textPlaceholder];
+  if (selector) return [hiddenValue('target', selector), textPlaceholder];
   const x = readNumber(result.x);
   const y = readNumber(result.y);
   if (x !== undefined && y !== undefined) return [String(x), String(y), textPlaceholder];

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -1,6 +1,5 @@
 import { PUBLIC_COMMANDS } from '../command-catalog.ts';
 import type { SessionAction } from './types.ts';
-import { definedEventDetails } from './session-event-details.ts';
 
 export function buildActionSummary(action: SessionAction): string {
   const message = readString(action.result?.message);
@@ -28,7 +27,7 @@ export function buildActionSummary(action: SessionAction): string {
 
 export function buildActionDetails(action: SessionAction): Record<string, unknown> {
   const result = action.result ?? {};
-  return definedEventDetails({
+  return {
     command: action.command,
     positionals: buildDisplayPositionals(action),
     flags: action.flags,
@@ -61,7 +60,7 @@ export function buildActionDetails(action: SessionAction): Record<string, unknow
     launchTarget: result.launchTarget,
     textLength: typeof result.text === 'string' ? Array.from(result.text).length : undefined,
     nodeCount: Array.isArray(result.nodes) ? result.nodes.length : undefined,
-  });
+  };
 }
 
 function readActionTargetLabel(action: SessionAction): string | undefined {

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -69,7 +69,7 @@ function readActionTargetLabel(action: SessionAction): string | undefined {
     readElementTargetLabel(result) ??
     readPointTargetLabel(result) ??
     readAppTargetLabel(result) ??
-    action.positionals[0]
+    readSafeDisplayPositional(action.positionals[0])
   );
 }
 
@@ -98,8 +98,9 @@ function readAppTargetLabel(result: Record<string, unknown>): string | undefined
 }
 
 function buildDisplayPositionals(action: SessionAction): string[] | undefined {
+  if (action.positionals.length === 0) return undefined;
   if (action.command === PUBLIC_COMMANDS.type) {
-    return [`<text:${readActionTextLength(action)} chars>`];
+    return [hiddenValueFromLength('text', readActionTextLength(action))];
   }
   if (action.command === PUBLIC_COMMANDS.fill) {
     return buildFillDisplayPositionals(action);
@@ -107,11 +108,20 @@ function buildDisplayPositionals(action: SessionAction): string[] | undefined {
   if (action.command === PUBLIC_COMMANDS.find) {
     return buildFindDisplayPositionals(action);
   }
-  return action.positionals.length > 0 ? action.positionals : undefined;
+  if (action.command === PUBLIC_COMMANDS.clipboard) {
+    return buildClipboardDisplayPositionals(action);
+  }
+  if (action.command === PUBLIC_COMMANDS.push) {
+    return buildPayloadDisplayPositionals(action, 'payload');
+  }
+  if (action.command === PUBLIC_COMMANDS.triggerAppEvent) {
+    return buildPayloadDisplayPositionals(action, 'payload');
+  }
+  return action.positionals.map(redactDisplayPositional);
 }
 
 function buildFillDisplayPositionals(action: SessionAction): string[] {
-  const textPlaceholder = `<text:${readActionTextLength(action)} chars>`;
+  const textPlaceholder = hiddenValueFromLength('text', readActionTextLength(action));
   const result = action.result ?? {};
   const ref = readString(result.ref);
   if (ref) return [ref.startsWith('@') ? ref : `@${ref}`, textPlaceholder];
@@ -124,16 +134,53 @@ function buildFillDisplayPositionals(action: SessionAction): string[] {
 }
 
 function buildFindDisplayPositionals(action: SessionAction): string[] | undefined {
-  const sensitiveActionIndex = action.positionals.findIndex(
-    (value) => value === 'fill' || value === 'type',
-  );
-  if (sensitiveActionIndex < 0) {
-    return action.positionals.length > 0 ? action.positionals : undefined;
-  }
-  return [
-    ...action.positionals.slice(0, sensitiveActionIndex + 1),
-    `<text:${readActionTextLength(action)} chars>`,
+  const queryIndex = isFindLocator(action.positionals[0]) ? 1 : 0;
+  const query = action.positionals[queryIndex];
+  if (query === undefined) return undefined;
+  const actionIndex = queryIndex + 1;
+  const prefix = [
+    ...(queryIndex === 1 ? [String(action.positionals[0])] : []),
+    hiddenValue('query', query),
   ];
+  const findAction = action.positionals[actionIndex];
+  if (!findAction) return prefix;
+  if (findAction === 'fill' || findAction === 'type') {
+    return [...prefix, findAction, hiddenValueFromLength('text', readActionTextLength(action))];
+  }
+  return [...prefix, ...action.positionals.slice(actionIndex).map(redactFindActionPositional)];
+}
+
+function buildClipboardDisplayPositionals(action: SessionAction): string[] {
+  const clipboardAction = action.positionals[0]?.toLowerCase();
+  if (clipboardAction === 'read') return ['read'];
+  if (clipboardAction === 'write') {
+    return ['write', hiddenValueFromLength('text', readClipboardWriteLength(action))];
+  }
+  return action.positionals.map(redactDisplayPositional);
+}
+
+function buildPayloadDisplayPositionals(action: SessionAction, payloadLabel: string): string[] {
+  const [target, payload, ...extra] = action.positionals;
+  return [
+    ...(target ? [target] : []),
+    ...(payload ? [hiddenValue(payloadLabel, payload)] : []),
+    ...extra.map(redactDisplayPositional),
+  ];
+}
+
+function redactFindActionPositional(value: string): string {
+  if (
+    value === 'click' ||
+    value === 'focus' ||
+    value === 'exists' ||
+    value === 'get' ||
+    value === 'text' ||
+    value === 'attrs' ||
+    value === 'wait'
+  ) {
+    return value;
+  }
+  return redactDisplayPositional(value);
 }
 
 function readActionTextLength(action: SessionAction): number {
@@ -143,6 +190,37 @@ function readActionTextLength(action: SessionAction): number {
     return Array.from(action.positionals.join(' ')).length;
   }
   return 0;
+}
+
+function readClipboardWriteLength(action: SessionAction): number {
+  const textLength = action.result?.textLength;
+  if (typeof textLength === 'number' && Number.isFinite(textLength)) return textLength;
+  return Array.from(action.positionals.slice(1).join(' ')).length;
+}
+
+function redactDisplayPositional(value: string): string {
+  return readSafeDisplayPositional(value) ?? hiddenValue('arg', value);
+}
+
+function readSafeDisplayPositional(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (/^@[a-zA-Z0-9:_-]+$/.test(trimmed)) return trimmed;
+  return undefined;
+}
+
+function hiddenValue(label: string, value: string): string {
+  return hiddenValueFromLength(label, Array.from(value).length);
+}
+
+function hiddenValueFromLength(label: string, length: number): string {
+  return `<${label}:${length} chars>`;
+}
+
+function isFindLocator(value: string | undefined): boolean {
+  return (
+    value === 'text' || value === 'label' || value === 'value' || value === 'role' || value === 'id'
+  );
 }
 
 function readString(value: unknown): string | undefined {

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -1,6 +1,8 @@
 import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../command-catalog.ts';
 import type { SessionAction } from './types.ts';
 
+type ActionTextReplacement = { raw: string; display: string };
+
 export function buildActionSummary(action: SessionAction): string {
   const message = readSanitizedActionMessage(action);
   if (message) return message;
@@ -70,20 +72,57 @@ function readSanitizedActionMessage(action: SessionAction): string | undefined {
 }
 
 function sanitizeActionDisplayText(action: SessionAction, value: string): string {
-  let sanitized = value;
+  const replacements = buildActionTextReplacements(action);
+  if (replacements.length === 0) return value;
+  const replacementByRaw = new Map(replacements.map(({ raw, display }) => [raw, display]));
+  const pattern = replacements.map(({ raw }) => escapeRegExp(raw)).join('|');
+  return value.replace(new RegExp(pattern, 'g'), (raw) => replacementByRaw.get(raw) ?? raw);
+}
+
+function buildActionTextReplacements(action: SessionAction): ActionTextReplacement[] {
+  return uniqueActionTextReplacements(
+    buildActionTextReplacementCandidates(action).sort(
+      (left, right) => right.raw.length - left.raw.length,
+    ),
+  );
+}
+
+function buildActionTextReplacementCandidates(action: SessionAction): ActionTextReplacement[] {
   const displayPositionals = buildDisplayPositionals(action) ?? [];
-  for (const [index, positional] of action.positionals.entries()) {
-    if (!positional) continue;
-    const replacement = displayPositionals[index] ?? redactDisplayPositional(positional);
-    if (replacement !== positional) {
-      sanitized = sanitized.split(positional).join(replacement);
-    }
-  }
+  const replacements = action.positionals.flatMap((positional, index) => {
+    const replacement = buildPositionalTextReplacement(positional, displayPositionals[index]);
+    return replacement ? [replacement] : [];
+  });
   const resultText = action.result?.text;
-  if (typeof resultText === 'string' && resultText.length > 0) {
-    sanitized = sanitized.split(resultText).join(hiddenValue('text', resultText));
+  return typeof resultText === 'string' && resultText.length > 0
+    ? [{ raw: resultText, display: hiddenValue('text', resultText) }, ...replacements]
+    : replacements;
+}
+
+function buildPositionalTextReplacement(
+  raw: string,
+  display: string | undefined,
+): ActionTextReplacement | undefined {
+  if (!raw) return undefined;
+  const replacement = display ?? redactDisplayPositional(raw);
+  return replacement === raw ? undefined : { raw, display: replacement };
+}
+
+function uniqueActionTextReplacements(
+  candidates: ActionTextReplacement[],
+): ActionTextReplacement[] {
+  const seen = new Set<string>();
+  const replacements: ActionTextReplacement[] = [];
+  for (const { raw, display } of candidates) {
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+    replacements.push({ raw, display });
   }
-  return sanitized;
+  return replacements;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function readActionTargetLabel(action: SessionAction): string | undefined {

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_COMMANDS } from '../command-catalog.ts';
+import { INTERNAL_COMMANDS, PUBLIC_COMMANDS } from '../command-catalog.ts';
 import type { SessionAction } from './types.ts';
 
 export function buildActionSummary(action: SessionAction): string {
@@ -18,7 +18,7 @@ export function buildActionSummary(action: SessionAction): string {
       return `Filled ${readActionTargetLabel(action) ?? 'target'}`;
     case PUBLIC_COMMANDS.install:
     case PUBLIC_COMMANDS.reinstall:
-    case 'install_source':
+    case INTERNAL_COMMANDS.installSource:
       return `Installed ${readActionTargetLabel(action) ?? 'app'}`;
     default:
       return `Ran ${action.command}`;
@@ -65,21 +65,35 @@ export function buildActionDetails(action: SessionAction): Record<string, unknow
 
 function readActionTargetLabel(action: SessionAction): string | undefined {
   const result = action.result ?? {};
+  return (
+    readElementTargetLabel(result) ??
+    readPointTargetLabel(result) ??
+    readAppTargetLabel(result) ??
+    action.positionals[0]
+  );
+}
+
+function readElementTargetLabel(result: Record<string, unknown>): string | undefined {
   const ref = readString(result.ref);
   if (ref) return ref.startsWith('@') ? ref : `@${ref}`;
   const selector = readString(result.selector);
   if (selector) return selector;
-  const refLabel = readString(result.refLabel);
-  if (refLabel) return refLabel;
+  return readString(result.refLabel);
+}
+
+function readPointTargetLabel(result: Record<string, unknown>): string | undefined {
   const x = readNumber(result.x);
   const y = readNumber(result.y);
   if (x !== undefined && y !== undefined) return `(${x}, ${y})`;
+  return undefined;
+}
+
+function readAppTargetLabel(result: Record<string, unknown>): string | undefined {
   return (
     readString(result.appName) ??
     readString(result.appBundleId) ??
     readString(result.bundleId) ??
-    readString(result.packageName) ??
-    action.positionals[0]
+    readString(result.packageName)
   );
 }
 
@@ -132,7 +146,8 @@ function readActionTextLength(action: SessionAction): number {
 }
 
 function readString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  return value.trim().length > 0 ? value : undefined;
 }
 
 function readNumber(value: unknown): number | undefined {

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -1,5 +1,6 @@
 import { PUBLIC_COMMANDS } from '../command-catalog.ts';
 import type { SessionAction } from './types.ts';
+import { definedEventDetails } from './session-event-details.ts';
 
 export function buildActionSummary(action: SessionAction): string {
   const message = readString(action.result?.message);
@@ -27,7 +28,7 @@ export function buildActionSummary(action: SessionAction): string {
 
 export function buildActionDetails(action: SessionAction): Record<string, unknown> {
   const result = action.result ?? {};
-  return compactDetails({
+  return definedEventDetails({
     command: action.command,
     positionals: buildDisplayPositionals(action),
     flags: action.flags,
@@ -143,12 +144,4 @@ function readStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((entry) => typeof entry === 'string')
     ? value
     : undefined;
-}
-
-function compactDetails(record: Record<string, unknown>): Record<string, unknown> {
-  const compact: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
-    if (value !== undefined) compact[key] = value;
-  }
-  return compact;
 }

--- a/src/daemon/session-event-details.ts
+++ b/src/daemon/session-event-details.ts
@@ -1,0 +1,4 @@
+/** Event detail builders collect optional fields; omit absent values before writing/returning them. */
+export function definedEventDetails(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+}

--- a/src/daemon/session-event-details.ts
+++ b/src/daemon/session-event-details.ts
@@ -1,4 +1,0 @@
-/** Event detail builders collect optional fields; omit absent values before writing/returning them. */
-export function definedEventDetails(record: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
-}

--- a/src/daemon/session-event-log.ts
+++ b/src/daemon/session-event-log.ts
@@ -6,7 +6,6 @@ import { redactDiagnosticData } from '../kernel/redaction.ts';
 import { getDiagnosticsMeta } from '../utils/diagnostics.ts';
 import type { DaemonRequest, DaemonResponse, SessionAction } from './types.ts';
 import { buildActionDetails, buildActionSummary } from './session-event-action.ts';
-import { definedEventDetails } from './session-event-details.ts';
 
 export const SESSION_EVENT_LOG_FILENAME = 'events.ndjson';
 
@@ -93,14 +92,14 @@ export function buildRequestStartedEvent(params: {
     requestId: req.meta?.requestId ?? getDiagnosticsMeta().requestId,
     command: req.command,
     summary: `Started ${req.command}`,
-    details: definedEventDetails({
+    details: {
       publicSession: req.session,
       effectiveSession: sessionName,
       tenant: req.meta?.tenantId,
       isolation: req.meta?.sessionIsolation,
       requestLogPath,
       runnerLogPath,
-    }),
+    },
   };
 }
 
@@ -117,7 +116,7 @@ export function buildRequestFinishedEvent(params: {
       command: req.command,
       status: 'ok',
       summary: `Finished ${req.command}`,
-      details: definedEventDetails({ durationMs }),
+      details: { durationMs },
     };
   }
   return {
@@ -126,14 +125,14 @@ export function buildRequestFinishedEvent(params: {
     command: req.command,
     status: 'error',
     summary: `Failed ${req.command}: ${response.error.message}`,
-    details: definedEventDetails({
+    details: {
       durationMs,
       code: response.error.code,
       message: response.error.message,
       hint: response.error.hint,
       diagnosticId: response.error.diagnosticId,
       logPath: response.error.logPath,
-    }),
+    },
   };
 }
 
@@ -149,7 +148,7 @@ export function readSessionEventLog(
 
   const rawLines = fs
     .readFileSync(eventLogPath, 'utf8')
-    .split('\n')
+    .split(/\r?\n/)
     .filter((line) => line.trim().length > 0);
   const end = Math.min(rawLines.length, cursor + limit);
   const events = rawLines.slice(cursor, end).flatMap((line) => {

--- a/src/daemon/session-event-log.ts
+++ b/src/daemon/session-event-log.ts
@@ -6,6 +6,7 @@ import { redactDiagnosticData } from '../kernel/redaction.ts';
 import { getDiagnosticsMeta } from '../utils/diagnostics.ts';
 import type { DaemonRequest, DaemonResponse, SessionAction } from './types.ts';
 import { buildActionDetails, buildActionSummary } from './session-event-action.ts';
+import { definedEventDetails } from './session-event-details.ts';
 
 export const SESSION_EVENT_LOG_FILENAME = 'events.ndjson';
 
@@ -92,7 +93,7 @@ export function buildRequestStartedEvent(params: {
     requestId: req.meta?.requestId ?? getDiagnosticsMeta().requestId,
     command: req.command,
     summary: `Started ${req.command}`,
-    details: compactDetails({
+    details: definedEventDetails({
       publicSession: req.session,
       effectiveSession: sessionName,
       tenant: req.meta?.tenantId,
@@ -116,7 +117,7 @@ export function buildRequestFinishedEvent(params: {
       command: req.command,
       status: 'ok',
       summary: `Finished ${req.command}`,
-      details: compactDetails({ durationMs }),
+      details: definedEventDetails({ durationMs }),
     };
   }
   return {
@@ -125,7 +126,7 @@ export function buildRequestFinishedEvent(params: {
     command: req.command,
     status: 'error',
     summary: `Failed ${req.command}: ${response.error.message}`,
-    details: compactDetails({
+    details: definedEventDetails({
       durationMs,
       code: response.error.code,
       message: response.error.message,
@@ -193,12 +194,4 @@ function parseSessionEventLogLine(line: string): SessionEventLogEntry | undefine
 
 function isSessionEventKind(value: unknown): value is SessionEventLogEntry['kind'] {
   return value === 'request.started' || value === 'request.finished' || value === 'action.recorded';
-}
-
-function compactDetails(record: Record<string, unknown>): Record<string, unknown> {
-  const compact: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
-    if (value !== undefined) compact[key] = value;
-  }
-  return compact;
 }

--- a/src/daemon/session-event-log.ts
+++ b/src/daemon/session-event-log.ts
@@ -1,0 +1,204 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { PUBLIC_COMMANDS } from '../command-catalog.ts';
+import { AppError } from '../kernel/errors.ts';
+import { redactDiagnosticData } from '../kernel/redaction.ts';
+import { getDiagnosticsMeta } from '../utils/diagnostics.ts';
+import type { DaemonRequest, DaemonResponse, SessionAction } from './types.ts';
+import { buildActionDetails, buildActionSummary } from './session-event-action.ts';
+
+export const SESSION_EVENT_LOG_FILENAME = 'events.ndjson';
+
+const EVENT_LOG_VERSION = 1;
+const DEFAULT_EVENT_LIMIT = 100;
+const MAX_EVENT_LIMIT = 500;
+
+export type SessionEventLogEntry = {
+  version: 1;
+  ts: string;
+  session: string;
+  kind: 'request.started' | 'request.finished' | 'action.recorded';
+  requestId?: string;
+  command?: string;
+  status?: 'ok' | 'error';
+  summary?: string;
+  details?: Record<string, unknown>;
+};
+
+export type SessionEventLogPage = {
+  path: string;
+  cursor: string;
+  limit: number;
+  events: SessionEventLogEntry[];
+  nextCursor?: string;
+};
+
+export type SessionEventLogInput = Omit<SessionEventLogEntry, 'version' | 'ts' | 'session'> & {
+  ts?: string;
+};
+
+type ReadSessionEventLogOptions = { cursor?: string; limit?: number };
+
+export function resolveSessionEventLogPath(sessionDir: string): string {
+  return path.join(sessionDir, SESSION_EVENT_LOG_FILENAME);
+}
+
+export function shouldRecordEventForRequest(req: Pick<DaemonRequest, 'command'>): boolean {
+  return req.command !== PUBLIC_COMMANDS.events;
+}
+
+export function appendSessionEvent(
+  eventLogPath: string,
+  sessionName: string,
+  event: SessionEventLogInput,
+): void {
+  try {
+    fs.mkdirSync(path.dirname(eventLogPath), { recursive: true });
+    const entry = redactDiagnosticData({
+      version: EVENT_LOG_VERSION,
+      ts: event.ts ?? new Date().toISOString(),
+      session: sessionName,
+      ...event,
+    } satisfies SessionEventLogEntry);
+    fs.appendFileSync(eventLogPath, `${JSON.stringify(entry)}\n`, 'utf8');
+  } catch {
+    // Event logging is best-effort and must never break device automation.
+  }
+}
+
+export function appendActionEvent(
+  eventLogPath: string,
+  sessionName: string,
+  action: SessionAction,
+): void {
+  appendSessionEvent(eventLogPath, sessionName, {
+    kind: 'action.recorded',
+    requestId: getDiagnosticsMeta().requestId,
+    command: action.command,
+    summary: buildActionSummary(action),
+    details: buildActionDetails(action),
+  });
+}
+
+export function buildRequestStartedEvent(params: {
+  req: DaemonRequest;
+  sessionName: string;
+  requestLogPath: string;
+  runnerLogPath: string;
+}): SessionEventLogInput {
+  const { req, sessionName, requestLogPath, runnerLogPath } = params;
+  return {
+    kind: 'request.started',
+    requestId: req.meta?.requestId ?? getDiagnosticsMeta().requestId,
+    command: req.command,
+    summary: `Started ${req.command}`,
+    details: compactDetails({
+      publicSession: req.session,
+      effectiveSession: sessionName,
+      tenant: req.meta?.tenantId,
+      isolation: req.meta?.sessionIsolation,
+      requestLogPath,
+      runnerLogPath,
+    }),
+  };
+}
+
+export function buildRequestFinishedEvent(params: {
+  req: DaemonRequest;
+  response: DaemonResponse;
+  durationMs: number;
+}): SessionEventLogInput {
+  const { req, response, durationMs } = params;
+  if (response.ok) {
+    return {
+      kind: 'request.finished',
+      requestId: req.meta?.requestId ?? getDiagnosticsMeta().requestId,
+      command: req.command,
+      status: 'ok',
+      summary: `Finished ${req.command}`,
+      details: compactDetails({ durationMs }),
+    };
+  }
+  return {
+    kind: 'request.finished',
+    requestId: req.meta?.requestId ?? getDiagnosticsMeta().requestId,
+    command: req.command,
+    status: 'error',
+    summary: `Failed ${req.command}: ${response.error.message}`,
+    details: compactDetails({
+      durationMs,
+      code: response.error.code,
+      message: response.error.message,
+      hint: response.error.hint,
+      diagnosticId: response.error.diagnosticId,
+      logPath: response.error.logPath,
+    }),
+  };
+}
+
+export function readSessionEventLog(
+  eventLogPath: string,
+  options: ReadSessionEventLogOptions = {},
+): SessionEventLogPage {
+  const cursor = normalizeCursor(options.cursor);
+  const limit = normalizeLimit(options.limit);
+  if (!fs.existsSync(eventLogPath)) {
+    return { path: eventLogPath, cursor: String(cursor), limit, events: [] };
+  }
+
+  const rawLines = fs
+    .readFileSync(eventLogPath, 'utf8')
+    .split('\n')
+    .filter((line) => line.trim().length > 0);
+  const end = Math.min(rawLines.length, cursor + limit);
+  const events = rawLines.slice(cursor, end).flatMap((line) => {
+    const parsed = parseSessionEventLogLine(line);
+    return parsed ? [parsed] : [];
+  });
+  return {
+    path: eventLogPath,
+    cursor: String(cursor),
+    limit,
+    events,
+    ...(end < rawLines.length ? { nextCursor: String(end) } : {}),
+  };
+}
+
+function normalizeCursor(value: string | undefined): number {
+  if (value === undefined || value.trim() === '') return 0;
+  const cursor = Number(value);
+  if (Number.isInteger(cursor) && cursor >= 0) return cursor;
+  throw new AppError('INVALID_ARGS', 'events cursor must be a non-negative integer string.');
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_EVENT_LIMIT;
+  if (Number.isInteger(value) && value >= 1 && value <= MAX_EVENT_LIMIT) return value;
+  throw new AppError('INVALID_ARGS', `events limit must be between 1 and ${MAX_EVENT_LIMIT}.`);
+}
+
+function parseSessionEventLogLine(line: string): SessionEventLogEntry | undefined {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    const record = parsed as Partial<SessionEventLogEntry>;
+    if (record.version !== EVENT_LOG_VERSION) return undefined;
+    if (typeof record.ts !== 'string' || typeof record.session !== 'string') return undefined;
+    if (!isSessionEventKind(record.kind)) return undefined;
+    return record as SessionEventLogEntry;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSessionEventKind(value: unknown): value is SessionEventLogEntry['kind'] {
+  return value === 'request.started' || value === 'request.finished' || value === 'action.recorded';
+}
+
+function compactDetails(record: Record<string, unknown>): Record<string, unknown> {
+  const compact: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (value !== undefined) compact[key] = value;
+  }
+  return compact;
+}

--- a/src/daemon/session-event-log.ts
+++ b/src/daemon/session-event-log.ts
@@ -14,6 +14,8 @@ const EVENT_LOG_VERSION = 1;
 const DEFAULT_EVENT_LIMIT = 100;
 const MAX_EVENT_LIMIT = 500;
 const EVENT_LOG_READ_CHUNK_BYTES = 64 * 1024;
+const pendingEventLogWrites = new Map<string, Promise<void>>();
+const ensuredEventLogDirs = new Set<string>();
 
 export type SessionEventLogEntry = {
   version: 1;
@@ -39,7 +41,7 @@ export type SessionEventLogInput = Omit<SessionEventLogEntry, 'version' | 'ts' |
   ts?: string;
 };
 
-type ReadSessionEventLogOptions = { cursor?: string; limit?: number };
+type ReadSessionEventLogOptions = { cursor?: string; limit?: number | string };
 type RawSessionEventLogEntry = Record<string, unknown> &
   Pick<SessionEventLogEntry, 'version' | 'ts' | 'session' | 'kind'>;
 
@@ -56,24 +58,64 @@ export function appendSessionEvent(
   sessionName: string,
   event: SessionEventLogInput,
 ): void {
+  const entry = redactDiagnosticData({
+    version: EVENT_LOG_VERSION,
+    ts: event.ts ?? new Date().toISOString(),
+    session: sessionName,
+    ...event,
+  } satisfies SessionEventLogEntry);
+  queueEventLogWrite(eventLogPath, `${JSON.stringify(entry)}\n`);
+}
+
+export async function flushSessionEventLogWrites(eventLogPath?: string): Promise<void> {
+  const pending = eventLogPath
+    ? pendingEventLogWrites.get(eventLogPath)
+    : Promise.all(pendingEventLogWrites.values());
+  await pending;
+}
+
+function queueEventLogWrite(eventLogPath: string, line: string): void {
+  const previous = pendingEventLogWrites.get(eventLogPath) ?? Promise.resolve();
+  const pending = previous
+    .catch(() => undefined)
+    .then(async () => {
+      await ensureEventLogDir(eventLogPath);
+      await fs.promises.appendFile(eventLogPath, line, 'utf8');
+    })
+    .catch((error) => {
+      emitDiagnostic({
+        level: 'warn',
+        phase: 'session_event_log_write_failed',
+        data: {
+          path: eventLogPath,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    })
+    .finally(() => {
+      if (pendingEventLogWrites.get(eventLogPath) === pending) {
+        pendingEventLogWrites.delete(eventLogPath);
+      }
+    });
+  pendingEventLogWrites.set(eventLogPath, pending);
+}
+
+async function ensureEventLogDir(eventLogPath: string): Promise<void> {
+  const dir = path.dirname(eventLogPath);
+  if (ensuredEventLogDirs.has(dir)) return;
   try {
-    fs.mkdirSync(path.dirname(eventLogPath), { recursive: true });
-    const entry = redactDiagnosticData({
-      version: EVENT_LOG_VERSION,
-      ts: event.ts ?? new Date().toISOString(),
-      session: sessionName,
-      ...event,
-    } satisfies SessionEventLogEntry);
-    fs.appendFileSync(eventLogPath, `${JSON.stringify(entry)}\n`, 'utf8');
+    await fs.promises.mkdir(dir, { recursive: true });
+    ensuredEventLogDirs.add(dir);
   } catch (error) {
     emitDiagnostic({
       level: 'warn',
-      phase: 'session_event_log_write_failed',
+      phase: 'session_event_log_dir_failed',
       data: {
         path: eventLogPath,
         error: error instanceof Error ? error.message : String(error),
       },
     });
+    throw error;
   }
 }
 
@@ -135,12 +177,10 @@ export function buildRequestFinishedEvent(params: {
     requestId: req.meta?.requestId ?? getDiagnosticsMeta().requestId,
     command: req.command,
     status: 'error',
-    summary: `Failed ${req.command}: ${response.error.message}`,
+    summary: `Failed ${req.command}: ${response.error.code}`,
     details: {
       durationMs,
       code: response.error.code,
-      message: response.error.message,
-      hint: response.error.hint,
       diagnosticId: response.error.diagnosticId,
       logPath: response.error.logPath,
     },
@@ -246,9 +286,11 @@ function normalizeCursor(value: string | undefined): number {
   throw new AppError('INVALID_ARGS', 'events cursor must be a non-negative integer string.');
 }
 
-function normalizeLimit(value: number | undefined): number {
+function normalizeLimit(value: number | string | undefined): number {
   if (value === undefined) return DEFAULT_EVENT_LIMIT;
-  if (Number.isInteger(value) && value >= 1 && value <= MAX_EVENT_LIMIT) return value;
+  if (typeof value === 'string' && value.trim() === '') return DEFAULT_EVENT_LIMIT;
+  const limit = typeof value === 'string' ? Number(value) : value;
+  if (Number.isInteger(limit) && limit >= 1 && limit <= MAX_EVENT_LIMIT) return limit;
   throw new AppError('INVALID_ARGS', `events limit must be between 1 and ${MAX_EVENT_LIMIT}.`);
 }
 

--- a/src/daemon/session-event-log.ts
+++ b/src/daemon/session-event-log.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 import { PUBLIC_COMMANDS } from '../command-catalog.ts';
 import { AppError } from '../kernel/errors.ts';
 import { redactDiagnosticData } from '../kernel/redaction.ts';
@@ -12,6 +13,7 @@ const SESSION_EVENT_LOG_FILENAME = 'events.ndjson';
 const EVENT_LOG_VERSION = 1;
 const DEFAULT_EVENT_LIMIT = 100;
 const MAX_EVENT_LIMIT = 500;
+const EVENT_LOG_READ_CHUNK_BYTES = 64 * 1024;
 
 export type SessionEventLogEntry = {
   version: 1;
@@ -155,12 +157,8 @@ export function readSessionEventLog(
     return { path: eventLogPath, cursor: String(cursor), limit, events: [] };
   }
 
-  const rawLines = fs
-    .readFileSync(eventLogPath, 'utf8')
-    .split(/\r?\n/)
-    .filter((line) => line.trim().length > 0);
-  const end = Math.min(rawLines.length, cursor + limit);
-  const events = rawLines.slice(cursor, end).flatMap((line) => {
+  const page = readSessionEventLogLines(eventLogPath, cursor, limit);
+  const events = page.lines.flatMap((line) => {
     const parsed = parseSessionEventLogLine(line);
     return parsed ? [parsed] : [];
   });
@@ -169,8 +167,76 @@ export function readSessionEventLog(
     cursor: String(cursor),
     limit,
     events,
-    ...(end < rawLines.length ? { nextCursor: String(end) } : {}),
+    ...(page.nextCursor !== undefined ? { nextCursor: String(page.nextCursor) } : {}),
   };
+}
+
+function readSessionEventLogLines(
+  eventLogPath: string,
+  cursor: number,
+  limit: number,
+): { lines: string[]; nextCursor?: number } {
+  const fd = fs.openSync(eventLogPath, 'r');
+  try {
+    const decoder = new StringDecoder('utf8');
+    const buffer = Buffer.allocUnsafe(EVENT_LOG_READ_CHUNK_BYTES);
+    const state = createLineScanState(cursor, limit);
+    let pending = '';
+    let bytesRead = 0;
+    do {
+      bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      const chunk = decoder.write(buffer.subarray(0, bytesRead));
+      pending = consumeEventLogChunk(`${pending}${chunk}`, state);
+    } while (bytesRead > 0 && state.nextCursor === undefined);
+    const remainder = `${pending}${decoder.end()}`;
+    if (state.nextCursor === undefined && remainder.length > 0) {
+      consumeEventLogLine(remainder, state);
+    }
+    return { lines: state.lines, nextCursor: state.nextCursor };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function createLineScanState(
+  cursor: number,
+  limit: number,
+): {
+  cursor: number;
+  limit: number;
+  lineIndex: number;
+  lines: string[];
+  nextCursor?: number;
+} {
+  return {
+    cursor,
+    limit,
+    lineIndex: 0,
+    lines: [],
+  };
+}
+
+function consumeEventLogChunk(text: string, state: ReturnType<typeof createLineScanState>): string {
+  let start = 0;
+  for (let index = text.indexOf('\n'); index !== -1; index = text.indexOf('\n', start)) {
+    consumeEventLogLine(text.slice(start, index), state);
+    start = index + 1;
+    if (state.nextCursor !== undefined) return '';
+  }
+  return text.slice(start);
+}
+
+function consumeEventLogLine(rawLine: string, state: ReturnType<typeof createLineScanState>): void {
+  const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+  if (line.trim().length === 0) return;
+  if (state.lineIndex >= state.cursor + state.limit) {
+    state.nextCursor = state.cursor + state.limit;
+    return;
+  }
+  if (state.lineIndex >= state.cursor) {
+    state.lines.push(line);
+  }
+  state.lineIndex += 1;
 }
 
 function normalizeCursor(value: string | undefined): number {

--- a/src/daemon/session-event-log.ts
+++ b/src/daemon/session-event-log.ts
@@ -3,12 +3,12 @@ import path from 'node:path';
 import { PUBLIC_COMMANDS } from '../command-catalog.ts';
 import { AppError } from '../kernel/errors.ts';
 import { redactDiagnosticData } from '../kernel/redaction.ts';
-import { getDiagnosticsMeta } from '../utils/diagnostics.ts';
+import { emitDiagnostic, getDiagnosticsMeta } from '../utils/diagnostics.ts';
+import { isRecord } from '../utils/parsing.ts';
 import type { DaemonRequest, DaemonResponse, SessionAction } from './types.ts';
 import { buildActionDetails, buildActionSummary } from './session-event-action.ts';
 
-export const SESSION_EVENT_LOG_FILENAME = 'events.ndjson';
-
+const SESSION_EVENT_LOG_FILENAME = 'events.ndjson';
 const EVENT_LOG_VERSION = 1;
 const DEFAULT_EVENT_LIMIT = 100;
 const MAX_EVENT_LIMIT = 500;
@@ -38,6 +38,8 @@ export type SessionEventLogInput = Omit<SessionEventLogEntry, 'version' | 'ts' |
 };
 
 type ReadSessionEventLogOptions = { cursor?: string; limit?: number };
+type RawSessionEventLogEntry = Record<string, unknown> &
+  Pick<SessionEventLogEntry, 'version' | 'ts' | 'session' | 'kind'>;
 
 export function resolveSessionEventLogPath(sessionDir: string): string {
   return path.join(sessionDir, SESSION_EVENT_LOG_FILENAME);
@@ -61,8 +63,15 @@ export function appendSessionEvent(
       ...event,
     } satisfies SessionEventLogEntry);
     fs.appendFileSync(eventLogPath, `${JSON.stringify(entry)}\n`, 'utf8');
-  } catch {
-    // Event logging is best-effort and must never break device automation.
+  } catch (error) {
+    emitDiagnostic({
+      level: 'warn',
+      phase: 'session_event_log_write_failed',
+      data: {
+        path: eventLogPath,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    });
   }
 }
 
@@ -179,18 +188,42 @@ function normalizeLimit(value: number | undefined): number {
 
 function parseSessionEventLogLine(line: string): SessionEventLogEntry | undefined {
   try {
-    const parsed = JSON.parse(line) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
-    const record = parsed as Partial<SessionEventLogEntry>;
-    if (record.version !== EVENT_LOG_VERSION) return undefined;
-    if (typeof record.ts !== 'string' || typeof record.session !== 'string') return undefined;
-    if (!isSessionEventKind(record.kind)) return undefined;
-    return record as SessionEventLogEntry;
+    const parsed = readRawSessionEventLogEntry(JSON.parse(line));
+    return parsed ? buildSessionEventLogEntry(parsed) : undefined;
   } catch {
     return undefined;
   }
 }
 
+function readRawSessionEventLogEntry(value: unknown): RawSessionEventLogEntry | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.version !== EVENT_LOG_VERSION) return undefined;
+  if (typeof value.ts !== 'string' || typeof value.session !== 'string') return undefined;
+  if (!isSessionEventKind(value.kind)) return undefined;
+  return value as RawSessionEventLogEntry;
+}
+
+function buildSessionEventLogEntry(parsed: RawSessionEventLogEntry): SessionEventLogEntry {
+  const details = isRecord(parsed.details) ? parsed.details : undefined;
+  return {
+    version: EVENT_LOG_VERSION,
+    ts: parsed.ts,
+    session: parsed.session,
+    kind: parsed.kind,
+    ...(typeof parsed.requestId === 'string' ? { requestId: parsed.requestId } : {}),
+    ...(typeof parsed.command === 'string' ? { command: parsed.command } : {}),
+    ...(isSessionEventStatus(parsed.status) ? { status: parsed.status } : {}),
+    ...(typeof parsed.summary === 'string' ? { summary: parsed.summary } : {}),
+    ...(details ? { details } : {}),
+  };
+}
+
 function isSessionEventKind(value: unknown): value is SessionEventLogEntry['kind'] {
   return value === 'request.started' || value === 'request.finished' || value === 'action.recorded';
+}
+
+function isSessionEventStatus(
+  value: unknown,
+): value is NonNullable<SessionEventLogEntry['status']> {
+  return value === 'ok' || value === 'error';
 }

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -5,6 +5,14 @@ import type { SessionRuntimeHints, SessionState } from './types.ts';
 import { recordActionEntry, type RecordActionEntry } from './session-action-recorder.ts';
 import { expandSessionPath, safeSessionName } from './session-paths.ts';
 import { SessionScriptWriter } from './session-script-writer.ts';
+import {
+  appendActionEvent,
+  appendSessionEvent,
+  readSessionEventLog,
+  resolveSessionEventLogPath,
+  type SessionEventLogInput,
+  type SessionEventLogPage,
+} from './session-event-log.ts';
 
 export class SessionStore {
   private readonly sessions = new Map<string, SessionState>();
@@ -51,7 +59,22 @@ export class SessionStore {
   }
 
   recordAction(session: SessionState, entry: RecordActionEntry): void {
-    recordActionEntry(session, entry);
+    const action = recordActionEntry(session, entry);
+    if (action) {
+      const sessionName = this.resolveStoredSessionName(session);
+      appendActionEvent(this.resolveEventLogPath(sessionName), sessionName, action);
+    }
+  }
+
+  recordEvent(sessionName: string, event: SessionEventLogInput): void {
+    appendSessionEvent(this.resolveEventLogPath(sessionName), sessionName, event);
+  }
+
+  readEvents(
+    sessionName: string,
+    options: { cursor?: string; limit?: number } = {},
+  ): SessionEventLogPage {
+    return readSessionEventLog(this.resolveEventLogPath(sessionName), options);
   }
 
   writeSessionLog(session: SessionState): void {
@@ -90,8 +113,19 @@ export class SessionStore {
     return path.join(this.resolveSessionDir(sessionName), 'app-log.pid');
   }
 
+  resolveEventLogPath(sessionName: string): string {
+    return resolveSessionEventLogPath(this.resolveSessionDir(sessionName));
+  }
+
   static expandHome(filePath: string, cwd?: string): string {
     return expandSessionPath(filePath, cwd);
+  }
+
+  private resolveStoredSessionName(session: SessionState): string {
+    for (const [name, value] of this.sessions) {
+      if (value === session) return name;
+    }
+    return session.name;
   }
 }
 

--- a/src/daemon/session-store.ts
+++ b/src/daemon/session-store.ts
@@ -8,6 +8,7 @@ import { SessionScriptWriter } from './session-script-writer.ts';
 import {
   appendActionEvent,
   appendSessionEvent,
+  flushSessionEventLogWrites,
   readSessionEventLog,
   resolveSessionEventLogPath,
   type SessionEventLogInput,
@@ -72,9 +73,15 @@ export class SessionStore {
 
   readEvents(
     sessionName: string,
-    options: { cursor?: string; limit?: number } = {},
+    options: { cursor?: string; limit?: number | string } = {},
   ): SessionEventLogPage {
     return readSessionEventLog(this.resolveEventLogPath(sessionName), options);
+  }
+
+  async flushEvents(sessionName?: string): Promise<void> {
+    await flushSessionEventLogWrites(
+      sessionName ? this.resolveEventLogPath(sessionName) : undefined,
+    );
   }
 
   writeSessionLog(session: SessionState): void {

--- a/src/daemon/web-session-names.ts
+++ b/src/daemon/web-session-names.ts
@@ -1,0 +1,8 @@
+import type { SessionStore } from './session-store.ts';
+
+export function openWebSessionNames(sessionStore: SessionStore): string[] {
+  return sessionStore
+    .toArray()
+    .filter((session) => session.device.platform === 'web')
+    .map((session) => session.name);
+}

--- a/test/integration/provider-scenarios/apple-platform-output-guard.test.ts
+++ b/test/integration/provider-scenarios/apple-platform-output-guard.test.ts
@@ -92,6 +92,7 @@ const DRIVEN_COMMANDS: Record<string, DriveSpec> = {
 
   // -- observability --
   [PUBLIC_COMMANDS.logs]: () => one(),
+  [PUBLIC_COMMANDS.events]: () => one(),
   [PUBLIC_COMMANDS.network]: () => one(),
   [PUBLIC_COMMANDS.audio]: () => one(),
   [PUBLIC_COMMANDS.screenshot]: ({ tmpDir }) => one([], { out: path.join(tmpDir, 'shot.png') }),

--- a/test/integration/provider-scenarios/remote-daemon-client.test.ts
+++ b/test/integration/provider-scenarios/remote-daemon-client.test.ts
@@ -317,10 +317,38 @@ function writeRemoteSuccess(
   payload: RemoteRpcRequest,
   state: RemoteDaemonState,
 ): void {
+  if (payload.params?.command === 'events') return writeEventsSuccess(res, payload);
   if (payload.params?.command === 'install') return writeInstallSuccess(res, payload);
   if (payload.params?.command === 'install_source') return writeInstallSourceSuccess(res, payload);
   if (payload.params?.command === 'record') return writeRecordSuccess(res, payload, state);
   writeScreenshotSuccess(res, payload, state.screenshotPath);
+}
+
+function writeEventsSuccess(res: http.ServerResponse, payload: RemoteRpcRequest): void {
+  writeJson(res, 200, {
+    jsonrpc: '2.0',
+    id: payload.id,
+    result: {
+      ok: true,
+      data: {
+        path: '/remote/sessions/default/events.ndjson',
+        cursor: payload.params?.positionals?.[1] ?? '0',
+        limit: Number(payload.params?.positionals?.[0] ?? 100),
+        nextCursor: '6',
+        events: [
+          {
+            version: 1,
+            ts: '2026-07-02T12:00:00.000Z',
+            session: 'default',
+            kind: 'action.recorded',
+            command: 'click',
+            summary: 'Tapped @e14',
+            details: { ref: '@e14' },
+          },
+        ],
+      },
+    },
+  });
 }
 
 function writeInstallSuccess(res: http.ServerResponse, payload: RemoteRpcRequest): void {
@@ -531,6 +559,25 @@ async function assertRecordingArtifactRoundTrip(
   assert.equal(recordStopRpc?.params?.meta?.clientArtifactPaths, undefined);
 }
 
+async function assertEventsRpc(
+  client: RemoteClient,
+  rpcRequests: RemoteRpcRequest[],
+): Promise<void> {
+  const page = await client.observability.events({ limit: 2, cursor: '4' });
+  assert.equal(page.path, '/remote/sessions/default/events.ndjson');
+  assert.equal(page.cursor, '4');
+  assert.equal(page.limit, 2);
+  assert.equal(page.nextCursor, '6');
+  assert.equal(Array.isArray(page.events), true);
+  assert.equal((page.events as Array<{ command?: string }>)[0]?.command, 'click');
+
+  const eventsRpc = rpcRequests.at(-1);
+  assert.equal(eventsRpc?.method, 'agent_device.command');
+  assert.equal(eventsRpc?.params?.command, 'events');
+  assert.deepEqual(eventsRpc?.params?.positionals, ['2', '4']);
+  assert.equal(eventsRpc?.params?.token, 'remote-token');
+}
+
 async function assertRemoteRpcErrorNormalization(client: RemoteClient): Promise<void> {
   await assert.rejects(
     async () => await client.sessions.list(),
@@ -584,6 +631,7 @@ test('Provider-backed integration remote daemon client materializes artifacts an
     await assertInstallUpload(client, paths, rpcRequests, uploadRequests);
     await assertInstallSourceUpload(client, paths, rpcRequests, uploadRequests);
     await assertRecordingArtifactRoundTrip(client, paths, rpcRequests);
+    await assertEventsRpc(client, rpcRequests);
     rejectRpcRequests();
     await assertRemoteRpcErrorNormalization(client);
   } finally {

--- a/test/integration/provider-scenarios/remote-daemon-client.test.ts
+++ b/test/integration/provider-scenarios/remote-daemon-client.test.ts
@@ -325,6 +325,10 @@ function writeRemoteSuccess(
 }
 
 function writeEventsSuccess(res: http.ServerResponse, payload: RemoteRpcRequest): void {
+  const positionals = payload.params?.positionals ?? [];
+  const limitArg = typeof positionals[0] === 'string' ? positionals[0] : undefined;
+  const cursorArg = typeof positionals[1] === 'string' ? positionals[1] : undefined;
+  const limit = limitArg === undefined || limitArg.trim() === '' ? 100 : Number(limitArg);
   writeJson(res, 200, {
     jsonrpc: '2.0',
     id: payload.id,
@@ -332,8 +336,8 @@ function writeEventsSuccess(res: http.ServerResponse, payload: RemoteRpcRequest)
       ok: true,
       data: {
         path: '/remote/sessions/default/events.ndjson',
-        cursor: payload.params?.positionals?.[1] ?? '0',
-        limit: Number(payload.params?.positionals?.[0] ?? 100),
+        cursor: cursorArg ?? '0',
+        limit,
         nextCursor: '6',
         events: [
           {
@@ -576,6 +580,16 @@ async function assertEventsRpc(
   assert.equal(eventsRpc?.params?.command, 'events');
   assert.deepEqual(eventsRpc?.params?.positionals, ['2', '4']);
   assert.equal(eventsRpc?.params?.token, 'remote-token');
+
+  const cursorOnlyPage = await client.observability.events({ cursor: '6' });
+  assert.equal(cursorOnlyPage.cursor, '6');
+  assert.equal(cursorOnlyPage.limit, 100);
+
+  const cursorOnlyRpc = rpcRequests.at(-1);
+  assert.equal(cursorOnlyRpc?.method, 'agent_device.command');
+  assert.equal(cursorOnlyRpc?.params?.command, 'events');
+  assert.deepEqual(cursorOnlyRpc?.params?.positionals, ['', '6']);
+  assert.equal(cursorOnlyRpc?.params?.token, 'remote-token');
 }
 
 async function assertRemoteRpcErrorNormalization(client: RemoteClient): Promise<void> {

--- a/test/integration/provider-scenarios/remote-daemon-client.test.ts
+++ b/test/integration/provider-scenarios/remote-daemon-client.test.ts
@@ -568,28 +568,34 @@ async function assertEventsRpc(
   rpcRequests: RemoteRpcRequest[],
 ): Promise<void> {
   const page = await client.observability.events({ limit: 2, cursor: '4' });
+  assertEventsPage(page);
+  assertEventsRpcRequest(rpcRequests.at(-1), ['2', '4']);
+
+  const cursorOnlyPage = await client.observability.events({ cursor: '6' });
+  assert.equal(cursorOnlyPage.cursor, '6');
+  assert.equal(cursorOnlyPage.limit, 100);
+  assertEventsRpcRequest(rpcRequests.at(-1), ['', '6']);
+}
+
+function assertEventsPage(
+  page: Awaited<ReturnType<RemoteClient['observability']['events']>>,
+): void {
   assert.equal(page.path, '/remote/sessions/default/events.ndjson');
   assert.equal(page.cursor, '4');
   assert.equal(page.limit, 2);
   assert.equal(page.nextCursor, '6');
   assert.equal(Array.isArray(page.events), true);
   assert.equal((page.events as Array<{ command?: string }>)[0]?.command, 'click');
+}
 
-  const eventsRpc = rpcRequests.at(-1);
+function assertEventsRpcRequest(
+  eventsRpc: RemoteRpcRequest | undefined,
+  positionals: string[],
+): void {
   assert.equal(eventsRpc?.method, 'agent_device.command');
   assert.equal(eventsRpc?.params?.command, 'events');
-  assert.deepEqual(eventsRpc?.params?.positionals, ['2', '4']);
+  assert.deepEqual(eventsRpc?.params?.positionals, positionals);
   assert.equal(eventsRpc?.params?.token, 'remote-token');
-
-  const cursorOnlyPage = await client.observability.events({ cursor: '6' });
-  assert.equal(cursorOnlyPage.cursor, '6');
-  assert.equal(cursorOnlyPage.limit, 100);
-
-  const cursorOnlyRpc = rpcRequests.at(-1);
-  assert.equal(cursorOnlyRpc?.method, 'agent_device.command');
-  assert.equal(cursorOnlyRpc?.params?.command, 'events');
-  assert.deepEqual(cursorOnlyRpc?.params?.positionals, ['', '6']);
-  assert.equal(cursorOnlyRpc?.params?.token, 'remote-token');
 }
 
 async function assertRemoteRpcErrorNormalization(client: RemoteClient): Promise<void> {

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -267,9 +267,11 @@ Additional CLI-backed methods are exposed on their domain groups with typed opti
 - `client.interactions.click()`, `press()`, `longPress()`, `swipe()`, `pan()`, `fling()`, `focus()`, `type()`, `fill()`, `scroll()`, `pinch()`, `rotateGesture()`, `transformGesture()`, `get()`, `is()`, `find()`
 - `client.replay.run()` and `client.replay.test()`
 - `client.batch.run()`
-- `client.observability.perf()`, `logs()`, `network()`, and `audio()`
+- `client.observability.perf()`, `logs()`, `events()`, `network()`, and `audio()`
 - `client.recording.record()` and `client.recording.trace()`
 - `client.settings.update()`
+
+`client.observability.events({ cursor, limit })` reads the session event timeline as paged JSON entries. Use `nextCursor` from the previous page to continue from the daemon-owned `events.ndjson` file without replaying already uploaded/displayed events.
 
 `client.observability.audio()` mirrors `audio probe start|status|stop`. Use it to collect compact RMS/peak dBFS buckets while other session actions continue:
 

--- a/website/docs/docs/client-api.md
+++ b/website/docs/docs/client-api.md
@@ -272,6 +272,7 @@ Additional CLI-backed methods are exposed on their domain groups with typed opti
 - `client.settings.update()`
 
 `client.observability.events({ cursor, limit })` reads the session event timeline as paged JSON entries. Use `nextCursor` from the previous page to continue from the daemon-owned `events.ndjson` file without replaying already uploaded/displayed events.
+The event timeline keeps operational context such as command/status/timing, paths, session/device/app identifiers, refs/selectors, and coordinates. Typed text, clipboard writes, push/event payloads, raw unknown command arguments, and matching raw message fragments are replaced with length-only placeholders.
 
 `client.observability.audio()` mirrors `audio probe start|status|stop`. Use it to collect compact RMS/peak dBFS buckets while other session actions continue:
 

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -835,6 +835,7 @@ agent-device network dump 25 --include headers --platform web # Browser requests
 - `logs start` appends to `app.log` and rotates to `app.log.1` when the file exceeds 5 MB.
 - `open` prints `Session state: <path>` and JSON includes `sessionStateDir`, `runnerLogPath`, `requestLogPath`, and `eventLogPath`. Use the session directory to inspect concurrent runs without parsing global daemon logs.
 - `events.ndjson` contains the session event timeline; `requests/<request-id>.ndjson` contains daemon request diagnostics; `runner.log` contains Apple runner and `xcodebuild` output.
+- Event timeline entries keep operational context such as command names, status, durations, paths, session/device/app identifiers, refs/selectors, and coordinates. Typed text, clipboard writes, push/event payloads, raw unknown command arguments, and matching raw message fragments are replaced with length-only placeholders. `--no-record` suppresses `action.recorded` entries, but request start/finish entries still record command/status/timing.
 - `network dump [limit] [summary|headers|body|all]` parses recent HTTP(s) entries from `app.log` for app/device sessions and from managed `agent-browser` request history for web sessions; `network log ...` is an alias.
 - Prefer `--include headers|body|all` when you want explicit detail level without relying on positional ordering.
 - On macOS, `logs` and `network dump` are app-scoped and parse Unified Logging output associated with the active session app.

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -823,6 +823,8 @@ agent-device logs clear                 # Truncate app.log + remove rotated app.
 agent-device logs clear --restart       # Stop stream, clear log files, and start streaming again
 agent-device logs doctor                # Show logs backend/tool checks and readiness hints
 agent-device logs mark "before submit"  # Insert timeline marker into app.log
+agent-device events                     # Print recent session request/action events
+agent-device events 50 100              # Page 50 events starting at cursor 100
 agent-device network dump 25            # Parse recent HTTP(s) requests (method/url/status)
 agent-device network dump 25 --include all # Include parsed headers/body when available (truncated)
 agent-device network dump 25 --include headers --platform web # Browser requests via managed agent-browser
@@ -831,8 +833,8 @@ agent-device network dump 25 --include headers --platform web # Browser requests
 - Supported on iOS simulator, iOS physical device, and Android.
 - Preferred debug entrypoint: `logs clear --restart` for clean-window repro loops.
 - `logs start` appends to `app.log` and rotates to `app.log.1` when the file exceeds 5 MB.
-- `open` prints `Session state: <path>` and JSON includes `sessionStateDir`, `runnerLogPath`, and `requestLogPath`. Use the session directory to inspect concurrent runs without parsing global daemon logs.
-- `requests/<request-id>.ndjson` contains daemon request diagnostics for the session; `runner.log` contains Apple runner and `xcodebuild` output.
+- `open` prints `Session state: <path>` and JSON includes `sessionStateDir`, `runnerLogPath`, `requestLogPath`, and `eventLogPath`. Use the session directory to inspect concurrent runs without parsing global daemon logs.
+- `events.ndjson` contains the session event timeline; `requests/<request-id>.ndjson` contains daemon request diagnostics; `runner.log` contains Apple runner and `xcodebuild` output.
 - `network dump [limit] [summary|headers|body|all]` parses recent HTTP(s) entries from `app.log` for app/device sessions and from managed `agent-browser` request history for web sessions; `network log ...` is an alias.
 - Prefer `--include headers|body|all` when you want explicit detail level without relying on positional ordering.
 - On macOS, `logs` and `network dump` are app-scoped and parse Unified Logging output associated with the active session app.

--- a/website/docs/docs/sessions.md
+++ b/website/docs/docs/sessions.md
@@ -24,6 +24,12 @@ Session artifact directories contain per-run evidence for concurrent agents:
 - `runner.log` - Apple runner and `xcodebuild` build/start output for this session.
 - `app.log` - app/device logs when `logs start` or `logs clear --restart` is active.
 
+`events.ndjson` is privacy-shaped for automation timelines: it preserves command names, status,
+durations, paths, session/device/app identifiers, refs/selectors, and coordinates, while replacing
+typed text, clipboard writes, push/event payloads, raw unknown command arguments, and matching raw
+message fragments with length-only placeholders. `--no-record` suppresses recorded action entries;
+request start/finish entries still record command, status, and timing.
+
 The top-level daemon log is for daemon lifecycle/startup issues. Use the session artifact directory first when debugging a specific run.
 
 Open an explicitly named session only when you intentionally want a shared/reusable handle:

--- a/website/docs/docs/sessions.md
+++ b/website/docs/docs/sessions.md
@@ -20,6 +20,7 @@ When a session is established, human output includes a `Session state: <path>` l
 Session artifact directories contain per-run evidence for concurrent agents:
 
 - `requests/<request-id>.ndjson` - daemon request diagnostics for this session.
+- `events.ndjson` - session event timeline for requests and recorded actions.
 - `runner.log` - Apple runner and `xcodebuild` build/start output for this session.
 - `app.log` - app/device logs when `logs start` or `logs clear --restart` is active.
 


### PR DESCRIPTION
## Summary
- Add a daemon-owned `events.ndjson` timeline under each session state dir so EAS and local tooling can show what the agent did during a run.
- Record request start/finish entries and recorded actions, with sensitive typed text redacted while keeping target/ref/coordinate and duration context.
- Expose the timeline through `agent-device events`, the typed observability client, and open-result `eventLogPath` for direct VM/local file collection.

## Validation
Verified with focused daemon/session-store/observability/CLI/remote-daemon tests, `pnpm typecheck`, `pnpm format`, `pnpm build`, and `pnpm check:unit` outside the sandbox. Unit + smoke passed: 2,979 unit tests and 9 smoke tests; the live web smoke stayed skipped because `AGENT_DEVICE_WEB_E2E` was not set.

Touched-file count: 23. Scope stayed within session event logging, observability command surface, client/open result plumbing, and remote RPC coverage.