### PR TITLE
docs: document conservative revisit triggers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,31 @@ pnpm test-app:maestro:android -- --session test-app-maestro -- --device "$ANDROI
 - Add/adjust integration tests when introducing new commands.
 - Prefer built-in Node APIs over new packages.
 
+### Conservative Code Comments
+
+When code deliberately chooses a slower or more conservative path, leave a short inline comment at
+the decision site. The comment should name:
+
+1. the failure or regression the conservative path prevents; and
+2. the condition that should trigger a revisit.
+
+Use a grep-able `CONSERVATIVE:` prefix when the choice is expected to outlive the current change.
+This applies to defensive fallbacks, temporary guards, disabled fast paths, serialization, retries,
+over-preservation, and teardown-to-be-safe behavior.
+
+Examples:
+
+```ts
+// CONSERVATIVE: Keep the preflight for non-allowlisted runner commands because only the
+// allowlist has proven healthy-mutation recovery. Revisit when lifecycle status coverage can
+// distinguish every mutating command's terminal state.
+```
+
+```ts
+// CONSERVATIVE: Preserve external runner artifacts because the checkout does not own their cache
+// root. Revisit only if external artifacts get an ownership marker that makes cleanup safe.
+```
+
 ## Issue Labels
 
 Issue labels describe workflow state, not who will do the work. See

--- a/src/platforms/apple/core/runner/runner-session.ts
+++ b/src/platforms/apple/core/runner/runner-session.ts
@@ -536,11 +536,10 @@ export async function detachIosSimulatorRunnerSessionsForShutdown(): Promise<num
   let detached = 0;
   for (const [deviceId, session] of runnerSessions) {
     if (session.device.kind !== 'simulator') continue;
-    // A held device-set redirect means this runner depends on the global
-    // XCTestDevices symlink pointing at a custom simulator set for its whole
-    // lifetime. Handing it off would either restore the symlink under a live
-    // runner or leak the redirect lock, so scoped-set runners keep the normal
-    // dispose-and-restore path.
+    // CONSERVATIVE: Scoped simulator sets depend on the global XCTestDevices symlink for their
+    // whole runner lifetime; handoff could restore the symlink under a live runner or leak the
+    // redirect lock. Revisit only if simulator-set redirects become runner-owned instead of
+    // daemon-session-owned.
     if (session.simulatorSetRedirect) continue;
     if (!session.lease || !isRunnerProcessAlive(session.child.pid)) continue;
     try {
@@ -936,6 +935,9 @@ function resolveRunnerReadinessPreflightDecision(
     };
   }
   if (!canSkipRunnerReadinessPreflightAfterHealthyMutation(command.command)) {
+    // CONSERVATIVE: Commands outside the healthy-mutation allowlist still preflight because their
+    // terminal runner state is not proven by recency. Revisit when lifecycle status coverage can
+    // distinguish every mutating command's safe terminal state.
     return {
       action: 'run',
       reason: 'conservative_command',

--- a/src/platforms/apple/core/runner/runner-xctestrun.ts
+++ b/src/platforms/apple/core/runner/runner-xctestrun.ts
@@ -880,6 +880,9 @@ export async function markRunnerXctestrunArtifactBadForRun(
   reason: string,
 ): Promise<void> {
   if (artifact.cache === 'external') {
+    // CONSERVATIVE: External xctestrun artifacts are outside this checkout's cache ownership, so
+    // deleting them could remove user-managed build output. Revisit only if external artifacts get
+    // an ownership marker that proves agent-device may clean them.
     emitRunnerXctestrunDecision('preserve', 'external_bad_artifact', {
       derived: artifact.derived,
       xctestrunPath: artifact.xctestrunPath,


### PR DESCRIPTION
## Summary

Document the house style for deliberately conservative code comments so agents preserve or revisit slow/safe decisions intentionally.

Add grep-able `CONSERVATIVE:` examples at three existing runner/cache decision sites covering preflight retention, scoped simulator-set handoff guards, and external artifact preservation.

Closes #1045

Touched files: 3

## Validation

Ran `pnpm format` and `pnpm typecheck`; both passed. No runtime tests were needed because this is documentation plus comment-only source examples.