### PR TITLE
refactor: derive command identity from descriptors

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,11 +70,14 @@ The perfect-shape refactor is complete and merged. Its end-state:
 
 - Two derivation registries. One `CommandDescriptor` per command
   (`src/core/command-descriptor/registry.ts`) is the single declaration site from which the
-  capability matrix, daemon command registry, batch allowlist, timeout policy, MCP exposure list, and
-  capability-checked CLI command list are *derived* by parity-tested projection. The command catalog
-  still owns identity, command families still own surface metadata/CLI schema, and system command
-  facets now project their simple Node client command methods; the rest of the Node client surface
-  remains a deferred derivation target. One
+  public/internal/local command catalog, capability matrix, daemon command registry, batch allowlist,
+  timeout policy, MCP exposure list, capability-checked CLI command list, post-action observation
+  traits, and platform dispatch command set are *derived* by parity-tested projection. Command
+  families still own surface metadata/CLI schema in `src/commands/**`, but descriptor/catalog
+  coherence guards prevent surface names from drifting; system command facets now project their
+  simple Node client command methods. Public Node-client result narrowing remains a deferred typed
+  contract target ([#1153](https://github.com/callstack/agent-device/issues/1153)), separate from
+  the completed descriptor registry migration. One
   `PlatformPlugin` per platform family (`src/core/platform-plugin/`) stops core/daemon from branching
   on platform, with the Apple plugin the first instance. See
   [ADR 0008](docs/adr/0008-command-descriptor-registry.md).

--- a/docs/adr/0008-command-descriptor-registry.md
+++ b/docs/adr/0008-command-descriptor-registry.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -28,14 +28,15 @@ model must preserve. This ADR is that model.
 Introduce one `CommandDescriptor` per command that **composes facets owned by their domains** and from which
 every consumer table is **derived** by pure, parity-tested projection:
 
-- The descriptor composes a `surface` facet (owned by `src/commands/**`: identity, CLI schema/reader, MCP),
-  a `capability` facet (owned by `src/core/capabilities`), and a `daemon` facet (route + request-policy
-  traits, **owned under `src/daemon/`** per ADR 0003), plus a typed result.
+- The descriptor composes catalog identity, command-family surface projection hooks
+  (`src/commands/**` remains the owner of CLI schema/reader and executable surface metadata), a
+  `capability` facet, a `daemon` facet (route + request-policy traits shaped by ADR 0003), platform
+  dispatch membership, response data transforms, and typed-result hooks.
 - Narrow command traits that affect multiple projections, such as interaction post-action observation
   (`--settle` / `--verify`), live on the descriptor so CLI flags, command metadata, timeout policy, and
   tests derive from one fact instead of repeating command-name lists.
 - The public catalog, capability matrix, daemon command registry, batch allowlist, MCP tool list, CLI
-  schema, and the Node client surface become pure projections of the descriptor set. The
+  schema exposure, and descriptor-backed Node client surface become pure projections of the descriptor set. The
   `src/core/dispatch.ts` `switch` is replaced by a total map keyed on the command-name union, so a missing
   handler is a compile error.
 - The cross-process `invoke` (client) and in-daemon `execute` seams stay distinct; the process boundary is
@@ -72,11 +73,20 @@ Each derived table must be asserted **byte-for-byte equivalent** to the hand-aut
 **before** the hand table is deleted. The principal risk is the import-cycle inversion: `command-catalog.ts`
 has ~95 importers and the family facet currently imports `AgentDeviceClient`, so the descriptor module must
 own the `Input`/`Result` types and the client must be derived as a view type, enforced by a lint boundary.
-As of 2026-07, the descriptor is live for the daemon registry, capability matrix, structured-batch
-allowlist, daemon-client timeout policy, MCP exposure list, and capability-checked CLI command list.
-The catalog still owns command identity and the command family facet still owns surface metadata, so
-future migration steps should keep deleting one live hand-maintained table at a time rather than
-introducing a parallel manifest.
+As of 2026-07, the descriptor registry is live for command identity (`PUBLIC_COMMANDS`,
+`INTERNAL_COMMANDS`, and local CLI names), daemon registry traits, capability matrix,
+structured-batch allowlist, daemon-client timeout policy, MCP exposure list,
+capability-checked CLI command list, post-action observation traits, and the platform dispatch
+command set (including dispatch-only aliases such as `read` and `swipe-preset`). Command-family
+surface metadata still lives under `src/commands/**`, where the CLI grammar and client-backed
+executors already live, but it is coherence-guarded against the descriptor CLI catalog so new
+surface names cannot drift from the descriptor root.
+
+The remaining deferred work is the public Node-client typed-result narrowing tracked outside this
+registry migration in [#1153](https://github.com/callstack/agent-device/issues/1153): commands whose
+daemon responses still expose dynamic payloads or whose closed result contracts live in runtime
+modules must move those contracts before their client methods can stop returning
+`CommandRequestResult`.
 
 This ADR owns the decision and its constraints; the roadmap that prototyped it has been retired, with
 the delivered end-state recorded in [CONTEXT.md](../../CONTEXT.md) (Architecture).

--- a/src/cli/commands/__tests__/client-backed.test.ts
+++ b/src/cli/commands/__tests__/client-backed.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { listCliCommandNames } from '../../../command-catalog.ts';
+import { listExecutableCommandNames } from '../../../commands/command-surface.ts';
+import { isClientBackedCliCommandName } from '../client-backed.ts';
+
+test('client-backed CLI command routing follows executable command metadata', () => {
+  const executableCommands = new Set<string>(listExecutableCommandNames());
+
+  for (const command of executableCommands) {
+    assert.equal(
+      isClientBackedCliCommandName(command),
+      true,
+      `${command} should route through the command-family client surface`,
+    );
+  }
+
+  for (const command of listCliCommandNames()) {
+    assert.equal(
+      isClientBackedCliCommandName(command),
+      executableCommands.has(command),
+      `${command} client-backed routing should match command-family executable metadata`,
+    );
+  }
+});

--- a/src/cli/commands/__tests__/generic.test.ts
+++ b/src/cli/commands/__tests__/generic.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { createAgentDeviceClient } from '../../../client/client.ts';
 import type { DaemonResponse } from '../../../kernel/contracts.ts';
 import type { CliFlags } from '../../parser/cli-flags.ts';
-import type { ClientBackedCliCommandName } from '../../../command-catalog.ts';
+import type { ClientBackedCliCommandName } from '../client-backed.ts';
 import { runGenericClientBackedCommand } from '../generic.ts';
 
 async function captureStdout(fn: () => Promise<unknown>): Promise<string> {

--- a/src/cli/commands/client-backed.ts
+++ b/src/cli/commands/client-backed.ts
@@ -1,0 +1,9 @@
+import { isCommandName, type CommandName } from '../../commands/command-metadata.ts';
+
+export type ClientBackedCliCommandName = CommandName;
+
+export function isClientBackedCliCommandName(
+  command: string,
+): command is ClientBackedCliCommandName {
+  return isCommandName(command);
+}

--- a/src/cli/commands/generic.ts
+++ b/src/cli/commands/generic.ts
@@ -7,7 +7,7 @@ import type { CliFlags } from '../parser/cli-flags.ts';
 import { readCommandMessage } from '../../utils/success-text.ts';
 import { isNonDefaultResponseLevel } from '../../kernel/contracts.ts';
 import { writeCommandOutput } from './shared.ts';
-import type { ClientBackedCliCommandName } from '../../command-catalog.ts';
+import type { ClientBackedCliCommandName } from './client-backed.ts';
 import type { ClientCommandParams } from './router-types.ts';
 
 export async function runGenericClientBackedCommand({

--- a/src/cli/commands/router.ts
+++ b/src/cli/commands/router.ts
@@ -1,9 +1,6 @@
 import type { CliFlags } from '../parser/cli-flags.ts';
 import type { AgentDeviceClient } from '../../client/client.ts';
-import {
-  isClientBackedCliCommandName,
-  type ClientBackedCliCommandName,
-} from '../../command-catalog.ts';
+import { isClientBackedCliCommandName, type ClientBackedCliCommandName } from './client-backed.ts';
 import { connectCommand, connectionCommand, disconnectCommand } from './connection.ts';
 import { authCommand } from './auth.ts';
 import { proxyCommand } from './proxy.ts';

--- a/src/command-catalog.ts
+++ b/src/command-catalog.ts
@@ -93,11 +93,6 @@ export type SpecialCliCommandName =
   (typeof SPECIAL_CLI_COMMANDS)[keyof typeof SPECIAL_CLI_COMMANDS];
 export type CliCommandName = PublicCommandName | LocalCliCommandName;
 export type KnownCliCommandName = CliCommandName | InternalCommandName | SpecialCliCommandName;
-export type ClientBackedCliCommandName =
-  | PublicCommandName
-  | typeof LOCAL_CLI_COMMANDS.debug
-  | typeof LOCAL_CLI_COMMANDS.metro
-  | typeof LOCAL_CLI_COMMANDS.session;
 
 export function listCliCommandNames(): CliCommandName[] {
   return [...Object.values(PUBLIC_COMMANDS), ...Object.values(LOCAL_CLI_COMMANDS)].sort();
@@ -107,15 +102,4 @@ export function isKnownCliCommandName(command: string): command is KnownCliComma
   if ((Object.values(SPECIAL_CLI_COMMANDS) as readonly string[]).includes(command)) return true;
   if ((Object.values(INTERNAL_COMMANDS) as readonly string[]).includes(command)) return true;
   return (listCliCommandNames() as readonly string[]).includes(command);
-}
-
-export function isClientBackedCliCommandName(
-  command: string,
-): command is ClientBackedCliCommandName {
-  return (
-    Object.values(PUBLIC_COMMANDS).includes(command as PublicCommandName) ||
-    command === LOCAL_CLI_COMMANDS.debug ||
-    command === LOCAL_CLI_COMMANDS.metro ||
-    command === LOCAL_CLI_COMMANDS.session
-  );
 }

--- a/src/command-catalog.ts
+++ b/src/command-catalog.ts
@@ -1,82 +1,14 @@
-export const PUBLIC_COMMANDS = {
-  alert: 'alert',
-  audio: 'audio',
-  appState: 'appstate',
-  appSwitcher: 'app-switcher',
-  artifacts: 'artifacts',
-  apps: 'apps',
-  back: 'back',
-  batch: 'batch',
-  boot: 'boot',
-  capabilities: 'capabilities',
-  click: 'click',
-  close: 'close',
-  clipboard: 'clipboard',
-  devices: 'devices',
-  doctor: 'doctor',
-  diff: 'diff',
-  fill: 'fill',
-  find: 'find',
-  focus: 'focus',
-  gesture: 'gesture',
-  get: 'get',
-  home: 'home',
-  install: 'install',
-  installFromSource: 'install-from-source',
-  is: 'is',
-  keyboard: 'keyboard',
-  logs: 'logs',
-  longPress: 'longpress',
-  network: 'network',
-  open: 'open',
-  perf: 'perf',
-  prepare: 'prepare',
-  press: 'press',
-  push: 'push',
-  record: 'record',
-  reactNative: 'react-native',
-  reinstall: 'reinstall',
-  replay: 'replay',
-  rotate: 'rotate',
-  scroll: 'scroll',
-  screenshot: 'screenshot',
-  settings: 'settings',
-  shutdown: 'shutdown',
-  snapshot: 'snapshot',
-  swipe: 'swipe',
-  test: 'test',
-  trace: 'trace',
-  triggerAppEvent: 'trigger-app-event',
-  type: 'type',
-  tvRemote: 'tv-remote',
-  viewport: 'viewport',
-  wait: 'wait',
-} as const;
+import {
+  listDescriptorCatalogEntries,
+  type DescriptorCatalogRecord,
+  type DescriptorCliCommandName,
+  type DescriptorCommandNameForCatalogGroup,
+} from './core/command-descriptor/registry.ts';
+import type { CommandCatalogGroup } from './core/command-descriptor/types.ts';
 
-export const INTERNAL_COMMANDS = {
-  installSource: 'install_source',
-  leaseAllocate: 'lease_allocate',
-  leaseHeartbeat: 'lease_heartbeat',
-  leaseRelease: 'lease_release',
-  releaseMaterializedPaths: 'release_materialized_paths',
-  runtime: 'runtime',
-  sessionList: 'session_list',
-} as const;
-
-const LOCAL_CLI_COMMANDS = {
-  cdp: 'cdp',
-  auth: 'auth',
-  connect: 'connect',
-  connection: 'connection',
-  debug: 'debug',
-  disconnect: 'disconnect',
-  mcp: 'mcp',
-  metro: 'metro',
-  proxy: 'proxy',
-  reactDevtools: 'react-devtools',
-  session: 'session',
-  web: 'web',
-} as const;
+export const PUBLIC_COMMANDS = deriveCommandCatalog('public');
+export const INTERNAL_COMMANDS = deriveCommandCatalog('internal');
+const LOCAL_CLI_COMMANDS = deriveCommandCatalog('local-cli');
 
 export const SPECIAL_CLI_COMMANDS = {
   help: 'help',
@@ -86,12 +18,12 @@ export const GESTURE_KINDS = ['pan', 'fling', 'swipe', 'pinch', 'rotate', 'trans
 export type GestureKind = (typeof GESTURE_KINDS)[number];
 export const GESTURE_SUBCOMMAND_ERROR = `gesture requires one of: ${GESTURE_KINDS.join(', ')}`;
 
-export type PublicCommandName = (typeof PUBLIC_COMMANDS)[keyof typeof PUBLIC_COMMANDS];
-export type InternalCommandName = (typeof INTERNAL_COMMANDS)[keyof typeof INTERNAL_COMMANDS];
-export type LocalCliCommandName = (typeof LOCAL_CLI_COMMANDS)[keyof typeof LOCAL_CLI_COMMANDS];
+export type PublicCommandName = DescriptorCommandNameForCatalogGroup<'public'>;
+export type InternalCommandName = DescriptorCommandNameForCatalogGroup<'internal'>;
+export type LocalCliCommandName = DescriptorCommandNameForCatalogGroup<'local-cli'>;
 export type SpecialCliCommandName =
   (typeof SPECIAL_CLI_COMMANDS)[keyof typeof SPECIAL_CLI_COMMANDS];
-export type CliCommandName = PublicCommandName | LocalCliCommandName;
+export type CliCommandName = DescriptorCliCommandName;
 export type KnownCliCommandName = CliCommandName | InternalCommandName | SpecialCliCommandName;
 
 export function listCliCommandNames(): CliCommandName[] {
@@ -102,4 +34,14 @@ export function isKnownCliCommandName(command: string): command is KnownCliComma
   if ((Object.values(SPECIAL_CLI_COMMANDS) as readonly string[]).includes(command)) return true;
   if ((Object.values(INTERNAL_COMMANDS) as readonly string[]).includes(command)) return true;
   return (listCliCommandNames() as readonly string[]).includes(command);
+}
+
+function deriveCommandCatalog<Group extends CommandCatalogGroup>(
+  group: Group,
+): DescriptorCatalogRecord<Group> {
+  const result: Record<string, string> = {};
+  for (const [key, name] of listDescriptorCatalogEntries(group)) {
+    result[key] = name;
+  }
+  return result as DescriptorCatalogRecord<Group>;
 }

--- a/src/commands/__tests__/command-surface-metadata.test.ts
+++ b/src/commands/__tests__/command-surface-metadata.test.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
+import { listCliCommandNames } from '../../command-catalog.ts';
 import {
   listCommandResponseDataTransforms,
   listMcpExposedCommandNames,
 } from '../../core/command-descriptor/registry.ts';
+import { getSchemaOnlyCliCommandSchema } from '../../utils/cli-command-overrides.ts';
 import {
   listCommandMetadata,
   listCommandMetadataNames,
@@ -85,6 +87,25 @@ test('command family facets expose one complete metadata and executable surface'
   assert.deepEqual(definitionNames, metadataNames);
   assert.deepEqual(metadataNames, listCommandMetadataNames());
   assert.deepEqual(definitionNames, listExecutableCommandNames());
+});
+
+test('descriptor CLI catalog and command surface metadata stay coherent', () => {
+  const cliCommandNames = listCliCommandNames();
+  const cliCommandNameSet = new Set<string>(cliCommandNames);
+  const metadataNames = listCommandMetadataNames();
+  const metadataNameSet = new Set<string>(metadataNames);
+
+  for (const name of metadataNames) {
+    assert.ok(cliCommandNameSet.has(name), `${name} command metadata must have a descriptor`);
+  }
+
+  for (const name of cliCommandNames) {
+    if (metadataNameSet.has(name)) continue;
+    assert.ok(
+      getSchemaOnlyCliCommandSchema(name),
+      `${name} descriptor CLI command needs metadata or a schema-only CLI schema`,
+    );
+  }
 });
 
 test('command family facets expose CLI schema and reader coverage centrally', () => {

--- a/src/core/command-descriptor/__tests__/parity.test.ts
+++ b/src/core/command-descriptor/__tests__/parity.test.ts
@@ -1,16 +1,23 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { STRUCTURED_BATCH_COMMAND_NAMES } from '../../../batch-policy.ts';
-import { listCliCommandNames, PUBLIC_COMMANDS } from '../../../command-catalog.ts';
+import {
+  INTERNAL_COMMANDS,
+  listCliCommandNames,
+  PUBLIC_COMMANDS,
+} from '../../../command-catalog.ts';
 import { BASE_COMMAND_CAPABILITY_MATRIX } from '../../capabilities.ts';
 import {
   DAEMON_COMMAND_DESCRIPTORS,
   type DaemonCommandDescriptor,
 } from '../../../daemon/daemon-command-registry.ts';
 import type { DaemonRequest } from '../../../daemon/types.ts';
+import { listRegisteredDispatchCommandNames } from '../../dispatch.ts';
 import { deriveDaemonCommandDescriptors, deriveStructuredBatchCommandNames } from '../derive.ts';
 import {
   commandDescriptors,
+  listDescriptorCatalogCommandNames,
+  listDescriptorDispatchCommandNames,
   listCapabilityCheckedCommandNames,
   listMcpExposedCommandNames,
 } from '../registry.ts';
@@ -46,6 +53,8 @@ const NO_CAPABILITY_PUBLIC_COMMANDS = new Set<string>([
   PUBLIC_COMMANDS.trace,
 ]);
 
+type TestCommandDescriptor = (typeof commandDescriptors)[number];
+
 function makeRequest(command: string, positionals: string[] = []): DaemonRequest {
   return { command, token: 'parity-token', session: 'parity-session', positionals, flags: {} };
 }
@@ -62,6 +71,26 @@ function sampleRequests(command: string): DaemonRequest[] {
     { ...makeRequest(PUBLIC_COMMANDS.test), flags: { shardAll: 2 } },
     { ...makeRequest(PUBLIC_COMMANDS.test), flags: { shardSplit: 1 } },
   ];
+}
+
+function hasDaemonFacet(descriptor: TestCommandDescriptor): boolean {
+  return 'daemon' in descriptor && descriptor.daemon !== undefined;
+}
+
+function hasCapabilityFacet(descriptor: TestCommandDescriptor): boolean {
+  return 'capability' in descriptor && descriptor.capability !== undefined;
+}
+
+function readCatalogGroupForTest(descriptor: TestCommandDescriptor): string {
+  return descriptor.catalog.group;
+}
+
+function isDescriptorOnlyCommand(descriptor: TestCommandDescriptor): boolean {
+  return !hasDaemonFacet(descriptor) && !hasCapabilityFacet(descriptor) && !descriptor.batchable;
+}
+
+function readDaemonRouteForTest(descriptor: TestCommandDescriptor): string | undefined {
+  return 'daemon' in descriptor ? descriptor.daemon?.route : undefined;
 }
 
 test('derived daemon registry holds its routing invariants', () => {
@@ -105,6 +134,59 @@ test('derived daemon descriptors preserve closure traits by presence and behavio
         }
       }
     }
+  }
+});
+
+test('command catalog projections are built from descriptor catalog facets', () => {
+  const publicCommands = listDescriptorCatalogCommandNames('public');
+  const internalCommands = listDescriptorCatalogCommandNames('internal');
+  const localCliCommands = listDescriptorCatalogCommandNames('local-cli');
+
+  assert.deepEqual(Object.values(PUBLIC_COMMANDS).sort(), publicCommands);
+  assert.deepEqual(Object.values(INTERNAL_COMMANDS).sort(), internalCommands);
+  assert.deepEqual(listCliCommandNames(), [...publicCommands, ...localCliCommands].sort());
+
+  assert.equal(PUBLIC_COMMANDS.appState, 'appstate');
+  assert.equal(PUBLIC_COMMANDS.longPress, 'longpress');
+  assert.equal(INTERNAL_COMMANDS.leaseAllocate, 'lease_allocate');
+});
+
+test('descriptor-only commands explicitly declare a non-public catalog group', () => {
+  const publicCommands = new Set<string>(listDescriptorCatalogCommandNames('public'));
+
+  for (const descriptor of commandDescriptors) {
+    if (!isDescriptorOnlyCommand(descriptor)) continue;
+
+    const group = readCatalogGroupForTest(descriptor);
+    assert.notEqual(group, 'public', `${descriptor.name} declares a non-public catalog group`);
+    assert.equal(publicCommands.has(descriptor.name), false, `${descriptor.name} is not public`);
+  }
+});
+
+test('platform dispatch command list is built from descriptor dispatch facets', () => {
+  const dispatchCommands = listDescriptorDispatchCommandNames();
+
+  assert.deepEqual(listRegisteredDispatchCommandNames(), dispatchCommands);
+  assert.ok(dispatchCommands.includes('read'), 'read stays dispatch-only');
+  assert.ok(dispatchCommands.includes('swipe-preset'), 'swipe-preset stays dispatch-only');
+  assert.equal(
+    (dispatchCommands as readonly string[]).includes(PUBLIC_COMMANDS.gesture),
+    false,
+    'gesture remains a daemon command that expands before platform dispatch',
+  );
+});
+
+test('generic route commands that reach platform dispatch declare the dispatch facet', () => {
+  const nonDispatchGenericCommands = new Set<string>([PUBLIC_COMMANDS.gesture]);
+
+  for (const descriptor of commandDescriptors) {
+    const route = readDaemonRouteForTest(descriptor);
+    if (route !== 'generic' || nonDispatchGenericCommands.has(descriptor.name)) continue;
+
+    assert.ok(
+      'dispatch' in descriptor && descriptor.dispatch !== undefined,
+      `${descriptor.name} declares dispatch coverage`,
+    );
   }
 });
 

--- a/src/core/command-descriptor/derive.ts
+++ b/src/core/command-descriptor/derive.ts
@@ -3,10 +3,9 @@ import type { DaemonCommandDescriptor } from '../../daemon/daemon-command-regist
 import type { CommandDescriptor } from './types.ts';
 
 /**
- * Pure folds that reconstruct today's hand-authored tables from the additive
- * {@link CommandDescriptor} registry. These exist so the parity tests can prove
- * the registry is byte-equal to the live tables; no production code reads them
- * yet (ADR-0008, Phase 1 step 1).
+ * Pure folds that project live command tables from the
+ * {@link CommandDescriptor} registry. These started as parity-test helpers and
+ * are now the production derivation path for descriptor-owned views.
  */
 
 /** Reconstructs the DAEMON_COMMAND_DESCRIPTORS array (same order, same shape). */

--- a/src/core/command-descriptor/post-action-observation.ts
+++ b/src/core/command-descriptor/post-action-observation.ts
@@ -1,13 +1,11 @@
-import { PUBLIC_COMMANDS, type PublicCommandName } from '../../command-catalog.ts';
-
 export type PostActionObservationSupport = 'settle' | 'settle-and-verify';
 
 const POST_ACTION_OBSERVATION_BY_COMMAND = {
-  [PUBLIC_COMMANDS.click]: 'settle-and-verify',
-  [PUBLIC_COMMANDS.press]: 'settle-and-verify',
-  [PUBLIC_COMMANDS.fill]: 'settle-and-verify',
-  [PUBLIC_COMMANDS.longPress]: 'settle',
-} as const satisfies Partial<Record<PublicCommandName, PostActionObservationSupport>>;
+  click: 'settle-and-verify',
+  press: 'settle-and-verify',
+  fill: 'settle-and-verify',
+  longpress: 'settle',
+} as const satisfies Record<string, PostActionObservationSupport>;
 
 export type PostActionObservationCommandName = keyof typeof POST_ACTION_OBSERVATION_BY_COMMAND;
 

--- a/src/core/command-descriptor/registry.ts
+++ b/src/core/command-descriptor/registry.ts
@@ -1,9 +1,3 @@
-import {
-  INTERNAL_COMMANDS,
-  listCliCommandNames,
-  type CliCommandName,
-  PUBLIC_COMMANDS,
-} from '../../command-catalog.ts';
 import type { CommandCapability } from '../capabilities.ts';
 import type { DaemonRequest } from '../../daemon/types.ts';
 import { resolveWaitBudgetMs } from '../wait-positionals.ts';
@@ -15,6 +9,7 @@ import {
 import { resolvePostActionObservationSupport } from './post-action-observation.ts';
 import type { PostActionObservationSupport } from './post-action-observation.ts';
 import type {
+  CommandCatalogGroup,
   CommandDescriptor,
   CommandResponseDataTransform,
   CommandTimeoutPolicy,
@@ -23,6 +18,43 @@ import type {
 type RawCommandDescriptor = Omit<CommandDescriptor, 'mcpExposed'> & {
   mcpExposed?: boolean;
 };
+
+type RawCommandCatalogGroup<T> = T extends { catalog: { group: infer Group } } ? Group : never;
+
+type RawCommandCatalogKey<T> = T extends { catalog: { key: infer Key extends string } }
+  ? Key
+  : T extends { name: infer Name extends string }
+    ? Name
+    : never;
+
+export type DescriptorCommandNameForCatalogGroup<Group extends CommandCatalogGroup> =
+  Extract<(typeof commandDescriptors)[number], { name: string }> extends infer Descriptor
+    ? Descriptor extends { name: infer Name extends string }
+      ? RawCommandCatalogGroup<Descriptor> extends Group
+        ? Name
+        : never
+      : never
+    : never;
+
+export type DescriptorCliCommandName =
+  | DescriptorCommandNameForCatalogGroup<'public'>
+  | DescriptorCommandNameForCatalogGroup<'local-cli'>;
+
+export type DescriptorCatalogRecord<Group extends CommandCatalogGroup> = {
+  readonly [Descriptor in Extract<
+    (typeof commandDescriptors)[number],
+    { name: string }
+  > as RawCommandCatalogGroup<Descriptor> extends Group
+    ? RawCommandCatalogKey<Descriptor>
+    : never]: Descriptor['name'];
+};
+
+export type DescriptorDispatchCommandName =
+  Extract<(typeof commandDescriptors)[number], { dispatch: object }> extends infer Descriptor
+    ? Descriptor extends { name: infer Name extends string }
+      ? Name
+      : never
+    : never;
 
 // ---------------------------------------------------------------------------
 // Daemon request-policy trait bundles — copied VERBATIM from
@@ -46,7 +78,7 @@ const isRecordingStartRequest = (req: DaemonRequest): boolean =>
   (req.positionals?.[0] ?? '').toLowerCase() === 'start';
 
 const isShardedTestRequest = (req: DaemonRequest): boolean =>
-  req.command === PUBLIC_COMMANDS.test &&
+  req.command === 'test' &&
   (typeof req.flags?.shardAll === 'number' || typeof req.flags?.shardSplit === 'number');
 
 // ---------------------------------------------------------------------------
@@ -160,36 +192,39 @@ function postActionObservation(command: string): PostActionObservationSupport {
 }
 
 // ---------------------------------------------------------------------------
-// The additive single source. Each entry carries the daemon route/traits +
-// capability + batchable flag copied VERBATIM from today's hand tables.
-//
-// Entry order matches DAEMON_COMMAND_DESCRIPTORS exactly (the two trailing
-// entries — `app-switcher` and `install-from-source` — have no daemon route and
-// live only in the capability/batch hand tables).
+// The additive single source. Each entry carries the command identity facets
+// plus whichever daemon, capability, batch, MCP, timeout, observation, and
+// platform-dispatch traits that command owns. Public catalog identity and the
+// non-public dispatch aliases now live here too; leaf views derive from this
+// array rather than recreating command-name sets.
 // ---------------------------------------------------------------------------
 
 const RAW_COMMAND_DESCRIPTORS = [
   // -- lease (route: lease) --
   {
-    name: INTERNAL_COMMANDS.leaseAllocate,
+    name: 'lease_allocate',
+    catalog: { group: 'internal', key: 'leaseAllocate' },
     daemon: { route: 'lease', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: INTERNAL_COMMANDS.leaseHeartbeat,
+    name: 'lease_heartbeat',
+    catalog: { group: 'internal', key: 'leaseHeartbeat' },
     daemon: { route: 'lease', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: INTERNAL_COMMANDS.leaseRelease,
+    name: 'lease_release',
+    catalog: { group: 'internal', key: 'leaseRelease' },
     daemon: { route: 'lease', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: PUBLIC_COMMANDS.artifacts,
+    name: 'artifacts',
+    catalog: { group: 'public' },
     daemon: { route: 'lease', ...ADMISSION_AND_LOCK_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
@@ -197,13 +232,15 @@ const RAW_COMMAND_DESCRIPTORS = [
 
   // -- session (route: session) --
   {
-    name: INTERNAL_COMMANDS.sessionList,
+    name: 'session_list',
+    catalog: { group: 'internal', key: 'sessionList' },
     daemon: { route: 'session', sessionKind: 'inventory', ...REQUEST_EXECUTION_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: PUBLIC_COMMANDS.devices,
+    name: 'devices',
+    catalog: { group: 'public' },
     daemon: {
       route: 'session',
       sessionKind: 'inventory',
@@ -214,7 +251,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.capabilities,
+    name: 'capabilities',
+    catalog: { group: 'public' },
     daemon: {
       route: 'session',
       sessionKind: 'inventory',
@@ -226,7 +264,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.doctor,
+    name: 'doctor',
+    catalog: { group: 'public' },
     daemon: {
       route: 'session',
       sessionKind: 'inventory',
@@ -238,7 +277,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.apps,
+    name: 'apps',
+    catalog: { group: 'public' },
     daemon: {
       route: 'session',
       sessionKind: 'inventory',
@@ -250,7 +290,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.boot,
+    name: 'boot',
+    catalog: { group: 'public' },
     daemon: { route: 'session', sessionKind: 'state' },
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
@@ -261,7 +302,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.shutdown,
+    name: 'shutdown',
+    catalog: { group: 'public' },
     daemon: { route: 'session', sessionKind: 'state' },
     capability: {
       apple: { simulator: true },
@@ -272,34 +314,39 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.appState,
+    name: 'appstate',
+    catalog: { group: 'public', key: 'appState' },
     daemon: { route: 'session', sessionKind: 'state' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.perf,
+    name: 'perf',
+    catalog: { group: 'public' },
     daemon: { route: 'session', sessionKind: 'observability' },
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.logs,
+    name: 'logs',
+    catalog: { group: 'public' },
     daemon: { route: 'session', sessionKind: 'observability' },
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.network,
+    name: 'network',
+    catalog: { group: 'public' },
     daemon: { route: 'session', sessionKind: 'observability' },
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.audio,
+    name: 'audio',
+    catalog: { group: 'public' },
     daemon: { route: 'session', sessionKind: 'observability' },
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
@@ -310,7 +357,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.replay,
+    name: 'replay',
+    catalog: { group: 'public' },
     daemon: {
       route: 'session',
       sessionKind: 'replay',
@@ -321,7 +369,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: false,
   },
   {
-    name: PUBLIC_COMMANDS.test,
+    name: 'test',
+    catalog: { group: 'public' },
     daemon: {
       route: 'session',
       sessionKind: 'replay',
@@ -333,14 +382,17 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: INTERNAL_COMMANDS.runtime,
+    name: 'runtime',
+    catalog: { group: 'internal' },
     daemon: { route: 'session' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: PUBLIC_COMMANDS.clipboard,
+    name: 'clipboard',
+    catalog: { group: 'public' },
     daemon: { route: 'session', replayScopedAction: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -350,8 +402,10 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.keyboard,
+    name: 'keyboard',
+    catalog: { group: 'public' },
     daemon: { route: 'session', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -361,34 +415,40 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.install,
+    name: 'install',
+    catalog: { group: 'public' },
     daemon: { route: 'session' },
     capability: APP_INSTALL_CAPABILITY,
     timeoutPolicy: INSTALL_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.reinstall,
+    name: 'reinstall',
+    catalog: { group: 'public' },
     daemon: { route: 'session' },
     capability: APP_INSTALL_CAPABILITY,
     timeoutPolicy: INSTALL_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: INTERNAL_COMMANDS.installSource,
+    name: 'install_source',
+    catalog: { group: 'internal', key: 'installSource' },
     daemon: { route: 'session' },
     timeoutPolicy: INSTALL_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: INTERNAL_COMMANDS.releaseMaterializedPaths,
+    name: 'release_materialized_paths',
+    catalog: { group: 'internal', key: 'releaseMaterializedPaths' },
     daemon: { route: 'session', ...REQUEST_EXECUTION_EXEMPT },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: PUBLIC_COMMANDS.push,
+    name: 'push',
+    catalog: { group: 'public' },
     daemon: { route: 'session' },
+    dispatch: {},
     capability: {
       apple: { simulator: true },
       android: ANDROID_ALL,
@@ -398,21 +458,26 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.triggerAppEvent,
+    name: 'trigger-app-event',
+    catalog: { group: 'public', key: 'triggerAppEvent' },
     daemon: { route: 'session' },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.open,
+    name: 'open',
+    catalog: { group: 'public' },
     daemon: { route: 'session', allowSessionlessDefaultDevice: allowAnyDeviceSessionless },
+    dispatch: {},
     capability: APP_RUNTIME_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.prepare,
+    name: 'prepare',
+    catalog: { group: 'public' },
     daemon: { route: 'session' },
     // Runner warm-up builds are the longest fixed envelope; --timeout overrides.
     timeoutPolicy: {
@@ -424,14 +489,17 @@ const RAW_COMMAND_DESCRIPTORS = [
     mcpExposed: false,
   },
   {
-    name: PUBLIC_COMMANDS.batch,
+    name: 'batch',
+    catalog: { group: 'public' },
     daemon: { route: 'session' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
-    name: PUBLIC_COMMANDS.close,
+    name: 'close',
+    catalog: { group: 'public' },
     daemon: { route: 'session', allowInvalidRecording: true },
+    dispatch: {},
     capability: APP_RUNTIME_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
@@ -439,8 +507,10 @@ const RAW_COMMAND_DESCRIPTORS = [
 
   // -- snapshot (route: snapshot) --
   {
-    name: PUBLIC_COMMANDS.snapshot,
+    name: 'snapshot',
+    catalog: { group: 'public' },
     daemon: { route: 'snapshot', replayScopedAction: true },
+    dispatch: {},
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     // First Apple snapshot on a device can sit behind runner startup; --timeout
     // widens the envelope, and a timeout must not tear down the daemon.
@@ -448,14 +518,16 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.diff,
+    name: 'diff',
+    catalog: { group: 'public' },
     daemon: { route: 'snapshot', replayScopedAction: true },
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.wait,
+    name: 'wait',
+    catalog: { group: 'public' },
     daemon: { route: 'snapshot', replayScopedAction: true },
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     // The wait budget travels as a positional, not a flag; parse it the same
@@ -467,7 +539,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.alert,
+    name: 'alert',
+    catalog: { group: 'public' },
     daemon: { route: 'snapshot', replayScopedAction: true },
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
@@ -478,8 +551,10 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.settings,
+    name: 'settings',
+    catalog: { group: 'public' },
     daemon: { route: 'snapshot', replayScopedAction: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -491,14 +566,16 @@ const RAW_COMMAND_DESCRIPTORS = [
 
   // -- specialized routes --
   {
-    name: PUBLIC_COMMANDS.reactNative,
+    name: 'react-native',
+    catalog: { group: 'public', key: 'reactNative' },
     daemon: { route: 'reactNative', replayScopedAction: true },
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.record,
+    name: 'record',
+    catalog: { group: 'public' },
     daemon: {
       route: 'recordTrace',
       replayScopedAction: true,
@@ -510,13 +587,15 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.trace,
+    name: 'trace',
+    catalog: { group: 'public' },
     daemon: { route: 'recordTrace' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.find,
+    name: 'find',
+    catalog: { group: 'public' },
     daemon: { route: 'find', replayScopedAction: true },
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: PRESERVE_DAEMON_TIMEOUT_POLICY,
@@ -531,79 +610,102 @@ const RAW_COMMAND_DESCRIPTORS = [
   // and rely on request cancellation + the per-request runner recycle budget to abort the
   // stuck Apple runner work.
   {
-    name: PUBLIC_COMMANDS.click,
+    name: 'click',
+    catalog: { group: 'public' },
     daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
-    timeoutPolicy: interactionTimeoutPolicy(PUBLIC_COMMANDS.click),
-    postActionObservation: postActionObservation(PUBLIC_COMMANDS.click),
+    timeoutPolicy: interactionTimeoutPolicy('click'),
+    postActionObservation: postActionObservation('click'),
     responseDataTransform: TOUCH_INTERACTION_RESPONSE_DATA_TRANSFORM,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.fill,
+    name: 'fill',
+    catalog: { group: 'public' },
     daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
-    timeoutPolicy: interactionTimeoutPolicy(PUBLIC_COMMANDS.fill),
-    postActionObservation: postActionObservation(PUBLIC_COMMANDS.fill),
+    timeoutPolicy: interactionTimeoutPolicy('fill'),
+    postActionObservation: postActionObservation('fill'),
     responseDataTransform: FILL_INTERACTION_RESPONSE_DATA_TRANSFORM,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.longPress,
+    name: 'longpress',
+    catalog: { group: 'public', key: 'longPress' },
     daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
-    timeoutPolicy: interactionTimeoutPolicy(PUBLIC_COMMANDS.longPress),
-    postActionObservation: postActionObservation(PUBLIC_COMMANDS.longPress),
+    timeoutPolicy: interactionTimeoutPolicy('longpress'),
+    postActionObservation: postActionObservation('longpress'),
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.press,
+    name: 'press',
+    catalog: { group: 'public' },
     daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
-    timeoutPolicy: interactionTimeoutPolicy(PUBLIC_COMMANDS.press),
-    postActionObservation: postActionObservation(PUBLIC_COMMANDS.press),
+    timeoutPolicy: interactionTimeoutPolicy('press'),
+    postActionObservation: postActionObservation('press'),
     responseDataTransform: TOUCH_INTERACTION_RESPONSE_DATA_TRANSFORM,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.type,
+    name: 'type',
+    catalog: { group: 'public' },
     daemon: { route: 'interaction', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
-    timeoutPolicy: interactionTimeoutPolicy(PUBLIC_COMMANDS.type),
+    timeoutPolicy: interactionTimeoutPolicy('type'),
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.get,
+    name: 'get',
+    catalog: { group: 'public' },
     daemon: { route: 'interaction', replayScopedAction: true },
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
-    timeoutPolicy: interactionTimeoutPolicy(PUBLIC_COMMANDS.get),
+    timeoutPolicy: interactionTimeoutPolicy('get'),
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.is,
+    name: 'read',
+    catalog: { group: 'dispatch-alias' },
+    dispatch: {},
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+  },
+  {
+    name: 'is',
+    catalog: { group: 'public' },
     daemon: { route: 'interaction', replayScopedAction: true },
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
-    timeoutPolicy: interactionTimeoutPolicy(PUBLIC_COMMANDS.is),
+    timeoutPolicy: interactionTimeoutPolicy('is'),
     batchable: true,
   },
 
   // -- generic (route: generic) --
   {
-    name: PUBLIC_COMMANDS.back,
+    name: 'back',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.gesture,
+    name: 'gesture',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.home,
+    name: 'home',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -613,8 +715,10 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.tvRemote,
+    name: 'tv-remote',
+    catalog: { group: 'public', key: 'tvRemote' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -624,8 +728,10 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.rotate,
+    name: 'rotate',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -635,22 +741,35 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.scroll,
+    name: 'scroll',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.swipe,
+    name: 'swipe',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
+  },
+  {
+    name: 'swipe-preset',
+    catalog: { group: 'dispatch-alias' },
+    dispatch: {},
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
   },
   {
     name: 'pinch',
+    catalog: { group: 'dispatch-alias' },
     daemon: { route: 'generic', replayScopedAction: true, androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -660,43 +779,55 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: false,
   },
   {
-    name: PUBLIC_COMMANDS.focus,
+    name: 'focus',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.screenshot,
+    name: 'screenshot',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true },
+    dispatch: {},
     capability: ALL_DEVICE_COMMAND_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.viewport,
+    name: 'viewport',
+    catalog: { group: 'public' },
     daemon: { route: 'generic', replayScopedAction: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
     name: 'pan',
+    catalog: { group: 'dispatch-alias' },
     daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_DEVICE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
     name: 'fling',
+    catalog: { group: 'dispatch-alias' },
     daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: { apple: APPLE_SIM_AND_DEVICE, android: ANDROID_ALL, linux: LINUX_NONE },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
     name: 'rotate-gesture',
+    catalog: { group: 'dispatch-alias' },
     daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -707,7 +838,9 @@ const RAW_COMMAND_DESCRIPTORS = [
   },
   {
     name: 'transform-gesture',
+    catalog: { group: 'dispatch-alias' },
     daemon: { route: 'generic', androidBlockingDialogGuard: true },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -719,7 +852,9 @@ const RAW_COMMAND_DESCRIPTORS = [
 
   // -- capability/batch-only commands (no daemon route) --
   {
-    name: PUBLIC_COMMANDS.appSwitcher,
+    name: 'app-switcher',
+    catalog: { group: 'public', key: 'appSwitcher' },
+    dispatch: {},
     capability: {
       apple: APPLE_SIM_AND_DEVICE,
       android: ANDROID_ALL,
@@ -729,7 +864,8 @@ const RAW_COMMAND_DESCRIPTORS = [
     batchable: true,
   },
   {
-    name: PUBLIC_COMMANDS.installFromSource,
+    name: 'install-from-source',
+    catalog: { group: 'public', key: 'installFromSource' },
     capability: APP_INSTALL_CAPABILITY,
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: true,
@@ -738,22 +874,94 @@ const RAW_COMMAND_DESCRIPTORS = [
   // -- local client-backed CLI/MCP commands (no daemon route/capability) --
   {
     name: 'debug',
+    catalog: { group: 'local-cli' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
     name: 'metro',
+    catalog: { group: 'local-cli' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
   {
     name: 'session',
+    catalog: { group: 'local-cli' },
     timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
     batchable: false,
   },
+  {
+    name: 'cdp',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'auth',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'connect',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'connection',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'disconnect',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'mcp',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'proxy',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'react-devtools',
+    catalog: { group: 'local-cli', key: 'reactDevtools' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
+  {
+    name: 'web',
+    catalog: { group: 'local-cli' },
+    timeoutPolicy: DEFAULT_TIMEOUT_POLICY,
+    batchable: false,
+    mcpExposed: false,
+  },
 ] as const satisfies readonly RawCommandDescriptor[];
 
-const CLI_COMMAND_NAMES = new Set<string>(listCliCommandNames());
+const CLI_CATALOG_GROUPS = new Set<CommandCatalogGroup>(['public', 'local-cli']);
+
+const CLI_COMMAND_NAMES = new Set<string>(
+  RAW_COMMAND_DESCRIPTORS.filter((descriptor) =>
+    CLI_CATALOG_GROUPS.has(readCatalogGroup(descriptor)),
+  ).map((descriptor) => descriptor.name),
+);
 
 /**
  * The additive single source of truth (ADR-0008, Phase 1 step 1). Proven
@@ -771,17 +979,46 @@ export const commandDescriptors = RAW_COMMAND_DESCRIPTORS.map((descriptor) => ({
 /** The literal union of every registered command name. */
 export type Command = (typeof commandDescriptors)[number]['name'];
 
-export function listMcpExposedCommandNames(): CliCommandName[] {
-  return commandDescriptors
-    .filter((descriptor) => isMcpExposedCliCommand(descriptor))
-    .map((descriptor) => descriptor.name as CliCommandName)
+export function listDescriptorCatalogCommandNames<Group extends CommandCatalogGroup>(
+  group: Group,
+): Array<DescriptorCommandNameForCatalogGroup<Group>> {
+  return listDescriptorCatalogEntries(group)
+    .map(([, name]) => name)
     .sort();
 }
 
-export function listCapabilityCheckedCommandNames(): CliCommandName[] {
+export function listDescriptorCatalogEntries<Group extends CommandCatalogGroup>(
+  group: Group,
+): Array<readonly [key: string, name: DescriptorCommandNameForCatalogGroup<Group>]> {
+  return commandDescriptors
+    .filter((descriptor) => readCatalogGroup(descriptor) === group)
+    .map(
+      (descriptor) =>
+        [
+          readCatalogKey(descriptor),
+          descriptor.name as DescriptorCommandNameForCatalogGroup<Group>,
+        ] as const,
+    );
+}
+
+export function listDescriptorDispatchCommandNames(): DescriptorDispatchCommandName[] {
+  return commandDescriptors
+    .filter((descriptor) => 'dispatch' in descriptor && descriptor.dispatch !== undefined)
+    .map((descriptor) => descriptor.name as DescriptorDispatchCommandName)
+    .sort();
+}
+
+export function listMcpExposedCommandNames(): DescriptorCliCommandName[] {
+  return commandDescriptors
+    .filter((descriptor) => isMcpExposedCliCommand(descriptor))
+    .map((descriptor) => descriptor.name as DescriptorCliCommandName)
+    .sort();
+}
+
+export function listCapabilityCheckedCommandNames(): DescriptorCliCommandName[] {
   return commandDescriptors
     .filter((descriptor) => isCapabilityCheckedCliCommand(descriptor))
-    .map((descriptor) => descriptor.name as CliCommandName)
+    .map((descriptor) => descriptor.name as DescriptorCliCommandName)
     .sort();
 }
 
@@ -789,7 +1026,7 @@ const COMMAND_DESCRIPTOR_BY_NAME: ReadonlyMap<string, CommandDescriptor> = new M
   commandDescriptors.map((descriptor) => [descriptor.name, descriptor]),
 );
 
-function isCliCommandName(command: string): command is CliCommandName {
+function isCliCommandName(command: string): command is DescriptorCliCommandName {
   return CLI_COMMAND_NAMES.has(command);
 }
 
@@ -803,6 +1040,20 @@ function isMcpExposedCliCommand(descriptor: CommandDescriptor): boolean {
 
 function isCapabilityCheckedCliCommand(descriptor: CommandDescriptor): boolean {
   return Boolean(descriptor.capability) && isCliCommandName(descriptor.name);
+}
+
+function readCatalogGroup(descriptor: {
+  name: string;
+  catalog: { group: CommandCatalogGroup; key?: string };
+}): CommandCatalogGroup {
+  return descriptor.catalog.group;
+}
+
+function readCatalogKey(descriptor: {
+  name: string;
+  catalog: { group: CommandCatalogGroup; key?: string };
+}): string {
+  return descriptor.catalog.key ?? descriptor.name;
 }
 
 const TIMEOUT_POLICY_BY_COMMAND: ReadonlyMap<string, CommandTimeoutPolicy> = new Map(

--- a/src/core/command-descriptor/types.ts
+++ b/src/core/command-descriptor/types.ts
@@ -69,6 +69,29 @@ export type CommandTimeoutPolicy = {
   onTimeout: 'preserve-daemon' | 'reset-daemon';
 };
 
+export type CommandCatalogGroup = 'public' | 'internal' | 'local-cli' | 'dispatch-alias';
+
+export type CommandCatalogFacet = {
+  /**
+   * The command catalog group. This is explicit on every descriptor so new
+   * descriptors cannot accidentally become public CLI/MCP commands by omission.
+   */
+  group: CommandCatalogGroup;
+  /**
+   * Stable property name used by catalog object projections, e.g.
+   * `longPress` for the command name `longpress`.
+   */
+  key?: string;
+};
+
+export type CommandDispatchFacet = {
+  /**
+   * Platform dispatch command handled by src/core/dispatch.ts. The descriptor
+   * name is the dispatched command; dispatch-only names such as `read` are
+   * modeled as named descriptors rather than hidden aliases.
+   */
+} & Record<string, never>;
+
 /**
  * The single additive command-descriptor shape (ADR-0008, Phase 1 step 1).
  *
@@ -94,6 +117,10 @@ export type CommandTimeoutPolicy = {
  *                   command-owned fields in daemon responses. This keeps
  *                   response shaping on the same descriptor surface as other
  *                   command traits.
+ *  - `catalog` — command identity projection metadata. Every descriptor
+ *                   declares its catalog group explicitly.
+ *  - `dispatch` — whether src/core/dispatch.ts accepts this command name as a
+ *                   platform dispatch target.
  *
  * The registry started dormant (proven byte-equal to the hand tables by the
  * parity tests) and is now the live source: the daemon registry, capability
@@ -109,4 +136,6 @@ export type CommandDescriptor = {
   timeoutPolicy: CommandTimeoutPolicy;
   postActionObservation?: PostActionObservationSupport;
   responseDataTransform?: CommandResponseDataTransform;
+  catalog: CommandCatalogFacet;
+  dispatch?: CommandDispatchFacet;
 };

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -37,6 +37,7 @@ import { readNotificationPayload } from './dispatch-payload.ts';
 import { parseDeviceRotation } from './device-rotation.ts';
 import { parseTvRemoteButton } from './tv-remote.ts';
 import { readViewportDimension } from './viewport-dimension.ts';
+import type { DescriptorDispatchCommandName } from './command-descriptor/registry.ts';
 
 export { resolveTargetDevice } from './dispatch-resolve.ts';
 export type { CommandFlags, DispatchContext } from './dispatch-context.ts';
@@ -89,44 +90,7 @@ export async function dispatchCommand(
   );
 }
 
-/**
- * The exact set of commands routed by {@link dispatchKnownCommand}. Hand-authored
- * to match the former `switch` cases verbatim: it is NOT the registry's `generic`
- * daemon route (that set is both narrower — e.g. it has no `open`/`type`/`read` —
- * and includes `gesture`, which dispatch never handled), and `swipe-preset` /
- * `read` are not registry command names at all. Keeping it explicit makes the
- * dispatch surface self-describing and lets the `Record` below enforce coverage.
- */
-type DispatchCommand =
-  | 'open'
-  | 'close'
-  | 'press'
-  | 'swipe'
-  | 'swipe-preset'
-  | 'pan'
-  | 'fling'
-  | 'longpress'
-  | 'focus'
-  | 'type'
-  | 'fill'
-  | 'scroll'
-  | 'pinch'
-  | 'rotate-gesture'
-  | 'transform-gesture'
-  | 'trigger-app-event'
-  | 'screenshot'
-  | 'viewport'
-  | 'back'
-  | 'home'
-  | 'rotate'
-  | 'app-switcher'
-  | 'clipboard'
-  | 'keyboard'
-  | 'tv-remote'
-  | 'settings'
-  | 'push'
-  | 'snapshot'
-  | 'read';
+type DispatchCommand = DescriptorDispatchCommandName;
 
 type DispatchHandlerArgs = {
   device: DeviceInfo;
@@ -140,11 +104,12 @@ type DispatchHandlerArgs = {
 type DispatchHandler = (args: DispatchHandlerArgs) => Promise<Record<string, unknown> | void>;
 
 /**
- * Registry-driven exhaustive dispatch table. The `Record<DispatchCommand, …>`
- * type forces every dispatch command to have a handler — a missing entry is a
- * COMPILE error, which replaces the former runtime `default: throw` as the
- * coverage safety net. Each entry routes to the IDENTICAL handler with the
- * IDENTICAL arguments the `switch` used, so dispatch stays strictly behaviorless.
+ * Descriptor-driven exhaustive dispatch table. The `Record<DispatchCommand, …>`
+ * type forces every descriptor-declared dispatch command to have a handler — a
+ * missing entry is a COMPILE error, which replaces the former runtime `default:
+ * throw` as the coverage safety net. Each entry routes to the IDENTICAL handler
+ * with the IDENTICAL arguments the `switch` used, so dispatch stays strictly
+ * behaviorless.
  */
 const DISPATCH_HANDLERS: Record<DispatchCommand, DispatchHandler> = {
   open: ({ device, interactor, positionals, context }) =>
@@ -215,6 +180,10 @@ const DISPATCH_HANDLERS: Record<DispatchCommand, DispatchHandler> = {
   snapshot: ({ interactor, context }) => handleSnapshotCommand(interactor, context),
   read: ({ device, positionals, context }) => handleReadCommand(device, positionals, context),
 };
+
+export function listRegisteredDispatchCommandNames(): string[] {
+  return Object.keys(DISPATCH_HANDLERS).sort();
+}
 
 async function dispatchKnownCommand(
   device: DeviceInfo,


### PR DESCRIPTION
## Summary

Derive PUBLIC_COMMANDS, INTERNAL_COMMANDS, local CLI names, and platform dispatch command coverage from CommandDescriptor facets.

This removes the live hand-maintained command catalog tables and the manual DispatchCommand union. Dispatch-only aliases such as read and swipe-preset are now explicit descriptor aliases, command-family metadata is coherence-guarded against the descriptor CLI catalog, and ADR 0008/CONTEXT now record the completed registry state.

Follow-up: public Node-client typed-result narrowing is tracked in #1153 because several remaining methods need public contract moves before they can safely stop returning CommandRequestResult.

## Validation

- pnpm format
- pnpm check:quick
- pnpm check:layering
- pnpm exec vitest run src/core/command-descriptor/__tests__/parity.test.ts src/core/command-descriptor/__tests__/timeout-policy.test.ts src/core/command-descriptor/__tests__/post-action-observation.test.ts src/commands/__tests__/command-surface-metadata.test.ts src/cli/commands/__tests__/client-backed.test.ts src/utils/__tests__/command-schema-guards.test.ts
- pnpm check:fallow --base origin/main