### PR TITLE
refactor: add shared TTL memo reset registry

### DIFF
--- a/src/__tests__/process-memo-setup.ts
+++ b/src/__tests__/process-memo-setup.ts
@@ -1,0 +1,7 @@
+import { afterEach } from 'vitest';
+
+import { resetAllProcessMemosForTests } from '../utils/ttl-memo.ts';
+
+afterEach(() => {
+  resetAllProcessMemosForTests();
+});

--- a/src/daemon/__tests__/device-ready.test.ts
+++ b/src/daemon/__tests__/device-ready.test.ts
@@ -20,7 +20,6 @@ import { waitForAndroidBoot } from '../../platforms/android/devices.ts';
 import { ensureBootedSimulator } from '../../platforms/apple/core/simulator.ts';
 import { ANDROID_EMULATOR, IOS_DEVICE, IOS_SIMULATOR } from '../../__tests__/test-utils/index.ts';
 import {
-  clearDeviceReadyCacheForTests,
   DEVICE_READY_CACHE_TTL_MS,
   ensureDeviceReady,
   parseIosReadyPayload,
@@ -34,7 +33,6 @@ const mockWaitForAndroidBoot = vi.mocked(waitForAndroidBoot);
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2026-04-01T10:00:00.000Z'));
-  clearDeviceReadyCacheForTests();
   mockRunCmd.mockReset();
   mockEnsureBootedSimulator.mockReset();
   mockEnsureBootedSimulator.mockResolvedValue(undefined);
@@ -43,7 +41,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  clearDeviceReadyCacheForTests();
   vi.useRealTimers();
 });
 

--- a/src/daemon/device-ready.ts
+++ b/src/daemon/device-ready.ts
@@ -9,6 +9,7 @@ import {
 } from '../platforms/apple/core/devicectl.ts';
 import { runXcrun } from '../platforms/apple/core/tool-provider.ts';
 import { isActiveProviderDevice } from '../provider-device-runtime.ts';
+import { createTtlMemo } from '../utils/ttl-memo.ts';
 
 const IOS_DEVICE_READY_TIMEOUT_MS = 15_000;
 const IOS_DEVICE_READY_COMMAND_TIMEOUT_BUFFER_MS = 3_000;
@@ -16,7 +17,7 @@ const IOS_DEVICE_READY_COMMAND_TIMEOUT_BUFFER_MS = 3_000;
 // Exported so unit tests can assert TTL behavior without duplicating the value.
 export const DEVICE_READY_CACHE_TTL_MS = 5_000;
 
