### PR TITLE
chore: delete dead tap-by-text runner arm and settledAfterMs; hint on tiny stable trees

### DIFF
--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+CommandExecution.swift
@@ -522,18 +522,6 @@ extension RunnerTests {
         }
         return Response(ok: false, error: ErrorPayload(code: "ELEMENT_NOT_FOUND", message: "element not found"))
       }
-      if let text = command.text {
-        if let element = findElement(app: activeApp, text: text) {
-          let (timing, outcome) = performGesture(activeApp) {
-            activateElement(app: activeApp, element: element, action: "tap by text")
-          }
-          if let response = unsupportedResponse(for: outcome) {
-            return response
-          }
-          return gestureResponse(message: "tapped", timing: timing)
-        }
-        return Response(ok: false, error: ErrorPayload(message: "element not found"))
-      }
       if let x = command.x, let y = command.y {
         var fallback: GestureFallback?
         if command.synthesized == true {
@@ -557,7 +545,7 @@ extension RunnerTests {
           fallback: fallback
         )
       }
-      return Response(ok: false, error: ErrorPayload(message: "tap requires text or x/y"))
+      return Response(ok: false, error: ErrorPayload(message: "tap requires a selector or x/y"))
     case .mouseClick:
       guard let x = command.x, let y = command.y else {
         return Response(ok: false, error: ErrorPayload(message: "mouseClick requires x and y"))

--- a/src/commands/interaction/runtime/selector-read.test.ts
+++ b/src/commands/interaction/runtime/selector-read.test.ts
@@ -367,9 +367,91 @@ test('runtime wait stable settles after two unchanged captures', async () => {
   if (result.kind === 'stable') {
     assert.equal(result.captures, 3);
     assert.equal(result.nodeCount, snapshot.nodes.length);
-    assert.equal(result.settledAfterMs, result.waitedMs);
   }
   assert.equal(captures, 3);
+});
+
+test('runtime wait stable hints when it settles on a nearly-empty tree', async () => {
+  const tinySnapshot = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Button',
+      label: 'One',
+      rect: { x: 0, y: 0, width: 10, height: 10 },
+    },
+    {
+      index: 1,
+      depth: 0,
+      type: 'Button',
+      label: 'Two',
+      rect: { x: 0, y: 20, width: 10, height: 10 },
+    },
+    {
+      index: 2,
+      depth: 0,
+      type: 'Button',
+      label: 'Three',
+      rect: { x: 0, y: 40, width: 10, height: 10 },
+    },
+  ]);
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => ({ snapshot: tinySnapshot }),
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot: tinySnapshot }]),
+    policy: localCommandPolicy(),
+    clock: createFakeClock(),
+  });
+
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable', quietMs: 500, timeoutMs: 10_000 },
+  });
+
+  assert.equal(result.kind, 'stable');
+  if (result.kind === 'stable') {
+    assert.equal(result.nodeCount, 3);
+    assert.equal(
+      result.hint,
+      'Settled on a nearly-empty tree — the app may still be loading. Wait for specific content (wait text ...) before interacting.',
+    );
+  }
+});
+
+test('runtime wait stable omits the loading hint for a normal-sized tree', async () => {
+  const normalSnapshot = makeSnapshotState(
+    Array.from({ length: 6 }, (_, index) => ({
+      index,
+      depth: 0,
+      type: 'Button',
+      label: `Item ${index}`,
+      rect: { x: 0, y: index * 20, width: 10, height: 10 },
+    })),
+  );
+  const device = createAgentDevice({
+    backend: {
+      platform: 'ios',
+      captureSnapshot: async () => ({ snapshot: normalSnapshot }),
+    } satisfies AgentDeviceBackend,
+    artifacts: createLocalArtifactAdapter(),
+    sessions: createMemorySessionStore([{ name: 'default', snapshot: normalSnapshot }]),
+    policy: localCommandPolicy(),
+    clock: createFakeClock(),
+  });
+
+  const result = await device.selectors.wait({
+    session: 'default',
+    target: { kind: 'stable', quietMs: 500, timeoutMs: 10_000 },
+  });
+
+  assert.equal(result.kind, 'stable');
+  if (result.kind === 'stable') {
+    assert.equal(result.nodeCount, 6);
+    assert.equal('hint' in result, false);
+  }
 });
 
 test('runtime wait stable requires quiet captures after instability before settling', async () => {

--- a/src/commands/interaction/runtime/selector-read.ts
+++ b/src/commands/interaction/runtime/selector-read.ts
@@ -123,9 +123,9 @@ export type WaitCommandResult =
   | {
       kind: 'stable';
       waitedMs: number;
-      settledAfterMs: number;
       captures: number;
       nodeCount: number;
+      hint?: string;
     };
 
 export type WaitForTextCommandOptions = CommandContext &
@@ -154,6 +154,9 @@ export function ref(refInput: string, options: { fallbackLabel?: string } = {}):
 const DEFAULT_TIMEOUT_MS = 10_000;
 const POLL_INTERVAL_MS = 300;
 const DEFAULT_QUIET_MS = 500;
+// Below this node count a settled tree is suspicious: real app surfaces have
+// more than a handful of accessibility nodes, splash/loading screens do not.
+const TINY_STABLE_TREE_NODE_COUNT = 5;
 
 export const findCommand: RuntimeCommand<FindReadCommandOptions, FindReadCommandResult> = async (
   runtime,
@@ -559,9 +562,15 @@ async function waitForStable(
       return {
         kind: 'stable',
         waitedMs: nowMs - start,
-        settledAfterMs: nowMs - start,
         captures,
         nodeCount: lastNodeCount,
+        // A settled-but-tiny tree usually means a splash/loading surface, not
+        // real content: stability alone is a weak readiness signal there.
+        ...(lastNodeCount < TINY_STABLE_TREE_NODE_COUNT
+          ? {
+              hint: 'Settled on a nearly-empty tree — the app may still be loading. Wait for specific content (wait text ...) before interacting.',
+            }
+          : {}),
       };
     }
     await sleep(runtime, POLL_INTERVAL_MS);

--- a/src/daemon/selector-recording.ts
+++ b/src/daemon/selector-recording.ts
@@ -70,9 +70,9 @@ export function toDaemonWaitData(result: Record<string, unknown>): Record<string
     waitedMs: result.waitedMs,
     ...(typeof result.text === 'string' ? { text: result.text } : {}),
     ...(typeof result.selector === 'string' ? { selector: result.selector } : {}),
-    ...(typeof result.settledAfterMs === 'number' ? { settledAfterMs: result.settledAfterMs } : {}),
     ...(typeof result.captures === 'number' ? { captures: result.captures } : {}),
     ...(typeof result.nodeCount === 'number' ? { nodeCount: result.nodeCount } : {}),
+    ...(typeof result.hint === 'string' ? { hint: result.hint } : {}),
   };
 }
 


### PR DESCRIPTION
Dead-code/polish pass (tier-1 items from the dead-code audit). Refs #1078.

## Changes

### 1. Delete the runner tap-by-text arm
The `.tap` case's `if let text = command.text { ... }` branch in `RunnerTests+CommandExecution.swift` is dead: the daemon only ever sends `selectorKey`/`selectorValue` or `x`/`y` taps (`src/platforms/apple/interactions.ts`), and daemon + runner ship in lockstep. The `findElement(app:text:)` helper stays — the `findText` probe still uses it. The tap fallthrough error message now says "tap requires a selector or x/y".

The `text?` field on `RunnerCommand` (`runner-contract.ts`) is a shared flat field legitimately used by `type`/`findText`/`readText`, so the contract type is unchanged.

### 2. Delete `settledAfterMs` from the wait stable result
It always equaled `waitedMs` and has never shipped: the latest tag (v0.18.3) predates the wait-stable merge (#1059, ab55db0b8 is in `v0.18.3..HEAD`; no tag contains it). Removed from `WaitCommandResult`, the `waitForStable` return, `toDaemonWaitData`, and the test assertion. No client-types/docs references existed.

### 3. Tiny-tree hint for wait stable (#1078)
When `wait stable` settles on a tree with fewer than 5 nodes, the result now carries:

> Settled on a nearly-empty tree — the app may still be loading. Wait for specific content (wait text ...) before interacting.

`toDaemonWaitData` passes the hint through. Tests: 3-node settle asserts the hint; 6-node settle asserts no `hint` key.

### 4. interaction-common.ts sweep
Audit-only outcome: after #1083, everything still exported from `src/daemon/handlers/interaction-common.ts` (`finalizeTouchInteraction`, `ContextFromFlags`, `InteractionHandlerParams`) has 3-4 consumers each. Nothing single-consumer or dead; `fallow audit --base origin/main` and `--gate all` report no issues. No code change.

### 5. GENERIC_EXIT_MESSAGE audit (no code change)
The `GENERIC_EXIT_MESSAGE` replacement branch in `src/kernel/errors.ts` is still load-bearing post-#1074: `createExitError` (`src/utils/exec.ts:334` sync path, `:684` async spawn close path) remains the default failure shape for every non-`allowFailure` exec and produces exactly `"<tool> exited with code N"` with `processExitError: true` via `execFailureDetails`. The branch is NOT deletable.

## Verification
- `pnpm format:check && pnpm typecheck && pnpm lint`
- `pnpm exec fallow audit --base origin/main` — no issues
- `pnpm exec vitest run src/commands src/daemon src/contracts` — 142 files, 1229 tests
- `pnpm exec vitest run test/integration` — 27 files, 89 tests
- Runner Swift files pass `swiftc -parse`
- Note: `request-handler-catalog.test.ts` and the doctor integration scenario timed out once each under heavy host load (load avg >60); both reproduce on origin/main and pass on retry — the known flaky-under-contention pattern, not a regression.