### PR TITLE
fix: recover completed Android recording from pending-only manifest

### DIFF
--- a/src/daemon/handlers/record-trace-android-recovery-manifest.ts
+++ b/src/daemon/handlers/record-trace-android-recovery-manifest.ts
@@ -186,7 +186,7 @@ function parseJsonObject(value: string): Record<string, unknown> | undefined {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object';
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function readAndroidRecoveryManifestRequired(

--- a/src/daemon/handlers/record-trace-android-recovery.ts
+++ b/src/daemon/handlers/record-trace-android-recovery.ts
@@ -161,7 +161,14 @@ async function resolvePendingAndroidRecoveryCandidate(
   const pending = await findLiveAndroidScreenrecordByPath(deviceId, pendingMetadata.remotePath);
   const adoptedPending = resolveLivePendingScreenrecord(manifest, pending);
   if (adoptedPending) return adoptedPending;
-  if (!manifest.current) return pendingOnlyResolution(pending);
+  if (!manifest.current) {
+    return await resolvePendingOnlyAndroidRecoveryCandidate(
+      deviceId,
+      manifest,
+      pendingMetadata.remotePath,
+      pending,
+    );
+  }
   return await resolveInterruptedRotationCurrent(deviceId, manifest, manifest.current, pending);
 }
 
@@ -199,8 +206,34 @@ function resolveLivePendingScreenrecord(
   });
 }
 
