### PR TITLE
fix: hint on iOS runner main-thread timeouts

### DIFF
--- a/src/platforms/apple/core/__tests__/runner-client.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-client.test.ts
@@ -845,7 +845,7 @@ AGENT_DEVICE_RUNNER_COMMAND_FAILED command=snapshot error=fetch failed
   );
 });
 
-test('parseRunnerResponse keeps ordinary runner failures generic without crash log evidence', async () => {
+test('parseRunnerResponse hints when XCTest main-thread execution times out', async () => {
   const logPath = writeRunnerLogTail(
     'AGENT_DEVICE_RUNNER_COMMAND_FAILED command=type error=main thread execution timed out',
   );
@@ -865,8 +865,10 @@ test('parseRunnerResponse keeps ordinary runner failures generic without crash l
     (error: unknown) => {
       assert.ok(error instanceof AppError);
       assert.equal(error.code, 'COMMAND_FAILED');
-      assert.equal(error.details?.runnerFailureReason, undefined);
-      assert.equal(error.details?.hint, undefined);
+      assert.equal(error.details?.runnerFailureReason, 'runner_main_thread_execution_timeout');
+      assert.match(String(error.details?.hint), /XCTest timed out waiting for main-thread work/);
+      assert.match(String(error.details?.hint), /screenshot as visual truth/);
+      assert.match(String(error.details?.hint), /coordinate presses/);
       return true;
     },
   );

--- a/src/platforms/apple/core/runner/runner-failure-diagnostics.ts
+++ b/src/platforms/apple/core/runner/runner-failure-diagnostics.ts
@@ -16,11 +16,16 @@ const IOS_TARGET_AX_CRASH_HINT =
 const IOS_TARGET_APP_CRASH_HINT =
   'The target iOS app appears to have crashed while the runner was executing the command. Reopen or reinstall the app, retry on a fresh/latest stable simulator runtime, and capture the app crash from Console.app or ~/Library/Logs/DiagnosticReports with the exact command, selector/ref, app build, Xcode, and simulator runtime.';
 
+const IOS_RUNNER_MAIN_THREAD_TIMEOUT_HINT =
+  'XCTest timed out waiting for main-thread work on the current iOS screen. The app may still be visually responsive, especially on focused React Native overlays or animating screens. Use screenshot as visual truth, use coordinate presses only to prove or leave the state, and retry snapshot -i after the UI settles or after navigating away.';
+
 export async function enrichRunnerFailureFromLog(params: {
   error: AppError;
   logPath?: string;
 }): Promise<AppError> {
-  const diagnostic = await resolveRunnerFailureDiagnostic(params.logPath);
+  const diagnostic =
+    (await resolveRunnerFailureDiagnostic(params.logPath)) ??
+    classifyRunnerFailureError(params.error);
   if (!diagnostic) return params.error;
 
   return new AppError(
@@ -66,6 +71,14 @@ function classifyRunnerFailureLog(logText: string): RunnerFailureDiagnostic | un
   return undefined;
 }
 
+function classifyRunnerFailureError(error: AppError): RunnerFailureDiagnostic | undefined {
+  if (!isMainThreadExecutionTimeout(error.message)) return undefined;
+  return {
+    reason: 'runner_main_thread_execution_timeout',
+    hint: IOS_RUNNER_MAIN_THREAD_TIMEOUT_HINT,
+  };
+}
+
 function isAxRuntimeAccessibilityCrash(normalized: string): boolean {
   return (
     normalized.includes('axruntime') &&
@@ -84,6 +97,10 @@ function isTargetAppCrash(normalized: string): boolean {
     normalized.includes('terminated unexpectedly') ||
     (normalized.includes('exception type:') && normalized.includes('thread 0 crashed'))
   );
+}
+
+function isMainThreadExecutionTimeout(message: string): boolean {
+  return message.toLowerCase().includes('main thread execution timed out');
 }
 
 async function readFileTail(filePath: string, maxBytes: number): Promise<string | undefined> {


### PR DESCRIPTION
## Summary

Adds a runner-client diagnostic for iOS XCTest `main thread execution timed out` failures.

When this timeout appears, the error now explains that the app can still be visually responsive on focused React Native overlays or animating screens, and points agents toward screenshot evidence, coordinate presses to prove or leave the state, and retrying `snapshot -i` after settling/navigation.

Refs #1138.

## Validation

- `pnpm format`
- `pnpm exec vitest run src/platforms/apple/core/__tests__/runner-client.test.ts`
- `pnpm check:quick`
- `pnpm build`
- `git diff --check`
