### PR TITLE
feat: golden tap-point parity table for TS and the iOS runner (ADR 0011)

### DIFF
--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTapPointPolicy.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTapPointPolicy.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+// The tap-point rule the runner shares with the TS runtime (ADR 0011 Layer 2).
+//
+// RULE: the tap point is the element frame's CENTER; a tap is allowed iff that
+// center lies inside the window frame, edges inclusive. An empty or invalid
+// window frame fails open (allowed): resolving the best available frame is the
+// impure caller's job (onScreenWindowFrame / app.frame), and the policy must
+// not turn a missing frame into a refusal.
+//
+// This is pure geometry on purpose — no XCUIElement — so the exact decision
+// can be proven against the golden fixture table shared with the TS twin:
+//   table:   contracts/fixtures/tap-point-policy.json
+//   TS twin: src/snapshot/mobile-snapshot-semantics.ts#isTapPointInsideViewport
+//   TS test: src/snapshot/__tests__/tap-point-policy-parity.test.ts
+// Drift on either side turns CI red without needing a simulator.
+enum TapPointPolicy {
+  static func isAllowed(elementFrame: CGRect, windowFrame: CGRect) -> Bool {
+    if windowFrame.isNull || windowFrame.isEmpty || windowFrame.isInfinite {
+      return true
+    }
+    let centerX = elementFrame.midX
+    let centerY = elementFrame.midY
+    return centerX >= windowFrame.minX && centerX <= windowFrame.maxX
+      && centerY >= windowFrame.minY && centerY <= windowFrame.maxY
+  }
+}
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+private struct TapPointPolicyFixture: Decodable {
+  struct Frame: Decodable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    var cgRect: CGRect {
+      CGRect(x: x, y: y, width: width, height: height)
+    }
+  }
+
+  let name: String
+  let elementFrame: Frame
+  let windowFrame: Frame
+  let allowed: Bool
+}
+
+extension RunnerTests {
+  // Golden parity table (ADR 0011 Layer 2): every case in
+  // contracts/fixtures/tap-point-policy.json must agree with the vitest twin
+  // (tap-point-policy-parity.test.ts). Add cases there, never fork the rule.
+  func testTapPointPolicyMatchesGoldenParityTable() throws {
+    let fixtureURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent() // AgentDeviceRunnerUITests
+      .deletingLastPathComponent() // AgentDeviceRunner
+      .deletingLastPathComponent() // apple-runner
+      .deletingLastPathComponent() // repo root
+      .appendingPathComponent("contracts")
+      .appendingPathComponent("fixtures")
+      .appendingPathComponent("tap-point-policy.json")
+    let data = try Data(contentsOf: fixtureURL)
+    let cases = try JSONDecoder().decode([TapPointPolicyFixture].self, from: data)
+    XCTAssertFalse(cases.isEmpty, "parity table must not be empty")
+    for fixture in cases {
+      XCTAssertEqual(
+        TapPointPolicy.isAllowed(
+          elementFrame: fixture.elementFrame.cgRect,
+          windowFrame: fixture.windowFrame.cgRect
+        ),
+        fixture.allowed,
+        fixture.name
+      )
+    }
+  }
+}
+#endif

