### PR TITLE
feat: actionable hint for adb timeouts

### DIFF
--- a/src/daemon/handlers/__tests__/session-doctor-device.test.ts
+++ b/src/daemon/handlers/__tests__/session-doctor-device.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { withDeviceInventoryProvider } from '../../../core/dispatch-resolve.ts';
+import { AppError } from '../../../kernel/errors.ts';
+import type { DeviceInfo } from '../../../kernel/device.ts';
+import { attachAdbFailureHint } from '../../../platforms/android/adb-executor.ts';
+import type { DaemonRequest } from '../../types.ts';
+import { appendDeviceInventoryCheck } from '../session-doctor-device.ts';
+import type { DoctorCheck } from '../session-doctor-types.ts';
+
+const BOOTED_IOS_SIMULATOR: DeviceInfo = {
+  platform: 'apple',
+  appleOs: 'ios',
+  id: 'SIM-UDID-1',
+  name: 'iPhone 16',
+  kind: 'simulator',
+  booted: true,
+};
+
+// Issue #1079 repro: a wedged adb makes `adb devices -l` time out during the
+// unscoped doctor inventory sweep. The Android listing routes that failure
+// through the adb classifier, and doctor must surface the classified hint on
+// the device-android check instead of the generic toolchain fallback.
+test('doctor android inventory timeout surfaces the wedged-adb-server hint', async () => {
+  const checks: DoctorCheck[] = [];
+  const req = { token: 't', session: 'default', command: 'doctor' } as DaemonRequest;
+
+  await withDeviceInventoryProvider(
+    async (request) => {
+      if (request.platform === 'android') {
+        // Same classified error listAndroidDeviceEntries throws when the
+        // exec layer times out an adb invocation.
+        throw attachAdbFailureHint(
+          new AppError('COMMAND_FAILED', 'adb timed out after 10000ms', {
+            cmd: 'adb',
+            args: ['devices', '-l'],
+            stdout: '',
+            stderr: '',
+            exitCode: -1,
+            timeoutMs: 10000,
+          }),
+        );
+      }
+      if (request.platform === 'apple') return [BOOTED_IOS_SIMULATOR];
+      return [];
+    },
+    async () => {
+      await appendDeviceInventoryCheck(checks, req, undefined);
+    },
+  );
+
+  const deviceCheck = checks.find((check) => check.id === 'device');
+  assert.equal(deviceCheck?.status, 'pass');
+
+  const androidCheck = checks.find((check) => check.id === 'device-android');
+  assert.equal(androidCheck?.status, 'warn');
+  assert.match(androidCheck?.summary ?? '', /Android device inventory could not be read/);
+  assert.match(androidCheck?.summary ?? '', /timed out after 10000ms/);
+  assert.match(androidCheck?.hint ?? '', /adb kill-server && adb start-server/);
+});

--- a/src/platforms/android/__tests__/adb-executor.test.ts
+++ b/src/platforms/android/__tests__/adb-executor.test.ts
@@ -429,6 +429,62 @@ test('the local adb executor flags transient transport failures retriable', asyn
   assert.equal(error.details?.retriable, true);
 });
 
