### PR TITLE
fix: accept selector-first `is` form and print find action confirmations

### DIFF
--- a/src/__tests__/cli-grammar.test.ts
+++ b/src/__tests__/cli-grammar.test.ts
@@ -124,7 +124,10 @@ test('is grammar explains the predicate/selector-key collision on invalid predic
     () => readInputFromCli('is', ['text=Zzznope', 'nope'], BASE_FLAGS),
     (err: any) => {
       assert.equal(err.code, 'INVALID_ARGS');
-      assert.match(err.message, /is requires predicate: visible\|hidden\|exists\|editable\|selected\|text/);
+      assert.match(
+        err.message,
+        /is requires predicate: visible\|hidden\|exists\|editable\|selected\|text/,
+      );
       assert.match(err.details?.hint ?? '', /is <selector> <predicate>/);
       assert.match(err.details?.hint ?? '', /visible=true/);
       return true;

--- a/src/__tests__/cli-grammar.test.ts
+++ b/src/__tests__/cli-grammar.test.ts
@@ -100,6 +100,38 @@ test('find and is grammar decodes command action positionals', () => {
   assert.equal(isOptions.value, 'Welcome');
 });
 
+test('is grammar accepts the selector-first form with a trailing predicate', () => {
+  // `visible` is both a selector boolean key and a predicate; the trailing bare token
+  // must be reserved as the predicate instead of being swallowed by the selector.
+  const trailingVisible = readInputFromCli('is', ['text=Zzznope', 'visible'], BASE_FLAGS);
+  assert.equal(trailingVisible.predicate, 'visible');
+  assert.equal(trailingVisible.selector, 'text=Zzznope');
+
+  const trailingText = readInputFromCli('is', ['id=title', 'text', 'Welcome'], BASE_FLAGS);
+  assert.equal(trailingText.predicate, 'text');
+  assert.equal(trailingText.selector, 'id=title');
+  assert.equal(trailingText.value, 'Welcome');
+
+  // Predicate-first stays canonical: a bare trailing predicate name after a
+  // predicate-first expression is a selector boolean term, not a second predicate.
+  const predicateFirst = readInputFromCli('is', ['visible', 'text=Foo', 'hidden'], BASE_FLAGS);
+  assert.equal(predicateFirst.predicate, 'visible');
+  assert.equal(predicateFirst.selector, 'text=Foo hidden');
+});
+
+test('is grammar explains the predicate/selector-key collision on invalid predicates', () => {
+  assert.throws(
+    () => readInputFromCli('is', ['text=Zzznope', 'nope'], BASE_FLAGS),
+    (err: any) => {
+      assert.equal(err.code, 'INVALID_ARGS');
+      assert.match(err.message, /is requires predicate: visible\|hidden\|exists\|editable\|selected\|text/);
+      assert.match(err.details?.hint ?? '', /is <selector> <predicate>/);
+      assert.match(err.details?.hint ?? '', /visible=true/);
+      return true;
+    },
+  );
+});
+
 test('settings grammar owns positional parsing for CLI commands', () => {
   const location = readInputFromCli('settings', ['location', 'set', '37.3349', '-122.009'], {
     ...BASE_FLAGS,

--- a/src/commands/interaction/output.test.ts
+++ b/src/commands/interaction/output.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { interactionCliOutputFormatters } from './output.ts';
+
+const formatFind = (result: Record<string, unknown>) =>
+  interactionCliOutputFormatters.find({ input: {}, result });
+
+describe('find CLI output', () => {
+  test('click prints the same success line as a direct press', () => {
+    const output = formatFind({
+      ref: '@e2',
+      locator: 'any',
+      query: 'Catalog',
+      x: 100,
+      y: 50,
+      message: 'Tapped @e2 (100, 50)',
+    });
+    expect(output.text).toBe('Tapped @e2 (100, 50)');
+  });
+
+  test('fill prefers the success message over the raw filled text', () => {
+    const output = formatFind({
+      x: 100,
+      y: 50,
+      text: 'qa@example.com',
+      message: 'Filled 14 chars',
+    });
+    expect(output.text).toBe('Filled 14 chars');
+  });
+
+  test('focus prints the delegated focus confirmation', () => {
+    const output = formatFind({ x: 100, y: 50, message: 'Focused (100, 50)' });
+    expect(output.text).toBe('Focused (100, 50)');
+  });
+
+  test('get text still prints the extracted text', () => {
+    const output = formatFind({ ref: '@e2', text: 'Catalog' });
+    expect(output.text).toBe('Catalog');
+  });
+
+  test('exists still prints the found flag', () => {
+    const output = formatFind({ found: true });
+    expect(output.text).toBe('Found: true');
+  });
+});

--- a/src/commands/interaction/output.ts
+++ b/src/commands/interaction/output.ts
@@ -1,5 +1,6 @@
 import type { CommandRequestResult } from '../../client/client-types.ts';
 import type { CliOutput } from '../command-contract.ts';
+import { readCommandMessage } from '../../utils/success-text.ts';
 import { messageCliOutput, resultOutput, type CliOutputFormatter } from '../output-common.ts';
 
 function getCliOutput(params: { result: CommandRequestResult; format?: string }): CliOutput {
@@ -15,6 +16,10 @@ function getCliOutput(params: { result: CommandRequestResult; format?: string })
 
 function findCliOutput(result: CommandRequestResult): CliOutput {
   const data = result as Record<string, unknown>;
+  // Interactive find actions (click/fill/focus/type) carry the same success message as
+  // their direct counterparts; prefer it over the raw text field fill responses include.
+  const message = readCommandMessage(data);
+  if (message) return { data, text: message };
   if (typeof data.text === 'string') return { data, text: data.text };
   if (typeof data.found === 'boolean') return { data, text: `Found: ${data.found}` };
   if (data.node) return { data, text: JSON.stringify(data.node, null, 2) };

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -22,6 +22,7 @@ import { buildSelectorChainForNode } from '../../../utils/selector-build.ts';
 import {
   evaluateIsPredicate,
   isSupportedPredicate,
+  IS_PREDICATE_REQUIRED_MESSAGE,
   type IsPredicate,
 } from '../../../utils/selector-is-predicates.ts';
 import type {
@@ -253,10 +254,7 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
   options,
 ): Promise<IsCommandResult> => {
   if (!isSupportedPredicate(options.predicate)) {
-    throw new AppError(
-      'INVALID_ARGS',
-      'is requires predicate: visible|hidden|exists|editable|selected|text',
-    );
+    throw new AppError('INVALID_ARGS', IS_PREDICATE_REQUIRED_MESSAGE);
   }
   if (options.predicate === 'text' && !options.expectedText) {
     throw new AppError('INVALID_ARGS', 'is text requires expected text value');

--- a/src/commands/interaction/selectors.ts
+++ b/src/commands/interaction/selectors.ts
@@ -3,6 +3,11 @@ import type { FindOptions, IsOptions } from '../../client/client-types.ts';
 import type { CliFlags } from '../../cli/parser/cli-flags.ts';
 import { AppError } from '../../kernel/errors.ts';
 import {
+  IS_PREDICATE_REQUIRED_MESSAGE,
+  IS_PREDICATE_USAGE_HINT,
+  normalizeIsPositionals,
+} from '../../utils/selector-is-predicates.ts';
+import {
   direct,
   optionalCliNumber,
   optionalNumber,
@@ -107,26 +112,27 @@ function readIsOptionsFromPositionals(positionals: string[], flags: CliFlags): I
     ...selectorSnapshotOptionsFromFlags(flags),
     ...selectionOptionsFromFlags(flags),
   };
-  const predicate = positionals[0];
-  const split = splitRequiredSelector(positionals.slice(1), {
+  const normalized = normalizeIsPositionals(positionals);
+  const predicate = normalized[0];
+  if (
+    predicate !== 'text' &&
+    predicate !== 'visible' &&
+    predicate !== 'hidden' &&
+    predicate !== 'exists' &&
+    predicate !== 'editable' &&
+    predicate !== 'selected'
+  ) {
+    throw new AppError('INVALID_ARGS', IS_PREDICATE_REQUIRED_MESSAGE, {
+      hint: IS_PREDICATE_USAGE_HINT,
+    });
+  }
+  const split = splitRequiredSelector(normalized.slice(1), {
     preferTrailingValue: predicate === 'text',
   });
   if (predicate === 'text') {
     return { ...base, predicate, selector: split.selectorExpression, value: split.rest.join(' ') };
   }
-  if (
-    predicate === 'visible' ||
-    predicate === 'hidden' ||
-    predicate === 'exists' ||
-    predicate === 'editable' ||
-    predicate === 'selected'
-  ) {
-    return { ...base, predicate, selector: split.selectorExpression };
-  }
-  throw new AppError(
-    'INVALID_ARGS',
-    'is requires predicate: visible|hidden|exists|editable|selected|text',
-  );
+  return { ...base, predicate, selector: split.selectorExpression };
 }
 
 function readFindLocator(value: string | undefined): FindOptions['locator'] | undefined {

--- a/src/daemon/__tests__/selectors.test.ts
+++ b/src/daemon/__tests__/selectors.test.ts
@@ -5,6 +5,7 @@ import {
   findSelectorChainMatch,
   parseSelectorChain,
   resolveSelectorChain,
+  splitIsSelectorArgs,
   splitSelectorFromArgs,
 } from '../selectors.ts';
 
@@ -342,4 +343,23 @@ test('appName selector matches nodes with appName field', () => {
   const match3 = findSelectorChainMatch(desktopNodes, chain3, { platform: 'linux' });
   assert.ok(match3);
   assert.equal(match3.matches, 1);
+});
+
+test('splitIsSelectorArgs accepts both predicate-first and selector-first forms', () => {
+  const predicateFirst = splitIsSelectorArgs(['visible', 'text=Zzznope']);
+  assert.equal(predicateFirst.predicate, 'visible');
+  assert.equal(predicateFirst.split?.selectorExpression, 'text=Zzznope');
+  assert.deepEqual(predicateFirst.split?.rest, []);
+
+  // The trailing bare predicate must not be swallowed into the selector as a
+  // boolean term (`visible` is both a selector key and a predicate name).
+  const selectorFirst = splitIsSelectorArgs(['text=Zzznope', 'visible']);
+  assert.equal(selectorFirst.predicate, 'visible');
+  assert.equal(selectorFirst.split?.selectorExpression, 'text=Zzznope');
+  assert.deepEqual(selectorFirst.split?.rest, []);
+
+  const selectorFirstText = splitIsSelectorArgs(['id=title', 'text', 'Welcome']);
+  assert.equal(selectorFirstText.predicate, 'text');
+  assert.equal(selectorFirstText.split?.selectorExpression, 'id=title');
+  assert.deepEqual(selectorFirstText.split?.rest, ['Welcome']);
 });

--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -93,7 +93,7 @@ test('handleFindCommands click returns deterministic metadata across locator var
       positionals: ['Increment', 'click'],
       nodes: [hittableParentNoRect, nonHittableChildWithRect],
       invoke: async () => ({ platformSpecificRef: 'XCUIElementTypeView' }),
-      expectedKeys: ['locator', 'query', 'ref', 'x', 'y'],
+      expectedKeys: ['locator', 'message', 'query', 'ref', 'x', 'y'],
       expectedLocator: 'any',
       expectedQuery: 'Increment',
       expectedCoordinates: { x: 100, y: 50 },
@@ -122,6 +122,37 @@ test('handleFindCommands click returns deterministic metadata across locator var
     expect(invokeCalls.length).toBe(1);
     expect(invokeCalls[0]!.positionals?.[0]).toBe(scenario.expectedRef);
   }
+});
+
+test('handleFindCommands click reports the same success message as a direct press', async () => {
+  const nodes = [
+    { index: 0, type: 'View', hittable: true, depth: 0 },
+    {
+      index: 1,
+      type: 'Button',
+      label: 'Catalog',
+      hittable: true,
+      rect: { x: 50, y: 0, width: 100, height: 100 },
+      depth: 1,
+      parentIndex: 0,
+    },
+  ];
+
+  // Default action (no explicit `click` token) must also confirm the tap.
+  const synthesized = await runFindClickScenario({ positionals: ['Catalog'], nodes });
+  expect(synthesized.response.ok).toBe(true);
+  const synthesizedData = (synthesized.response as { data: Record<string, unknown> }).data;
+  expect(synthesizedData.message).toBe('Tapped @e2 (100, 50)');
+
+  // When the delegated click supplies its own success message, it is passed through.
+  const delegated = await runFindClickScenario({
+    positionals: ['Catalog', 'click'],
+    nodes,
+    invoke: async () => ({ message: 'Tapped @e2 (100, 50)', x: 100, y: 50 }),
+  });
+  expect(delegated.response.ok).toBe(true);
+  const delegatedData = (delegated.response as { data: Record<string, unknown> }).data;
+  expect(delegatedData.message).toBe('Tapped @e2 (100, 50)');
 });
 
 test('handleFindCommands click prefers on-screen duplicate text matches', async () => {

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -18,6 +18,7 @@ import {
 } from '../../core/interaction-targeting.ts';
 import { isSnapshotNodeInteractionBlocked } from '../../snapshot/snapshot-occlusion.ts';
 import { readTextForNode } from './interaction-read.ts';
+import { readCommandMessage, successText } from '../../utils/success-text.ts';
 import { errorResponse, noActiveSessionError } from './response.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts';
@@ -509,6 +510,10 @@ async function handleFindClick(ctx: FindContext, match: ResolvedMatch): Promise<
     matchData.x = matchCoords.x;
     matchData.y = matchCoords.y;
   }
+  const clickMessage =
+    readCommandMessage(response.data as Record<string, unknown>) ??
+    `Tapped ${match.ref}${matchCoords ? ` (${matchCoords.x}, ${matchCoords.y})` : ''}`;
+  Object.assign(matchData, successText(clickMessage));
   recordSessionAction(
     sessionStore,
     session,

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -13,6 +13,8 @@ import { refSnapshotFlagGuardResponse } from './handlers/interaction-flags.ts';
 import {
   evaluateIsPredicate,
   isSupportedPredicate,
+  IS_PREDICATE_REQUIRED_MESSAGE,
+  IS_PREDICATE_USAGE_HINT,
   type IsPredicate,
 } from '../utils/selector-is-predicates.ts';
 import {
@@ -150,14 +152,13 @@ export async function dispatchIsViaRuntime(
 ): Promise<DaemonResponse | null> {
   const { req } = params;
   if (req.command !== 'is') return null;
-  const predicate = (req.positionals?.[0] ?? '').toLowerCase();
+  const { predicate: rawPredicate, split } = splitIsSelectorArgs(req.positionals ?? []);
+  const predicate = rawPredicate.toLowerCase();
   if (!isSupportedPredicate(predicate)) {
-    return errorResponse(
-      'INVALID_ARGS',
-      'is requires predicate: visible|hidden|exists|editable|selected|text',
-    );
+    return errorResponse('INVALID_ARGS', IS_PREDICATE_REQUIRED_MESSAGE, {
+      hint: IS_PREDICATE_USAGE_HINT,
+    });
   }
-  const { split } = splitIsSelectorArgs(req.positionals ?? []);
   if (!split) return errorResponse('INVALID_ARGS', 'is requires a selector expression');
   const expectedText = split.rest.join(' ').trim();
   if (predicate === 'text' && !expectedText) {

--- a/src/daemon/selectors-parse.ts
+++ b/src/daemon/selectors-parse.ts
@@ -1,4 +1,5 @@
 import { splitSelectorFromArgs } from '../utils/selectors-parse.ts';
+import { normalizeIsPositionals } from '../utils/selector-is-predicates.ts';
 
 export * from '../utils/selectors-parse.ts';
 
@@ -6,8 +7,9 @@ export function splitIsSelectorArgs(positionals: string[]): {
   predicate: string;
   split: { selectorExpression: string; rest: string[] } | null;
 } {
-  const predicate = positionals[0] ?? '';
-  const split = splitSelectorFromArgs(positionals.slice(1), {
+  const normalized = normalizeIsPositionals(positionals);
+  const predicate = normalized[0] ?? '';
+  const split = splitSelectorFromArgs(normalized.slice(1), {
     preferTrailingValue: predicate === 'text',
   });
   return { predicate, split };

--- a/src/utils/__tests__/selector-is-predicates.test.ts
+++ b/src/utils/__tests__/selector-is-predicates.test.ts
@@ -1,7 +1,48 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
-import { evaluateIsPredicate } from '../selector-is-predicates.ts';
+import { evaluateIsPredicate, normalizeIsPositionals } from '../selector-is-predicates.ts';
 import type { SnapshotNode } from '../../kernel/snapshot.ts';
+
+test('normalizeIsPositionals keeps canonical predicate-first arguments untouched', () => {
+  assert.deepEqual(normalizeIsPositionals(['visible', 'text=Zzznope']), [
+    'visible',
+    'text=Zzznope',
+  ]);
+  assert.deepEqual(normalizeIsPositionals(['text', 'id=title', 'Welcome']), [
+    'text',
+    'id=title',
+    'Welcome',
+  ]);
+  // Predicate-first wins even when the trailing token is also a predicate name: the
+  // bare `hidden` here is the boolean selector term, not a competing predicate.
+  assert.deepEqual(normalizeIsPositionals(['visible', 'hidden']), ['visible', 'hidden']);
+});
+
+test('normalizeIsPositionals rotates the selector-first form to predicate-first', () => {
+  assert.deepEqual(normalizeIsPositionals(['text=Zzznope', 'visible']), [
+    'visible',
+    'text=Zzznope',
+  ]);
+  assert.deepEqual(normalizeIsPositionals(['id=title', 'text', 'Welcome']), [
+    'text',
+    'id=title',
+    'Welcome',
+  ]);
+  // Boolean selector terms before the trailing predicate stay inside the selector.
+  assert.deepEqual(normalizeIsPositionals(['text=Foo', 'visible=true', 'selected']), [
+    'selected',
+    'text=Foo',
+    'visible=true',
+  ]);
+});
+
+test('normalizeIsPositionals leaves unparseable arguments untouched', () => {
+  assert.deepEqual(normalizeIsPositionals(['text=Zzznope', 'nope']), ['text=Zzznope', 'nope']);
+  assert.deepEqual(normalizeIsPositionals(['text=Zzznope']), ['text=Zzznope']);
+  // The token before `visible` is not a valid selector, so no rotation applies.
+  assert.deepEqual(normalizeIsPositionals(['Some Label', 'visible']), ['Some Label', 'visible']);
+  assert.deepEqual(normalizeIsPositionals([]), []);
+});
 
 test('visible predicate treats zero-height hittable Android nodes as hidden', () => {
   const nodes: SnapshotNode[] = [

--- a/src/utils/selector-is-predicates.ts
+++ b/src/utils/selector-is-predicates.ts
@@ -2,6 +2,7 @@ import type { Platform, PublicPlatform } from '../kernel/device.ts';
 import type { SnapshotState } from '../kernel/snapshot.ts';
 import { isNodeVisibleInEffectiveViewport } from '../snapshot/mobile-snapshot-semantics.ts';
 import { isNodeEditable, isNodeVisible } from './selector-node.ts';
+import { tryParseSelectorChain } from './selectors-parse.ts';
 import {
   buildSnapshotNodeByIndex,
   extractNodeText,
@@ -13,6 +14,28 @@ export type IsPredicate = 'visible' | 'hidden' | 'exists' | 'editable' | 'select
 
 export function isSupportedPredicate(input: string): input is IsPredicate {
   return ['visible', 'hidden', 'exists', 'editable', 'selected', 'text'].includes(input);
+}
+
+export const IS_PREDICATE_REQUIRED_MESSAGE =
+  'is requires predicate: visible|hidden|exists|editable|selected|text';
+
+export const IS_PREDICATE_USAGE_HINT =
+  'Use "is <predicate> <selector>" or "is <selector> <predicate>". visible|hidden|editable|selected double as selector keys: a bare predicate token after the selector is read as the predicate, so write key=true (e.g. visible=true) inside the selector to use it as a filter instead.';
+
+// visible|hidden|editable|selected double as selector boolean keys, so the selector-first
+// form (`is <selector> <predicate>`) cannot survive greedy selector parsing: the trailing
+// predicate token would be swallowed as a boolean selector term. Reserve the first bare
+// predicate token that terminates a valid selector prefix and rotate the positionals into
+// the canonical predicate-first shape.
+export function normalizeIsPositionals(positionals: string[]): string[] {
+  if (isSupportedPredicate((positionals[0] ?? '').toLowerCase())) return positionals;
+  for (let i = 1; i < positionals.length; i += 1) {
+    const candidate = (positionals[i] ?? '').toLowerCase();
+    if (!isSupportedPredicate(candidate)) continue;
+    if (!tryParseSelectorChain(positionals.slice(0, i).join(' '))) continue;
+    return [candidate, ...positionals.slice(0, i), ...positionals.slice(i + 1)];
+  }
+  return positionals;
 }
 
 export function evaluateIsPredicate(params: {


### PR DESCRIPTION
## What

Two UX fixes for error/confirmation paths found while dogfooding:

1. **`is <selector> <predicate>` now works.** `agent-device is text=Zzznope visible` used to fail with `is requires predicate: visible|hidden|exists|editable|selected|text` because every `is` entry point read `positionals[0]` as the predicate. The trailing-predicate form could not be recovered by selector splitting either: `visible|hidden|editable|selected` double as selector boolean keys, so `splitSelectorFromArgs` greedily swallowed the trailing `visible` as a boolean selector term.
2. **`find` interactive actions confirm success.** `agent-device find "Catalog"` (default click) printed nothing on exit 0. The delegated click response — which carries the `Tapped @e5 (100, 50)` message — was discarded by `handleFindClick`, and the find CLI formatter printed fill's raw `text` field instead of its `Filled N chars` message.

## How

- New `normalizeIsPositionals` (`src/utils/selector-is-predicates.ts`): when the first token is not a predicate, reserve the first bare predicate-named token that terminates a valid selector prefix and rotate into the canonical predicate-first shape. Predicate-first always wins, so `is visible hidden` still means predicate `visible` + selector `hidden`. Applied in the CLI reader (`readIsOptionsFromPositionals`) and inside `splitIsSelectorArgs`, so the daemon/MCP path and replay-heal behave identically. Both `is text=Zzznope visible` and `is id=title text Welcome` now parse.
- When nothing parses, the predicate error now carries a hint explaining both accepted forms and the key/predicate collision (write `visible=true` inside the selector to use it as a filter). The message string is shared via `IS_PREDICATE_REQUIRED_MESSAGE` across CLI/daemon/runtime layers.
- `handleFindClick` includes the delegated click's success message (or synthesizes `Tapped @ref (x, y)` from the resolved match), and `findCliOutput` prints the success message first. `find … click/fill/focus/type` now print the same lines as direct `press`/`fill`/`focus`/`type`. Read-only outputs (`get text`, `exists`, `wait`) are unchanged.

## Reviewer notes

- All shipped help examples document only the predicate-first form (`is visible 'label="Online"'`); the selector-first form was never parsed anywhere before this change. If it should stay blessed, a one-line mention in `cli-help.ts` could follow separately (left out here to keep agent-facing help lean).
- The find-click daemon response gains a `message` field; recorded session actions and replay inputs are unchanged.
- Ambiguity policy: the rotation takes the first bare predicate token whose preceding tokens parse as a valid selector chain. Deterministic and covered by tests, including `is text=Foo visible=true selected`.

## Tests

- `normalizeIsPositionals` unit tests: both orders, predicate-first precedence, unparseable inputs left untouched.
- CLI grammar: selector-first forms and the collision-hint error (`err.details.hint`).
- `splitIsSelectorArgs`: both orders at the daemon entry.
- Find handler: click message synthesized for the default action and passed through from the delegated click.
- New `src/commands/interaction/output.test.ts`: find output for click/fill/focus/get text/exists.
- `pnpm check:quick` green; `src/daemon src/commands src/utils src/__tests__` suites pass (210 files, 1926 tests).