-const readyCache = new Map<string, number>();
+const readyCache = createTtlMemo<string, true>({ ttlMs: DEVICE_READY_CACHE_TTL_MS });
 
 export type DeviceReadyOptions = {
   deviceHub?: boolean;
@@ -31,11 +32,9 @@ export async function ensureDeviceReady(
   if (isActiveProviderDevice(device)) return;
 
   const cacheKey = deviceReadyCacheKey(device);
-  const cachedUntil = readyCache.get(cacheKey);
-  if (cachedUntil !== undefined) {
-    if (cachedUntil > Date.now() && !options.focusExisting) {
-      return;
-    }
+  const isCached = readyCache.get(cacheKey) === true;
+  if (isCached) {
+    if (!options.focusExisting) return;
     readyCache.delete(cacheKey);
   }
 
@@ -63,13 +62,8 @@ export async function ensureDeviceReady(
   }
 }
 
-// Test-only reset hook for this daemon-local cache.
-export function clearDeviceReadyCacheForTests(): void {
-  readyCache.clear();
-}
-
 function markDeviceReady(cacheKey: string): void {
-  readyCache.set(cacheKey, Date.now() + DEVICE_READY_CACHE_TTL_MS);
+  readyCache.set(cacheKey, true);
 }
 
 function deviceReadyCacheKey(device: DeviceInfo): string {

--- a/src/platforms/apple/core/__tests__/index.test.ts
+++ b/src/platforms/apple/core/__tests__/index.test.ts
@@ -164,7 +164,6 @@ const mockPrepareStatusBarForScreenshot = vi.mocked(prepareStatusBarForScreensho
 
 beforeEach(() => {
   vi.resetAllMocks();
-  simulatorActual.__resetSimulatorBootedMemoForTests();
   invalidateSimulatorStatusBarOverrideCache(IOS_TEST_SIMULATOR);
   mockRunCmd.mockImplementation(execActual.runCmd);
   mockRetryWithPolicy.mockImplementation(retryActual.retryWithPolicy);

--- a/src/platforms/apple/core/__tests__/runner-xctestrun.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-xctestrun.test.ts
@@ -8,7 +8,6 @@ import path from 'node:path';
 import type { DeviceInfo } from '../../../../kernel/device.ts';
 import { withCommandExecutorOverride } from '../../../../utils/exec.ts';
 import {
-  __resetRunnerToolchainFingerprintCacheForTests,
   acquireXcodebuildSimulatorSetRedirect,
   ensureXctestrunArtifact,
   findXctestrun,
@@ -251,7 +250,6 @@ test('setup metadata script matches expected iOS simulator cache metadata', asyn
     });
     const previousPath = process.env.PATH;
     process.env.PATH = `${binDir}${path.delimiter}${previousPath ?? ''}`;
-    __resetRunnerToolchainFingerprintCacheForTests();
 
     try {
       execFileSync(
@@ -278,7 +276,6 @@ test('setup metadata script matches expected iOS simulator cache metadata', asyn
 
       assert.deepEqual(actualComparable, expectedComparable);
     } finally {
-      __resetRunnerToolchainFingerprintCacheForTests();
       restoreEnvVar('PATH', previousPath);
     }
   });

--- a/src/platforms/apple/core/__tests__/simulator-booted-memo.test.ts
+++ b/src/platforms/apple/core/__tests__/simulator-booted-memo.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import type { DeviceInfo } from '../../../../kernel/device.ts';
 import {
-  __resetSimulatorBootedMemoForTests,
   ensureBootedSimulator,
   markSimulatorBooted,
   shutdownSimulator,
@@ -41,7 +40,6 @@ function countSimctlListCalls(): number {
 
 beforeEach(() => {
   vi.useFakeTimers({ now: 1_000 });
-  __resetSimulatorBootedMemoForTests();
   mockRunXcrun.mockReset();
   mockRunXcrun.mockImplementation(async () => bootedListResult());
 });
@@ -85,4 +83,18 @@ test('booted memo is scoped per simulator set path', async () => {
 
   await ensureBootedSimulator({ ...simulator, simulatorSetPath: '/custom/set' });
   expect(countSimctlListCalls()).toBe(2);
+});
+
+test.sequential('process memo test setup clears simulator boot memo: seed', async () => {
+  markSimulatorBooted(simulator);
+
+  await ensureBootedSimulator(simulator);
+
+  expect(countSimctlListCalls()).toBe(0);
+});
+
+test.sequential('process memo test setup clears simulator boot memo: verify', async () => {
+  await ensureBootedSimulator(simulator);
+
+  expect(countSimctlListCalls()).toBe(1);
 });

--- a/src/platforms/apple/core/runner/runner-xctestrun.ts
+++ b/src/platforms/apple/core/runner/runner-xctestrun.ts
@@ -8,6 +8,7 @@ import { resolveIosSimulatorDeviceSetPath } from '../../../../utils/device-isola
 import { readProcessStartTime } from '../../../../utils/process-identity.ts';
 import { acquireProcessLock, type ProcessLockOwner } from '../../../../utils/process-lock.ts';
 import { isEnvTruthy } from '../../../../utils/retry.ts';
+import { createTtlMemo } from '../../../../utils/ttl-memo.ts';
 import { isIosFamily, isMacOs, type DeviceInfo } from '../../../../kernel/device.ts';
 import type { DefinedEnvMap as EnvMap } from '../../../../utils/env-map.ts';
 import { withKeyedLock } from '../../../../utils/keyed-lock.ts';
@@ -64,7 +65,7 @@ const RUNNER_UNIT_TEST_SWIFT_FLAGS =
 
 const runnerXctestrunBuildLocks = new Map<string, Promise<unknown>>();
 const badRunnerArtifactsForRun = new Set<string>();
-const appleToolFingerprintCache = new Map<string, string>();
+const appleToolFingerprintCache = createTtlMemo<string, string>();
 export const runnerPrepProcesses = new Set<ExecBackgroundResult['child']>();
 
 type XctestrunTarget = {
@@ -737,10 +738,6 @@ const RUNNER_ROOT_TRANSIENT_ENTRY_NAMES = new Set([
   'TextBasedInstallAPI',
   'info.plist',
 ]);
-
-export function __resetRunnerToolchainFingerprintCacheForTests(): void {
-  appleToolFingerprintCache.clear();
-}
 
 export function shouldDeleteRunnerDerivedRootEntry(entryName: string): boolean {
   return RUNNER_ROOT_TRANSIENT_ENTRY_NAMES.has(entryName);

--- a/src/platforms/apple/core/simulator.ts
+++ b/src/platforms/apple/core/simulator.ts
@@ -1,6 +1,7 @@
 import type { DeviceInfo } from '../../../kernel/device.ts';
 import { AppError } from '../../../kernel/errors.ts';
 import { Deadline, retryWithPolicy } from '../../../utils/retry.ts';
+import { createTtlMemo } from '../../../utils/ttl-memo.ts';
 import { bootFailureHint, classifyBootFailure } from '../../boot-diagnostics.ts';
 
 import {
@@ -32,21 +33,14 @@ type EnsureBootedSimulatorOptions = {
 // simctl error instead of an auto-boot. Transitions we own update the memo.
 // Exported so unit tests can assert TTL behavior without duplicating the value.
 export const SIMULATOR_BOOTED_MEMO_TTL_MS = 5_000;
-const simulatorBootedMemo = new Map<string, number>();
+const simulatorBootedMemo = createTtlMemo<string, true>({ ttlMs: SIMULATOR_BOOTED_MEMO_TTL_MS });
 
 function simulatorBootedMemoKey(device: DeviceInfo): string {
   return `${device.id}|${device.simulatorSetPath ?? ''}`;
 }
 
 function readSimulatorBootedMemo(device: DeviceInfo): boolean {
-  const key = simulatorBootedMemoKey(device);
-  const observedAt = simulatorBootedMemo.get(key);
-  if (observedAt === undefined) return false;
-  if (Date.now() - observedAt > SIMULATOR_BOOTED_MEMO_TTL_MS) {
-    simulatorBootedMemo.delete(key);
-    return false;
-  }
-  return true;
+  return simulatorBootedMemo.get(simulatorBootedMemoKey(device)) === true;
 }
 
 // Also called by the device-inventory parser: a `simctl list` that reports a
@@ -55,15 +49,11 @@ function readSimulatorBootedMemo(device: DeviceInfo): boolean {
 // same request cost nothing. Callers must only pass FRESH observations —
 // seeding from a cached or persisted device listing would poison the memo.
 export function markSimulatorBooted(device: DeviceInfo): void {
-  simulatorBootedMemo.set(simulatorBootedMemoKey(device), Date.now());
+  simulatorBootedMemo.set(simulatorBootedMemoKey(device), true);
 }
 
 function clearSimulatorBootedMemo(device: DeviceInfo): void {
   simulatorBootedMemo.delete(simulatorBootedMemoKey(device));
-}
-
-export function __resetSimulatorBootedMemoForTests(): void {
-  simulatorBootedMemo.clear();
 }
 
 export function requireSimulatorDevice(device: DeviceInfo, command: string): void {

--- a/src/utils/__tests__/ttl-memo.test.ts
+++ b/src/utils/__tests__/ttl-memo.test.ts
@@ -1,0 +1,53 @@
+import { expect, test, vi } from 'vitest';
+
+import { createTtlMemo } from '../ttl-memo.ts';
+
+const crossTestMemo = createTtlMemo<string, string>({ ttlMs: 60_000 });
+
+test.sequential('process memo setup clears values after each test: seed', () => {
+  crossTestMemo.set('key', 'value');
+
+  expect(crossTestMemo.get('key')).toBe('value');
+});
+
+test.sequential('process memo setup clears values after each test: verify', () => {
+  expect(crossTestMemo.get('key')).toBeUndefined();
+});
+
+test('ttl memo expires entries on read', () => {
+  let now = 1_000;
+  const memo = createTtlMemo<string, string>({ ttlMs: 5_000, now: () => now });
+
+  memo.set('device', 'ready');
+  now += 4_999;
+  expect(memo.get('device')).toBe('ready');
+
+  now += 1;
+  expect(memo.get('device')).toBeUndefined();
+});
+
+test('ttl memo can schedule entry expiry', () => {
+  vi.useFakeTimers();
+  try {
+    const memo = createTtlMemo<string, string>({ ttlMs: 5_000, scheduleExpiry: true });
+
+    memo.set('device', 'ready');
+    vi.advanceTimersByTime(4_999);
+    expect(memo.get('device')).toBe('ready');
+
+    vi.advanceTimersByTime(1);
+    expect(memo.get('device')).toBeUndefined();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('ttl memo delete removes a cached entry', () => {
+  const memo = createTtlMemo<string, string>();
+
+  memo.set('tool', 'fingerprint');
+
+  expect(memo.delete('tool')).toBe(true);
+  expect(memo.get('tool')).toBeUndefined();
+  expect(memo.delete('tool')).toBe(false);
+});

--- a/src/utils/ttl-memo.ts
+++ b/src/utils/ttl-memo.ts
@@ -1,0 +1,86 @@
+type MemoTimer = ReturnType<typeof setTimeout>;
+
+type TtlMemoEntry<Value> = {
+  value: Value;
+  expiresAt?: number;
+  timer?: MemoTimer;
+};
+
+export type TtlMemo<Key, Value> = {
+  get: (key: Key) => Value | undefined;
+  set: (key: Key, value: Value) => void;
+  delete: (key: Key) => boolean;
+  clear: () => void;
+};
+
+export type TtlMemoOptions = {
+  ttlMs?: number;
+  scheduleExpiry?: boolean;
+  now?: () => number;
+};
+
+const processMemoResets = new Set<() => void>();
+
+export function createTtlMemo<Key, Value>(options: TtlMemoOptions = {}): TtlMemo<Key, Value> {
+  const entries = new Map<Key, TtlMemoEntry<Value>>();
+  const now = options.now ?? (() => Date.now());
+
+  const clearEntryTimer = (entry: TtlMemoEntry<Value> | undefined): void => {
+    if (entry?.timer) {
+      clearTimeout(entry.timer);
+    }
+  };
+
+  const memo: TtlMemo<Key, Value> = {
+    get(key) {
+      const entry = entries.get(key);
+      if (!entry) return undefined;
+      if (entry.expiresAt !== undefined && entry.expiresAt <= now()) {
+        memo.delete(key);
+        return undefined;
+      }
+      return entry.value;
+    },
+    set(key, value) {
+      clearEntryTimer(entries.get(key));
+      const expiresAt = resolveExpiresAt(options.ttlMs, now);
+      const entry: TtlMemoEntry<Value> = { value, expiresAt };
+      if (options.scheduleExpiry && expiresAt !== undefined) {
+        entry.timer = setTimeout(
+          () => {
+            entries.delete(key);
+          },
+          Math.max(0, expiresAt - now()),
+        );
+        entry.timer.unref?.();
+      }
+      entries.set(key, entry);
+    },
+    delete(key) {
+      const entry = entries.get(key);
+      if (!entry) return false;
+      clearEntryTimer(entry);
+      return entries.delete(key);
+    },
+    clear() {
+      for (const entry of entries.values()) {
+        clearEntryTimer(entry);
+      }
+      entries.clear();
+    },
+  };
+
+  processMemoResets.add(memo.clear);
+  return memo;
+}
+
+export function resetAllProcessMemosForTests(): void {
+  for (const reset of processMemoResets) {
+    reset();
+  }
+}
+
+function resolveExpiresAt(ttlMs: number | undefined, now: () => number): number | undefined {
+  if (ttlMs === undefined || !Number.isFinite(ttlMs)) return undefined;
+  return now() + Math.max(0, ttlMs);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,12 +7,14 @@ export default defineConfig({
         test: {
           name: 'unit',
           include: ['src/**/*.test.ts'],
+          setupFiles: ['src/__tests__/process-memo-setup.ts'],
         },
       },
       {
         test: {
           name: 'provider-integration',
           include: ['test/integration/provider-scenarios/**/*.test.ts'],
+          setupFiles: ['src/__tests__/process-memo-setup.ts'],
         },
       },
     ],


### PR DESCRIPTION
## Summary

Add a shared TTL memo helper with a process-memo reset registry wired into Vitest setup, so registered process-global memos clear after each unit/provider test by construction.

Migrate the simulator booted memo, daemon device-ready cache, and Apple tool fingerprint cache off ad hoc test reset exports while preserving their cache keys and TTL/process-lifetime behavior.

Add focused coverage for TTL expiry, scheduled expiry, registry-backed cross-test cleanup, and a migrated simulator boot memo leak scenario. Closes #1042.

Touched files: 11.

## Validation

Passed: `pnpm exec vitest run src/utils/__tests__/ttl-memo.test.ts src/platforms/apple/core/__tests__/simulator-booted-memo.test.ts src/daemon/__tests__/device-ready.test.ts src/platforms/apple/core/__tests__/runner-xctestrun.test.ts --project unit`.

Passed: `pnpm check:quick`.

Passed after building dist: `pnpm build`, then `pnpm test:smoke`.

Residual risk: exact `pnpm check:unit` was run twice but did not pass in this local environment. The failures were nondeterministic across runs, mostly full-suite timeouts or mocked adb/xcrun helper misses in unrelated files; the failed files I reran in isolation passed.