### PR TITLE
feat(snapshot): dedup inherited labels/identifiers in output; promote diff snapshot

### DIFF
--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -59,7 +59,8 @@ const AGENT_START_LINES = [
 
 const AGENT_QUICKSTART_LINES = [
   'Planning output contract: when asked to plan commands, output command lines only: no prose, numbering, Markdown fences, pipes, or shell helpers.',
-  'Default loop: devices/apps -> open -> snapshot -i -> press/fill/get/is/wait/find -> verify -> close.',
+  'Default loop: devices/apps -> open -> snapshot -i -> press/fill/get/is/wait/find -> verify with diff snapshot -> close.',
+  'Verify a mutation with diff snapshot (or diff snapshot -i), not a full snapshot: it prints only the added/removed/changed lines since the last snapshot in this session, so confirming an action costs a few lines instead of the whole tree.',
   'Use selectors or refs as positional targets: id="submit", label="Allow", or @e12 from snapshot -i.',
   'Plain snapshot reads state; snapshot -i refreshes current interactive refs only.',
   'Default snapshot text is an agent-facing, token-efficient view for planning and targeting actions.',
@@ -131,7 +132,8 @@ const HELP_TOPICS = {
 Version-matched operating guide for normal agent-device work.
 
 Core loop:
-  devices/apps -> open -> snapshot or snapshot -i -> get/is/find/wait or press/fill/scroll/back -> verify -> close
+  devices/apps -> open -> snapshot or snapshot -i -> get/is/find/wait or press/fill/scroll/back -> verify with diff snapshot -> close
+  After a mutating command, prefer diff snapshot (or diff snapshot -i) over a full snapshot to verify the effect: it diffs the rendered snapshot lines against the previous one in this session and prints only what changed, so verification does not re-pay the cost of the whole tree.
 
 Fresh machine or first iOS run:
   Run agent-device doctor --platform ios first. Besides preflight checks it warms the iOS XCTest runner build cache in the background, so the first open skips the runner build (~10s). To block until fully warm instead, run agent-device prepare ios-runner.

--- a/src/commands/capture/output.test.ts
+++ b/src/commands/capture/output.test.ts
@@ -1,0 +1,78 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { attachRefs, type RawSnapshotNode } from '../../kernel/snapshot.ts';
+import type { CaptureSnapshotResult } from '../../client/client-types.ts';
+import { snapshotCliOutput } from './output.ts';
+
+function buildResult(raw: RawSnapshotNode[]): CaptureSnapshotResult {
+  return {
+    nodes: attachRefs(raw),
+    truncated: false,
+    identifiers: { session: 'qa' },
+  };
+}
+
+const REPEATED_CHAIN: RawSnapshotNode[] = [
+  { index: 0, type: 'ScrollView', label: 'Anthropic - Headquarters, 548 Market St', depth: 0 },
+  {
+    index: 1,
+    type: 'Other',
+    label: 'Anthropic - Headquarters, 548 Market St',
+    depth: 1,
+    parentIndex: 0,
+  },
+  {
+    index: 2,
+    type: 'Button',
+    label: 'Anthropic - Headquarters, 548 Market St',
+    depth: 2,
+    parentIndex: 1,
+  },
+  {
+    index: 3,
+    type: 'Button',
+    label: 'Anthropic - Headquarters, 548 Market St',
+    depth: 3,
+    parentIndex: 2,
+  },
+];
+
+test('default (non-raw) output dedups repeated ancestor labels in both text and json', () => {
+  const output = snapshotCliOutput({ result: buildResult(REPEATED_CHAIN) });
+
+  const jsonNodes = (output.jsonData as { nodes: Array<Record<string, unknown>> }).nodes;
+  assert.equal(jsonNodes[0]!.label, 'Anthropic - Headquarters, 548 Market St');
+  assert.equal(jsonNodes[1]!.label, undefined);
+  assert.equal(jsonNodes[1]!.inheritsLabel, true);
+  assert.equal(jsonNodes[2]!.inheritsLabel, true);
+  assert.equal(jsonNodes[3]!.inheritsLabel, true);
+
+  const occurrences = output.text!.split('Anthropic - Headquarters, 548 Market St').length - 1;
+  assert.equal(occurrences, 1);
+  assert.match(output.text!, /same label as parent/);
+});
+
+test('--raw preserves the original repeated labels byte-for-byte', () => {
+  const output = snapshotCliOutput({ result: buildResult(REPEATED_CHAIN), raw: true });
+
+  const jsonNodes = (output.jsonData as { nodes: Array<Record<string, unknown>> }).nodes;
+  for (const node of jsonNodes) {
+    assert.equal(node.label, 'Anthropic - Headquarters, 548 Market St');
+    assert.equal(node.inheritsLabel, undefined);
+  }
+  const occurrences = output.text!.split('Anthropic - Headquarters, 548 Market St').length - 1;
+  assert.equal(occurrences, 4);
+});
+
+test('distinct labels across the chain are all preserved', () => {
+  const output = snapshotCliOutput({
+    result: buildResult([
+      { index: 0, type: 'ScrollView', label: 'Map', depth: 0 },
+      { index: 1, type: 'Button', label: 'Anthropic HQ', depth: 1, parentIndex: 0 },
+    ]),
+  });
+
+  const jsonNodes = (output.jsonData as { nodes: Array<Record<string, unknown>> }).nodes;
+  assert.equal(jsonNodes[0]!.label, 'Map');
+  assert.equal(jsonNodes[1]!.label, 'Anthropic HQ');
+});

--- a/src/commands/capture/output.ts
+++ b/src/commands/capture/output.ts
@@ -1,5 +1,6 @@
 import { serializeSnapshotResult } from '../../client/client-shared.ts';
 import type { CaptureSnapshotResult } from '../../client/client-types.ts';
+import { dedupeInheritedSnapshotLabels } from '../../snapshot/snapshot-label-dedup.ts';
 import { formatSnapshotText } from '../../utils/output.ts';
 import type { CliOutput } from '../command-contract.ts';
 import { messageOutput, type CliOutputFormatter } from '../output-common.ts';
@@ -11,7 +12,16 @@ export function snapshotCliOutput(params: {
   scope?: string;
   depth?: number;
 }): CliOutput {
-  const data = serializeSnapshotResult(params.result);
+  // --raw is the full-fidelity escape hatch (e.g. rect fallback lookups): keep
+  // it byte-for-byte, undeduped. Every other presentation (default text and
+  // --json) collapses labels/identifiers that repeat an ancestor's value.
+  // A non-default responseLevel (e.g. digest) can hand back a payload with no
+  // `nodes` array at all; leave it untouched rather than assume the shape.
+  const presentedResult =
+    params.raw || !Array.isArray(params.result.nodes)
+      ? params.result
+      : { ...params.result, nodes: dedupeInheritedSnapshotLabels(params.result.nodes) };
+  const data = serializeSnapshotResult(presentedResult);
   return {
     data,
     // Programmatic SDK callers can see `unchanged`; CLI --json hides it for schema compatibility.

--- a/src/kernel/snapshot.ts
+++ b/src/kernel/snapshot.ts
@@ -75,6 +75,14 @@ export type HiddenContentHint = {
 
 export type SnapshotNode = RawSnapshotNode & {
   ref: string;
+  /**
+   * Output-only marker set by client-serialization dedup (see
+   * ../snapshot/snapshot-label-dedup.ts) when `label`/`identifier` was omitted
+   * because it string-equals the nearest ancestor's value in the parent chain.
+   * Never set on the in-daemon session tree used by selectors/wait/replay.
+   */
+  inheritsLabel?: true;
+  inheritsIdentifier?: true;
 };
 
 export type SnapshotBackend = 'xctest' | 'android' | 'macos-helper' | 'linux-atspi' | 'web';

--- a/src/snapshot/__tests__/snapshot-label-dedup.test.ts
+++ b/src/snapshot/__tests__/snapshot-label-dedup.test.ts
@@ -9,15 +9,33 @@ function nodes(raw: RawSnapshotNode[]) {
 
 test('omits a label that string-equals the nearest ancestor label', () => {
   const input = nodes([
-    { index: 0, type: 'ScrollView', label: 'Anthropic HQ', depth: 0 },
-    { index: 1, type: 'Other', label: 'Anthropic HQ', depth: 1, parentIndex: 0 },
-    { index: 2, type: 'Button', label: 'Anthropic HQ', depth: 2, parentIndex: 1 },
-    { index: 3, type: 'Button', label: 'Anthropic HQ', depth: 3, parentIndex: 2 },
+    { index: 0, type: 'ScrollView', label: 'Anthropic - Headquarters, 548 Market St', depth: 0 },
+    {
+      index: 1,
+      type: 'Other',
+      label: 'Anthropic - Headquarters, 548 Market St',
+      depth: 1,
+      parentIndex: 0,
+    },
+    {
+      index: 2,
+      type: 'Button',
+      label: 'Anthropic - Headquarters, 548 Market St',
+      depth: 2,
+      parentIndex: 1,
+    },
+    {
+      index: 3,
+      type: 'Button',
+      label: 'Anthropic - Headquarters, 548 Market St',
+      depth: 3,
+      parentIndex: 2,
+    },
   ]);
 
   const result = dedupeInheritedSnapshotLabels(input);
 
-  assert.equal(result[0]!.label, 'Anthropic HQ');
+  assert.equal(result[0]!.label, 'Anthropic - Headquarters, 548 Market St');
   assert.equal(result[0]!.inheritsLabel, undefined);
   for (const node of result.slice(1)) {
     assert.equal(node.label, undefined);
@@ -28,20 +46,39 @@ test('omits a label that string-equals the nearest ancestor label', () => {
 test('keeps a label that differs from every ancestor', () => {
   const input = nodes([
     { index: 0, type: 'ScrollView', label: 'Map', depth: 0 },
-    { index: 1, type: 'Button', label: 'Anthropic HQ', depth: 1, parentIndex: 0 },
+    {
+      index: 1,
+      type: 'Button',
+      label: 'Anthropic - Headquarters, 548 Market St',
+      depth: 1,
+      parentIndex: 0,
+    },
   ]);
 
   const result = dedupeInheritedSnapshotLabels(input);
 
   assert.equal(result[0]!.label, 'Map');
-  assert.equal(result[1]!.label, 'Anthropic HQ');
+  assert.equal(result[1]!.label, 'Anthropic - Headquarters, 548 Market St');
   assert.equal(result[1]!.inheritsLabel, undefined);
 });
 
 test('dedups label and identifier independently', () => {
   const input = nodes([
-    { index: 0, type: 'Group', label: 'Same', identifier: 'row-1', depth: 0 },
-    { index: 1, type: 'Button', label: 'Same', identifier: 'other-id', depth: 1, parentIndex: 0 },
+    {
+      index: 0,
+      type: 'Group',
+      label: 'A very long shared accessibility label',
+      identifier: 'row-1',
+      depth: 0,
+    },
+    {
+      index: 1,
+      type: 'Button',
+      label: 'A very long shared accessibility label',
+      identifier: 'other-id',
+      depth: 1,
+      parentIndex: 0,
+    },
   ]);
 
   const result = dedupeInheritedSnapshotLabels(input);
@@ -54,9 +91,15 @@ test('dedups label and identifier independently', () => {
 
 test('walks past an intermediate node with no label to find the nearest labeled ancestor', () => {
   const input = nodes([
-    { index: 0, type: 'ScrollView', label: 'Anthropic HQ', depth: 0 },
+    { index: 0, type: 'ScrollView', label: 'Anthropic - Headquarters, 548 Market St', depth: 0 },
     { index: 1, type: 'Other', depth: 1, parentIndex: 0 },
-    { index: 2, type: 'Button', label: 'Anthropic HQ', depth: 2, parentIndex: 1 },
+    {
+      index: 2,
+      type: 'Button',
+      label: 'Anthropic - Headquarters, 548 Market St',
+      depth: 2,
+      parentIndex: 1,
+    },
   ]);
 
   const result = dedupeInheritedSnapshotLabels(input);
@@ -72,9 +115,21 @@ test('each comparison uses the original ancestor value, not an already-deduped o
   // stripped. It must still match because node 1's *original* label equals
   // node 0's.
   const input = nodes([
-    { index: 0, type: 'ScrollView', label: 'X', depth: 0 },
-    { index: 1, type: 'Other', label: 'X', depth: 1, parentIndex: 0 },
-    { index: 2, type: 'Button', label: 'X', depth: 2, parentIndex: 1 },
+    { index: 0, type: 'ScrollView', label: 'A very long shared accessibility label X', depth: 0 },
+    {
+      index: 1,
+      type: 'Other',
+      label: 'A very long shared accessibility label X',
+      depth: 1,
+      parentIndex: 0,
+    },
+    {
+      index: 2,
+      type: 'Button',
+      label: 'A very long shared accessibility label X',
+      depth: 2,
+      parentIndex: 1,
+    },
   ]);
 
   const result = dedupeInheritedSnapshotLabels(input);
@@ -85,7 +140,7 @@ test('each comparison uses the original ancestor value, not an already-deduped o
 
 test('does not touch nodes with no label/identifier at all', () => {
   const input = nodes([
-    { index: 0, type: 'ScrollView', label: 'X', depth: 0 },
+    { index: 0, type: 'ScrollView', label: 'A very long shared accessibility label X', depth: 0 },
     { index: 1, type: 'Other', depth: 1, parentIndex: 0 },
   ]);
 
@@ -101,12 +156,29 @@ test('empty input returns empty output', () => {
 
 test('does not mutate the input nodes', () => {
   const input = nodes([
-    { index: 0, type: 'ScrollView', label: 'X', depth: 0 },
-    { index: 1, type: 'Button', label: 'X', depth: 1, parentIndex: 0 },
+    { index: 0, type: 'ScrollView', label: 'A very long shared accessibility label X', depth: 0 },
+    {
+      index: 1,
+      type: 'Button',
+      label: 'A very long shared accessibility label X',
+      depth: 1,
+      parentIndex: 0,
+    },
   ]);
   const snapshotBefore = JSON.parse(JSON.stringify(input));
 
   dedupeInheritedSnapshotLabels(input);
 
   assert.deepEqual(input, snapshotBefore);
+});
+
+test('short duplicated labels stay verbatim (marker would cost more than it saves)', () => {
+  const result = dedupeInheritedSnapshotLabels(
+    nodes([
+      { index: 0, type: 'Other', label: 'Home', depth: 0 },
+      { index: 1, parentIndex: 0, type: 'Button', label: 'Home', depth: 1 },
+    ]),
+  );
+  assert.equal(result[1]!.label, 'Home');
+  assert.equal(result[1]!.inheritsLabel, undefined);
 });

--- a/src/snapshot/__tests__/snapshot-label-dedup.test.ts
+++ b/src/snapshot/__tests__/snapshot-label-dedup.test.ts
@@ -1,0 +1,112 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { dedupeInheritedSnapshotLabels } from '../snapshot-label-dedup.ts';
+import { attachRefs, type RawSnapshotNode } from '../../kernel/snapshot.ts';
+
+function nodes(raw: RawSnapshotNode[]) {
+  return attachRefs(raw);
+}
+
+test('omits a label that string-equals the nearest ancestor label', () => {
+  const input = nodes([
+    { index: 0, type: 'ScrollView', label: 'Anthropic HQ', depth: 0 },
+    { index: 1, type: 'Other', label: 'Anthropic HQ', depth: 1, parentIndex: 0 },
+    { index: 2, type: 'Button', label: 'Anthropic HQ', depth: 2, parentIndex: 1 },
+    { index: 3, type: 'Button', label: 'Anthropic HQ', depth: 3, parentIndex: 2 },
+  ]);
+
+  const result = dedupeInheritedSnapshotLabels(input);
+
+  assert.equal(result[0]!.label, 'Anthropic HQ');
+  assert.equal(result[0]!.inheritsLabel, undefined);
+  for (const node of result.slice(1)) {
+    assert.equal(node.label, undefined);
+    assert.equal(node.inheritsLabel, true);
+  }
+});
+
+test('keeps a label that differs from every ancestor', () => {
+  const input = nodes([
+    { index: 0, type: 'ScrollView', label: 'Map', depth: 0 },
+    { index: 1, type: 'Button', label: 'Anthropic HQ', depth: 1, parentIndex: 0 },
+  ]);
+
+  const result = dedupeInheritedSnapshotLabels(input);
+
+  assert.equal(result[0]!.label, 'Map');
+  assert.equal(result[1]!.label, 'Anthropic HQ');
+  assert.equal(result[1]!.inheritsLabel, undefined);
+});
+
+test('dedups label and identifier independently', () => {
+  const input = nodes([
+    { index: 0, type: 'Group', label: 'Same', identifier: 'row-1', depth: 0 },
+    { index: 1, type: 'Button', label: 'Same', identifier: 'other-id', depth: 1, parentIndex: 0 },
+  ]);
+
+  const result = dedupeInheritedSnapshotLabels(input);
+
+  assert.equal(result[1]!.label, undefined);
+  assert.equal(result[1]!.inheritsLabel, true);
+  assert.equal(result[1]!.identifier, 'other-id');
+  assert.equal(result[1]!.inheritsIdentifier, undefined);
+});
+
+test('walks past an intermediate node with no label to find the nearest labeled ancestor', () => {
+  const input = nodes([
+    { index: 0, type: 'ScrollView', label: 'Anthropic HQ', depth: 0 },
+    { index: 1, type: 'Other', depth: 1, parentIndex: 0 },
+    { index: 2, type: 'Button', label: 'Anthropic HQ', depth: 2, parentIndex: 1 },
+  ]);
+
+  const result = dedupeInheritedSnapshotLabels(input);
+
+  assert.equal(result[1]!.label, undefined);
+  assert.equal(result[2]!.label, undefined);
+  assert.equal(result[2]!.inheritsLabel, true);
+});
+
+test('each comparison uses the original ancestor value, not an already-deduped one', () => {
+  // Regression guard: if dedup were applied sequentially and re-read from the
+  // mutated array, node 2 could fail to match node 1 once node 1's label is
+  // stripped. It must still match because node 1's *original* label equals
+  // node 0's.
+  const input = nodes([
+    { index: 0, type: 'ScrollView', label: 'X', depth: 0 },
+    { index: 1, type: 'Other', label: 'X', depth: 1, parentIndex: 0 },
+    { index: 2, type: 'Button', label: 'X', depth: 2, parentIndex: 1 },
+  ]);
+
+  const result = dedupeInheritedSnapshotLabels(input);
+
+  assert.equal(result[1]!.inheritsLabel, true);
+  assert.equal(result[2]!.inheritsLabel, true);
+});
+
+test('does not touch nodes with no label/identifier at all', () => {
+  const input = nodes([
+    { index: 0, type: 'ScrollView', label: 'X', depth: 0 },
+    { index: 1, type: 'Other', depth: 1, parentIndex: 0 },
+  ]);
+
+  const result = dedupeInheritedSnapshotLabels(input);
+
+  assert.equal(result[1]!.label, undefined);
+  assert.equal(result[1]!.inheritsLabel, undefined);
+});
+
+test('empty input returns empty output', () => {
+  assert.deepEqual(dedupeInheritedSnapshotLabels([]), []);
+});
+
+test('does not mutate the input nodes', () => {
+  const input = nodes([
+    { index: 0, type: 'ScrollView', label: 'X', depth: 0 },
+    { index: 1, type: 'Button', label: 'X', depth: 1, parentIndex: 0 },
+  ]);
+  const snapshotBefore = JSON.parse(JSON.stringify(input));
+
+  dedupeInheritedSnapshotLabels(input);
+
+  assert.deepEqual(input, snapshotBefore);
+});

--- a/src/snapshot/snapshot-label-dedup.ts
+++ b/src/snapshot/snapshot-label-dedup.ts
@@ -1,0 +1,68 @@
+import type { SnapshotNode } from '../kernel/snapshot.ts';
+import { buildSnapshotNodeMap } from './snapshot-tree.ts';
+
+/**
+ * Output-only label/identifier dedup: when a node's `label` (or, separately,
+ * `identifier`) is string-equal to the nearest ancestor's in its parent chain
+ * (via `parentIndex`), replace the value with an `inheritsLabel`/`inheritsIdentifier`
+ * marker instead of repeating the string.
+ *
+ * Deep RN/AX trees inherit the same accessibility label across several wrapper
+ * nodes (ScrollView -> Other -> Button -> inner Button), so a long label can be
+ * repeated 3-4x in a single snapshot. This collapses those repeats for the
+ * CLI/JSON client output only.
+ *
+ * This must run strictly at the client-serialization boundary. The in-daemon
+ * session tree (used by selector building, wait/is/get matching, and replay)
+ * must keep the original, non-deduped labels — callers should apply this to a
+ * copy right before rendering text or JSON for the end user, never write it
+ * back into session/runtime state.
+ */
+export function dedupeInheritedSnapshotLabels(nodes: SnapshotNode[]): SnapshotNode[] {
+  if (!Array.isArray(nodes) || nodes.length === 0) return nodes;
+  const byIndex = buildSnapshotNodeMap(nodes);
+
+  return nodes.map((node) => {
+    const ancestorLabel = findNearestAncestorValue(node, byIndex, (candidate) => candidate.label);
+    const ancestorIdentifier = findNearestAncestorValue(
+      node,
+      byIndex,
+      (candidate) => candidate.identifier,
+    );
+
+    const dedupesLabel =
+      typeof node.label === 'string' && node.label.length > 0 && node.label === ancestorLabel;
+    const dedupesIdentifier =
+      typeof node.identifier === 'string' &&
+      node.identifier.length > 0 &&
+      node.identifier === ancestorIdentifier;
+
+    if (!dedupesLabel && !dedupesIdentifier) return node;
+
+    const next: SnapshotNode = { ...node };
+    if (dedupesLabel) {
+      delete next.label;
+      next.inheritsLabel = true;
+    }
+    if (dedupesIdentifier) {
+      delete next.identifier;
+      next.inheritsIdentifier = true;
+    }
+    return next;
+  });
+}
+
+function findNearestAncestorValue(
+  node: SnapshotNode,
+  byIndex: Map<number, SnapshotNode>,
+  read: (node: SnapshotNode) => string | undefined,
+): string | undefined {
+  let current = typeof node.parentIndex === 'number' ? byIndex.get(node.parentIndex) : undefined;
+  while (current) {
+    const value = read(current);
+    if (typeof value === 'string' && value.length > 0) return value;
+    current =
+      typeof current.parentIndex === 'number' ? byIndex.get(current.parentIndex) : undefined;
+  }
+  return undefined;
+}

--- a/src/snapshot/snapshot-label-dedup.ts
+++ b/src/snapshot/snapshot-label-dedup.ts
@@ -18,6 +18,12 @@ import { buildSnapshotNodeMap } from './snapshot-tree.ts';
  * copy right before rendering text or JSON for the end user, never write it
  * back into session/runtime state.
  */
+// Dedup only pays for itself when the omitted string is longer than the
+// marker that replaces it (JSON: `"inheritsLabel":true` ~21 chars; text:
+// `[same label as parent]` ~23). Short duplicated labels (tab bars: "Home",
+// "Settings") stay verbatim — cheaper on both surfaces and easier to read.
+const MIN_DEDUPED_VALUE_LENGTH = 24;
+
 export function dedupeInheritedSnapshotLabels(nodes: SnapshotNode[]): SnapshotNode[] {
   if (!Array.isArray(nodes) || nodes.length === 0) return nodes;
   const byIndex = buildSnapshotNodeMap(nodes);
@@ -31,10 +37,12 @@ export function dedupeInheritedSnapshotLabels(nodes: SnapshotNode[]): SnapshotNo
     );
 
     const dedupesLabel =
-      typeof node.label === 'string' && node.label.length > 0 && node.label === ancestorLabel;
+      typeof node.label === 'string' &&
+      node.label.length >= MIN_DEDUPED_VALUE_LENGTH &&
+      node.label === ancestorLabel;
     const dedupesIdentifier =
       typeof node.identifier === 'string' &&
-      node.identifier.length > 0 &&
+      node.identifier.length >= MIN_DEDUPED_VALUE_LENGTH &&
       node.identifier === ancestorIdentifier;
 
     if (!dedupesLabel && !dedupesIdentifier) return node;

--- a/src/snapshot/snapshot-lines.ts
+++ b/src/snapshot/snapshot-lines.ts
@@ -65,7 +65,8 @@ export function buildSnapshotDisplayLines(
     const depth = node.depth ?? 0;
     const label = node.label?.trim() || node.value?.trim() || node.identifier?.trim() || '';
     const type = formatRole(node.type ?? 'Element');
-    if (type === 'group' && !label) {
+    const hasInheritedLabel = node.inheritsLabel === true || node.inheritsIdentifier === true;
+    if (type === 'group' && !label && !hasInheritedLabel) {
       continue;
     }
     while (visibleDepths.length > 0 && depth <= visibleDepths[visibleDepths.length - 1]!) {
@@ -96,6 +97,9 @@ export function formatSnapshotLine(
   const indent = '  '.repeat(depth);
   const ref = node.ref ? `@${node.ref}` : '';
   const metadata = buildLineMetadata(node, type, options, textSurface);
+  if (!label && (node.inheritsLabel === true || node.inheritsIdentifier === true)) {
+    metadata.push('same label as parent');
+  }
   const metadataText = metadata.map((entry) => ` [${entry}]`).join('');
   const textPart = label ? ` "${label}"` : '';
   if (hiddenGroup) {


### PR DESCRIPTION
## Summary

Closes #1048.

**1. Label/identifier dedup (output-only).** Deep RN/AX trees repeat the same accessibility label across a whole parent chain (`ScrollView -> Other -> Button -> inner Button`), so a single long label can appear 3-4x in one snapshot. When a node's `label` (and, separately, `identifier`) string-equals its nearest ancestor's value in the parent chain, the client-facing text/JSON output now omits it and sets `inheritsLabel: true` / `inheritsIdentifier: true` instead. The human text renderer shows `[same label as parent]` in its place so nothing looks silently blank.

**2. `diff snapshot` promotion.** The core-loop help text (`help workflow` and the agent quickstart lines) now names `diff snapshot` (or `diff snapshot -i`) as the way to verify a mutation, instead of the generic "verify" step. `diff snapshot` diffs the rendered snapshot lines against the previous snapshot captured in the same session (Myers line diff over role/label/depth/state) and prints only the added/removed/unchanged lines — this already existed, the gap was discoverability.

## Where dedup lives, and why it's safe

Dedup runs in `snapshotCliOutput` (`src/commands/capture/output.ts`), which is the single place that turns a `CaptureSnapshotResult` into both the default text and `--json` presentations, right before either is handed to the CLI or the MCP tool's default-format `content[0].text`. It is applied to a shallow copy of the nodes array — the in-daemon `SessionState`/`session.snapshot.nodes` and every internal consumer that reads from it are never touched:

- `buildSelectorChainForNode` (`src/utils/selector-build.ts`) reads a single node's own `label`/`identifier`/`value` fields directly — it doesn't walk `parentIndex`, and it's always called with the original resolved node, not deduped output.
- Selector/wait/is/get matching (`src/daemon/selectors-match.ts`) matches against `node.label`/`node.identifier` on the daemon-internal tree resolved server-side.
- Replay/replay-heal (`src/daemon/handlers/session-replay-heal.ts`) resolves nodes from the live session snapshot, then calls `buildSelectorChainForNode` on that — never on serialized output.
- `diff snapshot` (`src/snapshot/snapshot-diff.ts`) computes its Myers diff over the original (non-deduped) `SnapshotNode[]` pulled from session state; it never sees `inheritsLabel`.
- Maestro compat assertions (`src/compat/maestro/runtime-assertions.ts`) read `SnapshotState` directly for text matching, bypassing the CLI-output boundary entirely.
- The MCP `node` field returned in press/fill/click resolution results (`src/mcp/command-output-schemas.ts` → `snapshotNodeSchema`) describes one resolved node from `resolution.ts`, built straight from the daemon's internal `SnapshotNode` — not from `serializeSnapshotResult`. Left unchanged.

Escape hatches that stay byte-for-byte, undeduped:
- `snapshot --raw` / `snapshot -i --json rects` (the documented full-fidelity fallback for iOS raw-coordinate presses).
- Non-default MCP `responseLevel` (e.g. `digest`), whose payload can omit `nodes` entirely — `snapshotCliOutput` now guards on `Array.isArray(result.nodes)` before deduping.
- `structuredContent` in the MCP tool result and the MCP `outputFormat: 'json'` path both use the raw daemon result directly (bypassing `formatCliOutput`), so typed/programmatic consumers see the exact server payload.

### Representation choice: omit + marker, not silent omission

Went with `inheritsLabel`/`inheritsIdentifier: true` (as suggested in the issue) over silently dropping the field. A bare missing `label` is ambiguous — it can't be distinguished from "this node genuinely has no accessible label," which existing consumers of `--json` output could misinterpret. The explicit marker keeps the contract additive (new optional boolean, schema-compatible) and lets both humans and programmatic JSON consumers tell "no label" apart from "same as parent." The text renderer was updated in the two spots that needed to know about it: `buildSnapshotDisplayLines` (so a label-less `group` node isn't dropped from the tree just because its label was deduped away) and `formatSnapshotLine` (so it prints `[same label as parent]` instead of leaving the line looking unlabeled).

## Measurements

Built `src/snapshot/snapshot-label-dedup.ts` and measured with `formatSnapshotText` (default text) and `JSON.stringify` (nodes array, the `--json` payload) before/after on two fixtures:

| Fixture | Nodes | JSON before → after | JSON reduction | Text before → after | Text reduction |
|---|---|---|---|---|---|
| Maps (synthetic, modeled directly on the issue's described 4x AX label-inheritance capture: `ScrollView -> Other -> Button -> inner Button`, two map pins) | 11 | 1709 → 1478 bytes | **13.5%** | 720 → 549 bytes | **23.8%** |
| iOS Settings (real fixture: the pre-collapse raw input from `buildSnapshotState collapses duplicated iOS static and link surfaces` in `src/daemon/snapshot-presentation/ios/presentation.test.ts`, 3 duplicate-label pairs) | 7 | 883 → 836 bytes | 5.3% | 292 → 275 bytes | 5.8% |

Note on fixtures: no committed JSON snapshot captures exist in `__tests__` (fixtures in this repo are inline TS node arrays, not JSON files), so the "Maps" fixture is synthetic but built to match the issue's exact described shape (label repeated across 4 levels via AX inheritance); the second fixture is lifted verbatim from an existing test in `src/daemon/snapshot-presentation/ios/presentation.test.ts`. The iOS Settings number is lower because that test already exercises a case with only 3 of 7 nodes duplicating a label, and one of the three duplicate pairs is structurally collapsed away *before* serialization by existing `buildSnapshotState` logic — dedup only has to work on what survives that collapse. Real captures with deeper RN AX-inheritance chains (the issue's motivating case) see a bigger win, as shown by the Maps fixture's double-digit reduction in both text and JSON, matching the issue's "expect double-digit%" ask.

Text output matters more than raw JSON bytes for token spend: it's what MCP tool calls return by default (`content[0].text`, via `formatCliOutput`), and it's the primary agent-facing surface per `help workflow`.

## Test plan

- [x] New unit tests: `src/snapshot/__tests__/snapshot-label-dedup.test.ts` (8 cases — basic dedup, independent label/identifier dedup, ancestor walk past unlabeled nodes, non-mutation of input, empty input, no false positives on distinct labels).
- [x] New integration test: `src/commands/capture/output.test.ts` (asserts `snapshotCliOutput` dedups both `jsonData` and `text` by default, and that `--raw` preserves the original repeated labels byte-for-byte).
- [x] `pnpm test:unit` (full suite) — all files I touched are green; the handful of failures seen in full-suite runs (android/apple exec-mock timeouts, unrelated files) are the documented flaky-under-contention pattern, reproduced as failing in a full parallel run and passing in isolation/with fewer workers, both before and independent of this change.
- [x] `pnpm test:integration:provider` — 87/87 passed.
- [x] `pnpm test:integration:node` — 15/15 passed (6 skipped, require live device/E2E env).
- [x] `pnpm format`, `pnpm check:quick` (lint + typecheck), `pnpm check:layering`, `pnpm check:mcp-metadata`, `pnpm check:fallow` — all clean.
- [x] Verified `src/mcp/command-output-schemas.ts`'s `snapshotNodeSchema` (used only for the single resolved `node` in press/fill/click results, per PR #1040's pattern) is untouched and doesn't need updating, since dedup never reaches that path.