### PR TITLE
docs: native-ref dispatch path is web-only in production

### DIFF
--- a/src/contracts/interaction-guarantees.ts
+++ b/src/contracts/interaction-guarantees.ts
@@ -251,8 +251,13 @@ export const INTERACTION_DISPATCH_PATHS: Record<InteractionPathId, InteractionPa
     },
   },
   'native-ref': {
+    // WEB-ONLY in production: apple/android backends never define
+    // tapTarget/fillTarget - the sole wiring is the web provider's clickRef
+    // (a stable DOM-handle click). Verified 2026-07-04 while designing the
+    // #1088 retirement experiment, which this finding dissolved: there is no
+    // iOS runner round trip to retire.
     description:
-      'click @ref / fill @ref dispatch to backend.tapTarget/fillTarget without runtime resolution when no non-default options are set. A zero-round-trip preflight (preflightNativeRefInteraction) runs the shared guards against the stored session snapshot node first; no snapshot / no usable rect makes the preflight a no-op.',
+      'click @ref / fill @ref dispatch to backend.tapTarget/fillTarget (web provider clickRef only; no mobile backend implements these) without runtime resolution when no non-default options are set. A zero-round-trip preflight (preflightNativeRefInteraction) runs the shared guards against the stored session snapshot node first; no snapshot / no usable rect makes the preflight a no-op.',
     commands: ['click', 'fill'],
     guarantees: {
       disambiguation: {


### PR DESCRIPTION
While preparing the #1088 B-arm (Maestro suite with native-ref disabled), verification showed the experiment was moot: `tapTarget`/`fillTarget` appear zero times in the apple/android platforms — the only production wiring is `webProvider?.clickRef` (src/daemon/handlers/interaction-runtime.ts). The iOS Maestro suite can never exercise this path, so an A/B there would have compared identical binaries and produced a confidently wrong conclusion.

Records the fact on the registry row so the matrix stops implying mobile reach. Recommend closing #1088: there is no iOS round trip to retire, and web's stable-handle clickRef is clearly worth keeping.