+test('the local adb executor classifies exec-layer timeouts as a wedged adb server', async () => {
+  mockRunCmd.mockClear();
+  // Shape of createTimeoutError in utils/exec.ts: no stderr to classify, the
+  // structured `timeoutMs` detail is the signal.
+  mockRunCmd.mockRejectedValueOnce(
+    new AppError('COMMAND_FAILED', 'adb timed out after 10000ms', {
+      cmd: 'adb',
+      args: ['-s', 'emulator-5554', 'devices', '-l'],
+      stdout: '',
+      stderr: '',
+      exitCode: -1,
+      timeoutMs: 10000,
+    }),
+  );
+  const adb = createDeviceAdbExecutor({
+    platform: 'android',
+    id: 'emulator-5554',
+    name: 'Pixel Emulator',
+    kind: 'emulator',
+    booted: true,
+  });
+
+  const error = await adb(['devices', '-l']).then(
+    () => assert.fail('expected the adb call to reject'),
+    (err: unknown) => err,
+  );
+
+  assert.ok(error instanceof AppError);
+  assert.equal(error.details?.adbFailure, 'timeout');
+  assert.match(String(error.details?.hint), /adb kill-server && adb start-server/);
+  // A wedged adb server times out identically on an unchanged retry.
+  assert.equal(Object.hasOwn(error.details ?? {}, 'retriable'), false);
+});
+
+test('attachAdbFailureHint classifies timeouts over partial stderr and keeps site hints winning', () => {
+  // Partial output from the killed process must not reclassify the timeout
+  // (transport-error stderr would otherwise flag it retriable).
+  const timedOutWithPartialStderr = new AppError('COMMAND_FAILED', 'adb timed out after 5000ms', {
+    stderr: 'error: transport error',
+    timeoutMs: 5000,
+  });
+  attachAdbFailureHint(timedOutWithPartialStderr);
+  assert.equal(timedOutWithPartialStderr.details?.adbFailure, 'timeout');
+  assert.match(String(timedOutWithPartialStderr.details?.hint), /kill-server/);
+  assert.equal(Object.hasOwn(timedOutWithPartialStderr.details ?? {}, 'retriable'), false);
+
+  const withSiteHint = new AppError('COMMAND_FAILED', 'adb timed out after 5000ms', {
+    stderr: '',
+    timeoutMs: 5000,
+    hint: 'site-specific hint',
+  });
+  attachAdbFailureHint(withSiteHint);
+  assert.equal(withSiteHint.details?.hint, 'site-specific hint');
+  assert.equal(withSiteHint.details?.adbFailure, 'timeout');
+});
+
 test('attachAdbFailureHint preserves existing hints and ignores non-adb errors', () => {
   const withHint = new AppError('COMMAND_FAILED', 'adb exited with code 1', {
     stderr: 'adb: device offline',

--- a/src/platforms/android/__tests__/snapshot.test.ts
+++ b/src/platforms/android/__tests__/snapshot.test.ts
@@ -1418,7 +1418,10 @@ test('dumpUiHierarchy does not attach animation hint to non-dump timeouts', asyn
     (error: unknown) =>
       error instanceof AppError &&
       error.message === 'adb timed out after 8000ms' &&
-      typeof error.details?.hint === 'undefined',
+      // Non-dump timeouts keep the generic classified adb-timeout hint instead
+      // of the looping-animation explanation reserved for uiautomator dump.
+      !String(error.details?.hint).includes('Android accessibility snapshots can be blocked') &&
+      error.details?.adbFailure === 'timeout',
   );
 });
 

--- a/src/platforms/android/adb-executor.ts
+++ b/src/platforms/android/adb-executor.ts
@@ -190,6 +190,7 @@ const androidAdbProviderScope = new AsyncLocalStorage<AndroidAdbProviderScope>()
 export type AdbFailureClassification = {
   /** Machine-readable failure family, attached to error details as `adbFailure`. */
   reason:
+    | 'timeout'
     | 'device_offline'
     | 'device_unauthorized'
     | 'device_not_found'
@@ -284,6 +285,16 @@ const ADB_FAILURE_MATCHERS: readonly AdbFailureMatcher[] = [
   },
 ];
 
+// A timed-out adb invocation leaves no failure output to key on — the exec
+// layer kills the process and rejects with COMMAND_FAILED carrying `timeoutMs`
+// in details (see createTimeoutError in utils/exec.ts), so timeouts classify on
+// that structured signal instead of a stderr matcher. Not marked retriable: an
+// unchanged retry against a wedged adb server times out identically.
+const ADB_TIMEOUT_CLASSIFICATION: AdbFailureClassification = {
+  reason: 'timeout',
+  hint: 'adb timed out — the adb server may be wedged. Run adb kill-server && adb start-server, check adb devices, then retry.',
+};
+
 /**
  * Maps well-known adb failure output to an actionable hint (and a `retriable`
  * flag for clearly transient families). Matches stderr; install verdicts also
@@ -306,15 +317,14 @@ export function classifyAdbFailure(
 /**
  * Enriches a failed adb command error in place with the classified hint,
  * `retriable` flag, and machine-readable `adbFailure` family, so every adb call
- * site surfaces guidance without per-site classification. No-op for errors that
- * are not adb command failures or that carry no recognized failure output; an
+ * site surfaces guidance without per-site classification. Exec-layer timeouts
+ * classify as `timeout` even though they leave no stderr. No-op for errors that
+ * are not adb command failures or that carry no recognized failure signal; an
  * existing hint or retriable verdict is never overwritten.
  */
 export function attachAdbFailureHint<T>(error: T): T {
   if (!(error instanceof AppError) || error.code !== 'COMMAND_FAILED') return error;
-  const stderr = typeof error.details?.stderr === 'string' ? error.details.stderr : '';
-  const stdout = typeof error.details?.stdout === 'string' ? error.details.stdout : '';
-  const classification = classifyAdbFailure(stderr, stdout);
+  const classification = classifyAdbCommandError(error);
   if (!classification) return error;
   error.details = {
     ...error.details,
@@ -325,6 +335,17 @@ export function attachAdbFailureHint<T>(error: T): T {
       : {}),
   };
   return error;
+}
+
+// Timeout wins over text matchers: the exec layer deliberately builds timeout
+// errors around "timed out after Nms" because partial output from the killed
+// process is untrustworthy — classifying that partial stderr (e.g. flagging a
+// half-written transport line retriable) would point away from the real fix.
+function classifyAdbCommandError(error: AppError): AdbFailureClassification | undefined {
+  if (typeof error.details?.timeoutMs === 'number') return ADB_TIMEOUT_CLASSIFICATION;
+  const stderr = typeof error.details?.stderr === 'string' ? error.details.stderr : '';
+  const stdout = typeof error.details?.stdout === 'string' ? error.details.stdout : '';
+  return classifyAdbFailure(stderr, stdout);
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1079.

A timed-out adb invocation has no stderr for #1067's failure classifier to match, so it fell through to the generic retry hint — retrying against a wedged adb server times out identically. This adds a timeout branch to the centralized classifier:

- **Detection is structural, not textual**: the exec layer's `createTimeoutError` (`src/utils/exec.ts`) rejects with `COMMAND_FAILED` carrying `timeoutMs` in details — the same signal `snapshot.ts` and `devices.ts` already key on. `attachAdbFailureHint` now classifies that as a new `timeout` family with the hint: *"adb timed out — the adb server may be wedged. Run adb kill-server && adb start-server, check adb devices, then retry."*
- **Timeout wins over partial stderr**: output from the killed process is untrustworthy (a half-written `transport error` line would otherwise mark the failure retriable), mirroring the exec layer's own "timed out after Nms beats partial stderr" message rule.
- **Site-hint-wins preserved**: an existing `details.hint` is never overwritten; `adbFailure: 'timeout'` is still attached.
- **Not retriable**: an unchanged retry against a wedged server times out identically.

## Doctor wiring

No wiring needed — doctor's android inventory sweep already routes through the classifier: `listAndroidDeviceEntries` wraps its `adb devices -l` failure in `attachAdbFailureHint`, and `session-doctor-device.ts` surfaces `normalizeError(error).hint` on the `device-android` check (`failure.hint ?? generic`). A new regression test locks that end-to-end path against the issue's exact repro.

## Tests

- `adb-executor.test.ts`: executor timeout → `adbFailure: 'timeout'` + wedged-server hint + no `retriable`; timeout classification beats partial `transport error` stderr; site hint still wins.
- `session-doctor-device.test.ts` (new): unscoped doctor inventory with a classified adb timeout for android surfaces the kill-server hint on the `device-android` warn check while the `device` check passes on the remaining booted simulator.
- `snapshot.test.ts`: updated the non-dump-timeout test — it asserted no hint (documenting the old gap); it now asserts the classified timeout hint is attached but the looping-animation hint stays reserved for `uiautomator dump` timeouts.

Gates: format:check, typecheck, lint, fallow audit, `vitest run src/platforms/android src/daemon` (1245 passed), `vitest run test/integration` (89 passed).