### PR TITLE
feat: warn when @refs outlive the session snapshot they came from

### DIFF
--- a/src/daemon/handlers/__tests__/find.test.ts
+++ b/src/daemon/handlers/__tests__/find.test.ts
@@ -730,3 +730,30 @@ test('handleFindCommands wait captures fresh snapshots while polling', async () 
   }
   expect(mockDispatch).toHaveBeenCalledTimes(2);
 });
+
+test('handleFindCommands click re-issues a fresh ref and clears the stale-refs marker (#1076)', async () => {
+  const sessionName = 'default';
+  const session = makeSession(sessionName);
+  // As set by an earlier selector-resolution capture that replaced the tree.
+  session.snapshotRefsStale = true;
+
+  const { response, session: storedSession } = await runFindClickScenario({
+    positionals: ['Increment', 'click'],
+    nodes: [
+      {
+        index: 0,
+        type: 'Button',
+        label: 'Increment',
+        hittable: true,
+        rect: { x: 50, y: 0, width: 100, height: 100 },
+        depth: 0,
+      },
+    ],
+    session,
+  });
+
+  expect(response.ok).toBe(true);
+  // The response returns a ref minted from the freshly stored snapshot, so
+  // the marker clears before the internal click @ref sub-invocation runs.
+  expect(storedSession.snapshotRefsStale).toBe(false);
+});

--- a/src/daemon/handlers/__tests__/interaction.test.ts
+++ b/src/daemon/handlers/__tests__/interaction.test.ts
@@ -6,6 +6,7 @@ import type { CommandFlags } from '../../../core/dispatch.ts';
 import { attachRefs, type SnapshotBackend } from '../../../kernel/snapshot.ts';
 import { AppError } from '../../../kernel/errors.ts';
 import { buildSnapshotState } from '../snapshot-capture.ts';
+import { setSessionSnapshot, STALE_SNAPSHOT_REFS_WARNING } from '../../session-snapshot.ts';
 import { makeSessionStore } from '../../../__tests__/test-utils/store-factory.ts';
 import {
   makeIosSession,
@@ -106,7 +107,9 @@ async function emulateCaptureSnapshotForSession(
     contextFromFlags(effectiveFlags, session.appBundleId, session.trace?.outPath),
   )) as { nodes?: never[]; truncated?: boolean; backend?: SnapshotBackend };
   const snapshot = buildSnapshotState(snapshotData ?? {}, effectiveFlags);
-  session.snapshot = snapshot;
+  // Mirror the real captureSnapshotForSession: session snapshot writes go
+  // through setSessionSnapshot so snapshotRefsStale tracking (#1076) applies.
+  setSessionSnapshot(session, snapshot);
   sessionStore.set(session.name, session);
   return snapshot;
 }
@@ -3099,5 +3102,212 @@ test('is reports Android permission dialog blocker when app content assertion fa
       expectedPackage: 'com.example.demo',
       foregroundPackage: 'com.google.android.permissioncontroller',
     });
