### PR TITLE
fix(errors): close call-site and consumer gaps around the central error system

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,8 +58,10 @@ The perfect-shape refactor is complete and merged. Its end-state:
   `PlatformPlugin` per platform family (`src/core/platform-plugin/`) stops core/daemon from branching
   on platform, with the Apple plugin the first instance. See
   [ADR 0008](docs/adr/0008-command-descriptor-registry.md).
-- Typed result spine. Per-command typed results and a `TypedError` replaced the ad-hoc
-  `Record`-typed returns across the daemon/dispatch path.
+- Typed result spine. Per-command typed results replaced the ad-hoc `Record`-typed returns across
+  the daemon/dispatch path; errors gained machine-readable `retriable`/`supportedOn` signals on
+  `DaemonError` (#939). Error-system conventions live in
+  [ADR 0010](docs/adr/0010-error-system.md).
 - Apple platform model. Internally `Platform` is `apple` (plus `android`/`linux`/`web`) with an
   `appleOs` discriminant (`ios | ipados | tvos | watchos | visionos | macos`); the shared Apple
   engine lives under `src/platforms/apple/core/` with per-OS leaves under

--- a/docs/adr/0010-error-system.md
+++ b/docs/adr/0010-error-system.md
@@ -1,0 +1,58 @@
+# ADR 0010: Error system conventions
+
+- Status: accepted
+- Date: 2026-07-03
+
+## Context
+
+The error system is centralized in `src/kernel/errors.ts` (`AppError`, `normalizeError`,
+`defaultHintForCode`, `retriableForErrorCode`) but has ~1,200 construction sites across the CLI,
+daemon, and platform layers. A July 2026 audit (code sweep + iOS/Android dogfooding) found the
+kernel sound while call-site quality drifted: internal validation thrown as bare `Error`
+(surfacing as `UNKNOWN` with a misleading hint), semantically wrong codes (`COMMAND_FAILED` for
+busy devices, `INVALID_ARGS` for expired server-side resources), missing hints on the most common
+agent failures (selector/ref misses), and consumers that drop fields (MCP tool errors carried only
+`message`). Nothing documented the conventions, so each new site re-decided them.
+
+## Decision
+
+1. **Every thrown error a user or agent can reach is an `AppError`.** Bare `throw new Error(...)`
+   is reserved for provably unreachable invariants. Input validation — including daemon-side
+   decoding of command input — throws `AppError('INVALID_ARGS', ...)`. Coercion of unknown caught
+   errors uses `asAppError(err, fallbackCode)`, which preserves the cause chain; do not hand-roll
+   `err instanceof AppError ? err : new AppError(...)`.
+2. **Code selection.** Use the most specific `KnownAppErrorCode`; `COMMAND_FAILED` is for genuine
+   runtime failures of a well-formed request, never a catch-all for capability gaps
+   (`UNSUPPORTED_OPERATION`), contention (`DEVICE_IN_USE`, the only retriable code), or ambiguity
+   (`AMBIGUOUS_MATCH`). New codes are added to the union deliberately; machine-dispatchable
+   sub-classification rides in `details.reason` (the lease registry is the model).
+3. **Hints answer "what should the agent run next".** A hint is required wherever the per-code
+   default from `defaultHintForCode` would mislead; it is omitted where the default suffices —
+   mass-adding boilerplate hints is worse than the default. Shared failure modes get shared hint
+   constants next to the code that detects them (`selectorFailureHint`, `STALE_REF_HINT` in
+   `src/daemon/selectors-resolve.ts`; `resolveIosDevicectlHint`; `bootFailureHint`), not copy-pasted
+   strings. Re-wraps preserve an existing hint rather than clobbering it.
+4. **Wrapping external tool failures.** Prefer `exec.ts` errors as-is. A hand-rolled wrap of an
+   `allowFailure` result must carry `{ stdout, stderr, exitCode, processExitError: true }` so
+   `normalizeError` can surface the first meaningful stderr line instead of "tool exited with
+   code N".
+5. **The wire error contract** is `code`, `message`, `hint`, `details` (redacted), `diagnosticId`,
+   `logPath`, plus optional typed signals `retriable` / `supportedOn` — the fields are absent
+   unless confidently known. Every consumer surface (CLI human, CLI `--json`, SDK, MCP, events
+   timeline) must carry code + message + hint at minimum; rehydration helpers
+   (`throwDaemonError`, `toDaemonHttpRpcError`) copy all fields, and `NormalizedError` hoists the
+   typed signals so `--json` consumers see them.
+6. **Observability.** Failed requests always flush diagnostics: `diagnosticId` + ndjson `logPath`
+   accompany every error (daemon-side under the session state dir, client-side under
+   `~/.agent-device/logs`). Messages must not embed raw stderr dumps or secrets — structured
+   context belongs in `details`, which is redacted at normalize/write time.
+
+## Consequences
+
+- Agents can branch on `code`, retry on `retriable`, and follow `hint` without parsing prose;
+  wording can improve without breaking consumers (except strings pinned by help-text guarantees —
+  update those tests in lockstep).
+- The known-code union stays small and meaningful; the widened `(string & {})` type still lets
+  runner/daemon codes pass through, so SDK consumers keep a `default` branch.
+- New call sites have a documented bar: right code, contextual message naming the target, hint
+  only when the default misleads, cause preserved.

--- a/src/__tests__/cli-grammar.test.ts
+++ b/src/__tests__/cli-grammar.test.ts
@@ -54,6 +54,44 @@ test('interaction and fill grammar share ref, selector, and point parsing', () =
   });
 });
 
