### PR TITLE
feat: warm the iOS runner build cache from doctor and boot

### DIFF
--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -35,6 +35,8 @@ agent-device help dogfood
 
 Default loop: `open -> snapshot/-i -> get/is/find or press/fill/scroll/wait -> verify -> close`.
 
+On a fresh machine (first iOS run), start with `agent-device doctor --platform ios`: it preflights the environment and warms the iOS runner build cache in the background so the first `open` is fast.
+
 Use this skill only to route into version-matched CLI help. Let `help workflow` provide exact command shapes, platform limits, and current workflow guidance.
 
 For precise location workflows, read the installed `settings` help before planning so coordinate support and platform limits come from the active CLI version.

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -133,6 +133,9 @@ Version-matched operating guide for normal agent-device work.
 Core loop:
   devices/apps -> open -> snapshot or snapshot -i -> get/is/find/wait or press/fill/scroll/back -> verify -> close
 
+Fresh machine or first iOS run:
+  Run agent-device doctor --platform ios first. Besides preflight checks it warms the iOS XCTest runner build cache in the background, so the first open skips the runner build (~10s). To block until fully warm instead, run agent-device prepare ios-runner.
+
 Command shape:
   Plans should use agent-device commands, not raw platform tools, pseudo commands, package-manager aliases, or helper prose.
   If the user asks for a command plan, final output should be command lines only: no intro sentence, numbered list, Markdown fence, shell pipe, grep/head/tail helper, or explanatory bullets.
@@ -569,7 +572,7 @@ Choose the next help topic:
   Remote/cloud config, leases, and local service tunnels: help remote.
 
 React Native dev loop:
-  Before QA/dogfood runs, use doctor to separate environment setup from app failures:
+  Before QA/dogfood runs, use doctor to separate environment setup from app failures (on iOS simulators doctor also warms the runner build cache in the background):
     agent-device doctor --platform android
     agent-device doctor --platform ios
     agent-device doctor --platform android --app com.example.app

--- a/src/commands/management/doctor.ts
+++ b/src/commands/management/doctor.ts
@@ -29,7 +29,7 @@ const doctorCliSchema = {
   usageOverride:
     'doctor [--platform ios|android|macos|linux|web|apple] [--app <id-or-name>] [--remote]',
   helpDescription:
-    'Read-only preflight for QA and dogfood runs. Reports local device inventory, active sessions, optional app discovery, scoped toolchain info, and Metro reachability inferred from cwd/runtime. Pass --app to verify a target app on the one matching booted device without opening a session. Use --remote to check remote connection setup without probing local devices. Default output is compact; use --json for full checks and evidence.',
+    'Preflight for QA and dogfood runs. Reports local device inventory, active sessions, optional app discovery, scoped toolchain info, and Metro reachability inferred from cwd/runtime. On iOS simulators it also warms the XCTest runner build cache in the background when missing, so the first open on a fresh machine skips the runner build — run doctor first on new setups. Pass --app to verify a target app on the one matching booted device without opening a session. Use --remote to check remote connection setup without probing local devices. Default output is compact; use --json for full checks and evidence.',
   summary: 'Preflight device, app, Metro, and RN/Expo readiness',
   allowedFlags: ['targetApp', 'remote'],
 } as const satisfies CommandSchemaOverride;