+  }
+});
+
+// --- Stale @ref warnings (#1076) ---
+
+function makeTwoButtonNodes() {
+  return [
+    {
+      index: 0,
+      type: 'Application',
+      rect: { x: 0, y: 0, width: 390, height: 844 },
+    },
+    {
+      index: 1,
+      parentIndex: 0,
+      type: 'XCUIElementTypeButton',
+      label: 'Continue',
+      rect: { x: 10, y: 20, width: 100, height: 40 },
+      enabled: true,
+      hittable: true,
+    },
+    {
+      index: 2,
+      parentIndex: 0,
+      type: 'XCUIElementTypeButton',
+      label: 'Cancel',
+      rect: { x: 10, y: 80, width: 100, height: 40 },
+      enabled: true,
+      hittable: true,
+    },
+  ];
+}
+
+function makeStaleRefSession(sessionName: string): SessionState {
+  const session = makeSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs(makeTwoButtonNodes() as never),
+    createdAt: Date.now(),
+    backend: 'xctest',
+  };
+  // As if the snapshot command just returned these refs to the client.
+  session.snapshotRefsStale = false;
+  return session;
+}
+
+async function runInteraction(
+  sessionStore: SessionStore,
+  sessionName: string,
+  command: string,
+  positionals: string[],
+  flags: Record<string, unknown> = {},
+) {
+  return await handleInteractionCommands({
+    req: { token: 't', session: sessionName, command, positionals, flags },
+    sessionName,
+    sessionStore,
+    contextFromFlags,
+  });
+}
+
+test('press selector then press @ref warns that refs outlived the stored snapshot', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'stale-ref-warns';
+  const session = makeStaleRefSession(sessionName);
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockImplementation(async (_device, command) =>
+    command === 'snapshot' ? { nodes: makeTwoButtonNodes(), backend: 'xctest' } : {},
+  );
+
+  // Selector press: its resolution capture replaces the stored snapshot
+  // without handing the new refs back to the client.
+  const selectorPress = await runInteraction(sessionStore, sessionName, 'press', [
+    'label=Continue',
+  ]);
+  if (!selectorPress?.ok) {
+    throw new Error(`selector press failed: ${JSON.stringify(selectorPress)}`);
+  }
+  expect(selectorPress.data?.warning).toBeUndefined();
+  expect(sessionStore.get(sessionName)?.snapshotRefsStale).toBe(true);
+
+  const refPress = await runInteraction(sessionStore, sessionName, 'press', ['@e1']);
+  expect(refPress?.ok).toBe(true);
+  if (refPress?.ok) {
+    expect(refPress.data?.warning).toBe(STALE_SNAPSHOT_REFS_WARNING);
+  }
+});
+
+test('press @ref directly after refs were issued does not warn', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'fresh-ref-no-warning';
+  const session = makeStaleRefSession(sessionName);
+  sessionStore.set(sessionName, session);
+
+  const response = await runInteraction(sessionStore, sessionName, 'press', ['@e1']);
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    expect(response.data?.warning).toBeUndefined();
+  }
+});
+
+test('re-issuing refs clears the stale marker so press @ref does not warn', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'reissued-refs-no-warning';
+  const session = makeStaleRefSession(sessionName);
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockImplementation(async (_device, command) =>
+    command === 'snapshot' ? { nodes: makeTwoButtonNodes(), backend: 'xctest' } : {},
+  );
+
+  const selectorPress = await runInteraction(sessionStore, sessionName, 'press', [
+    'label=Continue',
+  ]);
+  expect(selectorPress?.ok).toBe(true);
+  expect(sessionStore.get(sessionName)?.snapshotRefsStale).toBe(true);
+
+  // Simulate the snapshot command re-issuing refs (its handler clears the
+  // marker through buildNextSnapshotSession; covered in snapshot-handler tests).
+  const stored = sessionStore.get(sessionName)!;
+  stored.snapshotRefsStale = false;
+  sessionStore.set(sessionName, stored);
+
+  const refPress = await runInteraction(sessionStore, sessionName, 'press', ['@e1']);
+  expect(refPress?.ok).toBe(true);
+  if (refPress?.ok) {
+    expect(refPress.data?.warning).toBeUndefined();
+  }
+});
+
+test('fill @ref warns while refs are stale', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'stale-ref-fill';
+  const session = makeStaleRefSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        type: 'XCUIElementTypeTextField',
+        label: 'Email',
+        rect: { x: 10, y: 20, width: 200, height: 40 },
+        enabled: true,
+        hittable: true,
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'xctest',
+  };
+  session.snapshotRefsStale = true;
+  sessionStore.set(sessionName, session);
+
+  const response = await runInteraction(sessionStore, sessionName, 'fill', [
+    '@e1',
+    'hello@example.com',
+  ]);
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    expect(response.data?.warning).toBe(STALE_SNAPSHOT_REFS_WARNING);
+  }
+});
+
+test('get text @ref warns while refs are stale', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'stale-ref-get-text';
+  const session = makeStaleRefSession(sessionName);
+  session.snapshotRefsStale = true;
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockRejectedValue(
+    new Error('dispatch should not be called for snapshot-derived get text'),
+  );
+
+  const response = await runInteraction(sessionStore, sessionName, 'get', ['text', '@e1']);
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    expect(response.data?.warning).toBe(STALE_SNAPSHOT_REFS_WARNING);
+    expect(response.data?.ref).toBe('e1');
+  }
+});
+
+test('stale-ref warning appends to an existing interaction warning', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'stale-ref-appends';
+  const session = makeStaleRefSession(sessionName);
+  session.snapshot = {
+    nodes: attachRefs([
+      {
+        index: 0,
+        // Non-fillable type produces the runtime fill warning the stale-ref
+        // warning must append to, not replace.
+        type: 'XCUIElementTypeStaticText',
+        label: 'Read-only',
+        rect: { x: 10, y: 20, width: 200, height: 40 },
+        enabled: true,
+        hittable: true,
+      },
+    ]),
+    createdAt: Date.now(),
+    backend: 'xctest',
+  };
+  session.snapshotRefsStale = true;
+  sessionStore.set(sessionName, session);
+
+  const response = await runInteraction(sessionStore, sessionName, 'fill', ['@e1', 'nope']);
+  expect(response?.ok).toBe(true);
+  if (response?.ok) {
+    const warning = String(response.data?.warning ?? '');
+    expect(warning).toContain('attempting fill anyway');
+    expect(warning).toContain(STALE_SNAPSHOT_REFS_WARNING);
+    expect(warning.endsWith(STALE_SNAPSHOT_REFS_WARNING)).toBe(true);
   }
 });

