### PR TITLE
refactor: centralize known CLI command checks

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import {
 import { resolveRemoteAuthForCli } from './cli/auth-session.ts';
 import type { CliFlags, FlagKey } from './cli/parser/cli-flags.ts';
 import type { SessionRuntimeHints } from './kernel/contracts.ts';
+import { isKnownCliCommandName } from './command-catalog.ts';
 
 type CliDeps = {
   sendToDaemon: typeof sendToDaemon;
@@ -405,7 +406,7 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
           return;
         }
 
-        throw new AppError('INVALID_ARGS', `Unknown command: ${command}`);
+        throw new AppError('INVALID_ARGS', formatUnhandledCommandMessage(command));
       } catch (err) {
         const appErr = asAppError(err);
         const normalized = normalizeError(appErr, {
@@ -455,6 +456,13 @@ function isDebugRequested(argv: string[]): boolean {
   } catch {
     return argv.includes('--debug') || argv.includes('-v') || argv.includes('--verbose');
   }
+}
+
+function formatUnhandledCommandMessage(command: string): string {
+  if (isKnownCliCommandName(command)) {
+    return `Command is registered but no CLI handler accepted it: ${command}`;
+  }
+  return `Unknown command: ${command}`;
 }
 
 function isParsedDebugRequested(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -460,6 +460,13 @@ function isDebugRequested(argv: string[]): boolean {
 
 function formatUnhandledCommandMessage(command: string): string {
   if (isKnownCliCommandName(command)) {
+    // Registered-but-unhandled means catalog/dispatch drift — make it visible
+    // in telemetry too, not just the thrown message (from #1055).
+    emitDiagnostic({
+      level: 'error',
+      phase: 'cli_known_command_unhandled',
+      data: { command },
+    });
     return `Command is registered but no CLI handler accepted it: ${command}`;
   }
   return `Unknown command: ${command}`;

--- a/src/cli/parser/args.ts
+++ b/src/cli/parser/args.ts
@@ -11,7 +11,7 @@ import {
 } from '../../utils/command-schema.ts';
 import { buildCommandUsageText, buildUsageText } from './cli-help.ts';
 import { isFlagSupportedForCommand } from '../../utils/cli-option-schema.ts';
-import { listCliCommandNames, INTERNAL_COMMANDS } from '../../command-catalog.ts';
+import { isKnownCliCommandName } from '../../command-catalog.ts';
 
 type ParsedArgs = {
   command: string | null;
@@ -153,7 +153,7 @@ export function finalizeParsedArgs(
   // Check if the command is known before validating flags
   // This ensures "Unknown command" errors take precedence over flag validation errors
   // However, skip this check if --help is provided, since cli.ts will handle it gracefully
-  if (parsed.command && !isCommandKnown(parsed.command) && !flags.help) {
+  if (parsed.command && !isKnownCliCommandName(parsed.command) && !flags.help) {
     const hint = getCommandAliasSuggestion(parsed.command);
     const message = hint
       ? `Unknown command: ${parsed.command}. Did you mean ${hint}?`
@@ -346,18 +346,9 @@ function normalizeParsedCommandAliases(parsed: ParsedArgs): ParsedArgs {
   return parsed;
 }
 
-function isCommandKnown(command: string): boolean {
-  // Must stay in sync with the authoritative dispatch fall-through in
-  // cli.ts ("Unknown command"): any command runnable there must be listed in
-  // the catalog (or below), or this early check rejects it at parse time.
-  // 'help' is handled specially in cli.ts and is not in the command catalog
-  if (command === 'help') return true;
-  // Internal commands are handled specially in cli.ts
-  if ((Object.values(INTERNAL_COMMANDS) as readonly string[]).includes(command)) return true;
-  return (listCliCommandNames() as readonly string[]).includes(command);
-}
-
-const COMMAND_ALIAS_SUGGESTIONS: Record<string, string> = {};
+const COMMAND_ALIAS_SUGGESTIONS: Record<string, string> = {
+  tap: 'press or click',
+};
 
 function getCommandAliasSuggestion(command: string): string | undefined {
   return COMMAND_ALIAS_SUGGESTIONS[command];

--- a/src/command-catalog.ts
+++ b/src/command-catalog.ts
@@ -76,13 +76,21 @@ const LOCAL_CLI_COMMANDS = {
   web: 'web',
 } as const;
 
+export const SPECIAL_CLI_COMMANDS = {
+  help: 'help',
+} as const;
+
 export const GESTURE_KINDS = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'transform'] as const;
 export type GestureKind = (typeof GESTURE_KINDS)[number];
 export const GESTURE_SUBCOMMAND_ERROR = `gesture requires one of: ${GESTURE_KINDS.join(', ')}`;
 
 export type PublicCommandName = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
+export type InternalCommandName = (typeof INTERNAL_COMMANDS)[keyof typeof INTERNAL_COMMANDS];
 export type LocalCliCommandName = (typeof LOCAL_CLI_COMMANDS)[keyof typeof LOCAL_CLI_COMMANDS];
+export type SpecialCliCommandName =
+  (typeof SPECIAL_CLI_COMMANDS)[keyof typeof SPECIAL_CLI_COMMANDS];
 export type CliCommandName = PublicCommandName | LocalCliCommandName;
+export type KnownCliCommandName = CliCommandName | InternalCommandName | SpecialCliCommandName;
 export type ClientBackedCliCommandName =
   | PublicCommandName
   | typeof LOCAL_CLI_COMMANDS.debug
@@ -133,6 +141,12 @@ function commandSet(...commands: readonly string[]): ReadonlySet<string> {
 
 export function listCliCommandNames(): CliCommandName[] {
   return [...Object.values(PUBLIC_COMMANDS), ...Object.values(LOCAL_CLI_COMMANDS)].sort();
+}
+
+export function isKnownCliCommandName(command: string): command is KnownCliCommandName {
+  if ((Object.values(SPECIAL_CLI_COMMANDS) as readonly string[]).includes(command)) return true;
+  if ((Object.values(INTERNAL_COMMANDS) as readonly string[]).includes(command)) return true;
+  return (listCliCommandNames() as readonly string[]).includes(command);
 }
 
 export function isClientBackedCliCommandName(

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1,9 +1,18 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
 import { parseArgs, usage, usageForCommand } from '../../cli/parser/args.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { listCapabilityCommands } from '../../core/capabilities.ts';
-import { listCapabilityCheckedCommandNames, listCliCommandNames } from '../../command-catalog.ts';
+import {
+  INTERNAL_COMMANDS,
+  isKnownCliCommandName,
+  listCapabilityCheckedCommandNames,
+  listCliCommandNames,
+  SPECIAL_CLI_COMMANDS,
+} from '../../command-catalog.ts';
 import { getCliCommandSchema } from '../command-schema.ts';
 
 test('parseArgs recognizes command-specific flag combinations', async () => {
@@ -1955,6 +1964,32 @@ test('every CLI command has a derived or local parser schema entry', () => {
   }
 });
 
+test('known CLI command predicate covers catalog, help, and internal commands', () => {
+  for (const command of listCliCommandNames()) {
+    assert.equal(isKnownCliCommandName(command), true, `Missing CLI command: ${command}`);
+  }
+  for (const command of Object.values(SPECIAL_CLI_COMMANDS)) {
+    assert.equal(isKnownCliCommandName(command), true, `Missing special command: ${command}`);
+  }
+  for (const command of Object.values(INTERNAL_COMMANDS)) {
+    assert.equal(isKnownCliCommandName(command), true, `Missing internal command: ${command}`);
+  }
+  assert.equal(isKnownCliCommandName('tap'), false);
+  assert.equal(isKnownCliCommandName('not-a-command'), false);
+});
+
+test('cli.ts command dispatch checks are recognized by parser-level unknown-command handling', () => {
+  const commands = collectCliDispatchCommandLiterals();
+  assert.notEqual(commands.size, 0);
+  for (const command of commands) {
+    assert.equal(
+      isKnownCliCommandName(command),
+      true,
+      `cli.ts checks command "${command}" but the parser does not recognize it`,
+    );
+  }
+});
+
 test('schema capability mappings match capability source-of-truth', () => {
   assert.deepEqual(
     listCapabilityCheckedCommandNames(),
@@ -2375,3 +2410,54 @@ test('removed trigger aliases are no longer documented as commands', () => {
   const help = usageForCommand('trigger-screenshot-notification');
   assert.equal(help, null);
 });
+
+function collectCliDispatchCommandLiterals(): Set<string> {
+  const cliPath = fileURLToPath(new URL('../../cli.ts', import.meta.url));
+  const sourceText = fs.readFileSync(cliPath, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    cliPath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const commands = new Set<string>();
+
+  function visit(node: ts.Node): void {
+    if (ts.isBinaryExpression(node) && isEqualityOperator(node.operatorToken.kind)) {
+      const command = readCommandComparisonLiteral(node.left, node.right);
+      if (command) commands.add(command);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return commands;
+}
+
+function isEqualityOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+    kind === ts.SyntaxKind.ExclamationEqualsEqualsToken
+  );
+}
+
+function readCommandComparisonLiteral(left: ts.Expression, right: ts.Expression): string | null {
+  if (isCommandExpression(left) && ts.isStringLiteralLike(right)) return right.text;
+  if (isCommandExpression(right) && ts.isStringLiteralLike(left)) return left.text;
+  return null;
+}
+
+function isCommandExpression(expression: ts.Expression): boolean {
+  const unwrapped = unwrapParenthesizedExpression(expression);
+  if (ts.isIdentifier(unwrapped)) return unwrapped.text === 'command';
+  return ts.isPropertyAccessExpression(unwrapped) && unwrapped.name.text === 'command';
+}
+
+function unwrapParenthesizedExpression(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) {
+    current = current.expression;
+  }
+  return current;
+}


### PR DESCRIPTION
## Summary

Centralizes known CLI command detection in the command catalog and reuses it from parser unknown-command handling and the CLI defensive fall-through.

Adds regression coverage for catalog/help/internal command recognition plus an AST-backed drift test that fails when cli.ts dispatch checks mention a command the parser does not recognize.

Closes #1043

Touched files: 4. Scope stayed within CLI command recognition/parser/dispatch contracts.

## Validation

Focused parser/help coverage passed: pnpm exec vitest run src/utils/__tests__/args.test.ts src/__tests__/cli-help.test.ts --project unit.

Static quick checks passed: pnpm check:quick.

Formatting passed: pnpm format.