### PR TITLE
fix: clarify prepare ios-runner timing overlap

### DIFF
--- a/src/client/client-types.ts
+++ b/src/client/client-types.ts
@@ -543,6 +543,10 @@ export type AgentDeviceCommandClient = {
   clipboard: (options: ClipboardCommandOptions) => Promise<CommandResult<'clipboard'>>;
   reactNative: (options: ReactNativeCommandOptions) => Promise<CommandRequestResult>;
   doctor: (options?: DoctorCommandOptions) => Promise<CommandRequestResult>;
+  /**
+   * JSON prepare results include timing.additiveParts for additive wall-clock phases.
+   * Top-level buildMs/connectMs/healthCheckMs are diagnostics and may overlap.
+   */
   prepare: (options: PrepareCommandOptions) => Promise<CommandRequestResult>;
   viewport: (options: ViewportCommandOptions) => Promise<CommandResult<'viewport'>>;
 };

--- a/src/commands/management/prepare.ts
+++ b/src/commands/management/prepare.ts
@@ -32,7 +32,7 @@ const prepareCliSchema = {
   usageOverride: 'prepare ios-runner --platform ios|macos [--timeout <ms>]',
   listUsageOverride: 'prepare',
   helpDescription:
-    'Prepare platform helper infrastructure. ios-runner builds/reuses, starts, and health-checks the XCTest runner so later Apple snapshots and interactions do not pay first-use startup cost. In CI, run it after boot/install and before replay/test; if replay/test starts a separate daemon, stop the prepare daemon before replay/test so it does not keep the prepared runner lease. It is not a recovery step for "runner already owned by another agent-device daemon"; stop the owning daemon on the Mac with simulator access instead. Runner build/start output is written to the session runner.log; daemon.log is for daemon lifecycle/startup issues.',
+    'Prepare platform helper infrastructure. ios-runner builds/reuses, starts, and health-checks the XCTest runner so later Apple snapshots and interactions do not pay first-use startup cost. In JSON output, top-level buildMs/connectMs/healthCheckMs are diagnostic fields and may overlap; use timing.additiveParts for additive wall-clock phase totals. In CI, run it after boot/install and before replay/test; if replay/test starts a separate daemon, stop the prepare daemon before replay/test so it does not keep the prepared runner lease. It is not a recovery step for "runner already owned by another agent-device daemon"; stop the owning daemon on the Mac with simulator access instead. Runner build/start output is written to the session runner.log; daemon.log is for daemon lifecycle/startup issues.',
   summary:
     'Pre-warm platform helpers, especially the iOS/macOS XCTest runner before Apple automation',
   positionalArgs: ['ios-runner'],

--- a/src/daemon/handlers/__tests__/session.test.ts
+++ b/src/daemon/handlers/__tests__/session.test.ts
@@ -2615,6 +2615,70 @@ test('prepare ios-runner starts the XCTest runner on an explicit iOS selector', 
   expect(sessionStore.get(sessionName)).toBeUndefined();
 });
 