--- a/src/daemon/handlers/__tests__/session-doctor-warmup.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-warmup.test.ts
@@ -10,7 +10,7 @@ import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts
 import type { DaemonResponse } from '../../types.ts';
 
 vi.mock('../../../platforms/apple/core/runner/runner-client.ts', () => ({
-  hasCachedAppleRunnerArtifact: vi.fn(() => false),
+  hasCachedAppleRunnerArtifact: vi.fn(async () => false),
   prewarmAppleRunnerCache: vi.fn(),
 }));
 vi.mock('../session-doctor-device.ts', async (importOriginal) => {
@@ -62,7 +62,7 @@ const IOS_SIMULATOR: DeviceInfo = {
 
 beforeEach(() => {
   mockHasCachedArtifact.mockReset();
-  mockHasCachedArtifact.mockReturnValue(false);
+  mockHasCachedArtifact.mockResolvedValue(false);
   mockPrewarmCache.mockReset();
   mockIsActiveProviderDevice.mockReset();
   mockIsActiveProviderDevice.mockReturnValue(false);
@@ -108,7 +108,7 @@ test('doctor warms the iOS runner cache in the background when the artifact is m
 });
 
 test('doctor reports a cached iOS runner artifact without rebuilding', async () => {
-  mockHasCachedArtifact.mockReturnValue(true);
+  mockHasCachedArtifact.mockResolvedValue(true);
 
   const response = await withMockedPlatform('darwin', () =>
     runDoctorWithSessionDevice(IOS_SIMULATOR),

--- a/src/daemon/handlers/__tests__/session-doctor-warmup.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-warmup.test.ts
@@ -4,6 +4,7 @@ import {
   hasCachedAppleRunnerArtifact,
   prewarmAppleRunnerCache,
 } from '../../../platforms/apple/core/runner/runner-client.ts';
+import { isActiveProviderDevice } from '../../../provider-device-runtime.ts';
 import { handleDoctorCommand } from '../session-doctor.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
 import type { DaemonResponse } from '../../types.ts';
@@ -32,9 +33,23 @@ vi.mock('../session-doctor-android.ts', () => ({
 vi.mock('../session-doctor-metro.ts', () => ({
   probeMetro: vi.fn(async () => ({ id: 'metro', status: 'pass', summary: 'mocked' })),
 }));
+vi.mock('../../../provider-device-runtime.ts', () => ({
+  isActiveProviderDevice: vi.fn(() => false),
+}));
 
 const mockHasCachedArtifact = vi.mocked(hasCachedAppleRunnerArtifact);
 const mockPrewarmCache = vi.mocked(prewarmAppleRunnerCache);
+const mockIsActiveProviderDevice = vi.mocked(isActiveProviderDevice);
+
+async function withMockedPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  }
+}
 
 const IOS_SIMULATOR: DeviceInfo = {
   platform: 'apple',
@@ -49,6 +64,8 @@ beforeEach(() => {
   mockHasCachedArtifact.mockReset();
   mockHasCachedArtifact.mockReturnValue(false);
   mockPrewarmCache.mockReset();
+  mockIsActiveProviderDevice.mockReset();
+  mockIsActiveProviderDevice.mockReturnValue(false);
 });
 
 async function runDoctorWithSessionDevice(device: DeviceInfo): Promise<DaemonResponse | null> {
@@ -79,7 +96,9 @@ function readCheck(response: DaemonResponse | null, id: string): Record<string, 
 }
 
 test('doctor warms the iOS runner cache in the background when the artifact is missing', async () => {
-  const response = await runDoctorWithSessionDevice(IOS_SIMULATOR);
+  const response = await withMockedPlatform('darwin', () =>
+    runDoctorWithSessionDevice(IOS_SIMULATOR),
+  );
 
   expect(response?.ok).toBe(true);
   expect(mockPrewarmCache).toHaveBeenCalledTimes(1);
@@ -91,7 +110,9 @@ test('doctor warms the iOS runner cache in the background when the artifact is m
 test('doctor reports a cached iOS runner artifact without rebuilding', async () => {
   mockHasCachedArtifact.mockReturnValue(true);
 
-  const response = await runDoctorWithSessionDevice(IOS_SIMULATOR);
+  const response = await withMockedPlatform('darwin', () =>
+    runDoctorWithSessionDevice(IOS_SIMULATOR),
+  );
 
   expect(response?.ok).toBe(true);
   expect(mockPrewarmCache).not.toHaveBeenCalled();
@@ -100,11 +121,35 @@ test('doctor reports a cached iOS runner artifact without rebuilding', async () 
 });
 
 test('doctor skips the runner warmup for non-simulator devices', async () => {
-  const response = await runDoctorWithSessionDevice({
-    ...IOS_SIMULATOR,
-    id: 'doctor-device-1',
-    kind: 'device',
-  });
+  const response = await withMockedPlatform('darwin', () =>
+    runDoctorWithSessionDevice({
+      ...IOS_SIMULATOR,
+      id: 'doctor-device-1',
+      kind: 'device',
+    }),
+  );
+
+  expect(response?.ok).toBe(true);
+  expect(mockPrewarmCache).not.toHaveBeenCalled();
+  expect(readCheck(response, 'ios-runner-cache')).toBeNull();
+});
+
+test('doctor skips the runner warmup on non-macOS hosts', async () => {
+  const response = await withMockedPlatform('linux', () =>
+    runDoctorWithSessionDevice(IOS_SIMULATOR),
+  );
+
+  expect(response?.ok).toBe(true);
+  expect(mockPrewarmCache).not.toHaveBeenCalled();
+  expect(readCheck(response, 'ios-runner-cache')).toBeNull();
+});
+
+test('doctor skips the runner warmup for provider-backed devices', async () => {
+  mockIsActiveProviderDevice.mockReturnValue(true);
+
+  const response = await withMockedPlatform('darwin', () =>
+    runDoctorWithSessionDevice(IOS_SIMULATOR),
+  );
 
   expect(response?.ok).toBe(true);
   expect(mockPrewarmCache).not.toHaveBeenCalled();

--- a/src/daemon/handlers/__tests__/session-doctor-warmup.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-warmup.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { DeviceInfo } from '../../../kernel/device.ts';
+import {
+  hasCachedAppleRunnerArtifact,
+  prewarmAppleRunnerCache,
+} from '../../../platforms/apple/core/runner/runner-client.ts';
+import { handleDoctorCommand } from '../session-doctor.ts';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+import type { DaemonResponse } from '../../types.ts';
+
+vi.mock('../../../platforms/apple/core/runner/runner-client.ts', () => ({
+  hasCachedAppleRunnerArtifact: vi.fn(() => false),
+  prewarmAppleRunnerCache: vi.fn(),
+}));
+vi.mock('../session-doctor-device.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../session-doctor-device.ts')>();
+  return {
+    ...actual,
+    appendDeviceInventoryCheck: vi.fn(async () => undefined),
+    resolveDoctorDeviceForAppCheck: vi.fn(() => undefined),
+  };
+});
+vi.mock('../session-doctor-toolchain.ts', () => ({
+  appendToolchainChecks: vi.fn(async () => {}),
+}));
+vi.mock('../session-doctor-app.ts', () => ({
+  appendAppChecks: vi.fn(async () => {}),
+}));
+vi.mock('../session-doctor-android.ts', () => ({
+  appendAndroidChecks: vi.fn(async () => {}),
+}));
+vi.mock('../session-doctor-metro.ts', () => ({
+  probeMetro: vi.fn(async () => ({ id: 'metro', status: 'pass', summary: 'mocked' })),
+}));
+
+const mockHasCachedArtifact = vi.mocked(hasCachedAppleRunnerArtifact);
+const mockPrewarmCache = vi.mocked(prewarmAppleRunnerCache);
+
+const IOS_SIMULATOR: DeviceInfo = {
+  platform: 'apple',
+  id: 'doctor-sim-1',
+  name: 'iPhone 17 Pro',
+  kind: 'simulator',
+  target: 'mobile',
+  booted: true,
+};
+
+beforeEach(() => {
+  mockHasCachedArtifact.mockReset();
+  mockHasCachedArtifact.mockReturnValue(false);
+  mockPrewarmCache.mockReset();
+});
+
+async function runDoctorWithSessionDevice(device: DeviceInfo): Promise<DaemonResponse | null> {
+  const sessionStore = makeSessionStore('agent-device-doctor-warmup-');
+  sessionStore.set('doctor-session', {
+    name: 'doctor-session',
+    createdAt: Date.now(),
+    device,
+    actions: [],
+  });
+  return await handleDoctorCommand({
+    req: {
+      token: 't',
+      session: 'doctor-session',
+      command: 'doctor',
+      positionals: [],
+      flags: { session: 'doctor-session' },
+    },
+    sessionName: 'doctor-session',
+    sessionStore,
+  });
+}
+
+function readCheck(response: DaemonResponse | null, id: string): Record<string, unknown> | null {
+  if (!response?.ok) return null;
+  const checks = (response.data as { checks?: Array<Record<string, unknown>> }).checks ?? [];
+  return checks.find((check) => check.id === id) ?? null;
+}
+
+test('doctor warms the iOS runner cache in the background when the artifact is missing', async () => {
+  const response = await runDoctorWithSessionDevice(IOS_SIMULATOR);
+
+  expect(response?.ok).toBe(true);
+  expect(mockPrewarmCache).toHaveBeenCalledTimes(1);
+  const check = readCheck(response, 'ios-runner-cache');
+  expect(check?.status).toBe('pass');
+  expect(String(check?.summary)).toMatch(/background/i);
+});
+
+test('doctor reports a cached iOS runner artifact without rebuilding', async () => {
+  mockHasCachedArtifact.mockReturnValue(true);
+
+  const response = await runDoctorWithSessionDevice(IOS_SIMULATOR);
+
+  expect(response?.ok).toBe(true);
+  expect(mockPrewarmCache).not.toHaveBeenCalled();
+  const check = readCheck(response, 'ios-runner-cache');
+  expect(String(check?.summary)).toMatch(/cached/i);
+});
+
+test('doctor skips the runner warmup for non-simulator devices', async () => {
+  const response = await runDoctorWithSessionDevice({
+    ...IOS_SIMULATOR,
+    id: 'doctor-device-1',
+    kind: 'device',
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(mockPrewarmCache).not.toHaveBeenCalled();
+  expect(readCheck(response, 'ios-runner-cache')).toBeNull();
+});

--- a/src/daemon/handlers/__tests__/session-state-boot-warmup.test.ts
+++ b/src/daemon/handlers/__tests__/session-state-boot-warmup.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { DeviceInfo } from '../../../kernel/device.ts';
+import { prewarmAppleRunnerCache } from '../../../platforms/apple/core/runner/runner-client.ts';
+import { resolveCommandDevice } from '../session-device-utils.ts';
+import { ensureDeviceReady } from '../../device-ready.ts';
+import { handleSessionStateCommands } from '../session-state.ts';
+import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
+
+vi.mock('../../../platforms/apple/core/runner/runner-client.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../platforms/apple/core/runner/runner-client.ts')>();
+  return { ...actual, prewarmAppleRunnerCache: vi.fn() };
+});
+vi.mock('../session-device-utils.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../session-device-utils.ts')>();
+  return { ...actual, resolveCommandDevice: vi.fn() };
+});
+vi.mock('../../device-ready.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../device-ready.ts')>();
+  return { ...actual, ensureDeviceReady: vi.fn(async () => {}) };
+});
+
+const mockPrewarmCache = vi.mocked(prewarmAppleRunnerCache);
+const mockResolveCommandDevice = vi.mocked(resolveCommandDevice);
+const mockEnsureDeviceReady = vi.mocked(ensureDeviceReady);
+
+const BOOTED_IOS_SIMULATOR: DeviceInfo = {
+  platform: 'apple',
+  id: 'boot-sim-1',
+  name: 'iPhone 17 Pro',
+  kind: 'simulator',
+  target: 'mobile',
+  booted: true,
+};
+
+beforeEach(() => {
+  mockPrewarmCache.mockReset();
+  mockResolveCommandDevice.mockReset();
+  mockEnsureDeviceReady.mockReset();
+  mockEnsureDeviceReady.mockResolvedValue(undefined);
+});
+
+async function runBoot(device: DeviceInfo) {
+  mockResolveCommandDevice.mockResolvedValue(device);
+  return await handleSessionStateCommands({
+    req: {
+      token: 't',
+      session: 'default',
+      command: 'boot',
+      positionals: [],
+      flags: { platform: 'ios', udid: device.id },
+    },
+    sessionName: 'default',
+    logPath: '/tmp/daemon.log',
+    sessionStore: makeSessionStore('agent-device-boot-warmup-'),
+  });
+}
+
+test('boot warms the iOS runner cache for an already-booted simulator', async () => {
+  const response = await runBoot(BOOTED_IOS_SIMULATOR);
+
+  expect(response?.ok).toBe(true);
+  expect(mockPrewarmCache).toHaveBeenCalledTimes(1);
+  expect(mockPrewarmCache.mock.calls[0]?.[0]).toMatchObject({ id: 'boot-sim-1' });
+});
+
+test('boot does not warm the runner cache for real iOS devices', async () => {
+  const response = await runBoot({
+    ...BOOTED_IOS_SIMULATOR,
+    id: 'boot-device-1',
+    kind: 'device',
+  });
+
+  expect(response?.ok).toBe(true);
+  expect(mockPrewarmCache).not.toHaveBeenCalled();
+});

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -72,7 +72,7 @@ export async function handleDoctorCommand(params: {
     options,
     session,
   });
-  appendIosRunnerWarmupCheck(checks, appCheckDevice ?? resolveWarmupSimulator(inventory));
+  await appendIosRunnerWarmupCheck(checks, appCheckDevice ?? resolveWarmupSimulator(inventory));
   return doctorResponse(checks, options, { device: appCheckDevice, includeMetro: true, inventory });
 }
 
@@ -91,7 +91,10 @@ function resolveWarmupSimulator(
   return simulators.find((device) => device.booted === true) ?? simulators[0];
 }
 
-function appendIosRunnerWarmupCheck(checks: DoctorCheck[], device: DeviceInfo | undefined): void {
+async function appendIosRunnerWarmupCheck(
+  checks: DoctorCheck[],
+  device: DeviceInfo | undefined,
+): Promise<void> {
   if (!device || !isIosFamily(device) || device.kind !== 'simulator') return;
   // The warmup drives local xcodebuild: skip on non-macOS hosts and for
   // provider-backed devices, whose runner lives with the remote daemon.
@@ -102,7 +105,7 @@ function appendIosRunnerWarmupCheck(checks: DoctorCheck[], device: DeviceInfo | 
     status: 'progress',
     message: `Checking iOS runner build cache (${device.name})...`,
   });
-  if (hasCachedAppleRunnerArtifact(device)) {
+  if (await hasCachedAppleRunnerArtifact(device)) {
     appendDoctorCheck(checks, {
       id: 'ios-runner-cache',
       status: 'pass',

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { AndroidAdbExecutor } from '../../platforms/android/adb-executor.ts';
 import { isIosFamily, publicPlatformString, type DeviceInfo } from '../../kernel/device.ts';
+import { emitRequestProgress } from '../request-progress.ts';
+import { isActiveProviderDevice } from '../../provider-device-runtime.ts';
 import { readVersion } from '../../utils/version.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
@@ -91,6 +93,15 @@ function resolveWarmupSimulator(
 
 function appendIosRunnerWarmupCheck(checks: DoctorCheck[], device: DeviceInfo | undefined): void {
   if (!device || !isIosFamily(device) || device.kind !== 'simulator') return;
+  // The warmup drives local xcodebuild: skip on non-macOS hosts and for
+  // provider-backed devices, whose runner lives with the remote daemon.
+  // (--remote returns before device checks and never reaches here.)
+  if (process.platform !== 'darwin' || isActiveProviderDevice(device)) return;
+  emitRequestProgress({
+    type: 'command',
+    status: 'progress',
+    message: `Checking iOS runner build cache (${device.name})...`,
+  });
   if (hasCachedAppleRunnerArtifact(device)) {
     appendDoctorCheck(checks, {
       id: 'ios-runner-cache',
@@ -100,6 +111,11 @@ function appendIosRunnerWarmupCheck(checks: DoctorCheck[], device: DeviceInfo | 
     return;
   }
   void prewarmAppleRunnerCache(device, {});
+  emitRequestProgress({
+    type: 'command',
+    status: 'progress',
+    message: `Warming iOS runner build cache in the background (${device.name})...`,
+  });
   appendDoctorCheck(checks, {
     id: 'ios-runner-cache',
     status: 'pass',

--- a/src/daemon/handlers/session-doctor.ts
+++ b/src/daemon/handlers/session-doctor.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { AndroidAdbExecutor } from '../../platforms/android/adb-executor.ts';
-import { publicPlatformString, type DeviceInfo } from '../../kernel/device.ts';
+import { isIosFamily, publicPlatformString, type DeviceInfo } from '../../kernel/device.ts';
 import { readVersion } from '../../utils/version.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
@@ -27,6 +27,10 @@ import {
 } from './session-doctor-output.ts';
 import { appendToolchainChecks } from './session-doctor-toolchain.ts';
 import type { DoctorCheck, DoctorOptions } from './session-doctor-types.ts';
+import {
+  hasCachedAppleRunnerArtifact,
+  prewarmAppleRunnerCache,
+} from '../../platforms/apple/core/runner/runner-client.ts';
 
 export async function handleDoctorCommand(params: {
   req: DaemonRequest;
@@ -66,7 +70,43 @@ export async function handleDoctorCommand(params: {
     options,
     session,
   });
+  appendIosRunnerWarmupCheck(checks, appCheckDevice ?? resolveWarmupSimulator(inventory));
   return doctorResponse(checks, options, { device: appCheckDevice, includeMetro: true, inventory });
+}
+
+// Doctor doubles as the fresh-machine warmup: when an iOS simulator is in
+// scope and the runner artifact is not built yet, kick the build in the
+// background so the first `open` skips the ~10s xcodebuild build. The check
+// line makes the warmup visible either way. Any simulator record works as
+// the build device — the artifact builds against a generic simulator
+// destination and is shared across simulators and runtimes.
+function resolveWarmupSimulator(
+  inventory: DoctorDeviceInventory | undefined,
+): DeviceInfo | undefined {
+  const simulators = (inventory?.devices ?? []).filter(
+    (device) => isIosFamily(device) && device.kind === 'simulator',
+  );
+  return simulators.find((device) => device.booted === true) ?? simulators[0];
+}
+
+function appendIosRunnerWarmupCheck(checks: DoctorCheck[], device: DeviceInfo | undefined): void {
+  if (!device || !isIosFamily(device) || device.kind !== 'simulator') return;
+  if (hasCachedAppleRunnerArtifact(device)) {
+    appendDoctorCheck(checks, {
+      id: 'ios-runner-cache',
+      status: 'pass',
+      summary: 'iOS runner artifact cached; first open skips the runner build',
+    });
+    return;
+  }
+  void prewarmAppleRunnerCache(device, {});
+  appendDoctorCheck(checks, {
+    id: 'ios-runner-cache',
+    status: 'pass',
+    summary:
+      'iOS runner build started in the background; the first open gets faster once it completes',
+    hint: 'Run `agent-device prepare ios-runner` to wait for a fully warmed runner instead.',
+  });
 }
 
 function resolveDoctorStateDir(sessionStore: SessionStore, sessionName: string): string {

--- a/src/daemon/handlers/session-state.ts
+++ b/src/daemon/handlers/session-state.ts
@@ -11,6 +11,7 @@ import { SessionStore } from '../session-store.ts';
 import { ensureDeviceReady } from '../device-ready.ts';
 import { shutdownDeviceTarget } from '../target-shutdown.ts';
 import { createAppleRunnerCachePrewarmOnColdBoot } from '../apple-runner-options.ts';
+import { prewarmAppleRunnerCache } from '../../platforms/apple/core/runner/runner-client.ts';
 import {
   hasExplicitSessionFlag,
   requireSessionOrExplicitSelector,
@@ -267,6 +268,15 @@ export async function handleSessionStateCommands(params: {
 
     const unsupported = requireCommandSupported('boot', device);
     if (unsupported) return unsupported;
+
+    // Cold boots warm the runner artifact cache via the
+    // onIosSimulatorColdBootStart hook above; an already-booted simulator
+    // never fires it, so kick the best-effort warmup here — boot is a
+    // natural fresh-machine entry point and a cached artifact makes this a
+    // fast no-op.
+    if (isIosFamily(device) && device.kind === 'simulator') {
+      void prewarmAppleRunnerCache(device, {});
+    }
 
     return {
       ok: true,

--- a/src/platforms/apple/core/__tests__/runner-cache-probe.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-cache-probe.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import type { DeviceInfo } from '../../../../kernel/device.ts';
+import { hasCachedAppleRunnerArtifact } from '../runner/runner-xctestrun.ts';
+
+const simulator: DeviceInfo = {
+  platform: 'apple',
+  id: 'cache-probe-sim-1',
+  name: 'iPhone 17 Pro',
+  kind: 'simulator',
+  target: 'mobile',
+  booted: true,
+};
+
+let derivedDir: string;
+
+beforeEach(() => {
+  derivedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-cache-probe-'));
+  process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH = derivedDir;
+});
+
+afterEach(() => {
+  delete process.env.AGENT_DEVICE_IOS_RUNNER_DERIVED_PATH;
+  fs.rmSync(derivedDir, { recursive: true, force: true });
+});
+
+test('probe reports no cache for an empty derived directory', async () => {
+  expect(await hasCachedAppleRunnerArtifact(simulator)).toBe(false);
+});
+
+test('probe rejects a partial cache holding only a stray xctestrun file', async () => {
+  // Regression: the probe used to treat any .xctestrun file as a usable
+  // cache, while the ensure path rejects it (no cache metadata, no product
+  // validation) and rebuilds — making doctor skip a warmup the first open
+  // still had to pay for.
+  const productsDir = path.join(derivedDir, 'Build', 'Products');
+  fs.mkdirSync(productsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(
+      productsDir,
+      'AgentDeviceRunner_AgentDeviceRunnerUITests_iphonesimulator26.2-arm64.xctestrun',
+    ),
+    'not a real xctestrun plist',
+    'utf8',
+  );
+
+  expect(await hasCachedAppleRunnerArtifact(simulator)).toBe(false);
+});

--- a/src/platforms/apple/core/runner/runner-client.ts
+++ b/src/platforms/apple/core/runner/runner-client.ts
@@ -181,6 +181,7 @@ export {
   resolveRunnerSigningBuildSettings,
   resolveRunnerBundleBuildSettings,
   assertSafeDerivedCleanup,
+  hasCachedAppleRunnerArtifact,
   IOS_RUNNER_CONTAINER_BUNDLE_IDS,
 } from './runner-xctestrun.ts';
 

--- a/src/platforms/apple/core/runner/runner-xctestrun.ts
+++ b/src/platforms/apple/core/runner/runner-xctestrun.ts
@@ -748,6 +748,19 @@ export function shouldDeleteRunnerDerivedRootEntry(entryName: string): boolean {
   return RUNNER_ROOT_TRANSIENT_ENTRY_NAMES.has(entryName);
 }
 
+// Cheap cache probe for preflight surfaces (doctor): does the expected
+// derived location already hold a usable xctestrun artifact? Resolving the
+// expected metadata stats the runner sources and reads tool versions
+// (~100ms, cached per process) but never builds.
+export function hasCachedAppleRunnerArtifact(device: DeviceInfo): boolean {
+  try {
+    const derived = resolveRunnerDerivedPath(device, resolveExpectedRunnerCacheMetadata(device));
+    return findXctestrun(derived, device) !== null;
+  } catch {
+    return false;
+  }
+}
+
 export function resolveRunnerCacheMetadataPath(derived: string): string {
   return path.join(derived, RUNNER_CACHE_METADATA_FILE);
 }

--- a/src/platforms/apple/core/runner/runner-xctestrun.ts
+++ b/src/platforms/apple/core/runner/runner-xctestrun.ts
@@ -533,13 +533,11 @@ async function ensureXctestrunUnderCacheLock(params: {
 }): Promise<RunnerXctestrunArtifact> {
   const { device, options, projectRoot, expectedCacheMetadata, derived } = params;
   cleanRunnerDerivedBeforeEvaluation(derived, params.forceRebuild);
-  const existing = await evaluateExistingXctestrun({
+  const existing = await evaluateExistingXctestrunForDevice({
+    device,
     derived,
     projectRoot,
     expectedCacheMetadata,
-    findXctestrun: (root) => findXctestrun(root, device),
-    xctestrunReferencesProjectRoot,
-    resolveExistingXctestrunProductPaths,
   });
   const cache =
     existing.reason === 'reuse_ready' ? 'exact' : existing.xctestrunPath ? 'restore-key' : 'miss';
@@ -748,17 +746,43 @@ export function shouldDeleteRunnerDerivedRootEntry(entryName: string): boolean {
   return RUNNER_ROOT_TRANSIENT_ENTRY_NAMES.has(entryName);
 }
 
-// Cheap cache probe for preflight surfaces (doctor): does the expected
-// derived location already hold a usable xctestrun artifact? Resolving the
-// expected metadata stats the runner sources and reads tool versions
-// (~100ms, cached per process) but never builds.
-export function hasCachedAppleRunnerArtifact(device: DeviceInfo): boolean {
+// Cache probe for preflight surfaces (doctor): runs the same no-build reuse
+// evaluation as the ensure path (cache metadata + product-path validation),
+// so a partial or stale cache never reports as ready. Resolving the expected
+// metadata stats the runner sources and reads tool versions (~100ms, cached
+// per process) but never builds.
+export async function hasCachedAppleRunnerArtifact(device: DeviceInfo): Promise<boolean> {
   try {
-    const derived = resolveRunnerDerivedPath(device, resolveExpectedRunnerCacheMetadata(device));
-    return findXctestrun(derived, device) !== null;
+    const projectRoot = findProjectRoot();
+    const expectedCacheMetadata = resolveExpectedRunnerCacheMetadata(device, projectRoot);
+    const derived = resolveRunnerDerivedPath(device, expectedCacheMetadata);
+    const existing = await evaluateExistingXctestrunForDevice({
+      device,
+      derived,
+      projectRoot,
+      expectedCacheMetadata,
+    });
+    return existing.reason === 'reuse_ready';
   } catch {
     return false;
   }
+}
+
+function evaluateExistingXctestrunForDevice(params: {
+  device: DeviceInfo;
+  derived: string;
+  projectRoot: string;
+  expectedCacheMetadata: RunnerXctestrunCacheMetadata;
+}): Promise<ExistingXctestrunState> {
+  const { device, derived, projectRoot, expectedCacheMetadata } = params;
+  return evaluateExistingXctestrun({
+    derived,
+    projectRoot,
+    expectedCacheMetadata,
+    findXctestrun: (root) => findXctestrun(root, device),
+    xctestrunReferencesProjectRoot,
+    resolveExistingXctestrunProductPaths,
+  });
 }
 
 export function resolveRunnerCacheMetadataPath(derived: string): string {


### PR DESCRIPTION
## Summary

Cold-cold startup — the first agent-device run ever on a machine — pays a ~10.6s `xcodebuild build-without-testing` before the first `open` can even start the runner ramp. The background cache prewarm (`prewarmAppleRunnerCache` → `ensureXctestrunArtifact`) already existed, but its only trigger was simulator *cold boot during open* — too late for the fresh-machine flow, where the build lands inside the user's first open (and inside demo videos).

- **`doctor` is now the fresh-machine warmup.** It resolves an iOS simulator from the session or the device inventory (booted preferred; any record works — the artifact builds against a generic simulator destination and is shared across simulators and runtimes, verified by identical cache keys for iOS 18.6 and 26.2 devices). When the artifact is missing it kicks the detached best-effort build and reports it as an `ios-runner-cache` check: *"build started in the background"* → later runs show *"artifact cached; first open skips the runner build"*.
- **`boot` fires the same warmup for already-booted simulators** (cold boots were already covered by the `onIosSimulatorColdBootStart` hook; the two paths serialize on the artifact cache lock).
- **Docs teach the pattern where agents will find it**: `help workflow` gains a "Fresh machine or first iOS run" section, `help debugging`'s doctor block notes the warmup, `doctor --help` no longer claims to be strictly read-only, and the agent-device skill tells models to start with `doctor --platform ios` on fresh setups — so small models (Haiku) get the fast path from the docs they actually read.

- **Progressive display + environment guards** (follow-up commit): doctor emits request-progress lines while it works — `Checking iOS runner build cache (iPhone 17 Pro)...` then `Warming iOS runner build cache in the background (...)` — so the warmup is visible as it happens, not only in the final check list. The warmup is skipped on non-macOS hosts and for provider-backed devices (their runner lives with the remote daemon); `--remote` already returned before device checks and never reaches it. Both guards are unit-tested with a mocked platform.

## Impact

Cold-cold to first snapshot drops from ~15–22s (build + ramp + app) to the normal daemon-cold ~4.5s, provided any `doctor` or `boot` ran beforehand — which is precisely the onboarding flow the docs prescribe. No behavior change when the artifact is already cached (the check reports and does nothing).

## Validation

- Live: wiped `derived/ios-simulator` → `doctor --platform ios` returned immediately with the warming check while the build ran detached → artifact present ~15s later → second doctor reports cached.
- 5 new unit tests: doctor warms when missing / reports cached without rebuilding / skips real devices; boot warms already-booted sims / skips real devices. 553 handler tests green.
- typecheck / lint / format / build clean.
