### PR TITLE
fix: name split declaration chunks

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,6 +5,41 @@ const packageJson = JSON.parse(
   fs.readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
 ) as { version: string };
 
+const publicSdkChunkGroups = [
+  [
+    'sdk-contracts',
+    /src[\\/]kernel[\\/]contracts\.d\.[cm]?ts$/,
+    /src[\\/]kernel[\\/]contracts\.ts$/,
+  ],
+  ['sdk-errors', /src[\\/]kernel[\\/]errors\.d\.[cm]?ts$/, /src[\\/]kernel[\\/]errors\.ts$/],
+  ['sdk-device', /src[\\/]kernel[\\/]device\.d\.[cm]?ts$/, /src[\\/]kernel[\\/]device\.ts$/],
+  ['sdk-snapshot', /src[\\/]kernel[\\/]snapshot\.d\.[cm]?ts$/, /src[\\/]kernel[\\/]snapshot\.ts$/],
+  ['sdk-io', /src[\\/]io\.d\.[cm]?ts$/, /src[\\/]io\.ts$/],
+  ['sdk-batch', /src[\\/]batch-policy\.d\.[cm]?ts$/, /src[\\/]batch-policy\.ts$/],
+  ['sdk-batch-runner', /src[\\/]core[\\/]batch\.d\.[cm]?ts$/, /src[\\/]core[\\/]batch\.ts$/],
+  ['sdk-finders', /src[\\/]finders\.d\.[cm]?ts$/, /src[\\/]finders\.ts$/],
+  [
+    'sdk-android-adb',
+    /src[\\/]platforms[\\/]android[\\/]adb-executor\.d\.[cm]?ts$/,
+    /src[\\/]platforms[\\/]android[\\/]adb-executor\.ts$/,
+  ],
+  [
+    'sdk-app-inventory',
+    /src[\\/]contracts[\\/]app-inventory\.d\.[cm]?ts$/,
+    /src[\\/]contracts[\\/]app-inventory\.ts$/,
+  ],
+  [
+    'sdk-remote-config',
+    /src[\\/]remote[\\/]remote-config-schema\.d\.[cm]?ts$/,
+    /src[\\/]remote[\\/]remote-config-schema\.ts$/,
+  ],
+  [
+    'sdk-selectors',
+    /src[\\/]daemon[\\/]selectors-parse\.d\.[cm]?ts$/,
+    /src[\\/]daemon[\\/]selectors-parse\.ts$/,
+  ],
+] as const;
+
 export default defineConfig({
   entry: {
     index: 'src/sdk/index.ts',
@@ -34,6 +69,14 @@ export default defineConfig({
   },
   shims: true,
   hash: false,
+  outputOptions: {
+    codeSplitting: {
+      groups: publicSdkChunkGroups.flatMap(([name, dtsTest, jsTest]) => [
+        { test: dtsTest, name: `${name}.d` },
+        { test: jsTest, name },
+      ]),
+    },
+  },
   outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
   minify: true,
   dts: {


### PR DESCRIPTION
## Summary

Name Rolldown code-splitting groups for public SDK shared chunks so `rolldown-plugin-dts` receives matching `.d` declaration chunk names.

Before, generated declaration imports pointed at implicit shared chunks such as `contracts2`, `io2`, and `remote-config-schema`. After, they point at explicit SDK chunks such as `sdk-contracts`, `sdk-io`, and `sdk-remote-config`.

Measured impact is effectively neutral: npm dry-run tarball changed by +34 bytes, unpacked size by +219 bytes, and total JS+DTS gzip by -165 bytes.

## Validation

Validated with focused formatter, lint, typecheck, layering, MCP metadata check, and tsdown build. Also compared before/after build output, declaration import targets, `dist/src` file counts/bytes, and npm dry-run package size.