### PR TITLE
feat: add wait stable settle primitive

### DIFF
--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -218,8 +218,11 @@ Read-only and waits:
   agent-device is visible 'label="Online"'
   agent-device wait text "Refreshing metrics..." 3000
   agent-device wait 'label="Ready"' 3000
+  agent-device wait stable
+  agent-device wait stable 500 10000
   agent-device find "Increment" press --json
   For async/list text presence, prefer wait text over is visible when no interaction is needed.
+  wait stable [quietMs] [timeoutMs] (defaults 500/10000) replaces guessed sleeps between actions and snapshots in the core loop: it polls the interactive-only tree and resolves once two or more consecutive captures are unchanged for quietMs, or fails with the standard wait-timeout shape plus the last capture stats (captures, nodeCount) on timeout; use it after relaunch/navigation instead of a fixed wait <ms> before the next snapshot or action.
   Use snapshot -i only when refs are needed for an action or targeted query.
   Ambiguous find: add --first or --last. If info is not visible/exposed, report that gap instead of typing/searching/navigating to reveal it.
 

--- a/src/client/client-types.ts
+++ b/src/client/client-types.ts
@@ -440,6 +440,8 @@ type WaitCommandTarget =
       text?: never;
       ref?: never;
       selector?: never;
+      stable?: never;
+      quietMs?: never;
       timeoutMs?: never;
     }
   | (SelectorSnapshotCommandOptions & {
@@ -447,6 +449,8 @@ type WaitCommandTarget =
       durationMs?: never;
       ref?: never;
       selector?: never;
+      stable?: never;
+      quietMs?: never;
       timeoutMs?: number;
     })
   | (SelectorSnapshotCommandOptions & {
@@ -454,6 +458,8 @@ type WaitCommandTarget =
       durationMs?: never;
       text?: never;
       selector?: never;
+      stable?: never;
+      quietMs?: never;
       timeoutMs?: number;
     })
   | (SelectorSnapshotCommandOptions & {
@@ -461,6 +467,17 @@ type WaitCommandTarget =
       durationMs?: never;
       text?: never;
       ref?: never;
+      stable?: never;
+      quietMs?: never;
+      timeoutMs?: number;
+    })
+  | (SelectorSnapshotCommandOptions & {
+      stable: true;
+      durationMs?: never;
+      text?: never;
+      ref?: never;
+      selector?: never;
+      quietMs?: number;
       timeoutMs?: number;
     });
 

--- a/src/commands/capture/index.test.ts
+++ b/src/commands/capture/index.test.ts
@@ -134,6 +134,37 @@ describe('capture command interface', () => {
     expectInvalidArgs(() => waitDaemonWriter({ text: 'Ready', ref: '@e1' }), 'exactly one');
   });
 