+test('interaction selectors reject unquoted trailing text instead of dropping it', () => {
+  assert.throws(
+    () => readInputFromCli('press', ['text=Gesture', 'lab'], BASE_FLAGS),
+    (err: any) => {
+      assert.equal(err.code, 'INVALID_ARGS');
+      assert.match(err.message, /unexpected extra arguments: "lab"/);
+      assert.match(err.message, /text="Gesture lab"/);
+      return true;
+    },
+  );
+  assert.throws(
+    () => readInputFromCli('click', ['role=button', 'text=Sign', 'in'], BASE_FLAGS),
+    (err: any) => {
+      assert.equal(err.code, 'INVALID_ARGS');
+      assert.match(err.message, /unexpected extra arguments: "in"/);
+      assert.match(err.message, /role=button text="Sign in"/);
+      return true;
+    },
+  );
+  assert.throws(
+    () => readInputFromCli('longpress', ['text=Gesture', 'lab'], BASE_FLAGS),
+    (err: any) => {
+      assert.equal(err.code, 'INVALID_ARGS');
+      assert.match(err.message, /unexpected extra arguments: "lab"/);
+      return true;
+    },
+  );
+
+  // Quoted selector values and fill's trailing text payload keep working.
+  assert.deepEqual(readInputFromCli('press', ['text="Gesture lab"'], BASE_FLAGS).target, {
+    kind: 'selector',
+    selector: 'text="Gesture lab"',
+  });
+  const fillAfterSelector = readInputFromCli('fill', ['id=email', 'qa@example.com'], BASE_FLAGS);
+  assert.deepEqual(fillAfterSelector.target, { kind: 'selector', selector: 'id=email' });
+  assert.equal(fillAfterSelector.text, 'qa@example.com');
+});
+
 test('bare snapshot refs without @ prefix throw helpful error', () => {
   assert.throws(
     () => readInputFromCli('click', ['e3'], BASE_FLAGS),

--- a/src/__tests__/contracts-schema-public.test.ts
+++ b/src/__tests__/contracts-schema-public.test.ts
@@ -297,7 +297,7 @@ test('public contract exports normalize and hint app errors', () => {
   assert.equal(normalized.hint, defaultHintForCode(invalidArgsCode));
   assert.equal(
     defaultHintForCode('UNKNOWN'),
-    'Retry with --debug and inspect diagnostics log for details.',
+    'Unexpected internal error. Retry with --debug and report the diagnostics log if it persists.',
   );
 });
 

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -11,6 +11,7 @@ import {
   type PlatformSelector,
 } from '../kernel/device.ts';
 import type { JsonSchema } from './command-contract.ts';
+import { AppError } from '../kernel/errors.ts';
 
 const INTERACTION_TARGET_KINDS = ['ref', 'selector', 'point'] as const;
 
@@ -251,7 +252,7 @@ export function readFieldInput<TFields extends CommandFieldMap>(
     Object.entries(fields).flatMap(([key, field]) => {
       const value = field.read(record, key);
       if (field.required && value === undefined) {
-        throw new Error(`Expected ${key} to be set.`);
+        throw new AppError('INVALID_ARGS',`Expected ${key} to be set.`);
       }
       return value === undefined ? [] : [[key, value]];
     }),
@@ -269,7 +270,7 @@ export function readFieldInput<TFields extends CommandFieldMap>(
 export function readInputRecord(input: unknown): Record<string, unknown> {
   if (input === undefined || input === null) return {};
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    throw new Error('Expected object arguments.');
+    throw new AppError('INVALID_ARGS','Expected object arguments.');
   }
   return input as Record<string, unknown>;
 }
@@ -308,7 +309,7 @@ function readDeviceTarget(
   if (options.readTargetAlias === false || record.target === undefined) return deviceTarget;
   const targetAlias = optionalEnum(record, 'target', DEVICE_TARGETS);
   if (deviceTarget !== undefined && targetAlias !== deviceTarget) {
-    throw new Error('Expected target alias to match deviceTarget when both are set.');
+    throw new AppError('INVALID_ARGS','Expected target alias to match deviceTarget when both are set.');
   }
   return deviceTarget ?? targetAlias;
 }
@@ -358,7 +359,7 @@ export function readPoint(record: Record<string, unknown>, key: string): PointIn
 function requiredString(record: Record<string, unknown>, key: string): string {
   const value = record[key];
   if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(`Expected ${key} to be a non-empty string.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be a non-empty string.`);
   }
   return value;
 }
@@ -367,7 +368,7 @@ function optionalString(record: Record<string, unknown>, key: string): string | 
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(`Expected ${key} to be a non-empty string.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be a non-empty string.`);
   }
   return value;
 }
@@ -375,7 +376,7 @@ function optionalString(record: Record<string, unknown>, key: string): string | 
 export function requiredNumber(record: Record<string, unknown>, key: string): number {
   const value = record[key];
   if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`Expected ${key} to be a finite number.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be a finite number.`);
   }
   return value;
 }
@@ -384,7 +385,7 @@ function optionalNumberValue(record: Record<string, unknown>, key: string): numb
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`Expected ${key} to be a finite number.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be a finite number.`);
   }
   return value;
 }
@@ -397,14 +398,14 @@ export function optionalInteger(
   const value = record[key];
   if (value === undefined) return undefined;
   if (!Number.isInteger(value)) {
-    throw new Error(`Expected ${key} to be an integer.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be an integer.`);
   }
   const numberValue = value as number;
   if (options.min !== undefined && numberValue < options.min) {
-    throw new Error(`Expected ${key} to be at least ${options.min}.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be at least ${options.min}.`);
   }
   if (options.max !== undefined && numberValue > options.max) {
-    throw new Error(`Expected ${key} to be at most ${options.max}.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be at most ${options.max}.`);
   }
   return numberValue;
 }
@@ -413,7 +414,7 @@ function optionalBoolean(record: Record<string, unknown>, key: string): boolean 
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'boolean') {
-    throw new Error(`Expected ${key} to be a boolean.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be a boolean.`);
   }
   return value;
 }
@@ -425,7 +426,7 @@ export function requiredEnum<const T extends readonly string[]>(
 ): T[number] {
   const value = record[key];
   if (typeof value !== 'string' || !values.includes(value)) {
-    throw new Error(`Expected ${key} to be one of: ${values.join(', ')}.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be one of: ${values.join(', ')}.`);
   }
   return value;
 }
@@ -438,7 +439,7 @@ export function optionalEnum<const T extends readonly string[]>(
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'string' || !values.includes(value)) {
-    throw new Error(`Expected ${key} to be one of: ${values.join(', ')}.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be one of: ${values.join(', ')}.`);
   }
   return value;
 }
@@ -514,7 +515,7 @@ export function assertAllowedKeys(
   const allowed = new Set(allowedKeys);
   const unknownKeys = Object.keys(record).filter((key) => !allowed.has(key));
   if (unknownKeys.length > 0) {
-    throw new Error(`${label} has unknown field(s): ${unknownKeys.join(', ')}.`);
+    throw new AppError('INVALID_ARGS',`${label} has unknown field(s): ${unknownKeys.join(', ')}.`);
   }
 }
 