+test('prepare ios-runner explains overlapping timing fields with additive parts', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'prepare-ios-runner-timing';
+  const dateNow = vi.spyOn(Date, 'now');
+  try {
+    dateNow.mockReturnValueOnce(1_000).mockReturnValueOnce(28_337);
+    mockResolveTargetDevice.mockResolvedValue({
+      platform: 'apple',
+      id: 'sim-1',
+      name: 'iPhone 17 Pro',
+      kind: 'simulator',
+      booted: true,
+    });
+    mockPrepareIosRunner.mockResolvedValueOnce({
+      runner: { currentUptimeMs: 42 },
+      buildMs: 10_642,
+      connectMs: 12_635,
+      healthCheckMs: 14_702,
+    });
+
+    const response = await handleSessionCommands({
+      req: {
+        token: 't',
+        session: sessionName,
+        command: 'prepare',
+        positionals: ['ios-runner'],
+        flags: { platform: 'ios', udid: 'sim-1' },
+      },
+      sessionName,
+      logPath: path.join(os.tmpdir(), 'daemon.log'),
+      sessionStore,
+      invoke: noopInvoke,
+    });
+
+    expect(response?.ok).toBe(true);
+    const data = (response as any).data;
+    expect(data).toMatchObject({
+      durationMs: 27_337,
+      buildMs: 10_642,
+      connectMs: 12_635,
+      healthCheckMs: 14_702,
+      timing: {
+        totalMs: 27_337,
+        additiveParts: {
+          buildMs: 10_642,
+          connectAfterBuildMs: 1_993,
+          healthCheckMs: 14_702,
+        },
+        containment: {
+          connectMs: ['buildMs'],
+          healthCheckMs: [],
+        },
+      },
+    });
+    expect(String(data.timing.note)).toMatch(/top-level prepare timing fields.*may overlap/i);
+    const additiveParts = data.timing.additiveParts as Record<string, number>;
+    const additiveTotalMs = Object.values(additiveParts).reduce((sum, value) => sum + value, 0);
+    expect(additiveTotalMs).toBeLessThanOrEqual(data.timing.totalMs);
+    expect(data.buildMs + data.connectMs + data.healthCheckMs).toBeGreaterThan(data.durationMs);
+  } finally {
+    dateNow.mockRestore();
+  }
+});
+
 test('prepare ios-runner starts the XCTest runner on an explicit macOS selector', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'prepare-macos-runner';

--- a/src/daemon/handlers/session.ts
+++ b/src/daemon/handlers/session.ts
@@ -43,6 +43,9 @@ import { PREPARE_REQUEST_TIMEOUT_MS } from '../request-timeouts.ts';
 import { Deadline } from '../../utils/retry.ts';
 import type { LeaseLifecycleProvider } from './lease.ts';
 
+const PREPARE_IOS_RUNNER_TIMING_NOTE =
+  'Top-level prepare timing fields are diagnostic and may overlap; use timing.additiveParts for additive wall-clock phases.';
+
 async function handlePrepareCommand(params: {
   req: DaemonRequest;
   sessionName: string;
@@ -126,8 +129,39 @@ function prepareIosRunnerResponseData(
     kind: device.kind,
     durationMs,
     ...result,
+    timing: prepareIosRunnerTiming(durationMs, result),
     message: `Prepared Apple runner: ${device.name}`,
   };
+}
+
+function prepareIosRunnerTiming(
+  durationMs: number,
+  result: PrepareIosRunnerResult,
+): Record<string, unknown> {
+  const buildMs = normalizeOptionalTimingMs(result.buildMs);
+  const connectMs = normalizeTimingMs(result.connectMs);
+  const healthCheckMs = normalizeTimingMs(result.healthCheckMs);
+  const additiveParts = {
+    ...(buildMs === undefined ? {} : { buildMs }),
+    connectAfterBuildMs: Math.max(0, connectMs - (buildMs ?? 0)),
+    healthCheckMs,
+  };
+
+  return {
+    totalMs: durationMs,
+    additiveParts,
+    containment:
+      buildMs === undefined ? { healthCheckMs: [] } : { connectMs: ['buildMs'], healthCheckMs: [] },
+    note: PREPARE_IOS_RUNNER_TIMING_NOTE,
+  };
+}
+
+function normalizeOptionalTimingMs(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : normalizeTimingMs(value);
+}
+
+function normalizeTimingMs(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
 }
 
 // fallow-ignore-next-line complexity

--- a/src/platforms/apple/core/__tests__/runner-command-retry.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-command-retry.test.ts
@@ -1105,6 +1105,10 @@ function assertRecoveredPrepareDiagnostics(): void {
   assert.equal(prepareDiagnostic.data?.xctestrunPath, '/tmp/rebuilt.xctestrun');
   assert.equal(prepareDiagnostic.data?.recoveryReason, 'Runner did not accept connection');
   assert.equal(prepareDiagnostic.data?.failureReason, undefined);
+  assert.deepEqual(prepareDiagnostic.data?.timingContainment, {
+    connectMs: ['buildMs'],
+    healthCheckMs: [],
+  });
 }
 
 function assertDiagnosticDecision(expected: {

--- a/src/platforms/apple/core/runner/runner-lifecycle.ts
+++ b/src/platforms/apple/core/runner/runner-lifecycle.ts
@@ -516,6 +516,10 @@ function emitPrepareDiagnostic(
       buildMs: result.buildMs,
       connectMs: result.connectMs,
       healthCheckMs: result.healthCheckMs,
+      timingContainment:
+        result.buildMs === undefined
+          ? { healthCheckMs: [] }
+          : { connectMs: ['buildMs'], healthCheckMs: [] },
       xctestrunPath: result.xctestrunPath,
       recoveryReason: result.recoveryReason,
       failureReason: result.failureReason,

--- a/src/utils/__tests__/args.test.ts
+++ b/src/utils/__tests__/args.test.ts
@@ -1498,6 +1498,8 @@ test('usageForCommand documents prepare ios-runner', () => {
   assert.match(help, /Prepare platform helper infrastructure/);
   assert.match(help, /--timeout <ms>/);
   assert.match(help, /XCTest runner/);
+  assert.match(help, /top-level buildMs\/connectMs\/healthCheckMs are diagnostic fields/);
+  assert.match(help, /timing\.additiveParts/);
   assert.match(help, /separate daemon/);
   assert.match(help, /stop the prepare daemon before replay\/test/);
   assert.doesNotMatch(help, /clean:daemon|pnpm/);

--- a/website/docs/docs/commands.md
+++ b/website/docs/docs/commands.md
@@ -182,6 +182,7 @@ agent-device prepare ios-runner --platform ios --timeout 240000
 - `prepare ios-runner` is intended for Apple-platform CI setup before `snapshot`, `replay`, or `test`.
 - Run it after the simulator/device is booted and the app is installed, but before the first snapshot, replay, or test command.
 - It builds or reuses the local XCTest runner, starts a runner session, and verifies that the runner can answer a lightweight health command.
+- In JSON output, top-level `buildMs`, `connectMs`, and `healthCheckMs` are diagnostic fields and may overlap; use `timing.additiveParts` for additive wall-clock phase totals. `connectMs` contains `buildMs` when a runner artifact is built or rebuilt.
 - If health checking exposes a bad restored runner artifact, Agent Device marks that artifact bad and rebuilds once.
 - If a fresh runner launch gets stuck before accepting connections, Agent Device invalidates that runner session and launches it once more without forcing a rebuild.
 - CI may cache `~/.agent-device/apple-runner/derived` when the cache key includes the exact Agent Device package contents and selected Xcode version.


### PR DESCRIPTION
## Summary

Closes #1046.

Adds machine-readable prepare timing guidance so agents do not add overlapping fields as wall-clock totals: legacy buildMs/connectMs/healthCheckMs stay in place, while timing.additiveParts and timing.containment explain the safe additive breakdown. Also mirrors the containment label in runner diagnostics and documents it in CLI help, typed client comments, and website command docs.

Touched files: 8.

## Validation

Focused prepare/runner timing tests passed: pnpm exec vitest run src/daemon/handlers/__tests__/session.test.ts src/platforms/apple/core/__tests__/runner-command-retry.test.ts src/utils/__tests__/args.test.ts.

Static quick checks passed: pnpm check:quick. Formatter passed: pnpm format. Build passed: pnpm build.

Residual risk: pnpm check:unit was attempted after building dist. The first run reached smoke tests and failed because dist was missing before the build. After building, reruns hit broad unrelated timeout/mocked-tool failures across Android, Apple, archive, Metro, and upload tests, while the focused touched tests stayed green.