--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -484,8 +484,13 @@ extension RunnerTests {
           // state. The check uses the main window frame, not app.frame: on RN
           // apps app.frame unions transformed subtrees (a closed drawer at
           // negative x), so it happily "contains" unreachable coordinates.
+          // The DECISION lives in TapPointPolicy (golden parity table with the
+          // TS twin); onScreenWindowFrame only supplies the frame.
           if !match.usedNonHittableFallback
-            && !onScreenWindowFrame(app: activeApp).contains(CGPoint(x: frame.midX, y: frame.midY)) {
+            && !TapPointPolicy.isAllowed(
+              elementFrame: frame,
+              windowFrame: onScreenWindowFrame(app: activeApp)
+            ) {
             return Response(ok: false, error: ErrorPayload(
               code: "ELEMENT_OFFSCREEN",
               message: "element resolved off-screen at (\(Int(frame.midX)), \(Int(frame.midY)))"))

--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -200,16 +200,17 @@ extension RunnerTests {
     )
   }
 
+  // Maestro-compat gate for the non-hittable coordinate fallback: an element
+  // with no frame at all cannot be coordinate-tapped, otherwise the decision
+  // is the shared TapPointPolicy center-in-frame rule (golden parity table
+  // with the TS twin). app.frame is the frame source here — replay taps
+  // resolved bounds Maestro-style, so the union frame is intentional.
   private func hasTappableFrame(app: XCUIApplication, element: XCUIElement) -> Bool {
     let frame = element.frame
     if frame.isEmpty {
       return false
     }
-    let appFrame = app.frame
-    if appFrame.isEmpty {
-      return true
-    }
-    return appFrame.contains(CGPoint(x: frame.midX, y: frame.midY))
+    return TapPointPolicy.isAllowed(elementFrame: frame, windowFrame: app.frame)
   }
 
   // The tappable on-screen viewport. app.frame is unsuitable: it unions

--- a/contracts/fixtures/tap-point-policy.json
+++ b/contracts/fixtures/tap-point-policy.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "closed drawer fully left of the viewport is refused (Bluesky #1075: tapped (-161, 265) reported as success)",
+    "elementFrame": { "x": -321.6, "y": 200, "width": 321.33, "height": 130 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": false
+  },
+  {
+    "name": "edge-grazing container with 0.07pt viewport overlap is still refused: the tap point is the CENTER, not any overlapping edge",
+    "elementFrame": { "x": -321.6, "y": 0, "width": 321.67, "height": 874 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": false
+  },
+  {
+    "name": "on-screen bottom tab is allowed",
+    "elementFrame": { "x": 252, "y": 820, "width": 75, "height": 50 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": true
+  },
+  {
+    "name": "element flush against the viewport right edge with its center inside is allowed",
+    "elementFrame": { "x": 302, "y": 100, "width": 100, "height": 44 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": true
+  },
+  {
+    "name": "element straddling the left edge with its center exactly on the edge is allowed (edges are inclusive)",
+    "elementFrame": { "x": -50, "y": 300, "width": 100, "height": 40 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": true
+  },
+  {
+    "name": "center exactly on the viewport bottom edge is allowed (closed interval on both max edges)",
+    "elementFrame": { "x": 0, "y": 844, "width": 100, "height": 60 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": true
+  },
+  {
+    "name": "empty window frame fails open: resolving a usable frame is the caller's job, the policy must not turn a missing frame into a refusal",
+    "elementFrame": { "x": 1000, "y": 1000, "width": 10, "height": 10 },
+    "windowFrame": { "x": 0, "y": 0, "width": 0, "height": 0 },
+    "allowed": true
+  },
+  {
+    "name": "middle-of-screen element is allowed",
+    "elementFrame": { "x": 100, "y": 400, "width": 200, "height": 48 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": true
+  },
+  {
+    "name": "element fully below the viewport is refused",
+    "elementFrame": { "x": 0, "y": 900, "width": 402, "height": 60 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": false
+  },
+  {
+    "name": "off-viewport carousel page fully right of the viewport is refused",
+    "elementFrame": { "x": 402, "y": 0, "width": 402, "height": 874 },
+    "windowFrame": { "x": 0, "y": 0, "width": 402, "height": 874 },
+    "allowed": false
+  },
+  {
+    "name": "window frame with a non-zero origin: center inside the offset frame is allowed",
+    "elementFrame": { "x": 60, "y": 80, "width": 100, "height": 40 },
+    "windowFrame": { "x": 10, "y": 20, "width": 1210, "height": 834 },
+    "allowed": true
+  },
+  {
+    "name": "window frame with a non-zero origin: center left of the offset frame is refused",
+    "elementFrame": { "x": -100, "y": 80, "width": 100, "height": 40 },
+    "windowFrame": { "x": 10, "y": 20, "width": 1210, "height": 834 },
+    "allowed": false
+  }
+]

--- a/src/contracts/interaction-guarantees.ts
+++ b/src/contracts/interaction-guarantees.ts
@@ -222,8 +222,12 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         trackingIssue: GAPS_UMBRELLA_ISSUE,
       },
       offscreen: {
+        // Decision: TapPointPolicy (pure geometry, parity-tested against the
+        // TS twin isTapPointInsideViewport). onScreenWindowFrame stays the
+        // impure frame getter feeding it.
         kind: 'runner',
-        via: 'RunnerTests+Interaction.swift#onScreenWindowFrame',
+        via: 'RunnerTapPointPolicy.swift#TapPointPolicy',
+        parityTable: 'contracts/fixtures/tap-point-policy.json',
       },
       nonHittable: {
         kind: 'waived',
@@ -357,8 +361,12 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
         reason: 'Intentional: Maestro taps resolved bounds regardless of overlay state.',
       },
       offscreen: {
+        // hasTappableFrame keeps two path-specific choices (empty element
+        // frames are refused; app.frame is the frame source, Maestro-style)
+        // but its center-in-frame decision is the shared TapPointPolicy.
         kind: 'runner',
         via: 'RunnerTests+Interaction.swift#hasTappableFrame',
+        parityTable: 'contracts/fixtures/tap-point-policy.json',
       },
       nonHittable: {
         kind: 'waived',

--- a/src/snapshot/__tests__/tap-point-policy-parity.test.ts
+++ b/src/snapshot/__tests__/tap-point-policy-parity.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { isTapPointInsideViewport } from '../mobile-snapshot-semantics.ts';
+import type { Rect } from '../../kernel/snapshot.ts';
+
+// ADR 0011 Layer 2 golden parity table: the SAME JSON is asserted against the
+// Swift twin (TapPointPolicy in apple-runner/AgentDeviceRunner/
+// AgentDeviceRunnerUITests/RunnerTapPointPolicy.swift, gated XCTest in the
+// same file), so drift between the runner's ELEMENT_OFFSCREEN guard and the
+// runtime's offscreen rule turns CI red on whichever side changed.
+//
+// Scope: the table proves the GEOMETRIC rule only — element-frame center
+// inside the window frame, edges inclusive, empty frame fails open. The
+// scrollable-ancestor (effective viewport) logic layered on top by
+// isNodeVisibleOnScreen is TS-only and out of scope here.
+
+type FixtureCase = {
+  name: string;
+  elementFrame: Rect;
+  windowFrame: Rect;
+  allowed: boolean;
+};
+
+const TABLE_PATH = path.resolve(
+  import.meta.dirname,
+  '..',
+  '..',
+  '..',
+  'contracts',
+  'fixtures',
+  'tap-point-policy.json',
+);
+
+test('the TS tap-point rule agrees with every golden parity table case', () => {
+  const cases = JSON.parse(fs.readFileSync(TABLE_PATH, 'utf8')) as FixtureCase[];
+  assert.ok(cases.length > 0, 'parity table must not be empty');
+  const names = new Set(cases.map((fixture) => fixture.name));
+  assert.equal(names.size, cases.length, 'parity table case names must be unique');
+  for (const fixture of cases) {
+    assert.equal(
+      isTapPointInsideViewport(fixture.elementFrame, fixture.windowFrame),
+      fixture.allowed,
+      fixture.name,
+    );
+  }
+});

--- a/src/snapshot/mobile-snapshot-semantics.ts
+++ b/src/snapshot/mobile-snapshot-semantics.ts
@@ -1,11 +1,10 @@
-import { isRectVisibleInViewport, resolveViewportRect } from '../utils/rect-visibility.ts';
-import { inferVerticalScrollIndicatorDirections } from '../utils/scroll-indicator.ts';
 import {
-  centerOfRect,
-  type HiddenContentHint,
-  type Rect,
-  type SnapshotNode,
-} from '../kernel/snapshot.ts';
+  containsPoint,
+  isRectVisibleInViewport,
+  resolveViewportRect,
+} from '../utils/rect-visibility.ts';
+import { inferVerticalScrollIndicatorDirections } from '../utils/scroll-indicator.ts';
+import type { HiddenContentHint, Rect, SnapshotNode } from '../kernel/snapshot.ts';
 import { buildSnapshotNodeMap, displayNodeLabel } from './snapshot-tree.ts';
 import { isScrollableNodeLike } from '../utils/scrollable.ts';
 
@@ -118,16 +117,25 @@ export function isNodeVisibleOnScreen(
     return false;
   }
   const rootViewport = resolveViewportRect(nodes, node.rect);
-  if (!rootViewport) {
+  return isTapPointInsideViewport(node.rect, rootViewport);
+}
+
+// The tap-point rule shared with the iOS runner (ADR 0011 Layer 2): the tap
+// point is the rect's exact CENTER; it is inside the viewport iff it lies
+// within the frame, edges inclusive. A missing, empty, or invalid viewport
+// fails open (allowed) — resolving the best available viewport is the
+// caller's job, and the rule must not turn a missing frame into a refusal.
+//
+// Swift twin: apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/
+// RunnerTapPointPolicy.swift (TapPointPolicy.isAllowed). Parity is enforced
+// by the golden fixture table contracts/fixtures/tap-point-policy.json,
+// asserted on both sides (tap-point-policy-parity.test.ts / the gated XCTest
+// in RunnerTapPointPolicy.swift). Change the rule only via the table.
+export function isTapPointInsideViewport(rect: Rect, viewport: Rect | null): boolean {
+  if (!viewport || viewport.width <= 0 || viewport.height <= 0) {
     return true;
   }
-  const center = centerOfRect(node.rect);
-  return (
-    center.x >= rootViewport.x &&
-    center.x <= rootViewport.x + rootViewport.width &&
-    center.y >= rootViewport.y &&
-    center.y <= rootViewport.y + rootViewport.height
-  );
+  return containsPoint(viewport, rect.x + rect.width / 2, rect.y + rect.height / 2);
 }
 
 export function resolveEffectiveViewportRect(


### PR DESCRIPTION
Implements the golden-fixture-table step of ADR 0011 Layer 2 for the `offscreen` guarantee: the tap-point rule now has exactly one implementation per side of the wire, and a shared JSON table proves they agree.

## The rule (contracted, both sides)

> The tap point is the element frame's **center**; a tap is allowed iff that center lies inside the window frame, **edges inclusive**. An **empty/invalid window frame fails open** (allowed) — resolving the best available frame is the impure caller's job (`onScreenWindowFrame` / `app.frame`), the policy must not turn a missing frame into a refusal.

Scope note: the table proves the **geometric** rule only. The TS `isNodeVisibleOnScreen` layers scrollable-ancestor (effective viewport) logic on top; that part is TS-only and out of scope for the table.

## What changed

- **`contracts/fixtures/tap-point-policy.json`** — 12 cases, including this week's real bug shapes: the Bluesky closed drawer fully left of the viewport (`x=-321.6, w=321.33` → tapped `(-161, 265)` reported as success, #1075) and the edge-grazing container (`w=321.67`, 0.07pt overlap, center off-screen → still refused), plus edge-inclusive boundary pins, empty-frame fail-open, non-zero-origin window frames.
- **Swift** — new pure `TapPointPolicy.isAllowed(elementFrame:windowFrame:)` (`RunnerTapPointPolicy.swift`, no `XCUIElement`). The `ELEMENT_OFFSCREEN` guard in `RunnerTests+CommandExecution.swift` now calls it; `onScreenWindowFrame` stays as the frame getter. A gated XCTest (`AGENT_DEVICE_RUNNER_UNIT_TESTS`) loads the JSON via `#filePath` and asserts every case.
- **TS** — `isTapPointInsideViewport(rect, viewport)` extracted from `isNodeVisibleOnScreen` (`src/snapshot/mobile-snapshot-semantics.ts`), used by both the production rule and the new parity test `src/snapshot/__tests__/tap-point-policy-parity.test.ts`. No duplicated math.
- **Registry** — `parityTable` wired on `direct-ios-selector/offscreen` (via now points at the policy) and on `maestro-non-hittable-fallback/offscreen`.

## hasTappableFrame: unified

`hasTappableFrame` used the same geometric decision (center-in-frame, empty app frame → allowed), so it now delegates to `TapPointPolicy` too. Its two path-specific choices stay outside the policy and are documented at the call site: empty **element** frames are refused (can't coordinate-tap a frameless element), and `app.frame` is deliberately the frame source (Maestro taps resolved bounds against the union frame).

## Deliberate micro-semantics (called out for review)

- **Max edges are now inclusive in Swift** (closed interval), matching the TS `containsPoint` rule; previously `CGRect.contains` was max-edge-exclusive. Only differs when a center sits *exactly* on `maxX`/`maxY` — pinned by a table case so it can't drift silently.
- **TS now uses the exact (unrounded) center** in the guard instead of `centerOfRect`'s `Math.round`, matching Swift's `midX`/`midY` exactly. Only differs within 0.5pt of an edge. (The tap *dispatch* still rounds; the guard evaluates geometry.)
- **Empty window frame fails open in the policy** on both sides. TS previously also treated a zero-size resolved viewport as an effective refusal wall; that now fails open, consistent with the contract.

## Running the Swift test

CI's "Swift Runner Unit Compile" job compiles the unit-test surface (`AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1 pnpm build:xcuitest:macos`) but does not execute tests — unchanged. To run locally (iOS simulator; the macOS UITest runner needs a UI session and hangs headless):

```sh
AGENT_DEVICE_XCUITEST_INCLUDE_UNIT_TESTS=1 pnpm build:xcuitest:ios
xcodebuild test-without-building \
  -xctestrun <derived>/Build/Products/AgentDeviceRunner_AgentDeviceRunnerUITests_iphonesimulator*.xctestrun \
  -destination 'platform=iOS Simulator,name=<any iPhone>' \
  -only-testing:AgentDeviceRunnerUITests/RunnerTests/testTapPointPolicyMatchesGoldenParityTable
```

## Verification

- Swift: CI compile command green for macOS **and** iOS with unit tests enabled; the XCTest executed on an iOS simulator — green in 0.02s, and red-checked (flipping a table case fails it with the case name).
- TS: `format:check`, `typecheck`, `lint`, `fallow audit --base origin/main` all green; `vitest run src/snapshot src/contracts` (18 tests), semantics/daemon suites (980 tests), `vitest run test/integration` green except the known flaky-under-contention doctor timeout, which passes in isolation.
- Rebased on `origin/main` after #1082 (native-ref preflight) landed; gates re-run green post-rebase.