### PR TITLE
fix: hint @ref when a bare snapshot ref is passed as interaction target

### DIFF
--- a/src/__tests__/cli-grammar.test.ts
+++ b/src/__tests__/cli-grammar.test.ts
@@ -54,6 +54,33 @@ test('interaction and fill grammar share ref, selector, and point parsing', () =
   });
 });
 
+test('bare snapshot refs without @ prefix throw helpful error', () => {
+  assert.throws(
+    () => readInputFromCli('click', ['e3'], BASE_FLAGS),
+    (err: any) => {
+      assert.equal(err.code, 'INVALID_ARGS');
+      assert.match(err.message, /Did you mean "@e3"\?/);
+      return true;
+    },
+  );
+  assert.throws(
+    () => readInputFromCli('press', ['e123'], BASE_FLAGS),
+    (err: any) => {
+      assert.equal(err.code, 'INVALID_ARGS');
+      assert.match(err.message, /Did you mean "@e123"\?/);
+      return true;
+    },
+  );
+  assert.throws(
+    () => readInputFromCli('fill', ['e5', 'text'], BASE_FLAGS),
+    (err: any) => {
+      assert.equal(err.code, 'INVALID_ARGS');
+      assert.match(err.message, /Did you mean "@e5"\?/);
+      return true;
+    },
+  );
+});
+
 test('find and is grammar decodes command action positionals', () => {
   const findOptions = readInputFromCli('find', ['label', 'Continue', 'wait', '3000'], {
     ...BASE_FLAGS,

--- a/src/core/interaction-positionals.ts
+++ b/src/core/interaction-positionals.ts
@@ -1,3 +1,4 @@
+import { AppError } from '../kernel/errors.ts';
 import { splitSelectorFromArgs } from '../utils/selectors-parse.ts';
 
 type PositionalInteractionTarget =
@@ -10,12 +11,20 @@ export type DecodedFillTarget =
   | { kind: 'selector'; target: { selector: string }; text: string }
   | { kind: 'point'; target: { x: number; y: number }; text: string };
 
+const BARE_SNAPSHOT_REF_PATTERN = /^e\d+$/;
+
 export function readInteractionTargetFromPositionals(
   positionals: string[],
 ): PositionalInteractionTarget {
   if (positionals[0]?.startsWith('@')) {
     const label = optionalTrimmedText(positionals.slice(1));
     return { ref: positionals[0], ...(label === undefined ? {} : { label }) };
+  }
+  if (BARE_SNAPSHOT_REF_PATTERN.test(positionals[0] ?? '')) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Did you mean "@${positionals[0]}"? Snapshot refs need the @ prefix.`,
+    );
   }
   const selectorArgs = splitSelectorFromArgs(positionals);
   if (selectorArgs) return { selector: selectorArgs.selectorExpression };
@@ -35,6 +44,12 @@ export function readFillTargetFromPositionals(positionals: string[]): DecodedFil
       },
       text,
     };
+  }
+  if (BARE_SNAPSHOT_REF_PATTERN.test(firstPositional ?? '')) {
+    throw new AppError(
+      'INVALID_ARGS',
+      `Did you mean "@${firstPositional}"? Snapshot refs need the @ prefix.`,
+    );
   }
   const selectorArgs = splitSelectorFromArgs(positionals, { preferTrailingValue: true });
   if (selectorArgs) {


### PR DESCRIPTION
## Summary

When a user forgets the @ prefix on a snapshot ref (e.g., `click e3` instead of `click @e3`), the positional parser would attempt to parse it as coordinates, resulting in a confusing error message "Expected x to be a finite number." 

This PR adds a helpful hint message that suggests the correct @-prefixed form.

## Before

```
$ agent-device click e3
Error: Expected x to be a finite number.
```

## After

```
$ agent-device click e3
Error [INVALID_ARGS]: Did you mean "@e3"? Snapshot refs need the @ prefix.
```

## Test plan

- Added unit tests verifying that click, press, and fill commands throw INVALID_ARGS with the helpful hint message when passed bare snapshot refs like `e3`, `e123`, `e5`
- All existing tests pass
- New test case "bare snapshot refs without @ prefix throw helpful error" validates the fix

Closes #1035