--- a/src/daemon/handlers/__tests__/snapshot-handler.test.ts
+++ b/src/daemon/handlers/__tests__/snapshot-handler.test.ts
@@ -402,6 +402,54 @@ test('snapshot on iOS runs when the session tracks an app', async () => {
   );
 });
 
+test('snapshot clears the stale-refs marker; diff leaves client refs stale (#1076)', async () => {
+  const sessionStore = makeSessionStore();
+  const sessionName = 'android-stale-refs-marker';
+  const session = makeSession(sessionName, androidDevice);
+  session.snapshot = {
+    nodes: [{ ref: 'e1', index: 0, depth: 0, type: 'android.widget.Button', label: 'Old' }],
+    createdAt: Date.now(),
+    backend: 'android',
+  };
+  // As set by a selector-resolution capture that replaced the stored tree.
+  session.snapshotRefsStale = true;
+  sessionStore.set(sessionName, session);
+  mockDispatch.mockResolvedValue({
+    nodes: [{ index: 0, depth: 0, type: 'android.widget.Button', label: 'Fresh' }],
+    truncated: false,
+    backend: 'android',
+  });
+
+  const snapshotResponse = await handleSnapshotCommands({
+    req: { token: 't', session: sessionName, command: 'snapshot', positionals: [], flags: {} },
+    sessionName,
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+  });
+
+  // The snapshot response hands every stored node's ref to the client.
+  expect(snapshotResponse?.ok).toBe(true);
+  expect(sessionStore.get(sessionName)?.snapshotRefsStale).toBe(false);
+
+  const diffResponse = await handleSnapshotCommands({
+    req: {
+      token: 't',
+      session: sessionName,
+      command: 'diff',
+      positionals: ['snapshot'],
+      flags: {},
+    },
+    sessionName,
+    logPath: '/tmp/daemon.log',
+    sessionStore,
+  });
+
+  // diff replaces the stored tree but only returns a summary, so the refs the
+  // client holds go stale again.
+  expect(diffResponse?.ok).toBe(true);
+  expect(sessionStore.get(sessionName)?.snapshotRefsStale).toBe(true);
+});
+
 test('snapshot surfaces filtered-to-zero Android guidance for interactive snapshots', async () => {
   const sessionStore = makeSessionStore();
   const sessionName = 'android-empty-interactive';

--- a/src/daemon/handlers/find.ts
+++ b/src/daemon/handlers/find.ts
@@ -23,6 +23,7 @@ import { errorResponse, noActiveSessionError } from './response.ts';
 import { recordSessionAction } from './handler-utils.ts';
 import { stripInternalInteractionFlags } from '../interaction-outcome-policy.ts';
 import { dispatchFindReadOnlyViaRuntime } from '../selector-runtime.ts';
+import { markSessionSnapshotRefsIssued } from '../session-snapshot.ts';
 import { createSelectorCaptureRuntime } from '../selector-capture-runtime.ts';
 import {
   isSparseSnapshotQualityVerdict,
@@ -156,6 +157,15 @@ export async function handleFindCommands(params: {
   const ref = `@${resolvedNode.ref}`;
   const actionFlags = { ...(req.flags ?? {}), noRecord: true };
   const match: ResolvedMatch = { node, resolvedNode, ref, nodes, actionFlags };
+  if (session) {
+    // #1076 clear choke point: every action below returns `match.ref`, minted
+    // from the snapshot the capture runtime just stored, so the client leaves
+    // with a ref that matches the stored tree. Clearing here also keeps the
+    // internal `click/fill @ref` sub-invocations from attaching a spurious
+    // stale-refs warning to the find response.
+    markSessionSnapshotRefsIssued(session);
+    sessionStore.set(sessionName, session);
+  }
 
   const actionHandlers: Record<string, () => Promise<DaemonResponse | null>> = {
     exists: () => handleFindExists(ctx),

--- a/src/daemon/handlers/interaction-touch-response.ts
+++ b/src/daemon/handlers/interaction-touch-response.ts
@@ -5,6 +5,7 @@ import type {
   PressCommandResult,
 } from '../../contracts/interaction.ts';
 import { successText } from '../../utils/success-text.ts';
+import { STALE_SNAPSHOT_REFS_WARNING } from '../session-snapshot.ts';
 import { interactionResultExtra, stripAtPrefix } from './interaction-touch-targets.ts';
 
 /**
@@ -55,6 +56,13 @@ export function buildInteractionResponseData(params: {
    * button tags for click, selector/maestro details for the direct path.
    */
   extra?: Record<string, unknown>;
+  /**
+   * The command consumed an `@ref` argument while the session's stored
+   * snapshot had been replaced without re-issuing refs to the client
+   * (`session.snapshotRefsStale`, #1076). Appends
+   * STALE_SNAPSHOT_REFS_WARNING to the response warning.
+   */
+  staleRefs?: boolean;
 }): InteractionResponsePayloads {
   const { source, referenceFrame, extra } = params;
   if (source.kind === 'runner-payload') {
@@ -89,11 +97,25 @@ export function buildInteractionResponseData(params: {
           ...interactionResultExtra(result),
         }
       : visualization;
-  if ('warning' in result && result.warning) {
-    visualization.warning = result.warning;
-    responseData.warning = result.warning;
+  const warning = composeResponseWarning(
+    'warning' in result ? result.warning : undefined,
+    params.staleRefs,
+  );
+  if (warning) {
+    visualization.warning = warning;
+    responseData.warning = warning;
   }
   return { result: visualization, responseData };
+}
+
+function composeResponseWarning(
+  resultWarning: string | undefined,
+  staleRefs: boolean | undefined,
+): string | undefined {
+  if (staleRefs !== true) return resultWarning;
+  return resultWarning
+    ? `${resultWarning} ${STALE_SNAPSHOT_REFS_WARNING}`
+    : STALE_SNAPSHOT_REFS_WARNING;
 }
 
 function buildTouchVisualizationResult(params: {

--- a/src/daemon/handlers/interaction-touch.ts
+++ b/src/daemon/handlers/interaction-touch.ts
@@ -116,6 +116,10 @@ async function dispatchTargetedTouchViaRuntime(
       ? parseLongPressTarget(req.positionals ?? [])
       : parseTouchTarget(req.positionals ?? [], commandLabel);
   if (!parsedTarget.ok) return parsedTarget.response;
+  // Staleness relative to what the client knew when it sent this @ref — read
+  // BEFORE any internal recapture (Android freshness refresh, --verify) flips
+  // the flag as a side effect of this same command (#1076).
+  const staleRefs = parsedTarget.target.kind === 'ref' && session.snapshotRefsStale === true;
   let androidFreshnessBaseline: SessionState['snapshot'];
   if (parsedTarget.target.kind === 'ref') {
     const invalidRefFlagsResponse = params.refSnapshotFlagGuardResponse(
@@ -163,6 +167,7 @@ async function dispatchTargetedTouchViaRuntime(
         params,
         session,
         result,
+        staleRefs,
         extra:
           command === 'longpress'
             ? {
@@ -219,6 +224,7 @@ async function buildTargetedTouchResponsePayloads(params: {
   };
   session: SessionState;
   result: TargetedTouchResult;
+  staleRefs: boolean;
   extra: Record<string, unknown>;
 }): Promise<InteractionResponsePayloads> {
   const { params: handlerParams, session, result, extra } = params;
@@ -236,6 +242,7 @@ async function buildTargetedTouchResponsePayloads(params: {
     source: { kind: 'runtime', result },
     referenceFrame,
     extra,
+    staleRefs: params.staleRefs,
   });
 }
 
@@ -418,6 +425,8 @@ async function dispatchFillViaRuntime(
 
   const parsedTarget = parseFillTarget(req.positionals ?? []);
   if (!parsedTarget.ok) return parsedTarget.response;
+  // Read before the Android freshness refresh recaptures — see the press path.
+  const staleRefs = parsedTarget.target.kind === 'ref' && session.snapshotRefsStale === true;
   if (parsedTarget.target.kind === 'ref') {
     const invalidRefFlagsResponse = params.refSnapshotFlagGuardResponse('fill', req.flags);
     if (invalidRefFlagsResponse) return invalidRefFlagsResponse;
@@ -459,6 +468,7 @@ async function dispatchFillViaRuntime(
         source: { kind: 'runtime', result, refBackendWireShape: true },
         referenceFrame,
         extra: { text: parsedTarget.text },
+        staleRefs,
       });
     },
   });
@@ -526,8 +536,14 @@ async function dispatchRuntimeInteraction<
     const actionFinishedAt = Date.now();
     const { result, responseData } = await options.buildPayloads(runtimeResult);
     if (readiness.status === 'recovered') {
-      result.warning = readiness.warning;
-      responseData.warning = readiness.warning;
+      // Append, don't clobber — the builder may already carry a warning
+      // (e.g. stale-refs, #1076).
+      const warning =
+        typeof responseData.warning === 'string'
+          ? `${responseData.warning} ${readiness.warning}`
+          : readiness.warning;
+      result.warning = warning;
+      responseData.warning = warning;
     }
     return finalizeTouchInteraction({
       session,

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -6,6 +6,7 @@ import { runAppleRunnerCommand } from '../platforms/apple/core/runner/runner-cli
 import { buildAppleRunnerRequestOptions } from './apple-runner-options.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from './types.ts';
 import { errorResponse, requireCommandSupported } from './handlers/response.ts';
+import { markSessionSnapshotRefsIssued, STALE_SNAPSHOT_REFS_WARNING } from './session-snapshot.ts';
 import { resolveSessionDevice, withSessionlessRunnerCleanup } from './handlers/snapshot-session.ts';
 import { parseFindArgs, type FindAction } from '../utils/finders.ts';
 import { splitIsSelectorArgs } from './selectors.ts';
@@ -100,7 +101,18 @@ export async function dispatchFindReadOnlyViaRuntime(
       req,
       buildFindRecordResult(result, action),
     );
-    return toDaemonFindData(result);
+    const data = toDaemonFindData(result);
+    // #1076 clear choke point: this response returns a ref minted from the
+    // freshly captured (and stored) session snapshot, so the client now holds
+    // refs that match the stored tree again.
+    if (typeof data.ref === 'string') {
+      const session = params.sessionStore.get(params.sessionName);
+      if (session) {
+        markSessionSnapshotRefsIssued(session);
+        params.sessionStore.set(params.sessionName, session);
+      }
+    }
+    return data;
   });
 }
 
@@ -130,6 +142,11 @@ export async function dispatchGetViaRuntime(
   });
   if (!resolvedRuntime.ok) return resolvedRuntime.response;
 
+  // #1076: get @ref reads from the stored snapshot; warn when that tree was
+  // replaced since the client last received refs.
+  const staleRefs =
+    target.target.kind === 'ref' &&
+    params.sessionStore.get(params.sessionName)?.snapshotRefsStale === true;
   return await toDaemonResponse(async () => {
     const result = await resolvedRuntime.runtime.selectors.get({
       session: params.sessionName,
@@ -143,7 +160,8 @@ export async function dispatchGetViaRuntime(
       req,
       buildGetRecordResult(result, sub),
     );
-    return toDaemonGetData(result);
+    const data = toDaemonGetData(result);
+    return staleRefs ? { ...data, warning: STALE_SNAPSHOT_REFS_WARNING } : data;
   });
 }
 
@@ -216,6 +234,9 @@ export async function dispatchWaitViaRuntime(
     });
     if (directResponse) return directResponse;
   }
+  // #1076: wait @ref re-resolves the ref against fresh polling captures; warn
+  // when the stored tree already drifted from the refs the client holds.
+  const staleRefs = parsed.kind === 'ref' && session?.snapshotRefsStale === true;
   const execute = async () => {
     const runtime = createSelectorRuntimeForDevice({
       ...params,
@@ -229,7 +250,8 @@ export async function dispatchWaitViaRuntime(
         target: toWaitTarget(parsed, session),
       });
       recordIfSession(sessionStore, sessionName, req, result);
-      return toDaemonWaitData(result);
+      const data = toDaemonWaitData(result);
+      return staleRefs ? { ...data, warning: STALE_SNAPSHOT_REFS_WARNING } : data;
     });
     const enrichedResponse = await maybeWaitTimeoutSurfaceResponse(
       { req, logPath: params.logPath, session, device },

--- a/src/daemon/session-snapshot.ts
+++ b/src/daemon/session-snapshot.ts
@@ -1,10 +1,52 @@
 import type { SnapshotState } from '../kernel/snapshot.ts';
 import type { SessionState } from './types.ts';
 
+/**
+ * Warning attached to responses of commands that consume an `@ref` argument
+ * while `session.snapshotRefsStale` is true (#1076). Warning, not error: the
+ * command still executes, and the geometric guards (offscreen/covered/
+ * STALE_REF) keep catching the cases where the drift is detectable.
+ */
+export const STALE_SNAPSHOT_REFS_WARNING =
+  'The session snapshot changed since your refs were issued — @refs may now point at different elements. Re-run snapshot -i to refresh refs.';
+
+/**
+ * The single daemon-side write choke point for replacing a session's stored
+ * snapshot outside the snapshot/diff command (which builds its next session in
+ * `buildNextSnapshotSession`, src/daemon/snapshot-runtime.ts, and manages
+ * `snapshotRefsStale` there because its response DOES hand refs to the client).
+ *
+ * Every caller of this function replaces the tree WITHOUT returning the new
+ * refs to the client, so the stored refs the client holds become positionally
+ * unreliable and `snapshotRefsStale` is set (#1076 honest marker):
+ * - selector-capture-runtime.ts — find/get/is/wait selector captures
+ * - selector-runtime-backend.ts — selector runtime session writes (get/wait)
+ * - handlers/interaction-runtime.ts — press/click/fill selector-resolution and
+ *   --verify evidence captures routed through the interaction runtime
+ * - handlers/interaction-snapshot.ts — Android ref-freshness refreshes and
+ *   recording reference-frame captures
+ * - handlers/session-replay-heal.ts — replay heal re-captures
+ * - request-generic-dispatch.ts — screenshot --overlay-refs capture (the
+ *   overlay burns in at most a scored subset of refs, so it does NOT count as
+ *   issuing the full ref set and stays conservative-stale)
+ *
+ * Cleared (set false) only where the client demonstrably receives the new
+ * refs: the snapshot command response (buildNextSnapshotSession) and find
+ * responses that return a ref minted from the freshly stored tree
+ * (handlers/find.ts, dispatchFindReadOnlyViaRuntime in selector-runtime.ts).
+ */
 export function setSessionSnapshot(session: SessionState, snapshot: SnapshotState): void {
+  if (session.snapshot !== snapshot) {
+    session.snapshotRefsStale = true;
+  }
   session.snapshot = snapshot;
   session.snapshotScopeSource = undefined;
   if (snapshot.comparisonSafe === true) {
     session.lastComparisonSafeSnapshot = snapshot;
   }
+}
+
+/** The response being returned hands the stored snapshot's refs to the client. */
+export function markSessionSnapshotRefsIssued(session: SessionState): void {
+  session.snapshotRefsStale = false;
 }

--- a/src/daemon/snapshot-runtime.ts
+++ b/src/daemon/snapshot-runtime.ts
@@ -209,6 +209,10 @@ function createSnapshotRuntime(params: {
             device,
             record: snapshotRecord,
             refScopedSnapshot: isRefScopedSnapshot(req),
+            // Only the snapshot command's response carries every stored node's
+            // ref back to the client; diff returns a summary, so its refreshed
+            // tree leaves client refs stale (#1076).
+            issuesRefsToClient: req.command === 'snapshot',
           }),
         );
       },
@@ -222,6 +226,7 @@ function buildNextSnapshotSession(params: {
   device: SessionState['device'];
   record: CommandSessionRecord & { snapshot: NonNullable<CommandSessionRecord['snapshot']> };
   refScopedSnapshot: boolean;
+  issuesRefsToClient: boolean;
 }): SessionState {
   const { current, sessionName, device, record, refScopedSnapshot } = params;
   const keepCurrentSnapshot = shouldKeepCurrentSnapshot(current, record, refScopedSnapshot);
@@ -238,6 +243,13 @@ function buildNextSnapshotSession(params: {
     keepCurrentSnapshot,
     refScopedSnapshot,
   });
+  // #1076 honest marker (see setSessionSnapshot in session-snapshot.ts):
+  // - kept current snapshot (empty ref-scoped result): tree unchanged, flag unchanged;
+  // - snapshot command: the response hands every node's ref to the client → cleared;
+  // - diff: tree replaced but the response is a summary → client refs go stale.
+  nextSession.snapshotRefsStale = keepCurrentSnapshot
+    ? current?.snapshotRefsStale
+    : !params.issuesRefsToClient;
   if (record.appName) nextSession.appName = record.appName;
   return nextSession;
 }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -248,6 +248,18 @@ export type SessionState = {
   appBundleId?: string;
   appName?: string;
   snapshot?: SnapshotState;
+  /**
+   * Honest-marker for stale client refs (#1076): true when the stored session
+   * snapshot was replaced by a capture whose response did NOT hand the new refs
+   * to the client (selector-resolution captures, wait/find polling captures,
+   * verify-evidence captures, ...). Commands that consume `@ref` arguments while
+   * this is true attach a warning — refs are positional indexes into the latest
+   * tree, so they may silently resolve to different elements. Cleared only where
+   * the client demonstrably receives the new refs (snapshot responses, find
+   * responses that return a ref). Set/cleared at the choke points documented in
+   * `setSessionSnapshot` (src/daemon/session-snapshot.ts).
+   */
+  snapshotRefsStale?: boolean;
   /** Source snapshot used to resolve repeated `snapshot -s @ref` after scoped output replaces refs. */
   snapshotScopeSource?: SnapshotState;
   /** Last broad snapshot safe for Android route-freshness comparisons after interactive snapshots. */

--- a/src/mcp/command-output-schemas.ts
+++ b/src/mcp/command-output-schemas.ts
@@ -208,6 +208,7 @@ export const COMMAND_OUTPUT_SCHEMAS = {
     properties: {
       backendResult: backendResultSchema,
       message: stringSchema(),
+      warning: stringSchema(),
       evidence: interactionEvidenceSchema,
     },
   }),
@@ -226,6 +227,7 @@ export const COMMAND_OUTPUT_SCHEMAS = {
       durationMs: numberSchema(),
       backendResult: backendResultSchema,
       message: stringSchema(),
+      warning: stringSchema(),
     },
   }),
 

--- a/test/integration/provider-scenarios/stale-ref-warning.test.ts
+++ b/test/integration/provider-scenarios/stale-ref-warning.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { assertRpcOk } from './assertions.ts';
+import { PROVIDER_SCENARIO_IOS_SIMULATOR } from './fixtures.ts';
+import { createProviderScenarioHarness, withProviderScenarioResource } from './harness.ts';
+import {
+  createAppleRunnerProviderFromTranscript,
+  createRecordingAppleToolProvider,
+  simctlListDevicesHandler,
+} from './providers.ts';
+import { createProviderTranscript, type ProviderScenarioProviderEntry } from './transcript.ts';
+
+const APP = 'com.example.app';
+const DEVICE_ID = PROVIDER_SCENARIO_IOS_SIMULATOR.id;
+
+// #1076: refs are positional indexes into the latest stored session tree. A
+// selector press recaptures that tree without handing the new refs to the
+// client, so a follow-up @ref command gets an honest stale-refs warning until
+// a snapshot response re-issues refs.
+const NODES = [
+  {
+    index: 0,
+    type: 'Application',
+    label: 'Example',
+    rect: { x: 0, y: 0, width: 400, height: 800 },
+  },
+  {
+    index: 1,
+    parentIndex: 0,
+    type: 'Button',
+    label: 'Continue',
+    hittable: true,
+    rect: { x: 100, y: 300, width: 200, height: 44 },
+  },
+  {
+    index: 2,
+    parentIndex: 0,
+    type: 'Button',
+    label: 'Cancel',
+    hittable: true,
+    rect: { x: 100, y: 400, width: 200, height: 44 },
+  },
+];
+
+function snapshotEntry(): ProviderScenarioProviderEntry {
+  return {
+    command: 'ios.runner.snapshot',
+    deviceId: DEVICE_ID,
+    platform: 'apple',
+    result: { nodes: NODES, truncated: false },
+  };
+}
+
+function tapEntry(x: number, y: number): ProviderScenarioProviderEntry {
+  return {
+    command: 'ios.runner.tap',
+    deviceId: DEVICE_ID,
+    platform: 'apple',
+    result: { x, y },
+  };
+}
+
+test('Provider-backed integration @refs warn after a selector press replaces the tree', async () => {
+  const runnerTranscript = createProviderTranscript([
+    // snapshot -i: issues refs to the client
+    snapshotEntry(),
+    // press label=Continue: selector resolution capture replaces the stored tree
+    snapshotEntry(),
+    tapEntry(200, 322),
+    // press @e2 while stale: executes, warns
+    tapEntry(200, 422),
+    // snapshot: re-issues refs
+    snapshotEntry(),
+    // press @e2 after refresh: no warning
+    tapEntry(200, 422),
+  ]);
+  const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
+    runnerTranscript,
+    'ios.runner',
+  );
+  const appleTool = createRecordingAppleToolProvider({
+    simctl: simctlListDevicesHandler('com.apple.CoreSimulator.SimRuntime.iOS-18-0', [
+      { name: PROVIDER_SCENARIO_IOS_SIMULATOR.name, udid: DEVICE_ID },
+    ]),
+  });
+
+  await withProviderScenarioResource(
+    async () =>
+      await createProviderScenarioHarness({
+        appleRunnerProvider: () => appleRunnerProvider,
+        appleToolProvider: () => appleTool.provider,
+        deviceInventoryProvider: async () => [PROVIDER_SCENARIO_IOS_SIMULATOR],
+      }),
+    async (daemon) => {
+      const open = await daemon.callCommand('open', [APP], {
+        platform: 'ios',
+        udid: DEVICE_ID,
+      });
+      assertRpcOk(open);
+
+      const snapshot = await daemon.callCommand('snapshot', [], {
+        snapshotInteractiveOnly: true,
+      });
+      assertRpcOk(snapshot);
+
+      const selectorPress = await daemon.callCommand('press', ['label=Continue'], {});
+      const selectorData = assertRpcOk(selectorPress);
+      assert.equal(selectorData.warning, undefined);
+
+      const stalePress = await daemon.callCommand('press', ['@e2'], {});
+      const staleData = assertRpcOk(stalePress);
+      assert.equal(typeof staleData.warning, 'string');
+      assert.match(String(staleData.warning), /snapshot changed since your refs were issued/);
+      assert.match(String(staleData.warning), /Re-run snapshot -i/);
+
+      const refresh = await daemon.callCommand('snapshot', [], {
+        snapshotInteractiveOnly: true,
+      });
+      assertRpcOk(refresh);
+
+      const freshPress = await daemon.callCommand('press', ['@e2'], {});
+      const freshData = assertRpcOk(freshPress);
+      assert.equal(freshData.warning, undefined);
+
+      runnerTranscript.assertComplete();
+    },
+  );
+});


### PR DESCRIPTION
Closes #1076.

## Problem

Refs are positional indexes into the *latest* stored session tree. Any selector-based command's resolution capture silently replaces that tree, so a previously issued `@ref` can resolve to a completely different node — `get text @e37` returning `"2.7K likes"` instead of the post body, with no warning. The existing `STALE_REF`/offscreen/covered guards only catch refs that vanish or drift geometrically; a ref that still exists but points at a different element is a silent wrong answer.

## Design: honest marker, not generation stamping

Instead of stamping every snapshot with a generation counter and tracking per-ref provenance, the daemon session carries one boolean, `SessionState.snapshotRefsStale`:

- **set `true`** whenever the stored session snapshot is replaced by a command whose response does NOT hand the fresh refs to the client;
- **set `false`** only where the client demonstrably receives the new refs;
- commands consuming an `@ref` argument while the flag is set attach a warning and **still execute** — the geometric guards keep catching the detectable cases.

Zero-cost paths stay zero-cost: no extra captures, no per-ref bookkeeping — one boolean read/write at existing choke points. The trade-off (documented on the field) is that a single boolean can't distinguish *which* refs are stale: after `find` re-issues one fresh ref, older refs are blessed too. That's the accepted cost of the cheap marker over generation stamping.

## Choke points

**Set (`snapshotRefsStale = true`)** — single write choke point `setSessionSnapshot()` (`src/daemon/session-snapshot.ts`), which every daemon-side session-snapshot replacement funnels through except the snapshot/diff command:
- `selector-capture-runtime.ts` — find/get/is/wait selector captures
- `selector-runtime-backend.ts` — selector runtime session writes (get/wait polling)
- `handlers/interaction-runtime.ts` — press/click/fill selector-resolution and `--verify` evidence captures
- `handlers/interaction-snapshot.ts` — Android ref-freshness refreshes, recording reference-frame captures
- `handlers/session-replay-heal.ts` — replay heal re-captures
- `request-generic-dispatch.ts` — `screenshot --overlay-refs` capture (the overlay burns in at most a scored subset of 24 refs, so it conservatively does NOT count as issuing refs)
- `snapshot-runtime.ts` `buildNextSnapshotSession` — `diff snapshot` replaces the tree but returns only a summary → stale

**Clear (`snapshotRefsStale = false`)** — only where the response hands refs to the client:
- `snapshot-runtime.ts` `buildNextSnapshotSession` — the snapshot command response carries every stored node's ref (empty ref-scoped results that keep the current tree leave the flag unchanged)
- `selector-runtime.ts` `dispatchFindReadOnlyViaRuntime` — find get_text/get_attrs responses that return a ref minted from the freshly stored tree
- `handlers/find.ts` — find click/fill/focus/type mint `match.ref` from the just-stored capture; clearing before the internal `click/fill @ref` sub-invoke also prevents a spurious warning inside the find response

**Warn on @ref consumption while stale:**
- press/click/longpress/fill — `staleRefs` read in the daemon handler *before* any internal recapture (Android freshness refresh, `--verify`) flips the flag as a side effect of the same command, then passed as a new `staleRefs` input to `buildInteractionResponseData`, which composes it with any existing runtime warning (appended, single `warning` field). No hand-rolled response assembly; the #1083 construction guard still passes.
- `get text|attrs @ref` and `wait @ref` — warning attached to the daemon response data in `selector-runtime.ts`.

The warning text: `The session snapshot changed since your refs were issued — @refs may now point at different elements. Re-run snapshot -i to refresh refs.`

Also fixed in passing: the Android dialog-readiness recovered warning now appends to an existing response warning instead of clobbering it, and the MCP output schemas for press/longpress now declare the (pre-existing) `warning` field.

## Tests

- `src/daemon/handlers/__tests__/interaction.test.ts` — press selector → press @ref warns; press @ref directly → no warning; marker cleared → no warning; fill @ref warns; get text @ref warns; stale warning appends to an existing fill-type warning (capture emulation now mirrors the real `setSessionSnapshot` path)
- `src/daemon/handlers/__tests__/snapshot-handler.test.ts` — snapshot command clears the marker; diff sets it
- `src/daemon/handlers/__tests__/find.test.ts` — find click clears the marker before the internal `click @ref`
- `test/integration/provider-scenarios/stale-ref-warning.test.ts` — full transcript-backed flow: open → snapshot -i → press `label=` (tree replaced) → press @ref warns → snapshot → press @ref clean

Gates: `format:check`, `typecheck`, `lint`, `fallow audit --base origin/main`, `vitest src/daemon src/commands src/contracts` (1235 passed), `vitest test/integration` (90 passed).
