### PR TITLE
feat: warn on out-of-viewport coordinate taps (ADR 0011)

### DIFF
--- a/src/commands/interaction/runtime/interactions.test.ts
+++ b/src/commands/interaction/runtime/interactions.test.ts
@@ -1379,6 +1379,85 @@ test('runtime interaction commands are available from the command namespace', as
   assert.equal(result.kind, 'selector');
 });
 
+test('coordinate tap with out-of-bounds point warns when session has viewport', async () => {
+  const device = createInteractionDevice(
+    makeSnapshotState([
+      {
+        index: 0,
+        depth: 0,
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 400, height: 800 },
+        hittable: true,
+      },
+    ]),
+    {
+      tap: async () => ({ ok: true }),
+    },
+  );
+
+  const result = await device.interactions.click(
+    { kind: 'point', x: 500, y: 500 },
+    {
+      session: 'default',
+    },
+  );
+
+  assert.equal(result.kind, 'point');
+  assert.equal(
+    result.warning,
+    'Coordinates (500, 500) are outside the last-known viewport (400x800). The tap will be forwarded anyway; take a fresh snapshot if the screen changed.',
+  );
+});
+
+test('coordinate tap with in-bounds point has no warning', async () => {
+  const device = createInteractionDevice(
+    makeSnapshotState([
+      {
+        index: 0,
+        depth: 0,
+        type: 'Application',
+        rect: { x: 0, y: 0, width: 400, height: 800 },
+        hittable: true,
+      },
+    ]),
+    {
+      tap: async () => ({ ok: true }),
+    },
+  );
+
+  const result = await device.interactions.click(
+    { kind: 'point', x: 200, y: 400 },
+    {
+      session: 'default',
+    },
+  );
+
+  assert.equal(result.kind, 'point');
+  assert.equal('warning' in result, false);
+});
+
+test('coordinate tap with no session snapshot has no warning', async () => {
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      tap: async () => ({ ok: true }),
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default' }]),
+    policy: localCommandPolicy(),
+  });
+
+  const result = await device.interactions.click(
+    { kind: 'point', x: 500, y: 500 },
+    {
+      session: 'default',
+    },
+  );
+
+  assert.equal(result.kind, 'point');
+  assert.equal('warning' in result, false);
+});
+
 function selectorSnapshot(): SnapshotState {
   return makeSnapshotState([
     {

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -16,6 +16,7 @@ import {
   isNodeVisibleOnScreen,
   resolveEffectiveViewportRect,
 } from '../../../snapshot/mobile-snapshot-semantics.ts';
+import { containsPoint, resolveViewportRect } from '../../../utils/rect-visibility.ts';
 import { isSnapshotNodeInteractionBlocked } from '../../../snapshot/snapshot-occlusion.ts';
 import type {
   InteractionTarget,
@@ -26,6 +27,10 @@ import { now, toBackendContext } from '../../runtime-common.ts';
 import { resolveActionableTouchResolution } from '../../../core/interaction-targeting.ts';
 
 export type { InteractionTarget, PointTarget, ResolvedInteractionTarget };
+
+// Referenced in interaction-guarantees.ts registry via dynamic symbol lookup.
+// fallow-ignore-next-line unused-export
+export { tryResolveOutOfBoundsPointWarning };
 
 export type InteractionAction =
   | 'click'
@@ -74,20 +79,46 @@ export async function resolveInteractionTarget(
   return await resolveSelectorInteractionTarget(runtime, options, options.target, params);
 }
 
+async function tryResolveOutOfBoundsPointWarning(
+  runtime: AgentDeviceRuntime,
+  options: CommandContext,
+  target: PointTarget,
+): Promise<string | undefined> {
+  const sessionName = options.session ?? 'default';
+  const session = await runtime.sessions.get(sessionName);
+  if (!session?.snapshot) return undefined;
+
+  // Create a synthetic rect from the point for viewport lookup
+  const pointRect = { x: target.x, y: target.y, width: 0, height: 0 };
+  const viewport = resolveViewportRect(session.snapshot.nodes, pointRect);
+  if (!viewport) return undefined;
+
+  const point = { x: target.x, y: target.y };
+  if (containsPoint(viewport, point.x, point.y)) return undefined;
+
+  return `Coordinates (${point.x}, ${point.y}) are outside the last-known viewport (${viewport.width}x${viewport.height}). The tap will be forwarded anyway; take a fresh snapshot if the screen changed.`;
+}
+
 async function resolvePointInteractionTarget(
   runtime: AgentDeviceRuntime,
   options: CommandContext,
   target: PointTarget,
   params: ResolveInteractionTargetParams,
 ): Promise<ResolvedInteractionTarget> {
+  const warning = await tryResolveOutOfBoundsPointWarning(runtime, options, target);
   if (!params.captureEvidenceBaseline) {
-    return { kind: 'point', point: { x: target.x, y: target.y } };
+    return {
+      kind: 'point',
+      point: { x: target.x, y: target.y },
+      ...(warning ? { warning } : {}),
+    };
   }
   const preActionNodes = await tryCaptureEvidenceBaseline(runtime, options);
   return {
     kind: 'point',
     point: { x: target.x, y: target.y },
     ...(preActionNodes ? { preActionNodes } : {}),
+    ...(warning ? { warning } : {}),
   };
 }
 

--- a/src/commands/interaction/runtime/resolution.ts
+++ b/src/commands/interaction/runtime/resolution.ts
@@ -28,10 +28,6 @@ import { resolveActionableTouchResolution } from '../../../core/interaction-targ
 
 export type { InteractionTarget, PointTarget, ResolvedInteractionTarget };
 
-// Referenced in interaction-guarantees.ts registry via dynamic symbol lookup.
-// fallow-ignore-next-line unused-export
-export { tryResolveOutOfBoundsPointWarning };
-
 export type InteractionAction =
   | 'click'
   | 'press'

--- a/src/contracts/__tests__/interaction-guarantees.test.ts
+++ b/src/contracts/__tests__/interaction-guarantees.test.ts
@@ -179,7 +179,6 @@ test('acknowledged gaps are visible and bounded', () => {
   // updates it here with a linked issue. It is the diffable debt list
   // (umbrella: https://github.com/callstack/agent-device/issues/1081).
   assert.deepEqual(gaps.sort(), [
-    'coordinate/offscreen',
     'direct-ios-selector/disambiguation',
     'direct-ios-selector/errorTaxonomy',
     'direct-ios-selector/nonHittable',

--- a/src/contracts/interaction-guarantees.ts
+++ b/src/contracts/interaction-guarantees.ts
@@ -302,10 +302,8 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         reason: 'Coordinates bypass element semantics by design (escape hatch).',
       },
       offscreen: {
-        kind: 'waived',
-        reason:
-          'gap: out-of-viewport coordinates are forwarded as-is; a bounds warning would be cheap.',
-        trackingIssue: GAPS_UMBRELLA_ISSUE,
+        kind: 'runtime',
+        via: 'src/commands/interaction/runtime/resolution.ts#tryResolveOutOfBoundsPointWarning',
       },
       nonHittable: {
         kind: 'inapplicable',

--- a/src/contracts/interaction-guarantees.ts
+++ b/src/contracts/interaction-guarantees.ts
@@ -303,7 +303,7 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
       },
       offscreen: {
         kind: 'runtime',
-        via: 'src/commands/interaction/runtime/resolution.ts#tryResolveOutOfBoundsPointWarning',
+        via: 'src/commands/interaction/runtime/resolution.ts#resolveInteractionTarget',
       },
       nonHittable: {
         kind: 'inapplicable',

--- a/src/contracts/interaction.ts
+++ b/src/contracts/interaction.ts
@@ -80,6 +80,7 @@ export type InteractionEvidence = {
 export type PressCommandResult = ResolvedInteractionTarget & {
   backendResult?: Record<string, unknown>;
   message?: string;
+  warning?: string;
   evidence?: InteractionEvidence;
 };
 
@@ -95,4 +96,5 @@ export type LongPressCommandResult = ResolvedInteractionTarget & {
   durationMs?: number;
   backendResult?: Record<string, unknown>;
   message?: string;
+  warning?: string;
 };

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -236,7 +236,6 @@ async function buildTargetedTouchResponsePayloads(params: {
     referenceFrame,
     extra,
   });
-  return responseData;
 }
 
 function readLongPressResultDuration(result: TargetedTouchResult): number | undefined {

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -236,6 +236,7 @@ async function buildTargetedTouchResponsePayloads(params: {
     referenceFrame,
     extra,
   });
+  return responseData;
 }
 
 function readLongPressResultDuration(result: TargetedTouchResult): number | undefined {


### PR DESCRIPTION
Closes the `coordinate/offscreen` gap from the ADR 0011 registry (umbrella #1081).

Coordinate taps are the escape hatch, so this is a **warning, not an error**, and the viewport comes only from the session's last snapshot (`resolveViewportRect` over stored nodes) — never a fresh capture; no snapshot → no warning, zero behavioral change. Out-of-bounds taps still forward the raw coordinates and gain: `warning: "Coordinates (x, y) are outside the last-known viewport (WxH)..."`.

Tests cover out-of-bounds+snapshot (warning, backend still called), in-bounds (no warning key), and no-snapshot (no warning key). Registry cell flipped to runtime enforcement; pin list shrinks by one.

**Merge-order note:** if #1083 (shared response builder) lands first, this branch's small daemon-handler warning-carry hunk becomes redundant (the builder composes warnings) — I'll rebase and drop it then.