@@ -552,7 +553,7 @@ function optionalRecord(
   const value = record[key];
   if (value === undefined) return undefined;
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`Expected ${key} to be an object.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be an object.`);
   }
   return value as Record<string, unknown>;
 }
@@ -561,7 +562,7 @@ function optionalStringArray(record: Record<string, unknown>, key: string): stri
   const value = record[key];
   if (value === undefined) return undefined;
   if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
-    throw new Error(`Expected ${key} to be an array of strings.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be an array of strings.`);
   }
   return value as string[];
 }
@@ -671,7 +672,7 @@ function elementTargetSchemaVariants(): JsonSchema[] {
 function readRecordField(record: Record<string, unknown>, key: string): Record<string, unknown> {
   const value = record[key];
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`Expected ${key} to be an object.`);
+    throw new AppError('INVALID_ARGS',`Expected ${key} to be an object.`);
   }
   return value as Record<string, unknown>;
 }

--- a/src/commands/command-input.ts
+++ b/src/commands/command-input.ts
@@ -97,7 +97,7 @@ function numberSchema(description?: string): JsonSchema {
   return { type: 'number', ...(description ? { description } : {}) };
 }
 
-export function integerSchema(description?: string): JsonSchema {
+function integerSchema(description?: string): JsonSchema {
   return { type: 'integer', ...(description ? { description } : {}) };
 }
 
@@ -252,7 +252,7 @@ export function readFieldInput<TFields extends CommandFieldMap>(
     Object.entries(fields).flatMap(([key, field]) => {
       const value = field.read(record, key);
       if (field.required && value === undefined) {
-        throw new AppError('INVALID_ARGS',`Expected ${key} to be set.`);
+        throw new AppError('INVALID_ARGS', `Expected ${key} to be set.`);
       }
       return value === undefined ? [] : [[key, value]];
     }),
@@ -270,7 +270,7 @@ export function readFieldInput<TFields extends CommandFieldMap>(
 export function readInputRecord(input: unknown): Record<string, unknown> {
   if (input === undefined || input === null) return {};
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    throw new AppError('INVALID_ARGS','Expected object arguments.');
+    throw new AppError('INVALID_ARGS', 'Expected object arguments.');
   }
   return input as Record<string, unknown>;
 }
@@ -309,7 +309,10 @@ function readDeviceTarget(
   if (options.readTargetAlias === false || record.target === undefined) return deviceTarget;
   const targetAlias = optionalEnum(record, 'target', DEVICE_TARGETS);
   if (deviceTarget !== undefined && targetAlias !== deviceTarget) {
-    throw new AppError('INVALID_ARGS','Expected target alias to match deviceTarget when both are set.');
+    throw new AppError(
+      'INVALID_ARGS',
+      'Expected target alias to match deviceTarget when both are set.',
+    );
   }
   return deviceTarget ?? targetAlias;
 }
@@ -359,7 +362,7 @@ export function readPoint(record: Record<string, unknown>, key: string): PointIn
 function requiredString(record: Record<string, unknown>, key: string): string {
   const value = record[key];
   if (typeof value !== 'string' || value.length === 0) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be a non-empty string.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be a non-empty string.`);
   }
   return value;
 }
@@ -368,7 +371,7 @@ function optionalString(record: Record<string, unknown>, key: string): string | 
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'string' || value.length === 0) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be a non-empty string.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be a non-empty string.`);
   }
   return value;
 }
@@ -376,7 +379,7 @@ function optionalString(record: Record<string, unknown>, key: string): string | 
 export function requiredNumber(record: Record<string, unknown>, key: string): number {
   const value = record[key];
   if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be a finite number.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be a finite number.`);
   }
   return value;
 }
@@ -385,7 +388,7 @@ function optionalNumberValue(record: Record<string, unknown>, key: string): numb
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be a finite number.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be a finite number.`);
   }
   return value;
 }
@@ -398,14 +401,14 @@ export function optionalInteger(
   const value = record[key];
   if (value === undefined) return undefined;
   if (!Number.isInteger(value)) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be an integer.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be an integer.`);
   }
   const numberValue = value as number;
   if (options.min !== undefined && numberValue < options.min) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be at least ${options.min}.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be at least ${options.min}.`);
   }
   if (options.max !== undefined && numberValue > options.max) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be at most ${options.max}.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be at most ${options.max}.`);
   }
   return numberValue;
 }
@@ -414,7 +417,7 @@ function optionalBoolean(record: Record<string, unknown>, key: string): boolean 
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'boolean') {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be a boolean.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be a boolean.`);
   }
   return value;
 }
@@ -426,7 +429,7 @@ export function requiredEnum<const T extends readonly string[]>(
 ): T[number] {
   const value = record[key];
   if (typeof value !== 'string' || !values.includes(value)) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be one of: ${values.join(', ')}.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be one of: ${values.join(', ')}.`);
   }
   return value;
 }
@@ -439,7 +442,7 @@ export function optionalEnum<const T extends readonly string[]>(
   const value = record[key];
   if (value === undefined) return undefined;
   if (typeof value !== 'string' || !values.includes(value)) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be one of: ${values.join(', ')}.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be one of: ${values.join(', ')}.`);
   }
   return value;
 }
@@ -515,7 +518,7 @@ export function assertAllowedKeys(
   const allowed = new Set(allowedKeys);
   const unknownKeys = Object.keys(record).filter((key) => !allowed.has(key));
   if (unknownKeys.length > 0) {
-    throw new AppError('INVALID_ARGS',`${label} has unknown field(s): ${unknownKeys.join(', ')}.`);
+    throw new AppError('INVALID_ARGS', `${label} has unknown field(s): ${unknownKeys.join(', ')}.`);
   }
 }
 
@@ -553,7 +556,7 @@ function optionalRecord(
   const value = record[key];
   if (value === undefined) return undefined;
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be an object.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be an object.`);
   }
   return value as Record<string, unknown>;
 }
@@ -562,7 +565,7 @@ function optionalStringArray(record: Record<string, unknown>, key: string): stri
   const value = record[key];
   if (value === undefined) return undefined;
   if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be an array of strings.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be an array of strings.`);
   }
   return value as string[];
 }
