### PR TITLE
fix: report expired daemon resources as expiry, not INVALID_ARGS

### DIFF
--- a/src/daemon/__tests__/materialized-path-registry.test.ts
+++ b/src/daemon/__tests__/materialized-path-registry.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { AppError } from '../../kernel/errors.ts';
 import {
   cleanupRetainedMaterializedPaths,
   cleanupRetainedMaterializedPathsForSession,
@@ -53,5 +54,61 @@ test('cleanupRetainedMaterializedPathsForSession removes retained paths bound to
   await cleanupRetainedMaterializedPathsForSession('session-one');
   assert.equal(fs.existsSync(retained.installablePath), false);
 
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('cleanup of unknown materialization reports expiry with a recovery hint', async () => {
+  const error = await cleanupRetainedMaterializedPaths('missing-id').then(
+    () => null,
+    (err: unknown) => err,
+  );
+  assert.equal(error instanceof AppError, true);
+  const appError = error as AppError;
+  assert.equal(appError.code, 'COMMAND_FAILED');
+  assert.equal(appError.message, 'Materialized paths not found or expired: missing-id');
+  assert.equal(appError.details?.reason, 'RESOURCE_EXPIRED');
+  assert.equal(typeof appError.details?.hint, 'string');
+});
+
+test('cleanup of tenant-owned materialization rejects other tenants', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-retained-tenant-'));
+  const appPath = path.join(tempRoot, 'Sample.app');
+  fs.mkdirSync(appPath, { recursive: true });
+
+  const retained = await retainMaterializedPaths({
+    installablePath: appPath,
+    tenantId: 'tenant-a',
+    ttlMs: 60_000,
+  });
+
+  const error = await cleanupRetainedMaterializedPaths(retained.materializationId, 'tenant-b').then(
+    () => null,
+    (err: unknown) => err,
+  );
+  assert.equal(error instanceof AppError, true);
+  assert.equal((error as AppError).code, 'UNAUTHORIZED');
+  assert.equal(fs.existsSync(retained.installablePath), true);
+
+  await cleanupRetainedMaterializedPaths(retained.materializationId, 'tenant-a');
+  assert.equal(fs.existsSync(retained.installablePath), false);
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+test('TTL expiry cleans up tenant-owned materializations without a tenant context', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-retained-ttl-'));
+  const appPath = path.join(tempRoot, 'Sample.app');
+  fs.mkdirSync(appPath, { recursive: true });
+
+  const retained = await retainMaterializedPaths({
+    installablePath: appPath,
+    tenantId: 'tenant-a',
+    ttlMs: 20,
+  });
+
+  const deadline = Date.now() + 5_000;
+  while (fs.existsSync(retained.installablePath) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(fs.existsSync(retained.installablePath), false);
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });

--- a/src/daemon/__tests__/request-cancel.test.ts
+++ b/src/daemon/__tests__/request-cancel.test.ts
@@ -20,6 +20,7 @@ test('createRequestCanceledError includes stable cancellation reason marker', ()
   assert.equal(err.code, 'COMMAND_FAILED');
   assert.equal(err.message, 'request canceled');
   assert.equal(err.details?.reason, 'request_canceled');
+  assert.match(String(err.details?.hint), /canceled intentionally/);
 });
 
 test('isRequestCanceledError accepts structured and legacy cancellation errors', () => {

--- a/src/daemon/__tests__/resumable-upload.test.ts
+++ b/src/daemon/__tests__/resumable-upload.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { AppError } from '../../kernel/errors.ts';
+import { finalizeResumableUpload } from '../resumable-upload.ts';
+
+test('finalizing an unknown upload reports expiry with a recovery hint', async () => {
+  const error = await finalizeResumableUpload('missing-upload-id').then(
+    () => null,
+    (err: unknown) => err,
+  );
+  assert.equal(error instanceof AppError, true);
+  const appError = error as AppError;
+  assert.equal(appError.code, 'COMMAND_FAILED');
+  assert.equal(appError.message, 'Upload not found or expired: missing-upload-id');
+  assert.equal(appError.details?.reason, 'RESOURCE_EXPIRED');
+  assert.equal(typeof appError.details?.hint, 'string');
+});

--- a/src/daemon/__tests__/tenant-owned-entry.test.ts
+++ b/src/daemon/__tests__/tenant-owned-entry.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { AppError } from '../../kernel/errors.ts';
+import {
+  expiredTenantOwnedEntryError,
+  requireTenantOwnedEntry,
+  type TenantOwnedResourceKind,
+} from '../tenant-owned-entry.ts';
+
+const RESOURCE: TenantOwnedResourceKind = {
+  label: 'Artifact',
+  expiredHint: 'Re-run the command that produced the artifact.',
+};
+
+function captureAppError(fn: () => unknown): AppError {
+  try {
+    fn();
+  } catch (error) {
+    assert.equal(error instanceof AppError, true);
+    return error as AppError;
+  }
+  throw new Error('expected an AppError to be thrown');
+}
+
+test('requireTenantOwnedEntry returns entries readable by the tenant', () => {
+  const map = new Map([
+    ['shared', {}],
+    ['owned', { tenantId: 'tenant-a' }],
+  ]);
+  assert.equal(requireTenantOwnedEntry(map, 'shared', undefined, RESOURCE), map.get('shared'));
+  assert.equal(requireTenantOwnedEntry(map, 'shared', 'tenant-b', RESOURCE), map.get('shared'));
+  assert.equal(requireTenantOwnedEntry(map, 'owned', 'tenant-a', RESOURCE), map.get('owned'));
+});
+
+test('missing entries surface as expired resources with a recovery hint', () => {
+  const err = captureAppError(() =>
+    requireTenantOwnedEntry(new Map(), 'gone', undefined, RESOURCE),
+  );
+  assert.equal(err.code, 'COMMAND_FAILED');
+  assert.equal(err.message, 'Artifact not found or expired: gone');
+  assert.equal(err.details?.reason, 'RESOURCE_EXPIRED');
+  assert.equal(err.details?.hint, RESOURCE.expiredHint);
+});
+
+test('tenant mismatch stays UNAUTHORIZED and honors plural labels', () => {
+  const map = new Map([['owned', { tenantId: 'tenant-a' }]]);
+  const singular = captureAppError(() =>
+    requireTenantOwnedEntry(map, 'owned', 'tenant-b', RESOURCE),
+  );
+  assert.equal(singular.code, 'UNAUTHORIZED');
+  assert.equal(singular.message, 'Artifact belongs to a different tenant');
+
+  const plural = captureAppError(() =>
+    requireTenantOwnedEntry(map, 'owned', undefined, {
+      ...RESOURCE,
+      label: 'Materialized paths',
+      plural: true,
+    }),
+  );
+  assert.equal(plural.code, 'UNAUTHORIZED');
+  assert.equal(plural.message, 'Materialized paths belong to a different tenant');
+});
+
+test('expiredTenantOwnedEntryError builds the same shape as the missing-entry throw', () => {
+  const err = expiredTenantOwnedEntryError(RESOURCE, 'abc');
+  assert.equal(err.code, 'COMMAND_FAILED');
+  assert.equal(err.message, 'Artifact not found or expired: abc');
+  assert.equal(err.details?.reason, 'RESOURCE_EXPIRED');
+  assert.equal(err.details?.hint, RESOURCE.expiredHint);
+});

--- a/src/daemon/artifact-tracking.ts
+++ b/src/daemon/artifact-tracking.ts
@@ -4,10 +4,20 @@ import os from 'node:os';
 import path from 'node:path';
 import { AppError } from '../kernel/errors.ts';
 import { runCmd } from '../utils/exec.ts';
+import {
+  expiredTenantOwnedEntryError,
+  requireTenantOwnedEntry,
+  type TenantOwnedResourceKind,
+} from './tenant-owned-entry.ts';
 
 // --- Downloadable artifact tracking ---
 
 const ARTIFACT_CLEANUP_TIMEOUT_MS = 15 * 60 * 1000;
+
+const DOWNLOADABLE_ARTIFACT_RESOURCE: TenantOwnedResourceKind = {
+  label: 'Artifact',
+  expiredHint: `Downloadable artifacts are removed after download or after ${ARTIFACT_CLEANUP_TIMEOUT_MS / 60_000} minutes. Re-run the command that produced the artifact and download it again.`,
+};
 const DEFAULT_DOWNLOAD_MIME_TYPE = 'application/octet-stream';
 const DIRECTORY_ARCHIVE_MIME_TYPE = 'application/gzip';
 
@@ -129,13 +139,12 @@ function readDownloadableArtifactEntry(
   artifactId: string,
   tenantId: string | undefined,
 ): { entry: ArtifactEntry; stat: fs.Stats } {
-  const entry = pendingArtifacts.get(artifactId);
-  if (!entry) {
-    throw new AppError('INVALID_ARGS', `Artifact not found: ${artifactId}`);
-  }
-  if (entry.tenantId && entry.tenantId !== tenantId) {
-    throw new AppError('UNAUTHORIZED', 'Artifact belongs to a different tenant');
-  }
+  const entry = requireTenantOwnedEntry(
+    pendingArtifacts,
+    artifactId,
+    tenantId,
+    DOWNLOADABLE_ARTIFACT_RESOURCE,
+  );
   let stat: fs.Stats;
   try {
     stat = fs.statSync(entry.artifactPath);
@@ -234,7 +243,7 @@ async function createDirectoryArchive(
     // The artifact may be consumed or expire while tar is still archiving.
     if (pendingArtifacts.get(artifactId) !== entry) {
       fs.rmSync(tempDir, { recursive: true, force: true });
-      throw new AppError('INVALID_ARGS', `Artifact not found: ${artifactId}`);
+      throw expiredTenantOwnedEntryError(DOWNLOADABLE_ARTIFACT_RESOURCE, artifactId);
     }
     entry.directoryArchive = archive;
     return archive;
@@ -305,6 +314,11 @@ function cleanupDirectoryArchive(entry: ArtifactEntry): void {
 
 const UPLOAD_CLEANUP_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+const UPLOADED_ARTIFACT_RESOURCE: TenantOwnedResourceKind = {
+  label: 'Uploaded artifact',
+  expiredHint: `Uploaded artifacts expire ${UPLOAD_CLEANUP_TIMEOUT_MS / 60_000} minutes after upload. Upload the file again and retry with the new upload id.`,
+};
+
 type UploadEntry = {
   artifactPath: string;
   tempDir: string;
@@ -334,13 +348,12 @@ export function trackUploadedArtifact(params: {
 }
 
 export function prepareUploadedArtifact(uploadId: string, tenantId?: string): string {
-  const entry = pendingUploads.get(uploadId);
-  if (!entry) {
-    throw new AppError('INVALID_ARGS', `Uploaded artifact not found: ${uploadId}`);
-  }
-  if (entry.tenantId && entry.tenantId !== tenantId) {
-    throw new AppError('UNAUTHORIZED', 'Uploaded artifact belongs to a different tenant');
-  }
+  const entry = requireTenantOwnedEntry(
+    pendingUploads,
+    uploadId,
+    tenantId,
+    UPLOADED_ARTIFACT_RESOURCE,
+  );
   clearTimeout(entry.timer);
   return entry.artifactPath;
 }

--- a/src/daemon/materialized-path-registry.ts
+++ b/src/daemon/materialized-path-registry.ts
@@ -2,9 +2,16 @@ import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { AppError } from '../kernel/errors.ts';
+import { requireTenantOwnedEntry, type TenantOwnedResourceKind } from './tenant-owned-entry.ts';
 
 const DEFAULT_MATERIALIZED_PATH_TTL_MS = 15 * 60 * 1000;
+
+const MATERIALIZED_PATHS_RESOURCE: TenantOwnedResourceKind = {
+  label: 'Materialized paths',
+  plural: true,
+  expiredHint:
+    'Materialized paths are released automatically when their TTL expires; re-run the command that materialized them if the paths are still needed.',
+};
 
 type RetainedEntry = {
   rootPath: string;
@@ -45,7 +52,7 @@ export async function retainMaterializedPaths(params: {
     const ttlMs = params.ttlMs ?? DEFAULT_MATERIALIZED_PATH_TTL_MS;
     const expiresAt = Date.now() + ttlMs;
     const timer = setTimeout(() => {
-      void cleanupRetainedMaterializedPaths(materializationId);
+      void expireRetainedMaterializedPaths(materializationId);
     }, ttlMs);
     retainedPaths.set(materializationId, {
       rootPath,
@@ -72,29 +79,44 @@ export async function cleanupRetainedMaterializedPaths(
   materializationId: string,
   tenantId?: string,
 ): Promise<void> {
-  const entry = retainedPaths.get(materializationId);
-  if (!entry) {
-    throw new AppError('INVALID_ARGS', `Materialized paths not found: ${materializationId}`);
-  }
-  if (entry.tenantId && entry.tenantId !== tenantId) {
-    throw new AppError('UNAUTHORIZED', 'Materialized paths belong to a different tenant');
-  }
-  clearTimeout(entry.timer);
-  retainedPaths.delete(materializationId);
-  await fs.rm(entry.rootPath, { recursive: true, force: true });
+  const entry = requireTenantOwnedEntry(
+    retainedPaths,
+    materializationId,
+    tenantId,
+    MATERIALIZED_PATHS_RESOURCE,
+  );
+  await removeRetainedEntry(materializationId, entry);
 }
 
 export async function cleanupRetainedMaterializedPathsForSession(
   sessionName: string,
 ): Promise<void> {
-  const matchingIds = Array.from(retainedPaths.entries())
-    .filter(([, entry]) => entry.sessionName === sessionName)
-    .map(([materializationId]) => materializationId);
+  const matchingEntries = Array.from(retainedPaths.entries()).filter(
+    ([, entry]) => entry.sessionName === sessionName,
+  );
   await Promise.all(
-    matchingIds.map(async (materializationId) => {
-      await cleanupRetainedMaterializedPaths(materializationId);
+    matchingEntries.map(async ([materializationId, entry]) => {
+      await removeRetainedEntry(materializationId, entry);
     }),
   );
+}
+
+// Daemon-internal expiry: skips the tenant check (the timer has no tenant
+// context) and must never reject — the caller is a bare setTimeout.
+async function expireRetainedMaterializedPaths(materializationId: string): Promise<void> {
+  const entry = retainedPaths.get(materializationId);
+  if (!entry) return;
+  try {
+    await removeRetainedEntry(materializationId, entry);
+  } catch {
+    // best-effort cleanup only
+  }
+}
+
+async function removeRetainedEntry(materializationId: string, entry: RetainedEntry): Promise<void> {
+  clearTimeout(entry.timer);
+  retainedPaths.delete(materializationId);
+  await fs.rm(entry.rootPath, { recursive: true, force: true });
 }
 
 async function copyPathInto(sourcePath: string, parentDir: string): Promise<string> {

--- a/src/daemon/request-cancel.ts
+++ b/src/daemon/request-cancel.ts
@@ -4,6 +4,8 @@ const canceledRequestIds = new Set<string>();
 const requestAbortControllers = new Map<string, AbortController>();
 const REQUEST_CANCELED_REASON = 'request_canceled';
 const REQUEST_CANCELED_MESSAGE = 'request canceled';
+const REQUEST_CANCELED_HINT =
+  'The request was canceled intentionally (explicit cancel or client disconnect) — no retry is needed unless the cancellation was unintended.';
 
 export function resolveRequestTrackingId(
   requestId: string | undefined,
@@ -84,6 +86,7 @@ export function getRequestSignal(requestId: string | undefined): AbortSignal | u
 export function createRequestCanceledError(): AppError {
   return new AppError('COMMAND_FAILED', REQUEST_CANCELED_MESSAGE, {
     reason: REQUEST_CANCELED_REASON,
+    hint: REQUEST_CANCELED_HINT,
   });
 }
 

--- a/src/daemon/request-handler-chain.ts
+++ b/src/daemon/request-handler-chain.ts
@@ -181,7 +181,8 @@ function expectHandlerResponse(
 ): DaemonResponse {
   if (response) return response;
   throw new AppError(
-    'INTERNAL_ERROR',
+    'UNKNOWN',
     `Daemon handler routing mismatch: ${handlerFamily} handler matched command "${command}" but returned no response.`,
+    { hint: 'This is a daemon-internal routing bug in agent-device — please report it.' },
   );
 }

--- a/src/daemon/resumable-upload.ts
+++ b/src/daemon/resumable-upload.ts
@@ -5,6 +5,7 @@ import type { IncomingMessage } from 'node:http';
 import { pipeline } from 'node:stream/promises';
 import { AppError } from '../kernel/errors.ts';
 import { extractTarInstallableArtifact } from './artifact-archive.ts';
+import { requireTenantOwnedEntry, type TenantOwnedResourceKind } from './tenant-owned-entry.ts';
 import {
   createArtifactTempDir,
   sanitizeArtifactFilename,
@@ -12,6 +13,11 @@ import {
 } from './artifact-download.ts';
 
 const RESUMABLE_UPLOAD_CLEANUP_TIMEOUT_MS = 5 * 60 * 1000;
+
+const RESUMABLE_UPLOAD_RESOURCE: TenantOwnedResourceKind = {
+  label: 'Upload',
+  expiredHint: `Resumable uploads expire ${RESUMABLE_UPLOAD_CLEANUP_TIMEOUT_MS / 60_000} minutes after the last received chunk. Start the upload again from the beginning.`,
+};
 const RESUMABLE_UPLOAD_HASH_ALGORITHM = 'sha256';
 const RESUMABLE_UPLOADS_BY_ID = new Map<string, ResumableUploadEntry>();
 const RESUMABLE_UPLOADS_BY_KEY = new Map<string, string>();
@@ -200,14 +206,12 @@ function requireResumableUpload(
   uploadId: string,
   tenantId: string | undefined,
 ): ResumableUploadEntry {
-  const entry = RESUMABLE_UPLOADS_BY_ID.get(uploadId);
-  if (!entry) {
-    throw new AppError('INVALID_ARGS', `Upload not found: ${uploadId}`);
-  }
-  if (entry.tenantId && entry.tenantId !== tenantId) {
-    throw new AppError('UNAUTHORIZED', 'Upload belongs to a different tenant');
-  }
-  return entry;
+  return requireTenantOwnedEntry(
+    RESUMABLE_UPLOADS_BY_ID,
+    uploadId,
+    tenantId,
+    RESUMABLE_UPLOAD_RESOURCE,
+  );
 }
 
 function currentResumableUploadOffset(entry: ResumableUploadEntry): number {

--- a/src/daemon/tenant-owned-entry.ts
+++ b/src/daemon/tenant-owned-entry.ts
@@ -1,0 +1,40 @@
+import { AppError } from '../kernel/errors.ts';
+
+type TenantOwnedEntry = { tenantId?: string };
+
+export type TenantOwnedResourceKind = {
+  label: string;
+  /** Set when the label is grammatically plural ("Materialized paths belong ..."). */
+  plural?: boolean;
+  expiredHint: string;
+};
+
+/**
+ * TTL registries GC entries silently, so a missing id is indistinguishable
+ * from one that never existed — report both as expiry, not INVALID_ARGS.
+ */
+export function expiredTenantOwnedEntryError(kind: TenantOwnedResourceKind, id: string): AppError {
+  return new AppError('COMMAND_FAILED', `${kind.label} not found or expired: ${id}`, {
+    reason: 'RESOURCE_EXPIRED',
+    hint: kind.expiredHint,
+  });
+}
+
+export function requireTenantOwnedEntry<T extends TenantOwnedEntry>(
+  map: Map<string, T>,
+  id: string,
+  tenantId: string | undefined,
+  kind: TenantOwnedResourceKind,
+): T {
+  const entry = map.get(id);
+  if (!entry) {
+    throw expiredTenantOwnedEntryError(kind, id);
+  }
+  if (entry.tenantId && entry.tenantId !== tenantId) {
+    throw new AppError(
+      'UNAUTHORIZED',
+      `${kind.label} ${kind.plural ? 'belong' : 'belongs'} to a different tenant`,
+    );
+  }
+  return entry;
+}

--- a/test/integration/provider-scenarios/daemon-http-server.test.ts
+++ b/test/integration/provider-scenarios/daemon-http-server.test.ts
@@ -699,6 +699,55 @@ test('Provider-backed integration daemon HTTP server isolates same-artifact uplo
   }
 });
 
+test('Provider-backed integration daemon HTTP server reports unknown upload tickets as expired', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t, 'daemon HTTP integration coverage')) {
+    return;
+  }
+
+  const server = await createDaemonHttpServer({
+    token: 'provider-scenario-token',
+    handleRequest: async (): Promise<DaemonResponse> => ({ ok: true, data: {} }),
+  });
+
+  try {
+    const port = await listenOnLoopback(server);
+    const unknownUploadId = crypto.randomUUID();
+    const auth = { authorization: 'Bearer provider-scenario-token' };
+
+    const directChunk = await fetch(`http://127.0.0.1:${port}/upload/direct/${unknownUploadId}`, {
+      method: 'PUT',
+      headers: { ...auth, 'content-type': 'application/octet-stream' },
+      body: Buffer.from('late-chunk'),
+    });
+    assert.equal(directChunk.status, 500);
+    const directBody = (await directChunk.json()) as {
+      ok?: boolean;
+      code?: string;
+      error?: string;
+    };
+    assert.equal(directBody.ok, false);
+    assert.equal(directBody.code, 'COMMAND_FAILED');
+    assert.match(directBody.error ?? '', /not found or expired/);
+
+    const finalize = await fetch(`http://127.0.0.1:${port}/upload/finalize`, {
+      method: 'POST',
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ uploadId: unknownUploadId }),
+    });
+    assert.equal(finalize.status, 500);
+    const finalizeBody = (await finalize.json()) as {
+      ok?: boolean;
+      code?: string;
+      error?: string;
+    };
+    assert.equal(finalizeBody.ok, false);
+    assert.equal(finalizeBody.code, 'COMMAND_FAILED');
+    assert.match(finalizeBody.error ?? '', /not found or expired/);
+  } finally {
+    await closeLoopbackServer(server);
+  }
+});
+
 test('Provider-backed integration daemon HTTP auth hook can scope tenants and reject requests', async (t) => {
   if (await skipWhenLoopbackUnavailable(t, 'daemon HTTP integration coverage')) {
     return;


### PR DESCRIPTION
## What

Fixes the server-side resource-lifecycle error sites flagged by the July 2026 error audit, following the ADR 0010 conventions (specific code, machine-dispatchable `details.reason`, explicit `hint` wherever the per-code default misleads).

- **New shared helper** `src/daemon/tenant-owned-entry.ts`: `requireTenantOwnedEntry(map, id, tenantId, kind)` replaces five duplicated not-found + wrong-tenant check pairs across `artifact-tracking.ts`, `materialized-path-registry.ts`, and `resumable-upload.ts`. Missing entries now throw `COMMAND_FAILED` with message `"<label> not found or expired: <id>"`, `details.reason: 'RESOURCE_EXPIRED'`, and a per-resource recovery hint (re-download / re-upload / restart upload / re-materialize — minute values computed from the TTL constants so they can't drift). Previously these were `INVALID_ARGS`, so agents got *"Check command arguments and run --help"* when the resource had simply expired. The paired tenant check stays `UNAUTHORIZED`.
- **`request-cancel.ts`**: the cancellation error now carries an explicit hint that the request was canceled intentionally (no retry needed), instead of inheriting the misleading "Retry with --debug" default.
- **`request-handler-chain.ts`**: the ad-hoc `INTERNAL_ERROR` code (not in the `KnownAppErrorCode` union) becomes `UNKNOWN` with a report-a-bug hint, keeping the known-code union small.

## Bug fixed along the way

In `materialized-path-registry.ts`, the TTL timer and session teardown called the tenant-checked cleanup with no `tenantId`, so any **tenant-owned** entry hitting its TTL threw `UNAUTHORIZED` inside a `void`-ed promise — an unhandled rejection, and the entry plus its temp dir leaked permanently. Internal expiry/teardown now use a cleanup path that skips the tenant check (the daemon owns the registry); the public `cleanupRetainedMaterializedPaths` keeps full validation.

## Reviewer notes

- Since these errors moved `INVALID_ARGS` → `COMMAND_FAILED`, the HTTP surfaces map them to **500 instead of 400** (JSON-RPC `-32000` instead of `-32602`). No client branches on those statuses for these paths (the upload client only special-cases redirect/resume statuses), and neither status was the "right" 404/410 anyway.
- `reason: 'RESOURCE_EXPIRED'` follows the lease-registry model (`LEASE_EXPIRED`, `DEVICE_LEASE_BUSY`) for machine-dispatchable sub-classification.

## Tests

- New `tenant-owned-entry.test.ts`: pass-through, expired-entry error shape, cross-tenant rejection incl. plural-label grammar.
- `materialized-path-registry.test.ts`: expired-id error shape, cross-tenant rejection, and a regression test that TTL expiry of a tenant-owned entry cleans up without a tenant context.
- `request-cancel.test.ts`: pins the new hint.
- `pnpm check:quick` and the full daemon unit suite pass (972 tests; one known flaky timing test failed once under contention, passes in isolation and on re-run).