### PR TITLE
fix: soften recovered snapshot warning

### DIFF
--- a/src/commands/capture/runtime/snapshot.test.ts
+++ b/src/commands/capture/runtime/snapshot.test.ts
@@ -255,7 +255,8 @@ test('runtime snapshot renders the structured quality verdict and skips legacy d
     String(result.warnings?.[0]),
     /Recovered this snapshot with the queries accessibility backend/,
   );
-  assert.match(String(result.warnings?.[0]), /fixing the app's accessibility is the real cure/);
+  assert.match(String(result.warnings?.[0]), /It is OK to continue/);
+  assert.match(String(result.warnings?.[0]), /snapshotQuality\.reason/);
   assert.match(String(result.warnings?.[1]), /@e2 \[Other\] merges many labels/);
   assert.deepEqual(result.snapshotQuality?.state, 'recovered');
 });

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -80,14 +80,8 @@ export function renderSnapshotQualityWarnings(
 
 function stateWarning(verdict: SnapshotQualityVerdict): string[] {
   if (verdict.state === 'recovered') {
-    const meaning =
-      verdict.reasonCode === 'budget'
-        ? ' The primary capture ran out of its time budget (busy app or simulator); the recovered tree is authoritative for this screen.'
-        : " This usually means the app publishes an unhealthy accessibility tree — fixing the app's accessibility is the real cure. Treat screenshot as visual truth when this warning appears.";
     return [
-      `Recovered this snapshot with the ${verdict.backend} accessibility backend` +
-        (verdict.reason ? ` after: ${verdict.reason}.` : '.') +
-        meaning,
+      `Recovered this snapshot with the ${verdict.backend} accessibility backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.`,
     ];
   }
   if (verdict.state === 'sparse') {
@@ -103,7 +97,7 @@ function stateWarning(verdict: SnapshotQualityVerdict): string[] {
 function depthWarning(verdict: SnapshotQualityVerdict): string[] {
   if (verdict.effectiveDepth === undefined) return [];
   return [
-    `The accessibility server rejected deeper requests; this tree is capped at depth ${verdict.effectiveDepth} — re-run with --depth ${verdict.effectiveDepth} --scope <container> for deeper content.`,
+    `Some deeper accessibility nodes were omitted; this tree is capped at depth ${verdict.effectiveDepth}. Re-run with --depth ${verdict.effectiveDepth} --scope <container> only if you need deeper content.`,
   ];
 }
 

--- a/src/utils/__tests__/snapshot-quality.test.ts
+++ b/src/utils/__tests__/snapshot-quality.test.ts
@@ -1,7 +1,10 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
-import { readSnapshotQualityVerdict } from '../../snapshot/snapshot-quality.ts';
+import {
+  readSnapshotQualityVerdict,
+  renderSnapshotQualityWarnings,
+} from '../../snapshot/snapshot-quality.ts';
 
 test('readSnapshotQualityVerdict accepts a well-formed verdict', () => {
   const verdict = readSnapshotQualityVerdict({
@@ -40,4 +43,23 @@ test('readSnapshotQualityVerdict keeps the verdict but drops an unknown reasonCo
   });
   assert.equal(verdict?.state, 'sparse');
   assert.equal(verdict?.reasonCode, undefined);
+});
+
+test('renderSnapshotQualityWarnings keeps recovered snapshot copy concise', () => {
+  const warnings = renderSnapshotQualityWarnings(
+    {
+      state: 'recovered',
+      backend: 'private-ax',
+      reason:
+        'iOS XCTest snapshot failed while serializing the accessibility tree. Error kAXErrorIllegalArgument getting snapshot for element <AXUIElementRef 0x1>',
+      reasonCode: 'ax-rejected',
+      effectiveDepth: 56,
+    },
+    [],
+  );
+
+  assert.deepEqual(warnings, [
+    'Recovered this snapshot with the private-ax accessibility backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.',
+    'Some deeper accessibility nodes were omitted; this tree is capped at depth 56. Re-run with --depth 56 --scope <container> only if you need deeper content.',
+  ]);
 });


### PR DESCRIPTION
## Summary

Soften recovered snapshot warnings so successful private-AX recovery reads as safe to continue instead of surfacing raw XCTest failure details by default.

Keep the low-level recovery reason available through JSON as `snapshotQuality.reason`, and make depth-cap guidance conditional on needing deeper content.

## Validation

- `node ./node_modules/oxfmt/bin/oxfmt --check src/snapshot/snapshot-quality.ts src/utils/__tests__/snapshot-quality.test.ts src/commands/capture/runtime/snapshot.test.ts`
- `pnpm exec vitest run src/utils/__tests__/snapshot-quality.test.ts src/commands/capture/runtime/snapshot.test.ts`
- `./node_modules/.bin/tsgo -p tsconfig.json`