### PR TITLE
fix: omit interaction uptime from wire responses

### DIFF
--- a/src/daemon/handlers/interaction-touch-response.ts
+++ b/src/daemon/handlers/interaction-touch-response.ts
@@ -179,24 +179,25 @@ function sanitizeWireBackendData(
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
 
+const OMITTED_WIRE_BACKEND_FIELDS = new Set([
+  'gestureStartUptimeMs',
+  'gestureEndUptimeMs',
+  'currentUptimeMs',
+  'sequenceResults',
+]);
+
+const DEFAULT_WIRE_BACKEND_FIELD_VALUES = new Map<string, unknown>([
+  ['count', 1],
+  ['intervalMs', 0],
+  ['holdMs', 0],
+  ['jitterPx', 0],
+  ['doubleTap', false],
+]);
+
 function shouldKeepWireBackendField(key: string, value: unknown): boolean {
-  switch (key) {
-    case 'gestureStartUptimeMs':
-    case 'gestureEndUptimeMs':
-    case 'currentUptimeMs':
-    case 'sequenceResults':
-      return false;
-    case 'count':
-      return value !== 1;
-    case 'intervalMs':
-    case 'holdMs':
-    case 'jitterPx':
-      return value !== 0;
-    case 'doubleTap':
-      return value !== false;
-    default:
-      return true;
-  }
+  if (OMITTED_WIRE_BACKEND_FIELDS.has(key)) return false;
+  if (!DEFAULT_WIRE_BACKEND_FIELD_VALUES.has(key)) return true;
+  return value !== DEFAULT_WIRE_BACKEND_FIELD_VALUES.get(key);
 }
 
 function buildTouchMessage(

--- a/src/daemon/handlers/interaction-touch-response.ts
+++ b/src/daemon/handlers/interaction-touch-response.ts
@@ -183,6 +183,7 @@ function shouldKeepWireBackendField(key: string, value: unknown): boolean {
   switch (key) {
     case 'gestureStartUptimeMs':
     case 'gestureEndUptimeMs':
+    case 'currentUptimeMs':
     case 'sequenceResults':
       return false;
     case 'count':

--- a/test/integration/interaction-contract/interaction-response-shape.contract.test.ts
+++ b/test/integration/interaction-contract/interaction-response-shape.contract.test.ts
@@ -128,17 +128,20 @@ test('interaction response shape: press selector uses the canonical selector env
 });
 
 test('interaction response shape: fill selector uses the canonical selector envelope', async () => {
-  await withIosContractDaemon([runnerTypeEntry({ x: 200, y: 322 })], async (daemon, transcript) => {
-    const data = assertRpcOk(await daemon.callCommand('fill', ['label=Continue', 'Hello']));
-    assertRunnerRequest(transcript, 'ios.runner.type', selectorTypeRequest('Hello'));
+  await withIosContractDaemon(
+    [runnerTypeEntry({ ...NOISY_DEFAULT_TAP_RESULT, x: 200, y: 322 })],
+    async (daemon, transcript) => {
+      const data = assertRpcOk(await daemon.callCommand('fill', ['label=Continue', 'Hello']));
+      assertRunnerRequest(transcript, 'ios.runner.type', selectorTypeRequest('Hello'));
 
-    assertCanonicalDirectSelector(data, {
-      message: 'Filled 5 chars',
-      x: 200,
-      y: 322,
-      extra: { delayMs: 0, text: 'Hello' },
-    });
-  });
+      assertCanonicalDirectSelector(data, {
+        message: 'Filled 5 chars',
+        x: 200,
+        y: 322,
+        extra: { delayMs: 0, text: 'Hello' },
+      });
+    },
+  );
 });
 
 test('interaction response shape: longpress selector uses the canonical selector envelope', async () => {

--- a/test/integration/interaction-contract/interaction-response-shape.contract.test.ts
+++ b/test/integration/interaction-contract/interaction-response-shape.contract.test.ts
@@ -40,9 +40,20 @@ const SELECTOR_KEYS = [
 
 const POINT_KEYS = ['message', 'targetKind', 'x', 'y'] as const;
 
+const NOISY_DEFAULT_TAP_RESULT = {
+  count: 1,
+  currentUptimeMs: 1_418_719_052.9,
+  doubleTap: false,
+  gestureEndUptimeMs: 1_418_719_052.338875,
+  gestureStartUptimeMs: 1_418_718_741.4275,
+  holdMs: 0,
+  intervalMs: 0,
+  jitterPx: 0,
+};
+
 test('interaction response shape: press @ref uses the canonical ref envelope', async () => {
   await withIosContractDaemon(
-    [runnerSnapshotEntry(RUNNER_CONTINUE_NODES), runnerTapEntry({})],
+    [runnerSnapshotEntry(RUNNER_CONTINUE_NODES), runnerTapEntry(NOISY_DEFAULT_TAP_RESULT)],
     async (daemon, transcript) => {
       assertRpcOk(await daemon.callCommand('snapshot', [], { snapshotInteractiveOnly: true }));
 
@@ -317,6 +328,7 @@ function assertExactKeys(data: WireData, expectedKeys: readonly string[]): void 
 function assertNoWireNoise(data: WireData): void {
   for (const key of [
     'count',
+    'currentUptimeMs',
     'doubleTap',
     'gestureEndUptimeMs',
     'gestureStartUptimeMs',


### PR DESCRIPTION
## Summary

Omit runner uptime internals from interaction wire responses.

Filters `currentUptimeMs` alongside the existing runner timing/default tap-option noise while keeping the unsanitized result available to daemon history and recording telemetry. Extends the interaction response-shape contract with a noisy default tap result matching the Bluesky dogfood report.

Closes #1077.

## Validation

- `pnpm --pm-on-fail=ignore format`
- `pnpm --pm-on-fail=ignore exec vitest run --project interaction-contract test/integration/interaction-contract/interaction-response-shape.contract.test.ts`
- `pnpm --pm-on-fail=ignore typecheck`
- `pnpm --pm-on-fail=ignore lint`
- `pnpm --pm-on-fail=ignore test:integration:provider` (passed outside sandbox after sandbox `listen EPERM`)
- `pnpm --pm-on-fail=ignore test:coverage` (passed outside sandbox after sandbox `listen EPERM`)
- `pnpm --pm-on-fail=ignore build`
- Live Bluesky iOS check: `node bin/agent-device.mjs press @e18 --json --session issue-1077-bluesky --platform ios` returned `x`, `y`, `message`, ref/selector metadata, and no `gestureStartUptimeMs`, `gestureEndUptimeMs`, `currentUptimeMs`, `count`, `intervalMs`, `holdMs`, `jitterPx`, or `doubleTap`.