@@ -672,7 +675,7 @@ function elementTargetSchemaVariants(): JsonSchema[] {
 function readRecordField(record: Record<string, unknown>, key: string): Record<string, unknown> {
   const value = record[key];
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new AppError('INVALID_ARGS',`Expected ${key} to be an object.`);
+    throw new AppError('INVALID_ARGS', `Expected ${key} to be an object.`);
   }
   return value as Record<string, unknown>;
 }

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -4,7 +4,12 @@ import { findNodeByRef, normalizeRef } from '../../../kernel/snapshot.ts';
 import { resolveRectCenter } from '../../../utils/rect-center.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import { parseSelectorChain } from '../../../utils/selectors-parse.ts';
-import { formatSelectorFailure, resolveSelectorChain } from '../../../daemon/selectors.ts';
+import {
+  formatSelectorFailure,
+  resolveSelectorChain,
+  selectorFailureHint,
+  STALE_REF_HINT,
+} from '../../../daemon/selectors.ts';
 import { buildSelectorChainForNode } from '../../../utils/selector-build.ts';
 import { findNodeByLabel, resolveRefLabel } from '../../../snapshot/snapshot-processing.ts';
 import {
@@ -173,6 +178,7 @@ async function resolveSelectorInteractionTarget(
     throw new AppError(
       'COMMAND_FAILED',
       formatSelectorFailure(chain, resolved?.diagnostics ?? [], { unique: true }),
+      { hint: selectorFailureHint(resolved?.diagnostics ?? []) },
     );
   }
   const node = params.promoteToHittableAncestor
@@ -355,7 +361,9 @@ async function resolveSnapshotForRef(
     fallbackLabel,
   });
   if (!refreshed) {
-    throw new AppError('COMMAND_FAILED', `Ref ${target.ref} not found or has no bounds`);
+    throw new AppError('COMMAND_FAILED', `Ref ${target.ref} not found or has no bounds`, {
+      hint: STALE_REF_HINT,
+    });
   }
   return { ...capture, resolved: refreshed };
 }

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -127,13 +127,7 @@ async function resolveRefInteractionTarget(
     kind: 'ref',
     point,
     target: { kind: 'ref', ref: `@${resolved.ref}` },
-    node,
-    selectorChain: buildSelectorChainForNode(node, runtime.backend.platform, {
-      action: params.action === 'fill' ? 'fill' : 'click',
-    }),
-    refLabel: resolveRefLabel(node, capture.snapshot.nodes),
-    ...describeNonHittableTarget(node, params.action),
-    preActionNodes: capture.snapshot.nodes,
+    ...describeResolvedNode(runtime, capture.snapshot.nodes, node, params.action),
   };
 }
 
@@ -196,13 +190,31 @@ async function resolveSelectorInteractionTarget(
     kind: 'selector',
     point,
     target: { kind: 'selector', selector: resolved.selector.raw },
+    ...describeResolvedNode(runtime, capture.snapshot.nodes, node, params.action),
+  };
+}
+
+function describeResolvedNode(
+  runtime: AgentDeviceRuntime,
+  nodes: SnapshotState['nodes'],
+  node: SnapshotNode,
+  action: InteractionAction,
+): {
+  node: SnapshotNode;
+  selectorChain: string[];
+  refLabel?: string;
+  targetHittable?: boolean;
+  hint?: string;
+  preActionNodes: SnapshotNode[];
+} {
+  return {
     node,
     selectorChain: buildSelectorChainForNode(node, runtime.backend.platform, {
-      action: params.action === 'fill' ? 'fill' : 'click',
+      action: action === 'fill' ? 'fill' : 'click',
     }),
-    refLabel: resolveRefLabel(node, capture.snapshot.nodes),
-    ...describeNonHittableTarget(node, params.action),
-    preActionNodes: capture.snapshot.nodes,
+    refLabel: resolveRefLabel(node, nodes),
+    ...describeNonHittableTarget(node, action),
+    preActionNodes: nodes,
   };
 }
 

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -17,6 +17,7 @@ import {
   findSelectorChainMatch,
   formatSelectorFailure,
   resolveSelectorChain,
+  selectorFailureHint,
 } from '../../../daemon/selectors.ts';
 import { buildSelectorChainForNode } from '../../../utils/selector-build.ts';
 import {
@@ -280,7 +281,9 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
       platform: runtime.backend.platform,
     });
     if (!matched) {
-      throw new AppError('COMMAND_FAILED', formatSelectorFailure(chain, [], { unique: false }));
+      throw new AppError('COMMAND_FAILED', formatSelectorFailure(chain, [], { unique: false }), {
+        hint: selectorFailureHint([]),
+      });
     }
     return {
       predicate: options.predicate,
@@ -303,6 +306,7 @@ export const isCommand: RuntimeCommand<IsCommandOptions, IsCommandResult> = asyn
       reason: 'selector_not_found',
       predicate: options.predicate,
       selector: chain.raw,
+      hint: selectorFailureHint([]),
     });
   }
   const result = evaluateIsPredicate({
@@ -642,7 +646,9 @@ async function resolveSelectorNode(
     disambiguateAmbiguous: params.disambiguateAmbiguous,
   });
   if (!resolved) {
-    throw new AppError('COMMAND_FAILED', formatSelectorFailure(chain, [], { unique: true }));
+    throw new AppError('COMMAND_FAILED', formatSelectorFailure(chain, [], { unique: true }), {
+      hint: selectorFailureHint([]),
+    });
   }
   return {
     capture,

--- a/src/core/interaction-positionals.ts
+++ b/src/core/interaction-positionals.ts
@@ -27,7 +27,15 @@ export function readInteractionTargetFromPositionals(
     );
   }
   const selectorArgs = splitSelectorFromArgs(positionals);
-  if (selectorArgs) return { selector: selectorArgs.selectorExpression };
+  if (selectorArgs) {
+    if (selectorArgs.rest.length > 0) {
+      throw new AppError(
+        'INVALID_ARGS',
+        formatSelectorTrailingArgsFailure(positionals, selectorArgs),
+      );
+    }
+    return { selector: selectorArgs.selectorExpression };
+  }
   return readPointTarget(positionals);
 }
 
