### PR TITLE
fix: make artifact inventory consumption deterministic on download

### DIFF
--- a/src/daemon/downloadable-artifact-http.ts
+++ b/src/daemon/downloadable-artifact-http.ts
@@ -113,6 +113,14 @@ async function handleArtifactDownload(
       didCleanupArtifact = true;
       cleanupDownloadableArtifact(artifactId);
     };
+    // Consume before the final chunk is written to the client: fetch treats a
+    // download as complete once content-length bytes arrive, which can happen
+    // before this stream emits 'end' (that needs one more threadpool read).
+    let bytesSent = 0;
+    stream.on('data', (chunk: string | Buffer) => {
+      bytesSent += chunk.length;
+      if (bytesSent >= artifact.sizeBytes) cleanupCompletedDownload();
+    });
     stream.on('end', cleanupCompletedDownload);
     res.on('finish', cleanupCompletedDownload);
     res.on('close', () => {


### PR DESCRIPTION
## Problem

The unit test `daemon artifact downloads can keep the source file while consuming the inventory entry` (`src/daemon/__tests__/http-server-artifacts.test.ts`) fails flakily on CI, always in the slower instrumented **Coverage** job, on PRs unrelated to the artifact code:

- #1053 (flagged in the PR comment thread)
- #1064 — run [28655306400](https://github.com/callstack/agent-device/actions/runs/28655306400) attempt 1 failed the Coverage job with this exact assertion, then passed on re-run

Failure: after downloading an artifact, `GET /artifacts` still lists the consumed artifact id (`expected false, received true` at line 261).

## Root cause — a production race, not a test bug

In `handleArtifactDownload` (`src/daemon/downloadable-artifact-http.ts`), the inventory entry was consumed only from the source stream's `'end'` / response `'finish'` / `'close'` handlers.

But the response carries an explicit `content-length`. The client's `fetch` body completes as soon as `content-length` bytes arrive — i.e. right after the **final data chunk** is written to the socket. At that point the server's `fs.createReadStream` still needs **one more threadpool `read()`** to detect EOF and emit `'end'`. Under CPU contention (coverage instrumentation, busy CI runners) that threadpool completion can land *after* the client's follow-up `GET /artifacts`, which then still lists the consumed artifact.

This is a real client-observable contract violation, not just a test-timing issue: any client that finishes a download and immediately lists the inventory can transiently see the already-consumed artifact. The two sibling "consume" tests only dodge it by polling for the file-deletion side effect (`waitFor(() => !fs.existsSync(...))`); the retain-file variant keeps the file, so it had no signal to wait on — it exposed the race directly.

## Fix

Consume the inventory entry as soon as the stream has emitted `content-length` bytes, in a `'data'` listener registered **before** `stream.pipe(res)` (listeners run in registration order, so consumption happens before `pipe` writes the final chunk to the client). Any client that observed a complete download is now guaranteed to observe the entry as consumed. The existing `'end'`/`'finish'`/`'close'` handlers stay as backstops (idempotent via `didCleanupArtifact`), covering edge cases like a file that shrank after `stat`. Failure semantics are unchanged: an aborted download still leaves the entry available for retry.

No test changes needed — the test was asserting the correct contract.

## Verification

- Reproduced on unmodified `main`: 1 failure in 20 `vitest run --coverage` iterations under CPU contention, with the exact CI assertion (`http-server-artifacts.test.ts:261`, `true !== false`)
- With the fix: 0 failures in 25 coverage iterations under the same contention, plus 0/27 plain runs
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all pass

(While verifying, `request-handler-catalog.test.ts > specialized daemon routes...` timed out when run alongside four other daemon test files — that reproduces identically on unmodified `main` and is the known contention flake, unrelated to this change.)