-function pendingOnlyResolution(pending: AndroidScreenrecordProbe): AndroidRecoveryResolution {
-  return pending === 'uncertain' ? { kind: 'uncertain' } : { kind: 'stale' };
+async function resolvePendingOnlyAndroidRecoveryCandidate(
+  deviceId: string,
+  manifest: AndroidRecordingRecoveryManifest,
+  pendingRemotePath: string,
+  pending: AndroidScreenrecordProbe,
+): Promise<AndroidRecoveryResolution> {
+  if (pending === 'uncertain') {
+    return { kind: 'uncertain' };
+  }
+  // The pending screenrecord process is gone. If it already produced an on-device file,
+  // recover it as a finished recording rather than discarding a completed capture — the
+  // same treatment resolveCurrentAndroidRecoveryCandidate gives a finished `current`.
+  if (await androidRemoteFileExists(deviceId, pendingRemotePath)) {
+    return liveAndroidRecoveryCandidate({
+      manifest,
+      current: {
+        remotePath: pendingRemotePath,
+        // A pending chunk never recorded a pid — the manifest is written before the
+        // screenrecord process starts. The process is confirmed gone, so there is
+        // nothing to signal; the empty pid tells finishCurrentAndroidRecordingChunk to
+        // skip the stop signal.
+        remotePid: '',
+        startedAt: manifest.startedAt,
+      },
+      recoveryWarning: ANDROID_RECOVERY_FINISHED_WARNING,
+    });
+  }
+  return { kind: 'stale' };
 }
 
 async function resolveCurrentAndroidRecoveryCandidate(

--- a/src/daemon/handlers/record-trace-android.ts
+++ b/src/daemon/handlers/record-trace-android.ts
@@ -542,6 +542,17 @@ async function finishCurrentAndroidRecordingChunk(params: {
     remotePid = recording.remotePid,
     waitForRemoteFileStability = true,
   } = params;
+  if (!remotePid) {
+    // A recovered finished recording with no tracked process (a pending chunk whose
+    // screenrecord already exited): there is nothing to signal, and the on-device file
+    // is already complete. Skip the kill entirely — probing/signalling an empty pid is
+    // unsafe (`isAndroidProcessRunning('')` can report a false positive).
+    appendAndroidRecordingWarning(recording, resolveAndroidScreenrecordLimitWarning(recording));
+    if (waitForRemoteFileStability) {
+      await waitForAndroidRemoteFileStability(device.id, remotePath);
+    }
+    return undefined;
+  }
   const wasRunningBeforeStop = await isAndroidProcessRunning(device.id, remotePid);
   if (!wasRunningBeforeStop) {
     appendAndroidRecordingWarning(recording, resolveAndroidScreenrecordLimitWarning(recording));

--- a/test/integration/provider-scenarios/android-recording.test.ts
+++ b/test/integration/provider-scenarios/android-recording.test.ts
@@ -229,6 +229,13 @@ test('Provider-backed integration Android record stop recovers pending manifest 
   );
 });
 
+test('Provider-backed integration Android record stop recovers finished pending manifest after process exit', async () => {
+  await withProviderScenarioTempDir(
+    'agent-device-provider-scenario-android-record-pending-finished-',
+    runAndroidPendingFinishedManifestRecoveryScenario,
+  );
+});
+
 test('Provider-backed integration Android record stop recovers rotating manifest after daemon state loss', async () => {
   await withProviderScenarioTempDir(
     'agent-device-provider-scenario-android-record-rotating-recovery-',
@@ -632,6 +639,65 @@ async function runAndroidPendingManifestRecoveryScenario(tmpDir: string): Promis
     assertCommandCall(adbCalls, ['shell', 'ps', '-A', '-o', 'pid=,args=']);
     assertCommandCall(adbCalls, ['shell', 'kill', '-2', '4321']);
     assert.deepEqual(pullCalls, [{ remotePath, localPath: recordingPath }]);
+  } finally {
+    await daemon.close();
+  }
+}
+
+async function runAndroidPendingFinishedManifestRecoveryScenario(tmpDir: string): Promise<void> {
+  const adbCalls: string[][] = [];
+  const pullCalls: PullCall[] = [];
+  const remotePath = '/sdcard/agent-device-recording-624000001.mp4';
+  const recordingPath = path.join(tmpDir, 'pending-finished-recovered.mp4');
+  const manifest = buildAndroidRecordingManifest({
+    outPath: recordingPath,
+    remotePath,
+    sessionName: 'default',
+    status: 'pending',
+  });
+  const daemon = await createProviderScenarioHarness({
+    androidAdbProvider: () => ({
+      exec: async (args) => {
+        adbCalls.push([...args]);
+        const command = args.join(' ');
+        if (command === 'shell cat /sdcard/agent-device-recording-active.json') {
+          return { stdout: JSON.stringify(manifest), stderr: '', exitCode: 0 };
+        }
+        if (command === 'shell cat /data/local/tmp/agent-device-recording-active.json') {
+          return { stdout: '', stderr: '', exitCode: 1 };
+        }
+        // The pending screenrecord process already exited: the full process scan finds no
+        // match, but the on-device file still exists (default stat returns a non-zero size).
+        if (command === 'shell ps -A -o pid=,args=') {
+          return { stdout: '', stderr: '', exitCode: 0 };
+        }
+        return androidAdbResult(args);
+      },
+      pull: async (from, to) => {
+        pullCalls.push({ remotePath: from, localPath: to });
+        writePlayableMp4(to);
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+    }),
+    deviceInventoryProvider: async () => [PROVIDER_SCENARIO_ANDROID],
+  });
+
+  try {
+    const recordStop = await stopAndroidRecording(daemon, recordingPath);
+    const data = assertRpcOk<{ recording?: unknown; outPath?: unknown; warning?: unknown }>(
+      recordStop,
+    );
+    assert.equal(data.recording, 'stopped');
+    assert.equal(data.outPath, recordingPath);
+    assert.match(String(data.warning), /no longer running/);
+    // A pending manifest never recorded a pid and the process is confirmed gone, so stop
+    // sends no signal — it just pulls the completed file instead of discarding it.
+    assert.equal(
+      adbCalls.some((args) => args.join(' ').startsWith('shell kill -2')),
+      false,
+    );
+    assert.deepEqual(pullCalls, [{ remotePath, localPath: recordingPath }]);
+    assert.equal(fs.existsSync(recordingPath), true);
   } finally {
     await daemon.close();
   }


### PR DESCRIPTION
## Summary

Follow-up to #1135 (Android recording durable-manifest recovery). Fixes one confirmed data-loss gap plus a small parser hardening. The other review items either turned out to be already addressed on `main` or looked like deliberate conservative choices — see **Scope notes** below.

### 1. Recover a completed recording from a pending-only manifest

`record start` writes a `pending` recovery manifest *before* the screenrecord process starts, then upgrades it to a `current` manifest once frames are flowing. If the daemon crashes in that brief window and the screenrecord process later finishes on its own, it leaves a complete MP4 on the device — but `record stop` discarded it as `stale`, because the pending-only recovery path never checked for an on-device file. The `current` path already recovers a finished recording via `androidRemoteFileExists`; this makes the pending-only path consistent.

A pending chunk never records a pid (the manifest is written before the process exists), so the recovered recording carries no pid. `finishCurrentAndroidRecordingChunk` now skips the stop signal when there is no tracked pid — probing/signalling an empty pid is unsafe (`isAndroidProcessRunning('')` can report a false positive via `[''].includes('')`).

### 2. Treat JSON arrays as invalid recovery manifests

`isRecord` accepted arrays (`typeof [] === 'object'`), so a stray `[]` manifest was classified `blocked` (which is never cleaned up) rather than `delete`, wedging every subsequent `record stop`. Now rejects arrays and `null`.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm check:fallow --base origin/main`
- `pnpm vitest run --project provider-integration test/integration/provider-scenarios/android-recording.test.ts` (21 passed, incl. new `recovers finished pending manifest after process exit`)
- `pnpm vitest run --project unit-core src/daemon/handlers/__tests__/record-trace.test.ts` (48 passed)

## Scope notes (other review items, deliberately not included)

- **Owner-mismatch recovery from a different cwd** — already resolved on `main`: the scoped hint now says "retry record stop from the original working directory without --session," which is the working recovery path. No change needed.
- **`ps -p` non-zero exit → `uncertain`** — treating any pid-probe failure as uncertain is a deliberate, tested choice (a test asserts `ps -A` is *not* consulted after a `ps -p` failure). Left as-is; if `ps -p` turns out to exit non-zero for dead pids on some OEM builds, that's worth revisiting separately.
- **`manifests.length > 1` → ambiguous even when exactly one is owned** — narrow (needs two live manifests across `/sdcard` + `/data/local/tmp`) and consistent with the existing conservative "cannot safely recover" stance. Left as-is.

Happy to fold any of these in if you'd like a different call on them.