@@ -83,6 +91,29 @@ function formatTargetParseFailure(positionals: string[]): string {
     return `${base} Selector values with spaces need quotes, e.g. text="Sign in".`;
   }
   return `${base} To match by visible text, use text=${quoteSelectorValue(raw)} (or label=/id=/role=), or pass an @ref from snapshot.`;
+}
+
+function formatSelectorTrailingArgsFailure(
+  positionals: string[],
+  selectorArgs: { selectorExpression: string; rest: string[] },
+): string {
+  const base = `Selector ${selectorArgs.selectorExpression} is followed by unexpected extra arguments: "${selectorArgs.rest.join(' ')}".`;
+  const suggestion = mergeRestIntoSelectorValue(positionals, selectorArgs) ?? 'text="Sign in"';
+  return `${base} Selector values with spaces need quotes, e.g. ${suggestion}.`;
+}
+
+function mergeRestIntoSelectorValue(
+  positionals: string[],
+  selectorArgs: { selectorExpression: string; rest: string[] },
+): string | undefined {
+  const boundary = positionals.length - selectorArgs.rest.length;
+  const lastSelectorToken = positionals[boundary - 1];
+  if (lastSelectorToken === undefined) return undefined;
+  const equalsIdx = lastSelectorToken.indexOf('=');
+  if (equalsIdx <= 0) return undefined;
+  const mergedValue = [lastSelectorToken.slice(equalsIdx + 1), ...selectorArgs.rest].join(' ');
+  const mergedToken = `${lastSelectorToken.slice(0, equalsIdx + 1)}${quoteSelectorValue(mergedValue)}`;
+  return [...positionals.slice(0, boundary - 1), mergedToken].join(' ');
 }
 
 function quoteSelectorValue(value: string): string {

--- a/src/core/interaction-positionals.ts
+++ b/src/core/interaction-positionals.ts
@@ -1,5 +1,5 @@
 import { AppError } from '../kernel/errors.ts';
-import { splitSelectorFromArgs } from '../utils/selectors-parse.ts';
+import { isSelectorToken, splitSelectorFromArgs } from '../utils/selectors-parse.ts';
 
 type PositionalInteractionTarget =
   | { x: number; y: number }
@@ -28,7 +28,7 @@ export function readInteractionTargetFromPositionals(
   }
   const selectorArgs = splitSelectorFromArgs(positionals);
   if (selectorArgs) return { selector: selectorArgs.selectorExpression };
-  return { x: Number(positionals[0]), y: Number(positionals[1]) };
+  return readPointTarget(positionals);
 }
 
 export function readFillTargetFromPositionals(positionals: string[]): DecodedFillTarget {
@@ -61,9 +61,32 @@ export function readFillTargetFromPositionals(positionals: string[]): DecodedFil
   }
   return {
     kind: 'point',
-    target: { x: Number(positionals[0]), y: Number(positionals[1]) },
+    target: readPointTarget(positionals.slice(0, 2)),
     text: positionals.slice(2).join(' '),
   };
+}
+
+function readPointTarget(positionals: string[]): { x: number; y: number } {
+  const x = Number(positionals[0]);
+  const y = Number(positionals[1]);
+  if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+  throw new AppError('INVALID_ARGS', formatTargetParseFailure(positionals));
+}
+
+function formatTargetParseFailure(positionals: string[]): string {
+  const raw = positionals.filter((part) => part !== undefined).join(' ');
+  if (!raw.trim()) {
+    return 'Missing target. Pass an @ref from snapshot, a selector like text="Sign in", or "x y" coordinates.';
+  }
+  const base = `Target "${raw}" is not a @ref, selector, or "x y" point.`;
+  if (positionals.some((part) => isSelectorToken(part ?? ''))) {
+    return `${base} Selector values with spaces need quotes, e.g. text="Sign in".`;
+  }
+  return `${base} To match by visible text, use text=${quoteSelectorValue(raw)} (or label=/id=/role=), or pass an @ref from snapshot.`;
+}
+
+function quoteSelectorValue(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
 }
 
 function optionalTrimmedText(parts: string[]): string | undefined {

--- a/src/daemon-error.ts
+++ b/src/daemon-error.ts
@@ -7,5 +7,7 @@ export function throwDaemonError(error: DaemonError): never {
     hint: error.hint,
     diagnosticId: error.diagnosticId,
     logPath: error.logPath,
+    retriable: error.retriable,
+    supportedOn: error.supportedOn,
   });
 }

--- a/src/daemon/client/daemon-client-rpc.ts
+++ b/src/daemon/client/daemon-client-rpc.ts
@@ -72,6 +72,8 @@ function toDaemonHttpRpcError(
       hint: typeof data.hint === 'string' ? data.hint : undefined,
       diagnosticId: typeof data.diagnosticId === 'string' ? data.diagnosticId : undefined,
       logPath: typeof data.logPath === 'string' ? data.logPath : undefined,
+      retriable: typeof data.retriable === 'boolean' ? data.retriable : undefined,
+      supportedOn: typeof data.supportedOn === 'string' ? data.supportedOn : undefined,
       requestId,
     },
   );

--- a/src/daemon/handlers/interaction-touch-targets.ts
+++ b/src/daemon/handlers/interaction-touch-targets.ts
@@ -4,7 +4,10 @@ import type {
   LongPressCommandResult,
   PressCommandResult,
 } from '../../contracts/interaction.ts';
-import { readFillTargetFromPositionals } from '../../core/interaction-positionals.ts';
+import {
+  readFillTargetFromPositionals,
+  type DecodedFillTarget,
+} from '../../core/interaction-positionals.ts';
 import type { DaemonResponse } from '../types.ts';
 import { parseCoordinateTarget } from './interaction-targeting.ts';
 import { errorResponse } from './response.ts';
@@ -99,8 +102,8 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
     return { ok: true, target: { kind: 'point', x: coordinates.x, y: coordinates.y }, text };
   }
 