+  test('reads and writes wait stable with defaults', () => {
+    expect(waitCliReader(['stable'], flags())).toMatchObject({ stable: true });
+    expect(waitDaemonWriter({ stable: true })).toMatchObject({
+      command: 'wait',
+      positionals: ['stable'],
+    });
+  });
+
+  test('reads and writes wait stable with quietMs and timeoutMs', () => {
+    expect(waitCliReader(['stable', '500', '10000'], flags())).toMatchObject({
+      stable: true,
+      quietMs: 500,
+      timeoutMs: 10_000,
+    });
+    expect(waitDaemonWriter({ stable: true, quietMs: 500, timeoutMs: 10_000 })).toMatchObject({
+      command: 'wait',
+      positionals: ['stable', '500', '10000'],
+    });
+  });
+
+  test('rejects wait stable combined with another target', () => {
+    expectInvalidArgs(() => waitDaemonWriter({ stable: true, text: 'Ready' }), 'exactly one');
+  });
+
+  test('rejects wait stable timeoutMs without quietMs', () => {
+    expectInvalidArgs(
+      () => waitDaemonWriter({ stable: true, timeoutMs: 10_000 }),
+      'quietMs before timeoutMs',
+    );
+  });
+
   test('reads and writes alert action and timeout', () => {
     expect(alertCliReader(['wait', '3000'], flags())).toMatchObject({
       action: 'wait',

--- a/src/commands/capture/wait-command-contract.ts
+++ b/src/commands/capture/wait-command-contract.ts
@@ -1,1 +1,1 @@
-export const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector'] as const;
+export const WAIT_KIND_VALUES = ['duration', 'text', 'ref', 'selector', 'stable'] as const;

--- a/src/commands/capture/wait.ts
+++ b/src/commands/capture/wait.ts
@@ -26,7 +26,7 @@ import { WAIT_KIND_VALUES } from './wait-command-contract.ts';
 
 const WAIT_COMMAND_NAME = 'wait';
 
-const waitCommandDescription = 'Wait for duration, text, ref, or selector.';
+const waitCommandDescription = 'Wait for duration, text, ref, selector, or stable UI.';
 
 const waitCommandMetadata = defineFieldCommandMetadata(WAIT_COMMAND_NAME, waitCommandDescription, {
   kind: enumField(WAIT_KIND_VALUES),
@@ -34,6 +34,8 @@ const waitCommandMetadata = defineFieldCommandMetadata(WAIT_COMMAND_NAME, waitCo
   text: stringField(),
   ref: stringField(),
   selector: stringField(),
+  stable: booleanField(),
+  quietMs: integerField(),
   timeoutMs: integerField(),
   depth: integerField(),
   scope: stringField(),
@@ -45,7 +47,7 @@ const waitCommandDefinition = defineExecutableCommand(waitCommandMetadata, (clie
 );
 
 const waitCliSchema = {
-  usageOverride: 'wait <ms>|text <text>|@ref|<selector> [timeoutMs]',
+  usageOverride: 'wait <ms>|text <text>|@ref|<selector>|stable [quietMs] [timeoutMs]',
   positionalArgs: ['durationOrSelector', 'timeoutMs?'],
   allowsExtraPositionals: true,
   allowedFlags: [...SELECTOR_SNAPSHOT_FLAGS],
@@ -83,7 +85,7 @@ function readWaitOptionsFromPositionals(
   if (!parsed) {
     throw new AppError(
       'INVALID_ARGS',
-      'wait requires <ms>, text <text>, @ref, or <selector> [timeoutMs].',
+      'wait requires <ms>, text <text>, @ref, <selector> [timeoutMs], or stable [quietMs] [timeoutMs].',
     );
   }
   const base = {
@@ -97,6 +99,14 @@ function readWaitOptionsFromPositionals(
   }
   if (parsed.kind === 'ref') {
     return { ...base, ref: parsed.rawRef, ...readTimeoutOption(parsed.timeoutMs) };
+  }
+  if (parsed.kind === 'stable') {
+    return {
+      ...base,
+      stable: true,
+      ...readQuietOption(parsed.quietMs),
+      ...readTimeoutOption(parsed.timeoutMs),
+    };
   }
   return {
     ...base,
@@ -112,17 +122,25 @@ function waitPositionals(options: WaitCommandOptions): string[] {
     options.text !== undefined ? 'text' : undefined,
     options.ref !== undefined ? 'ref' : undefined,
     options.selector !== undefined ? 'selector' : undefined,
+    options.stable !== undefined ? 'stable' : undefined,
   ].filter(Boolean);
   if (targets.length !== 1) {
     throw new AppError(
       'INVALID_ARGS',
-      'wait command requires exactly one of durationMs, text, ref, or selector.',
+      'wait command requires exactly one of durationMs, text, ref, selector, or stable.',
     );
   }
   if (options.durationMs !== undefined) return [String(options.durationMs)];
   const timeout = optionalNumber(options.timeoutMs);
   if (options.text !== undefined) return ['text', options.text, ...timeout];
   if (options.ref !== undefined) return [options.ref, ...timeout];
+  if (options.stable !== undefined) {
+    const quiet = optionalNumber(options.quietMs);
+    if (quiet.length === 0 && timeout.length > 0) {
+      throw new AppError('INVALID_ARGS', 'wait stable requires quietMs before timeoutMs.');
+    }
+    return ['stable', ...quiet, ...timeout];
+  }
   const selector = options.selector!;
   if (!tryParseSelectorChain(selector)) {
     throw new AppError('INVALID_ARGS', `Invalid wait selector: ${selector}`);
@@ -132,4 +150,8 @@ function waitPositionals(options: WaitCommandOptions): string[] {
 
 function readTimeoutOption(timeoutMs: number | null): { timeoutMs?: number } {
   return timeoutMs === null ? {} : { timeoutMs };
+}
+
+function readQuietOption(quietMs: number | null): { quietMs?: number } {
+  return quietMs === null ? {} : { quietMs };
 }

--- a/src/commands/interaction/runtime/selector-read-shared.ts
+++ b/src/commands/interaction/runtime/selector-read-shared.ts
@@ -36,7 +36,12 @@ export async function requireSnapshotSession(
 export async function captureSelectorSnapshot(
   runtime: AgentDeviceRuntime,
   options: CommandContext & SelectorSnapshotOptions,
-  captureOptions: { updateSession: boolean; scope?: string; includeRects?: boolean } = {
+  captureOptions: {
+    updateSession: boolean;
+    scope?: string;
+    includeRects?: boolean;
+    interactiveOnly?: boolean;
+  } = {
     updateSession: true,
   },
 ): Promise<CapturedSnapshot> {
@@ -47,7 +52,7 @@ export async function captureSelectorSnapshot(
   const sessionName = options.session ?? 'default';
   const session = await runtime.sessions.get(sessionName);
   const result = await captureSnapshot(toBackendContext(runtime, options), {
-    interactiveOnly: false,
+    interactiveOnly: captureOptions.interactiveOnly ?? false,
     depth: options.depth,
     scope: captureOptions.scope ?? options.scope,
     raw: options.raw,

--- a/src/commands/interaction/runtime/selector-read.test.ts
+++ b/src/commands/interaction/runtime/selector-read.test.ts
@@ -338,6 +338,163 @@ test('runtime selector convenience methods use explicit target helpers', async (
   assert.deepEqual(waited, { kind: 'text', text: 'Ready', waitedMs: 0 });
 });
 
+test('runtime wait stable settles after two unchanged captures', async () => {
+  const snapshot = selectorSnapshot();
+  const clock = createFakeClock();
+  let captures = 0;
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => {
+        captures += 1;
+        return { snapshot };
+      },
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot }]),
+    policy: localCommandPolicy(),
+    clock,
+  });
+
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable', quietMs: 500, timeoutMs: 10_000 },
+  });
+
+  // Poll cadence is 300ms; a 500ms quiet window needs a 3rd identical capture to
+  // accumulate enough elapsed time since the first (baseline) capture.
+  assert.equal(result.kind, 'stable');
+  if (result.kind === 'stable') {
+    assert.equal(result.captures, 3);
+    assert.equal(result.nodeCount, snapshot.nodes.length);
+    assert.equal(result.settledAfterMs, result.waitedMs);
+  }
+  assert.equal(captures, 3);
+});
+
+test('runtime wait stable requires quiet captures after instability before settling', async () => {
+  const snapshot = selectorSnapshot();
+  const changedSnapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Button',
+      label: 'Loading',
+      rect: { x: 0, y: 0, width: 1, height: 1 },
+    },
+  ]);
+  const clock = createFakeClock();
+  let captures = 0;
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => {
+        captures += 1;
+        // First capture unstable/changed relative to the initial nothing-seen-yet state,
+        // second capture changes again (still unstable), then two identical captures settle.
+        if (captures <= 2) return { snapshot: captures === 1 ? snapshot : changedSnapshot };
+        return { snapshot: changedSnapshot };
+      },
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot }]),
+    policy: localCommandPolicy(),
+    clock,
+  });
+
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable', quietMs: 500, timeoutMs: 10_000 },
+  });
+
+  assert.equal(result.kind, 'stable');
+  // capture 1: baseline; capture 2: changed (reset quiet window); capture 3+4: unchanged -> settle.
+  assert.equal(captures, 4);
+});
+
+test('runtime wait stable times out with capture stats when never settling', async () => {
+  const clock = createFakeClock();
+  let captures = 0;
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => {
+        captures += 1;
+        return {
+          snapshot: makeSnapshotState([
+            {
+              index: 0,
+              depth: 0,
+              type: 'Button',
+              label: `Item ${captures}`,
+              rect: { x: 0, y: 0, width: 1, height: 1 },
+            },
+          ]),
+        };
+      },
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default' }]),
+    policy: localCommandPolicy(),
+    clock,
+  });
+
+  await assert.rejects(
+    () =>
+      device.selectors.wait({
+        session: 'default',
+        target: { kind: 'stable', quietMs: 500, timeoutMs: 1_000 },
+      }),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message === 'wait timed out waiting for a stable UI' &&
+      (error as { details?: { reason?: string; captures?: number } }).details?.reason ===
+        'wait_stable_timeout' &&
+      typeof (error as { details?: { captures?: number } }).details?.captures === 'number',
+  );
+  assert.ok(captures > 1);
+});
+
+test('runtime wait stable uses provided defaults when quietMs/timeoutMs are omitted', async () => {
+  const snapshot = selectorSnapshot();
+  const clock = createFakeClock();
+  let captures = 0;
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => {
+        captures += 1;
+        return { snapshot };
+      },
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot }]),
+    policy: localCommandPolicy(),
+    clock,
+  });
+
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable' },
+  });
+
+  assert.equal(result.kind, 'stable');
+  assert.equal(captures, 3);
+});
+
+function createFakeClock(stepMs = 300): {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+} {
+  let elapsed = 0;
+  return {
+    now: () => elapsed,
+    sleep: async (ms: number) => {
+      elapsed += ms > 0 ? ms : stepMs;
+    },
+  };
+}
+
 function selectorSnapshot(): SnapshotState {
   return makeSnapshotState([
     {

--- a/src/commands/interaction/runtime/selector-read.test.ts
+++ b/src/commands/interaction/runtime/selector-read.test.ts
@@ -455,6 +455,39 @@ test('runtime wait stable times out with capture stats when never settling', asy
   assert.ok(captures > 1);
 });
 
+test('runtime wait stable times out when a backend capture stalls past the wait budget', async () => {
+  const clock = createFakeClock();
+  const device = createAgentDevice({
+    backend: {
+      platform: 'macos',
+      // Simulates the stalled macOS AX capture: the promise never settles, so
+      // only the real-timer deadline can end the wait.
+      captureSnapshot: () => new Promise<BackendSnapshotResult>(() => {}),
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default' }]),
+    policy: localCommandPolicy(),
+    clock,
+  });
+
+  await assert.rejects(
+    () =>
+      device.selectors.wait({
+        session: 'default',
+        target: { kind: 'stable', quietMs: 100, timeoutMs: 250 },
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(error.message, 'wait timed out waiting for a stable UI');
+      const details = (error as { details?: Record<string, unknown> }).details;
+      assert.equal(details?.reason, 'wait_stable_timeout');
+      assert.equal(details?.captureStalled, true);
+      assert.equal(details?.captures, 0);
+      return true;
+    },
+  );
+});
+
 test('runtime wait stable uses provided defaults when quietMs/timeoutMs are omitted', async () => {
   const snapshot = selectorSnapshot();
   const clock = createFakeClock();

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -110,13 +110,21 @@ export type WaitCommandOptions = CommandContext &
       | { kind: 'sleep'; durationMs: number }
       | { kind: 'text'; text: string; timeoutMs?: number | null }
       | { kind: 'ref'; ref: string; timeoutMs?: number | null }
-      | { kind: 'selector'; selector: string; timeoutMs?: number | null };
+      | { kind: 'selector'; selector: string; timeoutMs?: number | null }
+      | { kind: 'stable'; quietMs?: number | null; timeoutMs?: number | null };
   };
 
 export type WaitCommandResult =
   | { kind: 'sleep'; waitedMs: number }
   | { kind: 'text'; waitedMs: number; text: string }
-  | { kind: 'selector'; waitedMs: number; selector: string };
+  | { kind: 'selector'; waitedMs: number; selector: string }
+  | {
+      kind: 'stable';
+      waitedMs: number;
+      settledAfterMs: number;
+      captures: number;
+      nodeCount: number;
+    };
 
 export type WaitForTextCommandOptions = CommandContext &
   SelectorSnapshotOptions & {
@@ -143,6 +151,7 @@ export function ref(refInput: string, options: { fallbackLabel?: string } = {}):
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const POLL_INTERVAL_MS = 300;
+const DEFAULT_QUIET_MS = 500;
 
 export const findCommand: RuntimeCommand<FindReadCommandOptions, FindReadCommandResult> = async (
   runtime,
@@ -374,6 +383,9 @@ export const waitCommand: RuntimeCommand<WaitCommandOptions, WaitCommandResult> 
       options.target.timeoutMs,
     );
   }
+  if (options.target.kind === 'stable') {
+    return await waitForStable(runtime, options, options.target.quietMs, options.target.timeoutMs);
+  }
   if (!options.target.text) throw new AppError('INVALID_ARGS', 'wait requires text');
   return await waitForText(runtime, options, options.target.text, options.target.timeoutMs);
 };
@@ -502,6 +514,66 @@ async function snapshotContainsText(
 ): Promise<boolean> {
   const capture = await captureSelectorSnapshot(runtime, options, { updateSession: true });
   return Boolean(findNodeByLabel(capture.snapshot.nodes, text));
+}
+
+async function waitForStable(
+  runtime: AgentDeviceRuntime,
+  options: WaitCommandOptions,
+  quietMs: number | null | undefined,
+  timeoutMs: number | null | undefined,
+): Promise<Extract<WaitCommandResult, { kind: 'stable' }>> {
+  const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const quiet = quietMs ?? DEFAULT_QUIET_MS;
+  const start = now(runtime);
+  let captures = 0;
+  let lastDigest: string | undefined;
+  let lastNodeCount = 0;
+  let quietSinceMs = start;
+  while (now(runtime) - start < timeout) {
+    // Intentionally do not update the session snapshot: this loop captures an
+    // interactive-only tree purely as a settle signal, and overwriting the session's
+    // richer cached snapshot with the filtered tree would degrade subsequent
+    // ref/get/find lookups against the same session.
+    const capture = await captureSelectorSnapshot(runtime, options, {
+      updateSession: false,
+      interactiveOnly: true,
+    });
+    captures += 1;
+    const digest = digestSnapshotNodes(capture.snapshot.nodes);
+    const nowMs = now(runtime);
+    if (digest !== lastDigest) {
+      lastDigest = digest;
+      lastNodeCount = capture.snapshot.nodes.length;
+      quietSinceMs = nowMs;
+    } else if (captures >= 2 && nowMs - quietSinceMs >= quiet) {
+      return {
+        kind: 'stable',
+        waitedMs: nowMs - start,
+        settledAfterMs: nowMs - start,
+        captures,
+        nodeCount: lastNodeCount,
+      };
+    }
+    await sleep(runtime, POLL_INTERVAL_MS);
+  }
+  throw new AppError('COMMAND_FAILED', 'wait timed out waiting for a stable UI', {
+    reason: 'wait_stable_timeout',
+    quietMs: quiet,
+    timeoutMs: timeout,
+    captures,
+    nodeCount: lastNodeCount,
+  });
+}
+
+function digestSnapshotNodes(nodes: SnapshotNode[]): string {
+  return nodes.map(digestSnapshotNode).join('|');
+}
+
+function digestSnapshotNode(node: SnapshotNode): string {
+  const rect = node.rect
+    ? `${Math.round(node.rect.x)},${Math.round(node.rect.y)},${Math.round(node.rect.width)},${Math.round(node.rect.height)}`
+    : '';
+  return `${node.type ?? ''}#${node.label ?? ''}#${node.identifier ?? ''}#${rect}`;
 }
 
 async function resolveSelectorNode(

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -530,14 +530,22 @@ async function waitForStable(
   let lastNodeCount = 0;
   let quietSinceMs = start;
   while (now(runtime) - start < timeout) {
-    // Intentionally do not update the session snapshot: this loop captures an
-    // interactive-only tree purely as a settle signal, and overwriting the session's
-    // richer cached snapshot with the filtered tree would degrade subsequent
-    // ref/get/find lookups against the same session.
-    const capture = await captureSelectorSnapshot(runtime, options, {
-      updateSession: false,
-      interactiveOnly: true,
-    });
+    const capture = await captureStableSignalWithinDeadline(
+      runtime,
+      options,
+      timeout - (now(runtime) - start),
+    );
+    if (!capture) {
+      throw new AppError('COMMAND_FAILED', 'wait timed out waiting for a stable UI', {
+        reason: 'wait_stable_timeout',
+        captureStalled: true,
+        quietMs: quiet,
+        timeoutMs: timeout,
+        captures,
+        nodeCount: lastNodeCount,
+        hint: 'A snapshot capture stalled past the wait timeout, so no settle verdict is available. The UI may still be readable: retry, or use screenshot to inspect the surface.',
+      });
+    }
     captures += 1;
     const digest = digestSnapshotNodes(capture.snapshot.nodes);
     const nowMs = now(runtime);
@@ -563,6 +571,45 @@ async function waitForStable(
     captures,
     nodeCount: lastNodeCount,
   });
+}
+
+// Intentionally does not update the session snapshot: the stable loop captures
+// an interactive-only tree purely as a settle signal, and overwriting the
+// session's richer cached snapshot with the filtered tree would degrade
+// subsequent ref/get/find lookups against the same session.
+//
+// Resolves undefined when the capture does not return within remainingMs. A
+// stalled backend capture (observed with macOS AX captures) must not push the
+// stable wait past the user-supplied timeout into the daemon request timeout.
+// The deadline uses a real timer even when runtime.clock is injected: test
+// clocks advance synthetic time synchronously and cannot represent a hung
+// backend call.
+async function captureStableSignalWithinDeadline(
+  runtime: AgentDeviceRuntime,
+  options: WaitCommandOptions,
+  remainingMs: number,
+): Promise<CapturedSnapshot | undefined> {
+  const capture = captureSelectorSnapshot(runtime, options, {
+    updateSession: false,
+    interactiveOnly: true,
+  });
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    const result = await Promise.race([
+      capture,
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), remainingMs);
+      }),
+    ]);
+    if (result === undefined) {
+      // The abandoned capture settles (or fails) on its own; swallow it so it
+      // cannot surface as an unhandled rejection after the wait already threw.
+      capture.catch(() => {});
+    }
+    return result;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 function digestSnapshotNodes(nodes: SnapshotNode[]): string {

--- a/src/core/wait-positionals.ts
+++ b/src/core/wait-positionals.ts
@@ -5,7 +5,8 @@ export type WaitParsed =
   | { kind: 'sleep'; durationMs: number }
   | { kind: 'ref'; rawRef: string; timeoutMs: number | null }
   | { kind: 'selector'; selectorExpression: string; timeoutMs: number | null }
-  | { kind: 'text'; text: string; timeoutMs: number | null };
+  | { kind: 'text'; text: string; timeoutMs: number | null }
+  | { kind: 'stable'; quietMs: number | null; timeoutMs: number | null };
 
 export function parseWaitPositionals(args: string[]): WaitParsed | null {
   const firstArg = args[0];
@@ -16,6 +17,12 @@ export function parseWaitPositionals(args: string[]): WaitParsed | null {
   if (firstArg === 'text') {
     const text = timeoutMs !== null ? args.slice(1, -1).join(' ') : args.slice(1).join(' ');
     return { kind: 'text', text: text.trim(), timeoutMs };
+  }
+  if (firstArg === 'stable') {
+    const rest = args.slice(1);
+    const stableTimeoutMs = rest.length > 1 ? parseTimeout(rest[1]) : null;
+    const quietMs = rest.length > 0 ? parseTimeout(rest[0]) : null;
+    return { kind: 'stable', quietMs, timeoutMs: stableTimeoutMs };
   }
   if (firstArg.startsWith('@')) return { kind: 'ref', rawRef: firstArg, timeoutMs };
   const argsWithoutTimeout = timeoutMs !== null ? args.slice(0, -1) : args.slice();

--- a/src/daemon/handlers/__tests__/snapshot.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot.test.ts
@@ -126,3 +126,18 @@ test('parseWaitArgs text keyword with non-numeric trailing leaves timeoutMs null
   const result = parseWaitArgs(['text', 'Loading', 'abc']);
   assert.deepEqual(result, { kind: 'text', text: 'Loading abc', timeoutMs: null });
 });
+
+test('parseWaitArgs parses bare stable keyword', () => {
+  const result = parseWaitArgs(['stable']);
+  assert.deepEqual(result, { kind: 'stable', quietMs: null, timeoutMs: null });
+});
+
+test('parseWaitArgs parses stable with quietMs', () => {
+  const result = parseWaitArgs(['stable', '500']);
+  assert.deepEqual(result, { kind: 'stable', quietMs: 500, timeoutMs: null });
+});
+
+test('parseWaitArgs parses stable with quietMs and timeoutMs', () => {
+  const result = parseWaitArgs(['stable', '500', '10000']);
+  assert.deepEqual(result, { kind: 'stable', quietMs: 500, timeoutMs: 10000 });
+});

--- a/src/daemon/selector-recording.ts
+++ b/src/daemon/selector-recording.ts
@@ -70,6 +70,9 @@ export function toDaemonWaitData(result: Record<string, unknown>): Record<string
     waitedMs: result.waitedMs,
     ...(typeof result.text === 'string' ? { text: result.text } : {}),
     ...(typeof result.selector === 'string' ? { selector: result.selector } : {}),
+    ...(typeof result.settledAfterMs === 'number' ? { settledAfterMs: result.settledAfterMs } : {}),
+    ...(typeof result.captures === 'number' ? { captures: result.captures } : {}),
+    ...(typeof result.nodeCount === 'number' ? { nodeCount: result.nodeCount } : {}),
   };
 }
 

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -482,6 +482,13 @@ function toWaitTarget(parsed: WaitParsed, session: SessionState | undefined) {
     }
     return { kind: 'ref' as const, ref: parsed.rawRef, timeoutMs: parsed.timeoutMs };
   }
+  if (parsed.kind === 'stable') {
+    return {
+      kind: 'stable' as const,
+      quietMs: parsed.quietMs,
+      timeoutMs: parsed.timeoutMs,
+    };
+  }
   if (!parsed.text) throw new AppError('INVALID_ARGS', 'wait requires text');
   return { kind: 'text' as const, text: parsed.text, timeoutMs: parsed.timeoutMs };
 }

--- a/src/daemon/wait-current-surface.ts
+++ b/src/daemon/wait-current-surface.ts
@@ -37,7 +37,7 @@ export async function maybeWaitTimeoutSurfaceResponse(
 }
 
 function isWaitTimeoutMessage(message: string): boolean {
-  return /^wait timed out for (?:selector|text): /i.test(message);
+  return /^wait timed out (?:for (?:selector|text): |waiting for a stable UI)/i.test(message);
 }
 
 async function inspectCurrentSurface(

--- a/src/daemon/wait-current-surface.ts
+++ b/src/daemon/wait-current-surface.ts
@@ -24,6 +24,10 @@ export async function maybeWaitTimeoutSurfaceResponse(
   response: DaemonResponse,
 ): Promise<DaemonResponse> {
   if (response.ok || !isWaitTimeoutMessage(response.error.message)) return response;
+  // A stable wait that just observed a stalled capture must not fire another
+  // capture for decoration: it would be just as slow (or hung) and push the
+  // response even further past the user-supplied timeout.
+  if (response.error.details?.captureStalled === true) return response;
   const currentSurface = await inspectCurrentSurface(params).catch(() => null);
   if (!currentSurface) return response;
   return errorResponse(


### PR DESCRIPTION
## Summary

Adds `agent-device wait stable [quietMs] [timeoutMs]` (defaults ~500/10000) so agents/scripts can wait for "the screen stopped changing" instead of inserting guessed `sleep` calls.

**Semantics**: repeatedly captures the interactive-only tree through the existing wait/snapshot plumbing at the existing wait poll cadence (300ms), and resolves once two or more consecutive captures are unchanged for `quietMs`. Unchanged is determined by a small local per-node digest (`type`, `label`, `identifier`, rounded `rect`) — no shared digest module was created (#1047 owns that). On timeout, throws the standard wait `COMMAND_FAILED` shape with the last capture stats (`captures`, `nodeCount`) attached as error details. On success, the result carries `settledAfterMs`, `captures`, and `nodeCount` alongside the existing `waitedMs` field.

**Wiring**: `stable` is a new target kind on the existing `wait` command (mirrors how `text`/`ref`/`selector` are modeled as a discriminated `kind` on one command, not separate subcommands):
- `src/core/wait-positionals.ts` — positional grammar (`wait stable [quietMs] [timeoutMs]`)
- `src/commands/capture/wait-command-contract.ts`, `src/commands/capture/wait.ts` — CLI/MCP field metadata, CLI reader/writer, validation
- `src/client/client-types.ts` — typed `WaitCommandOptions` variant
- `src/daemon/selector-runtime.ts` — daemon dispatch target mapping
- `src/commands/interaction/runtime/selector-read.ts` — the actual poll loop (`waitForStable`) and digest comparator, alongside the existing `waitForText`/`waitForSelector` loops
- `src/daemon/selector-recording.ts` — typed daemon response data (`settledAfterMs`/`captures`/`nodeCount`)
- `src/daemon/wait-current-surface.ts` — timeout message recognized for current-surface enrichment
- `src/cli/parser/cli-help.ts` — `help workflow` documentation

No new runner protocol: reuses the existing `captureSnapshot` backend call (now with an `interactiveOnly` override plumbed through `captureSelectorSnapshot`, which previously hardcoded `interactiveOnly: false`).

## Judgment calls

- **Session snapshot cache is not updated by `wait stable` polling captures.** Existing `wait text`/`wait selector` loops call `captureSelectorSnapshot(..., { updateSession: true })` with a full tree. Since `wait stable` intentionally captures the *interactive-only* tree as a cheap settle signal, writing that filtered tree into the session cache would degrade subsequent `get`/`find`/ref-based lookups in the same session that expect the richer full tree. `wait stable` passes `updateSession: false`.
- **Settle rule requires `captures >= 2` AND elapsed time since the last change `>= quietMs`.** With the existing 300ms poll cadence and a 500ms default `quietMs`, this naturally requires 3 captures in the common case (capture 1 establishes a baseline, capture 2 can't yet prove 500ms of quiet since only ~300ms elapsed, capture 3 confirms it) rather than literally "any 2 identical captures" — this matches the issue's intent of a *time-based* quiet window, not just a capture-count threshold.
- **Timeout message** (`wait timed out waiting for a stable UI`) is a new pattern; extended the existing `isWaitTimeoutMessage` regex in `wait-current-surface.ts` so `wait stable` timeouts get the same "Current surface" enrichment as `wait text`/`wait selector` timeouts, for consistency.
- CLI validation rejects `stable` combined with `timeoutMs` but no `quietMs` positional (ambiguous positional order), matching the "quietMs before timeoutMs" positional grammar.

## Test plan

- [x] `pnpm format`
- [x] `pnpm check:quick` (lint + typecheck)
- [x] `pnpm exec vitest run` on touched areas (`selector-read.test.ts`, `capture/index.test.ts`, `daemon/handlers/__tests__/snapshot.test.ts`) — all green
- [x] `pnpm test:integration:provider` — all green (26 files / 87 tests)
- [x] New unit tests cover: settles after N stable captures, detects instability then settles, times out with capture stats in error details, CLI/daemon-writer parameter validation (exactly-one-target, quietMs-before-timeoutMs ordering)
- [x] Full `--project unit` run showed unrelated pre-existing flakiness in `src/platforms/apple/core/__tests__/*` (xcodebuild/xctestrun process-spawn tests under CPU contention — documented existing flake pattern); verified those same files pass in isolation both with and without this change

Closes #1049