### PR TITLE
refactor: single construction site for interaction responses (ADR 0011 Layer 2)

### DIFF
--- a/src/contracts/__tests__/interaction-guarantees.test.ts
+++ b/src/contracts/__tests__/interaction-guarantees.test.ts
@@ -180,17 +180,11 @@ test('acknowledged gaps are visible and bounded', () => {
   // (umbrella: https://github.com/callstack/agent-device/issues/1081).
   assert.deepEqual(gaps.sort(), [
     'coordinate/offscreen',
-    'coordinate/responseConstruction',
     'direct-ios-selector/disambiguation',
     'direct-ios-selector/errorTaxonomy',
     'direct-ios-selector/nonHittable',
     'direct-ios-selector/occlusion',
-    'direct-ios-selector/responseConstruction',
     'direct-ios-selector/responseIdentity',
     'maestro-non-hittable-fallback/errorTaxonomy',
-    'maestro-non-hittable-fallback/responseConstruction',
-    'native-ref/responseConstruction',
-    'runtime-ref/responseConstruction',
-    'runtime-selector/responseConstruction',
   ]);
 });

--- a/src/contracts/interaction-guarantees.ts
+++ b/src/contracts/interaction-guarantees.ts
@@ -41,7 +41,8 @@ export const INTERACTION_GUARANTEES = [
   'nonHittable',
   // Response payloads are assembled by a single shared construction site,
   // never hand-rolled per branch (the class of bug that dropped fill @ref
-  // evidence). Closure is ADR 0011 Layer 2 (buildInteractionResponseData).
+  // evidence). Closed by ADR 0011 Layer 2: buildInteractionResponseData plus
+  // the hand-rolled-literal guard test.
   'responseConstruction',
   // The identity fields a path can echo back: refLabel, selectorChain, the
   // resolved target. Distinct from construction — a path may build responses
@@ -121,6 +122,14 @@ export type InteractionPathContract = {
 
 const GAPS_UMBRELLA_ISSUE = 'https://github.com/callstack/agent-device/issues/1081';
 
+// Every path shares the SAME cell by construction: response payloads have one
+// construction site (ADR 0011 Layer 2), and the hand-rolled-literal guard test
+// (interaction-response-construction-guard.test.ts) keeps new branches on it.
+const SHARED_RESPONSE_CONSTRUCTION: GuaranteeEnforcement = {
+  kind: 'runtime',
+  via: 'src/daemon/handlers/interaction-touch-response.ts#buildInteractionResponseData',
+};
+
 export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPathContract> = {
   'runtime-selector': {
     description: 'Daemon tree capture, selector chain resolution, guarded coordinate tap.',
@@ -142,12 +151,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         kind: 'runtime',
         via: 'src/core/interaction-targeting.ts#resolveActionableTouchResolution',
       },
-      responseConstruction: {
-        kind: 'waived',
-        reason:
-          'gap: response payloads are assembled per handler branch; Layer-2 buildInteractionResponseData consolidation pending.',
-        trackingIssue: GAPS_UMBRELLA_ISSUE,
-      },
+      responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
       responseIdentity: {
         kind: 'runtime',
         via: 'src/daemon/handlers/interaction-touch-targets.ts#interactionResultExtra',
@@ -183,12 +187,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         kind: 'runtime',
         via: 'src/core/interaction-targeting.ts#resolveActionableTouchResolution',
       },
-      responseConstruction: {
-        kind: 'waived',
-        reason:
-          'gap: the ref response branch is hand-assembled (this exact shape dropped fill @ref evidence, #1064); Layer-2 consolidation pending.',
-        trackingIssue: GAPS_UMBRELLA_ISSUE,
-      },
+      responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
       responseIdentity: {
         kind: 'runtime',
         via: 'src/daemon/handlers/interaction-touch-targets.ts#interactionResultExtra',
@@ -231,12 +230,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
           'gap: non-hittable matches are skipped runner-side (ELEMENT_NOT_FOUND) instead of promoted/annotated; closure strategy is delegation-on-error into the runtime path.',
         trackingIssue: GAPS_UMBRELLA_ISSUE,
       },
-      responseConstruction: {
-        kind: 'waived',
-        reason:
-          'gap: the response is assembled from the raw runner payload; Layer-2 consolidation pending.',
-        trackingIssue: GAPS_UMBRELLA_ISSUE,
-      },
+      responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
       responseIdentity: {
         kind: 'waived',
         reason: 'gap: refLabel/selectorChain are absent on the direct path.',
@@ -279,11 +273,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         kind: 'runtime',
         via: 'src/commands/interaction/runtime/resolution.ts#preflightNativeRefInteraction',
       },
-      responseConstruction: {
-        kind: 'waived',
-        reason: 'gap: native ref responses are hand-assembled; Layer-2 consolidation pending.',
-        trackingIssue: GAPS_UMBRELLA_ISSUE,
-      },
+      responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
       responseIdentity: {
         kind: 'runtime',
         via: 'src/daemon/handlers/interaction-touch-targets.ts#interactionResultExtra',
@@ -321,12 +311,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         kind: 'inapplicable',
         reason: 'No element to promote or annotate.',
       },
-      responseConstruction: {
-        kind: 'waived',
-        reason:
-          'gap: coordinate responses flow through the same per-branch assembly; Layer-2 consolidation pending.',
-        trackingIssue: GAPS_UMBRELLA_ISSUE,
-      },
+      responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
       responseIdentity: {
         kind: 'inapplicable',
         reason: 'No resolved node, so no refLabel/selectorChain.',
@@ -364,12 +349,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         kind: 'waived',
         reason: 'Intentional: the entire point of this path is tapping non-hittable elements.',
       },
-      responseConstruction: {
-        kind: 'waived',
-        reason:
-          'gap: shares the direct path payload-based assembly; Layer-2 consolidation pending.',
-        trackingIssue: GAPS_UMBRELLA_ISSUE,
-      },
+      responseConstruction: SHARED_RESPONSE_CONSTRUCTION,
       responseIdentity: {
         kind: 'waived',
         reason: 'Intentional: replay-only path; Maestro semantics do not consume identity fields.',

--- a/src/daemon/handlers/__tests__/interaction-response-construction-guard.test.ts
+++ b/src/daemon/handlers/__tests__/interaction-response-construction-guard.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'vitest';
+
+// ADR 0011 Layer-2 guard: interaction response payloads have exactly ONE
+// construction site — buildInteractionResponseData in
+// interaction-touch-response.ts. A hand-rolled `responseData` branch is the
+// class of bug that dropped fill @ref `evidence` (#1064 review): the branch
+// compiles, ships, and silently misses a field its siblings carry. This test
+// reads the touch interaction handler sources and fails when a `responseData`
+// is assigned anything other than the shared builder's output, so a new
+// branch cannot regress without tripping CI.
+
+const HANDLERS_DIR = path.resolve(import.meta.dirname, '..');
+const BUILDER_FILE = 'interaction-touch-response.ts';
+
+function touchHandlerSourceFiles(): string[] {
+  return fs
+    .readdirSync(HANDLERS_DIR)
+    .filter(
+      (file) =>
+        (file.startsWith('interaction-touch') || file === 'interaction-common.ts') &&
+        file.endsWith('.ts') &&
+        file !== BUILDER_FILE,
+    );
+}
+
+// Allowed right-hand sides after `responseData:` / `responseData =`:
+// - type annotations (`Record<...>`, `Promise<...>`)
+// - the shared builder call
+// - forwarding an already-built payload (bare identifier / member expression
+//   immediately terminated, so `cond ? {...} : x` ternaries still fail)
+const ALLOWED_RHS = [
+  /^(?:Record|Promise)</,
+  /^(?:await\s+)?buildInteractionResponseData\(/,
+  /^[A-Za-z_$][\w.$]*\s*[,;})\]]/,
+];
+
+function findHandRolledResponseData(source: string): string[] {
+  // Collapse whitespace so multi-line hand-rolled literals cannot hide.
+  const collapsed = source.replace(/\s+/g, ' ');
+  const offenders: string[] = [];
+  const assignment = /\bresponseData\s*[:=]\s*/g;
+  for (let match = assignment.exec(collapsed); match; match = assignment.exec(collapsed)) {
+    const rhs = collapsed.slice(match.index + match[0].length, match.index + match[0].length + 160);
+    if (!ALLOWED_RHS.some((pattern) => pattern.test(rhs))) {
+      offenders.push(rhs.slice(0, 80));
+    }
+  }
+  return offenders;
+}
+
+test('interaction responses are only constructed by buildInteractionResponseData', () => {
+  const files = touchHandlerSourceFiles();
+  assert.ok(
+    files.includes('interaction-touch.ts'),
+    'guard lost sight of interaction-touch.ts — update touchHandlerSourceFiles()',
+  );
+  const offenders: string[] = [];
+  for (const file of files) {
+    const source = fs.readFileSync(path.join(HANDLERS_DIR, file), 'utf8');
+    for (const offender of findHandRolledResponseData(source)) {
+      offenders.push(`${file}: responseData = ${offender}...`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `Hand-rolled interaction responseData found. Route it through ` +
+      `buildInteractionResponseData (${BUILDER_FILE}) so identity extras ` +
+      `(evidence, refLabel, selectorChain, hints) cannot be dropped per-branch:\n` +
+      offenders.map((offender) => `  - ${offender}`).join('\n'),
+  );
+});
+
+test('the guard itself flags a hand-rolled responseData literal', () => {
+  assert.equal(
+    findHandRolledResponseData('const responseData = { ...backendResult, x, y };').length,
+    1,
+  );
+  assert.equal(
+    findHandRolledResponseData('const responseData = result.kind === "ref" ? { a: 1 } : built;')
+      .length,
+    1,
+  );
+  assert.equal(
+    findHandRolledResponseData(
+      'const responseData = buildInteractionResponseData({ source }).responseData;',
+    ).length,
+    0,
+  );
+  assert.equal(findHandRolledResponseData('finalize({ result, responseData });').length, 0);
+});

--- a/src/daemon/handlers/interaction-common.ts
+++ b/src/daemon/handlers/interaction-common.ts
@@ -1,11 +1,9 @@
 import type { CommandFlags } from '../../core/dispatch.ts';
 import type { SnapshotState } from '../../kernel/snapshot.ts';
-import type { GestureReferenceFrame } from '../../core/scroll-gesture.ts';
 import type { DaemonCommandContext } from '../context.ts';
 import { recordTouchVisualizationEvent } from '../recording-gestures.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../types.ts';
 import { SessionStore } from '../session-store.ts';
-import { successText } from '../../utils/success-text.ts';
 import {
   isNavigationSensitiveAction,
   markAndroidSnapshotFreshness,
@@ -29,50 +27,6 @@ export type InteractionHandlerParams = {
   sessionStore: SessionStore;
   contextFromFlags: ContextFromFlags;
 };
-
-export function buildTouchVisualizationResult(params: {
-  data: Record<string, unknown> | undefined;
-  fallbackX?: number;
-  fallbackY?: number;
-  referenceFrame?: GestureReferenceFrame;
-  extra?: Record<string, unknown>;
-}): Record<string, unknown> {
-  const { data, fallbackX, fallbackY, referenceFrame, extra } = params;
-  const message =
-    buildTouchMessage(extra, fallbackX, fallbackY) ??
-    (typeof data?.message === 'string' ? data.message : undefined);
-  return {
-    ...(fallbackX === undefined || fallbackY === undefined ? {} : { x: fallbackX, y: fallbackY }),
-    ...(referenceFrame ?? {}),
-    ...(extra ?? {}),
-    ...(data ?? {}),
-    ...successText(message),
-  };
-}
-
-function buildTouchMessage(
-  extra: Record<string, unknown> | undefined,
-  x: number | undefined,
-  y: number | undefined,
-): string | undefined {
-  const ref = typeof extra?.ref === 'string' ? extra.ref : undefined;
-  const button = typeof extra?.button === 'string' ? extra.button : undefined;
-  const gesture = typeof extra?.gesture === 'string' ? extra.gesture : undefined;
-  const pointSuffix = x === undefined || y === undefined ? '' : ` (${x}, ${y})`;
-  if (typeof extra?.text === 'string') {
-    return `Filled ${Array.from(extra.text).length} chars`;
-  }
-  if (ref) {
-    if (gesture === 'longpress') {
-      return `Long pressed @${ref}${pointSuffix}`;
-    }
-    if (button && button !== 'primary') {
-      return `Clicked ${button} @${ref}${pointSuffix}`;
-    }
-    return `Tapped @${ref}${pointSuffix}`;
-  }
-  return undefined;
-}
 
 export function finalizeTouchInteraction(params: {
   session: SessionState;

--- a/src/daemon/handlers/interaction-touch-response.ts
+++ b/src/daemon/handlers/interaction-touch-response.ts
@@ -1,0 +1,146 @@
+import type { GestureReferenceFrame } from '../../core/scroll-gesture.ts';
+import type {
+  FillCommandResult,
+  LongPressCommandResult,
+  PressCommandResult,
+} from '../../contracts/interaction.ts';
+import { successText } from '../../utils/success-text.ts';
+import { interactionResultExtra, stripAtPrefix } from './interaction-touch-targets.ts';
+
+/**
+ * The single construction site for interaction response payloads (ADR 0011
+ * Layer 2). Every press/click/fill/longpress dispatch branch builds its
+ * `result` (session history + touch visualization) and `responseData` (wire)
+ * payloads here, so identity extras (ref/refLabel/selectorChain/
+ * targetHittable/hint/evidence) are composed in exactly one place — the class
+ * of bug where a hand-rolled branch dropped a field (fill @ref dropped
+ * `evidence`, #1064 review) cannot recur. A guard test fails any interaction
+ * touch handler that assembles a `responseData` object literal outside this
+ * module.
+ */
+
+type InteractionRuntimeResult = PressCommandResult | FillCommandResult | LongPressCommandResult;
+
+export type InteractionResponseSource =
+  | {
+      kind: 'runtime';
+      result: InteractionRuntimeResult;
+      /**
+       * Wire-compat for fill @ref: the response echoes backendResult (or a
+       * minimal ref/point fallback) plus the identity extras instead of the
+       * visualization shape. Only applies when the result resolved as a ref.
+       */
+      refBackendWireShape?: boolean;
+    }
+  | {
+      // Direct iOS selector dispatch: no runtime result exists, only the raw
+      // runner payload; identity extras are a declared gap on that path.
+      kind: 'runner-payload';
+      data: Record<string, unknown>;
+      point: { x: number; y: number };
+    };
+
+export type InteractionResponsePayloads = {
+  /** Recorded in session history and used for touch visualization. */
+  result: Record<string, unknown>;
+  /** The wire payload returned to the client. */
+  responseData: Record<string, unknown>;
+};
+
+export function buildInteractionResponseData(params: {
+  source: InteractionResponseSource;
+  referenceFrame: GestureReferenceFrame | undefined;
+  /**
+   * Per-command extras: `text` for fill, `durationMs`/`gesture` for longpress,
+   * button tags for click, selector/maestro details for the direct path.
+   */
+  extra?: Record<string, unknown>;
+}): InteractionResponsePayloads {
+  const { source, referenceFrame, extra } = params;
+  if (source.kind === 'runner-payload') {
+    const payload = buildTouchVisualizationResult({
+      data: source.data,
+      fallbackX: source.point.x,
+      fallbackY: source.point.y,
+      referenceFrame,
+      extra,
+    });
+    return { result: payload, responseData: payload };
+  }
+
+  const { result } = source;
+  const visualization = buildTouchVisualizationResult({
+    data: result.backendResult,
+    fallbackX: result.point?.x,
+    fallbackY: result.point?.y,
+    referenceFrame,
+    extra: {
+      ...interactionResultExtra(result),
+      ...(extra ?? {}),
+    },
+  });
+  const responseData =
+    source.refBackendWireShape && result.kind === 'ref'
+      ? {
+          ...(result.backendResult ?? {
+            ref: stripAtPrefix(result.target?.kind === 'ref' ? result.target.ref : undefined),
+            ...(result.point ? { x: result.point.x, y: result.point.y } : {}),
+          }),
+          ...interactionResultExtra(result),
+        }
+      : visualization;
+  if ('warning' in result && result.warning) {
+    visualization.warning = result.warning;
+    responseData.warning = result.warning;
+  }
+  return { result: visualization, responseData };
+}
+
+function buildTouchVisualizationResult(params: {
+  data: Record<string, unknown> | undefined;
+  fallbackX?: number;
+  fallbackY?: number;
+  referenceFrame?: GestureReferenceFrame;
+  extra?: Record<string, unknown>;
+}): Record<string, unknown> {
+  const { data, fallbackX, fallbackY, referenceFrame, extra } = params;
+  const message =
+    buildTouchMessage(extra, fallbackX, fallbackY) ??
+    (typeof data?.message === 'string' ? data.message : undefined);
+  return {
+    ...(fallbackX === undefined || fallbackY === undefined ? {} : { x: fallbackX, y: fallbackY }),
+    ...(referenceFrame ?? {}),
+    ...(extra ?? {}),
+    ...(data ?? {}),
+    ...successText(message),
+  };
+}
+
+function buildTouchMessage(
+  extra: Record<string, unknown> | undefined,
+  x: number | undefined,
+  y: number | undefined,
+): string | undefined {
+  if (typeof extra?.text === 'string') {
+    return `Filled ${Array.from(extra.text).length} chars`;
+  }
+  const ref = typeof extra?.ref === 'string' ? extra.ref : undefined;
+  if (!ref) return undefined;
+  const pointSuffix = x === undefined || y === undefined ? '' : ` (${x}, ${y})`;
+  return buildRefTouchMessage(ref, extra ?? {}, pointSuffix);
+}
+
+function buildRefTouchMessage(
+  ref: string,
+  extra: Record<string, unknown>,
+  pointSuffix: string,
+): string {
+  const button = typeof extra.button === 'string' ? extra.button : undefined;
+  if (extra.gesture === 'longpress') {
+    return `Long pressed @${ref}${pointSuffix}`;
+  }
+  if (button && button !== 'primary') {
+    return `Clicked ${button} @${ref}${pointSuffix}`;
+  }
+  return `Tapped @${ref}${pointSuffix}`;
+}

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -13,11 +13,11 @@ import type {
 } from '../../contracts/interaction.ts';
 import { asAppError, normalizeError } from '../../kernel/errors.ts';
 import type { DaemonResponse, SessionState } from '../types.ts';
+import { finalizeTouchInteraction, type InteractionHandlerParams } from './interaction-common.ts';
 import {
-  buildTouchVisualizationResult,
-  finalizeTouchInteraction,
-  type InteractionHandlerParams,
-} from './interaction-common.ts';
+  buildInteractionResponseData,
+  type InteractionResponsePayloads,
+} from './interaction-touch-response.ts';
 import type { CaptureSnapshotForSession } from './interaction-snapshot.ts';
 import type { RefSnapshotFlagGuardResponse } from './interaction-flags.ts';
 import {
@@ -33,11 +33,9 @@ import {
 import { createInteractionRuntime } from './interaction-runtime.ts';
 import {
   formatTouchTargetLabel,
-  interactionResultExtra,
   parseFillTarget,
   parseLongPressTarget,
   parseTouchTarget,
-  stripAtPrefix,
 } from './interaction-touch-targets.ts';
 import { getActiveAndroidSnapshotFreshness } from '../android-snapshot-freshness.ts';
 import { emitDiagnostic } from '../../utils/diagnostics.ts';
@@ -160,7 +158,7 @@ async function dispatchTargetedTouchViaRuntime(
     },
     buildPayloads: async (result) => {
       const durationMs = readLongPressResultDuration(result);
-      const responseData = await buildTargetedTouchResponseData({
+      return await buildTargetedTouchResponsePayloads({
         params,
         session,
         result,
@@ -172,7 +170,6 @@ async function dispatchTargetedTouchViaRuntime(
               }
             : resultButtonTag,
       });
-      return { result: responseData, responseData };
     },
   });
 }
@@ -215,14 +212,14 @@ async function runTargetedTouchInteraction(params: {
     : await runtime.interactions.press(target, options);
 }
 
-async function buildTargetedTouchResponseData(params: {
+async function buildTargetedTouchResponsePayloads(params: {
   params: InteractionHandlerParams & {
     captureSnapshotForSession: CaptureSnapshotForSession;
   };
   session: SessionState;
   result: TargetedTouchResult;
   extra: Record<string, unknown>;
-}): Promise<Record<string, unknown>> {
+}): Promise<InteractionResponsePayloads> {
   const { params: handlerParams, session, result, extra } = params;
   const referenceFrame =
     result.kind === 'point'
@@ -234,15 +231,10 @@ async function buildTargetedTouchResponseData(params: {
           captureSnapshotForSession: handlerParams.captureSnapshotForSession,
         })
       : readSnapshotNodesReferenceFrame(session.snapshot?.nodes ?? []);
-  return buildTouchVisualizationResult({
-    data: result.backendResult,
-    fallbackX: result.point?.x,
-    fallbackY: result.point?.y,
+  return buildInteractionResponseData({
+    source: { kind: 'runtime', result },
     referenceFrame,
-    extra: {
-      ...interactionResultExtra(result),
-      ...extra,
-    },
+    extra,
   });
 }
 
@@ -330,10 +322,8 @@ async function dispatchDirectIosSelectorInteraction(params: {
       })) ?? {};
     const actionFinishedAt = Date.now();
     const point = readPointFromDirectSelectorTapResult(data);
-    const responseData = buildTouchVisualizationResult({
-      data,
-      fallbackX: point.x,
-      fallbackY: point.y,
+    const { result, responseData } = buildInteractionResponseData({
+      source: { kind: 'runner-payload', data, point },
       referenceFrame: readReferenceFrameFromDirectSelectorTapResult(data),
       extra: {
         ...extra,
@@ -347,7 +337,7 @@ async function dispatchDirectIosSelectorInteraction(params: {
       positionals: handlerParams.req.positionals ?? [],
       retryPositionals: pointPositionals(point),
       flags: handlerParams.req.flags,
-      result: responseData,
+      result,
       responseData,
       actionStartedAt,
       actionFinishedAt,
@@ -452,33 +442,15 @@ async function dispatchFillViaRuntime(
         result.kind === 'point'
           ? undefined
           : readSnapshotNodesReferenceFrame(session.snapshot?.nodes ?? []);
-      const recordedResult = buildTouchVisualizationResult({
-        data: result.backendResult,
-        fallbackX: result.point?.x,
-        fallbackY: result.point?.y,
+      return buildInteractionResponseData({
+        // refBackendWireShape keeps the historical fill @ref wire response
+        // (backendResult + identity extras) while the shared builder owns the
+        // extras — the hand-rolled version of this branch dropped evidence
+        // (PR #1064 review).
+        source: { kind: 'runtime', result, refBackendWireShape: true },
         referenceFrame,
-        extra: {
-          ...interactionResultExtra(result),
-          text: parsedTarget.text,
-        },
+        extra: { text: parsedTarget.text },
       });
-      if (result.warning) recordedResult.warning = result.warning;
-
-      const responseData =
-        result.kind === 'ref'
-          ? {
-              ...(result.backendResult ?? {
-                ref: stripAtPrefix(result.target?.kind === 'ref' ? result.target.ref : undefined),
-                ...(result.point ? { x: result.point.x, y: result.point.y } : {}),
-              }),
-              // Same extras press @ref already returns — without this the ref
-              // branch rebuilt the response from backendResult and dropped
-              // evidence, so fill @ref --verify returned none (PR #1064 review).
-              ...interactionResultExtra(result),
-            }
-          : recordedResult;
-      if (result.warning) responseData.warning = result.warning;
-      return { result: recordedResult, responseData };
     },
   });
 }


### PR DESCRIPTION
Implements ADR 0011 Layer 2 (response construction) for the interaction guarantee contract. Part of #1081.

## What

Every `press`/`click`/`fill`/`longpress` dispatch branch now builds its `result` (session history + touch visualization) and `responseData` (wire) payloads through **one shared construction site**: `buildInteractionResponseData` in `src/daemon/handlers/interaction-touch-response.ts`.

- **`source: { kind: 'runtime', result }`** — runtime results (runtime-selector, runtime-ref, coordinate, native-ref via the runtime fast paths). Identity extras (`ref`/`refLabel`/`selectorChain`/`targetHittable`/`hint`/`evidence`) are composed *inside* the builder via `interactionResultExtra`, so a branch can no longer drop them — the class of bug where fill @ref's hand-built response dropped `evidence` (#1064 review) is structurally impossible.
- **`source: { kind: 'runner-payload', data, point }`** — the direct iOS selector path (and its maestro non-hittable fallback variant), built from the raw runner payload.
- Branch-specific inputs are **parameters**, not parallel construction sites: `extra` carries the per-command extras (fill `text`, longpress `durationMs`/`gesture`, click button tags, direct-path selector/maestro details); `referenceFrame` acquisition stays caller-side (it differs per branch and is input data, not construction).
- `refBackendWireShape` preserves the historical fill @ref wire response (backendResult + identity extras) inside the builder instead of as a hand-rolled sibling branch.
- `buildTouchVisualizationResult`/`buildTouchMessage` moved out of `interaction-common.ts` into the builder module and became private — there is no exported bypass.

## Guard (repo-precedented, cf. the apple-leak guard)

`src/daemon/handlers/__tests__/interaction-response-construction-guard.test.ts` reads the touch interaction handler sources (whitespace-collapsed, so multi-line literals can't hide) and fails when `responseData` is assigned anything other than the shared builder's output — type annotations and payload forwarding are allowed; object literals and ternary hand-rolls (the old fill shape) are flagged. The builder's own module is exempt, and the guard self-tests that it still catches the historical offender shapes.

## Registry

All six `responseConstruction` cells flip from `gap:` waivers to a single shared runtime cell (`SHARED_RESPONSE_CONSTRUCTION` → `interaction-touch-response.ts#buildInteractionResponseData`), and the six entries leave the pinned gap list in `interaction-guarantees.test.ts`. The Layer-1 gate verifies the `via` symbol actually exists.

## Wire shapes are byte-identical

This is a refactor, not a shape change. Composition order, key order, warning placement (appended last, truthiness-gated), the fill @ref backendResult fallback (`ref` + optional `x`/`y`), and the direct-path payload spread are all preserved exactly. Verified by running the existing suites **unchanged** (zero expectation edits):

- `pnpm exec vitest run src/daemon test/integration` — 139 files / 1060 tests, green before and after
- `pnpm exec vitest run src/daemon src/commands src/contracts` — 1219 tests green
- `pnpm format:check`, `pnpm typecheck`, `pnpm lint`, `pnpm exec fallow audit --base origin/main` — all green

Refs: ADR 0011 (`docs/adr/0011-interaction-guarantee-contract.md`), umbrella issue #1081.