-  const parsed = readFillTargetFromPositionals(positionals);
-  if (parsed.kind !== 'selector') {
+  const parsed = tryReadFillSelectorTarget(positionals);
+  if (!parsed || parsed.kind !== 'selector') {
     return {
       ok: false,
       response: errorResponse(
@@ -122,6 +125,16 @@ export function parseFillTarget(positionals: string[]): ParsedFillTarget {
     target: { kind: 'selector', selector: parsed.target.selector },
     text: parsed.text,
   };
+}
+
+// Valid points and @refs are handled above, so a parse failure here only means
+// "not a selector either" — fold it into this handler's uniform INVALID_ARGS response.
+function tryReadFillSelectorTarget(positionals: string[]): DecodedFillTarget | null {
+  try {
+    return readFillTargetFromPositionals(positionals);
+  } catch {
+    return null;
+  }
 }
 
 export function interactionResultExtra(

--- a/src/daemon/lease-registry.ts
+++ b/src/daemon/lease-registry.ts
@@ -371,7 +371,7 @@ export class LeaseRegistry {
       (lease) => lease.backend === 'ios-simulator',
     ).length;
     if (activeSimulatorLeases < this.maxActiveSimulatorLeases) return;
-    throw new AppError('COMMAND_FAILED', 'No simulator lease capacity available', {
+    throw new AppError('DEVICE_IN_USE', 'No simulator lease capacity available', {
       reason: 'LEASE_CAPACITY_EXCEEDED',
       activeLeases: activeSimulatorLeases,
       maxActiveLeases: this.maxActiveSimulatorLeases,
@@ -511,7 +511,7 @@ export class LeaseRegistry {
   }
 
   private throwDeviceBusy(activeLease: DeviceLease): never {
-    throw new AppError('COMMAND_FAILED', 'Device is already leased', {
+    throw new AppError('DEVICE_IN_USE', 'Device is already leased', {
       reason: 'DEVICE_LEASE_BUSY',
       deviceKey: activeLease.deviceKey,
       backend: activeLease.backend,

--- a/src/daemon/selectors-resolve.ts
+++ b/src/daemon/selectors-resolve.ts
@@ -79,6 +79,21 @@ export function findSelectorChainMatch(
   return null;
 }
 
+export const SELECTOR_NO_MATCH_HINT =
+  'Selector text/label values match exactly (quote multi-word values: text="Sign in"). Run snapshot -i to see current elements and refs, or use find <text> for contains matching.';
+
+export const SELECTOR_NOT_UNIQUE_HINT =
+  'Add more terms to disambiguate (e.g. role=button text="Sign in"), use an @ref from snapshot -i, or use find <text> --first/--last.';
+
+export const STALE_REF_HINT =
+  'Snapshot refs expire when the UI changes. Run snapshot -i and retry with a fresh @ref.';
+
+export function selectorFailureHint(diagnostics: SelectorDiagnostics[]): string {
+  return diagnostics.some((entry) => entry.matches > 1)
+    ? SELECTOR_NOT_UNIQUE_HINT
+    : SELECTOR_NO_MATCH_HINT;
+}
+
 export function formatSelectorFailure(
   chain: SelectorChain,
   diagnostics: SelectorDiagnostics[],

--- a/src/daemon/selectors-resolve.ts
+++ b/src/daemon/selectors-resolve.ts
@@ -79,10 +79,10 @@ export function findSelectorChainMatch(
   return null;
 }
 
-export const SELECTOR_NO_MATCH_HINT =
+const SELECTOR_NO_MATCH_HINT =
   'Selector text/label values match exactly (quote multi-word values: text="Sign in"). Run snapshot -i to see current elements and refs, or use find <text> for contains matching.';
 
-export const SELECTOR_NOT_UNIQUE_HINT =
+const SELECTOR_NOT_UNIQUE_HINT =
   'Add more terms to disambiguate (e.g. role=button text="Sign in"), use an @ref from snapshot -i, or use find <text> --first/--last.';
 
 export const STALE_REF_HINT =

--- a/src/daemon/selectors.ts
+++ b/src/daemon/selectors.ts
@@ -14,6 +14,8 @@ export {
   resolveSelectorChain,
   findSelectorChainMatch,
   formatSelectorFailure,
+  selectorFailureHint,
+  STALE_REF_HINT,
 } from './selectors-resolve.ts';
 
 export { buildSelectorChainForNode } from '../utils/selector-build.ts';

--- a/src/kernel/errors.ts
+++ b/src/kernel/errors.ts
@@ -92,20 +92,11 @@ export function normalizeError(
 ): NormalizedError {
   const appErr = asAppError(err);
   const details = appErr.details ? redactDiagnosticData(appErr.details) : undefined;
-  const detailHint = details && typeof details.hint === 'string' ? details.hint : undefined;
-  const diagnosticId =
-    (details && typeof details.diagnosticId === 'string' ? details.diagnosticId : undefined) ??
-    context.diagnosticId;
-  const logPath =
-    (details && typeof details.logPath === 'string' ? details.logPath : undefined) ??
-    context.logPath;
-  const hint = detailHint ?? defaultHintForCode(appErr.code);
-  const retriable =
-    details && typeof details.retriable === 'boolean'
-      ? details.retriable
-      : retriableForErrorCode(appErr.code);
-  const supportedOn =
-    details && typeof details.supportedOn === 'string' ? details.supportedOn : undefined;
+  const diagnosticId = stringDetail(details, 'diagnosticId') ?? context.diagnosticId;
+  const logPath = stringDetail(details, 'logPath') ?? context.logPath;
+  const hint = stringDetail(details, 'hint') ?? defaultHintForCode(appErr.code);
+  const retriable = booleanDetail(details, 'retriable') ?? retriableForErrorCode(appErr.code);
+  const supportedOn = stringDetail(details, 'supportedOn');
   const cleanDetails = stripDiagnosticMeta(details);
   const message = maybeEnrichCommandFailedMessage(appErr.code, appErr.message, details);
 
@@ -156,6 +147,22 @@ function firstStderrLine(stderr: string): string | null {
     return line.length > 200 ? `${line.slice(0, 200)}...` : line;
   }
   return null;
+}
+
+function stringDetail(
+  details: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = details?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function booleanDetail(
+  details: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = details?.[key];
+  return typeof value === 'boolean' ? value : undefined;
 }
 
 function stripDiagnosticMeta(

--- a/src/kernel/errors.ts
+++ b/src/kernel/errors.ts
@@ -35,6 +35,7 @@ type AppErrorDetails = Record<string, unknown> & {
   diagnosticId?: string;
   logPath?: string;
   retriable?: boolean;
+  supportedOn?: string;
 };
 
 export type NormalizedError = {
@@ -49,6 +50,7 @@ export type NormalizedError = {
    * error wire shape is unchanged.
    */
   retriable?: boolean;
+  supportedOn?: string;
   details?: Record<string, unknown>;
 };
 
@@ -65,12 +67,12 @@ export class AppError extends Error {
   }
 }
 
-export function asAppError(err: unknown): AppError {
+export function asAppError(err: unknown, fallbackCode: AppErrorCode = 'UNKNOWN'): AppError {
   if (err instanceof AppError) return err;
   if (err instanceof Error) {
-    return new AppError('UNKNOWN', err.message, undefined, err);
+    return new AppError(fallbackCode, err.message, undefined, err);
   }
-  return new AppError('UNKNOWN', 'Unknown error', { err });
+  return new AppError(fallbackCode, 'Unknown error', { err });
 }
 
 export function isAgentDeviceError(err: unknown): err is AppError {
@@ -99,7 +101,11 @@ export function normalizeError(
     context.logPath;
   const hint = detailHint ?? defaultHintForCode(appErr.code);
   const retriable =
-    details && typeof details.retriable === 'boolean' ? details.retriable : undefined;
+    details && typeof details.retriable === 'boolean'
+      ? details.retriable
+      : retriableForErrorCode(appErr.code);
+  const supportedOn =
+    details && typeof details.supportedOn === 'string' ? details.supportedOn : undefined;
   const cleanDetails = stripDiagnosticMeta(details);
   const message = maybeEnrichCommandFailedMessage(appErr.code, appErr.message, details);
 
@@ -109,7 +115,9 @@ export function normalizeError(
     hint,
     diagnosticId,
     logPath,
+    // Typed-error signals stay absent unless confidently known (#939 wire shape).
     ...(retriable !== undefined ? { retriable } : {}),
+    ...(supportedOn !== undefined ? { supportedOn } : {}),
     details: cleanDetails,
   };
 }
@@ -159,6 +167,7 @@ function stripDiagnosticMeta(
   delete output.diagnosticId;
   delete output.logPath;
   delete output.retriable;
+  delete output.supportedOn;
   return Object.keys(output).length > 0 ? output : undefined;
 }
 
@@ -194,12 +203,20 @@ export function defaultHintForCode(code: string): string | undefined {
       return 'Run apps to discover the exact installed package or bundle id, or install the app before open.';
     case 'UNSUPPORTED_OPERATION':
       return 'This command is not available for the selected platform/device.';
+    case 'UNSUPPORTED_PLATFORM':
+      return 'This platform is not supported for the requested operation; run devices to inspect available targets.';
+    case 'AMBIGUOUS_MATCH':
+      return 'Multiple candidates matched. Narrow the query or pass an exact identifier.';
+    case 'DEVICE_IN_USE':
+      return 'The device is busy with another agent-device request; retry once it frees up.';
     case 'NOT_IMPLEMENTED':
       return 'This command is part of the planned API but is not implemented yet.';
     case 'COMMAND_FAILED':
       return 'Retry with --debug and inspect diagnostics log for details.';
     case 'UNAUTHORIZED':
       return 'Refresh daemon metadata and retry the command.';
+    case 'UNKNOWN':
+      return 'Unexpected internal error. Retry with --debug and report the diagnostics log if it persists.';
     default:
       return 'Retry with --debug and inspect diagnostics log for details.';
   }

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -1,7 +1,7 @@
 import { listCommandTools, commandToolExecutor, type ToolResult } from './command-tools.ts';
 import { readVersion } from '../utils/version.ts';
 import type { JsonRpcId, JsonRpcRequestEnvelope } from '../kernel/contracts.ts';
-import { AppError } from '../kernel/errors.ts';
+import { AppError, normalizeError } from '../kernel/errors.ts';
 
 const MCP_SERVER_NAME = 'agent-device';
 const SUPPORTED_PROTOCOL_VERSION = '2025-11-25';
@@ -63,8 +63,18 @@ async function callTool(params: unknown): Promise<ToolResult> {
   try {
     return await commandToolExecutor.execute(name, record.arguments);
   } catch (error) {
-    return textToolResult(error instanceof Error ? error.message : String(error), true);
+    return textToolResult(formatToolError(error), true);
   }
+}
+
+// Keep the full error contract (code + hint) visible to MCP agents; a bare
+// message string strips exactly the guidance the hint system exists to give.
+function formatToolError(error: unknown): string {
+  const normalized = normalizeError(error);
+  const lines = [`Error (${normalized.code}): ${normalized.message}`];
+  if (normalized.hint) lines.push(`Hint: ${normalized.hint}`);
+  if (normalized.supportedOn) lines.push(`Supported on: ${normalized.supportedOn}`);
+  return lines.join('\n');
 }
 
 function supportedProtocolVersion(_params: unknown): string {

--- a/src/platforms/apple/core/runner/runner-lifecycle.ts
+++ b/src/platforms/apple/core/runner/runner-lifecycle.ts
@@ -1,4 +1,4 @@
-import { AppError } from '../../../../kernel/errors.ts';
+import { AppError, asAppError } from '../../../../kernel/errors.ts';
 import type { DeviceInfo } from '../../../../kernel/device.ts';
 import { emitDiagnostic } from '../../../../utils/diagnostics.ts';
 import { getRequestSignal, isRequestCanceledError } from '../../../../daemon/request-cancel.ts';
@@ -115,7 +115,7 @@ async function handlePrepareHealthFailure(params: {
   error: unknown;
 }): Promise<PrepareAttemptResult> {
   const { device, session, command, options, signal, attempt, error } = params;
-  const appErr = error instanceof AppError ? error : new AppError('COMMAND_FAILED', String(error));
+  const appErr = asAppError(error, 'COMMAND_FAILED');
   if (attempt === 1 && shouldRecoverBadCachedRunnerArtifact(appErr, session)) {
     return {
       kind: 'prepared',
@@ -256,7 +256,7 @@ export async function executeRunnerCommand(
       signal,
     );
   } catch (err) {
-    const appErr = err instanceof AppError ? err : new AppError('COMMAND_FAILED', String(err));
+    const appErr = asAppError(err, 'COMMAND_FAILED');
     if (
       appErr.code === 'COMMAND_FAILED' &&
       typeof appErr.message === 'string' &&
@@ -343,7 +343,7 @@ async function restartSessionAndRunCommand(params: {
     return recovered;
   } catch (retryErr) {
     const retryAppErr =
-      retryErr instanceof AppError ? retryErr : new AppError('COMMAND_FAILED', String(retryErr));
+      asAppError(retryErr, 'COMMAND_FAILED');
     if (isRetryableRunnerError(retryAppErr)) {
       return await handleRunnerTransportErrorAfterCommandSend({
         device,
@@ -444,7 +444,7 @@ function wrapPrepareHealthFailure(
   session: RunnerSession,
   restoredFailureReason: string,
 ): AppError {
-  const appErr = error instanceof AppError ? error : new AppError('COMMAND_FAILED', String(error));
+  const appErr = asAppError(error, 'COMMAND_FAILED');
   return new AppError(
     appErr.code,
     'artifact restored but runner did not connect',

--- a/src/platforms/apple/core/runner/runner-lifecycle.ts
+++ b/src/platforms/apple/core/runner/runner-lifecycle.ts
@@ -342,8 +342,7 @@ async function restartSessionAndRunCommand(params: {
     }
     return recovered;
   } catch (retryErr) {
-    const retryAppErr =
-      asAppError(retryErr, 'COMMAND_FAILED');
+    const retryAppErr = asAppError(retryErr, 'COMMAND_FAILED');
     if (isRetryableRunnerError(retryAppErr)) {
       return await handleRunnerTransportErrorAfterCommandSend({
         device,

--- a/src/platforms/apple/core/runner/runner-macos-products.ts
+++ b/src/platforms/apple/core/runner/runner-macos-products.ts
@@ -45,8 +45,7 @@ export async function repairMacOsRunnerProductsIfNeeded(
     try {
       await runAppleToolCommand('codesign', ['--force', '--sign', '-', productPath]);
     } catch (error) {
-      const appError =
-        asAppError(error, 'COMMAND_FAILED');
+      const appError = asAppError(error, 'COMMAND_FAILED');
       throw new AppError('COMMAND_FAILED', 'Failed to repair macOS runner product signature', {
         reason: 'RUNNER_PRODUCT_REPAIR_FAILED',
         productPath,

--- a/src/platforms/apple/core/runner/runner-macos-products.ts
+++ b/src/platforms/apple/core/runner/runner-macos-products.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { isMacOs, type DeviceInfo } from '../../../../kernel/device.ts';
-import { AppError } from '../../../../kernel/errors.ts';
+import { AppError, asAppError } from '../../../../kernel/errors.ts';
 import { runAppleToolCommand } from '../tool-provider.ts';
 
 const RUNNER_PRODUCT_REPAIR_FAILURE_REASONS = new Set([
@@ -46,7 +46,7 @@ export async function repairMacOsRunnerProductsIfNeeded(
       await runAppleToolCommand('codesign', ['--force', '--sign', '-', productPath]);
     } catch (error) {
       const appError =
-        error instanceof AppError ? error : new AppError('COMMAND_FAILED', String(error));
+        asAppError(error, 'COMMAND_FAILED');
       throw new AppError('COMMAND_FAILED', 'Failed to repair macOS runner product signature', {
         reason: 'RUNNER_PRODUCT_REPAIR_FAILED',
         productPath,


### PR DESCRIPTION
## Summary

Holistic error-handling pass: audited all ~1,200 `AppError` sites + the full error pipeline (daemon → wire → CLI/SDK/MCP), dogfooded error paths on the test-app (iOS simulator + Android emulator), and fixed the highest-leverage gaps. The kernel (`src/kernel/errors.ts`) was sound — the drift was at call sites and consumer surfaces. Conventions are now written down in **ADR 0010** (`docs/adr/0010-error-system.md`).

## What changed

**Killed the `UNKNOWN: Expected x to be a finite number` family** (worst dogfood finding — hit by `press` with no args, `press Catalog`, and unquoted multi-word selectors like `press text=Gesture lab`):
- `src/core/interaction-positionals.ts`: non-ref/non-selector/non-point targets now fail with `INVALID_ARGS` grammar guidance — bare text suggests `text="Catalog"`, an almost-selector suggests quoting multi-word values
- `src/commands/command-input.ts`: daemon-side input validation throws `AppError('INVALID_ARGS', …)` instead of bare `Error` (which surfaced as `UNKNOWN` with a misleading "retry with --debug" hint)

**Targeted hints for the two most common agent failures** (both previously got the generic default hint):
- selector-no-match → shared `selectorFailureHint` (exact-match semantics, quote multi-word values, `snapshot -i` / `find` next steps)
- stale ref → `STALE_REF_HINT` ("refs expire when the UI changes; re-run snapshot -i")

**Consumer surfaces stop dropping fields:**
- `retriable`/`supportedOn` (#939 typed-error graft) were dropped at both client rehydration points (`throwDaemonError`, `toDaemonHttpRpcError`); they now reach CLI `--json` and the SDK. Keys stay absent unless confidently known, preserving the wire shape
- MCP tool errors now carry `Error (CODE): message` + `Hint:` (+ `Supported on:`) instead of a bare message string

**Semantics:**
- lease busy / simulator-lease capacity → `DEVICE_IN_USE` (the one retriable code; `details.reason` preserved)
- `asAppError(err, fallbackCode)` replaces six cause-dropping `err instanceof AppError ? err : new AppError('COMMAND_FAILED', String(err))` coercions in the Apple runner
- new default hints for `AMBIGUOUS_MATCH`, `DEVICE_IN_USE`, `UNSUPPORTED_PLATFORM`, and a distinct `UNKNOWN` hint
- fixed stale `TypedError` claim in `CONTEXT.md`

## Verification

- Full unit suite (3,059 tests), lint, typecheck, layering, smoke — all green post-rebase on latest main
- Dogfooded before/after on iPhone 17 Pro simulator + Pixel 9 Pro XL emulator with the test-app: all previously-broken scenarios now produce actionable `INVALID_ARGS`/hinted errors; `keyboard get --json` on iOS shows `"supportedOn": "apple, android"` end-to-end

## Out of scope (follow-ups spun off separately)

adb-stderr→hint classifier, TTL-registry expiry codes, remaining bare-`Error` clusters (Metro/XML/MCP validation), `is` predicate/selector-key collision, silent `find` click success, exec-wrap `processExitError` conversion. Design questions needing buy-in: per-code exit codes, message-string redaction, remote logPath.