### PR TITLE
fix: improve settle observation guidance

### DIFF
--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -392,7 +392,7 @@ extension RunnerTests {
         ? " The primary capture ran out of its time budget (busy app or simulator); the recovered tree is authoritative for this screen."
         : " This usually means the app publishes an unhealthy accessibility tree — fixing the app's accessibility is the real cure. Treat screenshot as visual truth when this warning appears."
       parts.append(
-        "Recovered this snapshot with the \(quality.backend) accessibility backend"
+        "Detected an overly complex or slow accessibility tree. Fell back to the \(quality.backend) snapshot backend"
           + (quality.reason.map { " after: \($0)." } ?? ".")
           + meaning
       )
@@ -486,7 +486,7 @@ extension RunnerTests {
       collapsedLeafIndexes: nil
     )
     let message = Self.legacyQualityMessage(recovered)
-    XCTAssertTrue(message?.contains("queries accessibility backend") == true)
+    XCTAssertTrue(message?.contains("queries snapshot backend") == true)
     XCTAssertTrue(message?.contains("fixing the app's accessibility") == true)
     XCTAssertTrue(message?.contains("screenshot as visual truth") == true)
     XCTAssertNil(

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "build:macos-helper": "swift build -c release --package-path macos-helper",
     "build:all": "pnpm build:node && pnpm build:xcuitest",
     "ad": "node bin/agent-device.mjs",
+    "bench:help-conformance": "node scripts/help-conformance-bench.mjs",
     "size": "node scripts/size-report.mjs",
     "size:markdown": "node scripts/size-report.mjs --json .tmp/size-report.json --markdown .tmp/size-report.md",
     "perf": "node --experimental-strip-types scripts/perf/run.ts",

--- a/scripts/help-conformance-bench.mjs
+++ b/scripts/help-conformance-bench.mjs
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const OUT_DIR = process.env.HELP_BENCH_OUT ?? join(ROOT, '.tmp', 'help-conformance-bench');
+const RUN_TIMEOUT_MS = Number(process.env.HELP_BENCH_TIMEOUT_MS ?? 90_000);
+const DEFAULT_RUNNERS = ['codex:gpt-5.4-mini', 'claude:claude-haiku-4-5'];
+const OPTION_SPECS = {
+  '--runner': { target: 'runners', mode: 'append' },
+  '--runners': { target: 'runners', mode: 'csv' },
+  '--case': { target: 'cases', mode: 'append' },
+  '--cases': { target: 'cases', mode: 'csv' },
+  '--out': { target: 'outDir', mode: 'value' },
+};
+const OPTION_APPLIERS = {
+  append: (args, target, value) => {
+    args[target] = [...(args[target] ?? []), value];
+  },
+  csv: (args, target, value) => {
+    args[target] = [...(args[target] ?? []), ...value.split(',').filter(Boolean)];
+  },
+  value: (args, target, value) => {
+    args[target] = value;
+  },
+};
+
+const CASES = [
+  {
+    id: 'raw-first-screen-bluesky',
+    docs: ['--help:first30'],
+    task: 'Plan commands to open an already installed Bluesky app, search "callstack", open the @callstack.com account, press Follow or Following, and close.',
+    expectations: ['fullPrefix', 'usesSnapshotI', 'usesSettleOnMutations', 'noWaitStable'],
+  },
+  {
+    id: 'manual-qa-bluesky-script',
+    docs: ['--help:first30', 'manual-qa'],
+    task: 'You are following a manual QA script: on Bluesky, open Search, search "callstack", open @callstack.com, press Follow or Following, verify the button state changed, then close. Plan commands only.',
+    expectations: [
+      'fullPrefix',
+      'usesSnapshotI',
+      'usesSettleOnMutations',
+      'verifiesNamedExpectation',
+      'noWaitStable',
+    ],
+  },
+  {
+    id: 'dogfood-mode',
+    docs: ['--help:first30', 'dogfood'],
+    task: 'Plan a short dogfood pass for a logged-in mobile app that captures reproducible evidence for any issue found.',
+    expectations: ['fullPrefix', 'usesDogfoodEvidence', 'opensAndCloses'],
+  },
+  {
+    id: 'engineering-validate-mode',
+    docs: ['--help:first30', 'validate'],
+    task: 'Plan commands to validate a CLI/runtime change in agent-device against an iOS app without accidentally using stale built output.',
+    expectations: ['fullPrefix', 'usesValidationPrep', 'opensAndCloses'],
+  },
+];
+
+function parseArgs(argv) {
+  const args = { runners: undefined, cases: undefined, dryRun: false };
+  readArgs(args, argv, 0);
+  applyDefaultArgs(args);
+  return args;
+}
+
+function readArgs(args, argv, index) {
+  if (index >= argv.length) return;
+  readArgs(args, argv, readArg(args, argv, index));
+}
+
+function readArg(args, argv, index) {
+  const arg = argv[index];
+  if (arg === '--dry-run') return applyDryRun(args, index);
+  applyOption(args, optionSpec(arg), argv[index + 1]);
+  return index + 2;
+}
+
+function applyDryRun(args, index) {
+  args.dryRun = true;
+  return index + 1;
+}
+
+function optionSpec(arg) {
+  const spec = OPTION_SPECS[arg];
+  if (!spec) throw new Error(`Unknown argument: ${arg}`);
+  return spec;
+}
+
+function applyOption(args, spec, value) {
+  assertOptionValue(spec, value);
+  OPTION_APPLIERS[spec.mode](args, spec.target, value);
+}
+
+function assertOptionValue(spec, value) {
+  if (value === undefined) throw new Error(`Missing value for ${spec.target}`);
+}
+
+function applyDefaultArgs(args) {
+  args.runners ??= DEFAULT_RUNNERS;
+  args.cases ??= CASES.map((testCase) => testCase.id);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outDir = resolveOutDir(args);
+  await mkdir(outDir, { recursive: true });
+  const selectedCases = selectCases(args.cases);
+  const docs = await loadDocs(requiredDocIds(selectedCases));
+
+  const results = await runBenchmarkMatrix(args.runners, selectedCases, docs, outDir, args.dryRun);
+  const reportPath = join(outDir, `report-${Date.now()}.json`);
+  await writeFile(reportPath, `${JSON.stringify(results, null, 2)}\n`);
+  console.log(`Wrote ${reportPath}`);
+  updateExitCode(results, args.dryRun);
+}
+
+function resolveOutDir(args) {
+  return args.outDir ?? OUT_DIR;
+}
+
+function selectCases(caseIds) {
+  const selectedCases = CASES.filter((testCase) => caseIds.includes(testCase.id));
+  assertCasesSelected(selectedCases);
+  return selectedCases;
+}
+
+function assertCasesSelected(selectedCases) {
+  if (selectedCases.length === 0) throw new Error('No benchmark cases selected.');
+}
+
+function requiredDocIds(selectedCases) {
+  return [...new Set(selectedCases.flatMap((testCase) => testCase.docs))];
+}
+
+function updateExitCode(results, dryRun) {
+  if (!dryRun && results.some((result) => !result.passed)) process.exitCode = 1;
+}
+
+async function runBenchmarkMatrix(runners, selectedCases, docs, outDir, dryRun) {
+  const results = [];
+  for (const runner of runners) {
+    for (const testCase of selectedCases) {
+      const result = await runBenchmarkEntry(runner, testCase, docs, outDir, dryRun);
+      results.push(result);
+      printResult(result, dryRun);
+    }
+  }
+  return results;
+}
+
+async function runBenchmarkEntry(runner, testCase, docs, outDir, dryRun) {
+  const prompt = buildPrompt(testCase, docs);
+  return dryRun
+    ? { runner, caseId: testCase.id, prompt }
+    : runCase(runner, testCase, prompt, outDir);
+}
+
+function printResult(result, dryRun) {
+  if (dryRun) return;
+  console.log(
+    `${result.passed ? 'PASS' : 'FAIL'} ${result.runner} ${result.caseId} ${result.score}/${result.total}`,
+  );
+}
+
+async function loadDocs(docIds) {
+  return Object.fromEntries(await Promise.all(docIds.map(loadDocEntry)));
+}
+
+async function loadDocEntry(docId) {
+  return [docId, await loadDoc(docId)];
+}
+
+async function loadDoc(docId) {
+  if (docId === '--help:first30') return firstLines(await cliHelp(['--help']), 30);
+  return cliHelp(['help', docId]);
+}
+
+async function cliHelp(args) {
+  const { stdout } = await execFileAsync('node', [join(ROOT, 'bin', 'agent-device.mjs'), ...args], {
+    cwd: ROOT,
+    maxBuffer: 1024 * 1024 * 10,
+  });
+  return stdout.trim();
+}
+
+function firstLines(text, count) {
+  return text.split('\n').slice(0, count).join('\n');
+}
+
+function buildPrompt(testCase, docs) {
+  const helpText = testCase.docs.map((docId) => `### ${docId}\n${docs[docId]}`).join('\n\n');
+  return [
+    'Do not run shell commands.',
+    'You are evaluating agent-device CLI help. Return only JSON with keys commands and rationale.',
+    'commands must be an array of command lines you would run.',
+    `Task: ${testCase.task}`,
+    '',
+    helpText,
+  ].join('\n');
+}
+
+async function runCase(runner, testCase, prompt, outDir) {
+  const { raw, runnerError } = await runCaseRawOutput(runner, prompt, outDir);
+  const outputPath = join(outDir, `${safeName(runner)}-${testCase.id}.txt`);
+  await writeFile(outputPath, raw);
+  const commands = extractCommands(raw);
+  const checks = scoreExpectations(testCase.expectations, commands, raw);
+  const score = countPassingChecks(checks);
+  return {
+    runner,
+    caseId: testCase.id,
+    commands,
+    checks,
+    score,
+    total: testCase.expectations.length,
+    passed: runnerError === undefined && score === testCase.expectations.length,
+    ...(runnerError ? { runnerError } : {}),
+    outputPath,
+  };
+}
+
+async function runCaseRawOutput(runner, prompt, outDir) {
+  const [kind, model] = runner.split(':');
+  try {
+    const raw = await runModel(kind, model, prompt, outDir);
+    return {
+      raw,
+      runnerError: raw.trim().length === 0 ? 'Runner returned empty output.' : undefined,
+    };
+  } catch (error) {
+    return { raw: errorOutput(error), runnerError: errorMessage(error) };
+  }
+}
+
+function errorOutput(error) {
+  const payload = Object(error);
+  return [payload.stdout, payload.stderr].filter(Boolean).join('\n');
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function runModel(kind, model, prompt, outDir) {
+  return kind === 'claude' ? runClaude(model, prompt) : runCodex(model, prompt, outDir);
+}
+
+async function runClaude(model, prompt) {
+  const { stdout } = await execFileWithInput(
+    'claude',
+    [
+      '-p',
+      '--model',
+      model,
+      '--tools',
+      '',
+      '--permission-mode',
+      'dontAsk',
+      '--no-session-persistence',
+      '--output-format',
+      'json',
+    ],
+    prompt,
+    { cwd: ROOT, maxBuffer: 1024 * 1024 * 20, timeout: RUN_TIMEOUT_MS },
+  );
+  return stdout;
+}
+
+function execFileWithInput(file, args, input, options) {
+  return new Promise((resolve, reject) => {
+    const child = execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        reject(Object.assign(error, { stdout, stderr }));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+    child.stdin?.end(input);
+  });
+}
+
+async function runCodex(model, prompt, outDir) {
+  const outFile = join(outDir, `codex-${model}-${Date.now()}.json`);
+  const { stdout } = await execFileAsync(
+    'codex',
+    [
+      'exec',
+      '--ignore-rules',
+      '--ignore-user-config',
+      '--ephemeral',
+      '--sandbox',
+      'read-only',
+      '-m',
+      model,
+      '-C',
+      ROOT,
+      '-o',
+      outFile,
+      prompt,
+    ],
+    { cwd: ROOT, maxBuffer: 1024 * 1024 * 20, timeout: RUN_TIMEOUT_MS },
+  );
+  let lastMessage = '';
+  try {
+    lastMessage = await readFile(outFile, 'utf8');
+  } catch {
+    // stdout still carries the transcript when -o fails.
+  }
+  return `${stdout}\n${lastMessage}`;
+}
+
+function extractCommands(raw) {
+  const json = parseJsonPayload(raw);
+  if (json && Array.isArray(json.commands)) {
+    return json.commands.map((command) => String(command).trim()).filter(Boolean);
+  }
+  return raw
+    .split('\n')
+    .map((line) => line.replace(/^[-*\d.]+\s*/, '').trim())
+    .filter(
+      (line) =>
+        line.startsWith('agent-device ') || line.match(/^(open|snapshot|press|fill|click|close)\b/),
+    );
+}
+
+function parseJsonPayload(raw) {
+  const candidates = jsonPayloadCandidates(raw);
+  for (const candidate of candidates) {
+    const parsed = parseJsonCandidate(candidate);
+    if (parsed !== undefined) return parsed;
+  }
+  return null;
+}
+
+function jsonPayloadCandidates(raw) {
+  return [raw, raw.match(/```json\s*([\s\S]*?)```/)?.[1], raw.match(/\{[\s\S]*\}/)?.[0]].filter(
+    Boolean,
+  );
+}
+
+function parseJsonCandidate(candidate) {
+  try {
+    return normalizeParsedJson(JSON.parse(candidate));
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeParsedJson(parsed) {
+  if (typeof parsed?.result === 'string') return parseJsonPayload(parsed.result);
+  return parsed;
+}
+
+const EXPECTATION_SCORERS = {
+  fullPrefix: ({ commands }) =>
+    commands.length > 0 &&
+    commands.every(
+      (command) => !/^(open|snapshot|press|fill|click|longpress|wait|close)\b/.test(command),
+    ),
+  usesSnapshotI: ({ commands }) => commands.some((command) => /\bsnapshot\b.*\s-i\b/.test(command)),
+  usesSettleOnMutations: ({ commands }) => allMutationsUseSettle(commands),
+  noWaitStable: ({ joined }) => !joined.includes('wait stable'),
+  verifiesNamedExpectation: ({ joined }) => /\b(wait|is|get|find)\b/.test(joined),
+  usesDogfoodEvidence: ({ joined }) =>
+    /(?:\bscreenshot\b|\brecord\b|\blogs\b|\bnetwork\b|\bperf\b|\btrace\b|dogfood-output)/i.test(
+      joined,
+    ),
+  usesValidationPrep: ({ joined }) =>
+    /(?:pnpm\s+(?:build|clean:daemon|prepare)|agent-device\s+(?:doctor|prepare)\b|\bbuild:xcuitest\b)/i.test(
+      joined,
+    ),
+  opensAndCloses: ({ joined }) => /\bopen\b/.test(joined) && /\bclose\b/.test(joined),
+};
+
+function scoreExpectations(expectations, commands, raw) {
+  const context = { commands, joined: commands.join('\n').toLowerCase(), raw };
+  return Object.fromEntries(
+    expectations.map((expectation) => [expectation, scoreExpectation(expectation, context)]),
+  );
+}
+
+function scoreExpectation(expectation, context) {
+  const scorer = EXPECTATION_SCORERS[expectation];
+  if (!scorer) throw new Error(`Unknown expectation: ${expectation}`);
+  return scorer(context);
+}
+
+function allMutationsUseSettle(commands) {
+  const mutating = commands.filter(isMutationCommand);
+  return mutating.length > 0 && mutating.every((command) => command.includes('--settle'));
+}
+
+function isMutationCommand(command) {
+  return /\b(press|click|fill|longpress)\b/.test(command) && !/\bsnapshot\b/.test(command);
+}
+
+function countPassingChecks(checks) {
+  return Object.values(checks).filter(Boolean).length;
+}
+
+function safeName(name) {
+  return basename(name).replace(/[^a-z0-9_.-]+/gi, '-');
+}
+
+await main();

--- a/skills/agent-device/SKILL.md
+++ b/skills/agent-device/SKILL.md
@@ -13,15 +13,18 @@ agent-device --version
 
 If that fails but the user may have installed `agent-device` globally, check the user's configured login/interactive shell and environment before using `npx`. Resolve the command the same way the user would from a normal terminal session, then run the absolute binary path if found. This may require inspecting shell startup behavior or package-manager/global bin locations; do not assume the Codex process `PATH` is the user's `PATH`.
 
-Require `agent-device >= 0.14.0`; older CLIs lack these help topics. If older, stop and tell the user to upgrade the trusted install or approve an exact-version npm command. Do not run `npm install -g agent-device@latest` or `npx -y agent-device@latest` autonomously, and do not include version/upgrade commands in final plans.
+Require `agent-device >= 0.19.1`; older CLIs lack these help topics. If older, stop and tell the user to upgrade the trusted install or approve an exact-version npm command. Do not run `npm install -g agent-device@latest` or `npx -y agent-device@latest` autonomously, and do not include version/upgrade commands in final plans.
 
-Before your first agent-device command or plan, read the version-matched CLI guide:
+Before your first agent-device command or plan, read the smallest version-matched CLI guide that fits the task:
 
 ```bash
-agent-device help workflow
+agent-device help manual-qa   # scripted/manual QA, acceptance checks, checklist execution
+agent-device help validate    # code/runtime validation, stale build or daemon risk
+agent-device help dogfood     # exploratory app dogfooding and evidence collection
+agent-device help workflow    # fallback reference for general app driving or mixed tasks
 ```
 
-Escalate only when relevant:
+Read additional topics only when relevant:
 
 ```bash
 agent-device help debugging
@@ -37,6 +40,6 @@ Default loop: `open -> snapshot/-i -> get/is/find or press/fill/scroll/wait -> v
 
 On a fresh machine (first iOS run), start with `agent-device doctor --platform ios`: it preflights the environment and warms the iOS runner build cache in the background so the first `open` is fast.
 
-Use this skill only to route into version-matched CLI help. Let `help workflow` provide exact command shapes, platform limits, and current workflow guidance.
+Use this skill only to route into version-matched CLI help. Let the selected help topic provide exact command shapes, platform limits, and current workflow guidance; use `help workflow` as the full reference when a task-specific topic is too narrow.
 
 For precise location workflows, read the installed `settings` help before planning so coordinate support and platform limits come from the active CLI version.

--- a/src/cli/parser/__tests__/cli-help-topics.test.ts
+++ b/src/cli/parser/__tests__/cli-help-topics.test.ts
@@ -86,25 +86,15 @@ test('usage includes agent workflows, config, environment, and examples footers'
     'The agent starting point should appear before topic selection.',
   );
   assert.match(usageText, /Agent Starting Point:/);
-  assert.match(
-    usageText,
-    /agent-device is the default automation surface for app\/device workflows across supported targets/,
-  );
-  assert.match(
-    usageText,
-    /Default to agent-device for installs, opens, snapshots, interactions, screenshots, logs, network\/perf evidence, and verification/,
-  );
-  assert.match(
-    usageText,
-    /Use raw adb, simctl, xcrun, or platform scripts only when this help calls out a tool gap or platform setup step/,
-  );
-  assert.match(
-    usageText,
-    /Start with agent-device help workflow to understand the core loop and how to use the tool/,
-  );
+  assert.match(usageText, /Write full command lines starting with agent-device/);
+  assert.match(usageText, /Default app loop: agent-device open <app>/);
+  assert.match(usageText, /Use --settle on every mutating app action that supports it/);
+  assert.match(usageText, /The settled diff is the next snapshot/);
+  assert.match(usageText, /If --settle prints not settled, follow its hint/);
+  assert.match(usageText, /Use refs or selectors as targets/);
+  assert.match(usageText, /Pick the help mode below/);
   assert.match(usageText, /Agent Quickstart:/);
-  assert.match(usageText, /Default loop: devices\/apps -> open -> snapshot -i/);
-  assert.match(usageText, /Use selectors or refs as positional targets/);
+  assert.match(usageText, /Planning output contract/);
   assert.match(
     usageText,
     /Plain snapshot reads state; snapshot -i refreshes current interactive refs only/,
@@ -149,7 +139,19 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /Agent Workflows:/);
   assert.match(
     usageText,
-    /agent-device help workflow\s+Start here for the core loop, command shape, refs\/selectors, and verification/,
+    /agent-device help manual-qa\s+Follow a manual test script with exact interactions and verification/,
+  );
+  assert.match(
+    usageText,
+    /agent-device help dogfood\s+Explore an app and report issues with evidence/,
+  );
+  assert.match(
+    usageText,
+    /agent-device help validate\s+Validate code changes, perf, visuals, logs, and cleanup/,
+  );
+  assert.match(
+    usageText,
+    /agent-device help workflow\s+Full app automation reference for commands, refs, selectors, and waits/,
   );
   assert.match(
     usageText,
@@ -444,6 +446,28 @@ test('usageForCommand resolves physical-device help topic', async () => {
   assert.match(help, /AGENT_DEVICE_IOS_TEAM_ID=ABCDE12345/);
   assert.match(help, /AGENT_DEVICE_IOS_BUNDLE_ID=com\.yourname\.agentdevice\.runner/);
   assert.match(help, /profile name\/specifier, not a file path/);
+});
+
+test('usageForCommand resolves manual QA help topic', async () => {
+  const help = await usageForCommand('manual-qa');
+  if (help === null) throw new Error('Expected manual QA help text');
+  assert.match(help, /agent-device help manual-qa/);
+  assert.match(help, /Execute the script/);
+  assert.match(help, /Run snapshot -i to get current refs/);
+  assert.match(help, /press\/fill\/click\/longpress <ref-or-selector> --settle/);
+  assert.match(help, /A bare screenshot\/snapshot is not verification/);
+  assert.match(help, /Do not use placeholders such as @ref/);
+});
+
+test('usageForCommand resolves validate help topic', async () => {
+  const help = await usageForCommand('validate');
+  if (help === null) throw new Error('Expected validate help text');
+  assert.match(help, /agent-device help validate/);
+  assert.match(help, /validating a code change/);
+  assert.match(help, /pnpm build first, then pnpm clean:daemon/);
+  assert.match(help, /pnpm build:xcuitest/);
+  assert.match(help, /Use the settled diff as evidence/);
+  assert.match(help, /Close sessions and release leases/);
 });
 
 test('usageForCommand resolves macos help topic', async () => {

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -11,8 +11,20 @@ import {
 
 const AGENT_WORKFLOWS = [
   {
+    label: 'agent-device help manual-qa',
+    description: 'Follow a manual test script with exact interactions and verification',
+  },
+  {
+    label: 'agent-device help dogfood',
+    description: 'Explore an app and report issues with evidence',
+  },
+  {
+    label: 'agent-device help validate',
+    description: 'Validate code changes, perf, visuals, logs, and cleanup',
+  },
+  {
     label: 'agent-device help workflow',
-    description: 'Start here for the core loop, command shape, refs/selectors, and verification',
+    description: 'Full app automation reference for commands, refs, selectors, and waits',
   },
   {
     label: 'agent-device help debugging',
@@ -51,29 +63,26 @@ const AGENT_WORKFLOWS = [
     label: 'agent-device help macos',
     description: 'Use when targeting desktop, frontmost app, or menu bar surfaces',
   },
-  { label: 'agent-device help dogfood', description: 'Use when producing exploratory QA evidence' },
 ] as const;
 
 const AGENT_START_LINES = [
-  'agent-device is the default automation surface for app/device workflows across supported targets.',
-  'Default to agent-device for installs, opens, snapshots, interactions, screenshots, logs, network/perf evidence, and verification.',
-  'Use raw adb, simctl, xcrun, or platform scripts only when this help calls out a tool gap or platform setup step.',
-  'Start with agent-device help workflow to understand the core loop and how to use the tool.',
+  'Write full command lines starting with agent-device; do not output pseudo commands, helper prose, pipes, grep, jq, or hidden stderr.',
   // Benchmarked 2026-07-05 (#1101): agents that only read --help skipped the
   // help-workflow pointer and fell into plain-snapshot loops; stating the loop
   // here is what makes small models pick snapshot -i and --settle unprompted.
-  'Core loop: open <app> -> snapshot -i (interactive tree with @refs) -> press/click/fill <target> --settle (returns the settled diff with fresh @refs) -> repeat. Verify with diff snapshot -i.',
+  'Default app loop: agent-device open <app> -> agent-device snapshot -i -> agent-device press/fill/click <target> --settle -> continue from that settled diff -> agent-device close.',
+  'Use --settle on every mutating app action that supports it: press, click, fill, longpress.',
+  'The settled diff is the next snapshot. Do not run wait stable or snapshot after settled:true unless the diff lacks the next target/evidence.',
+  'If --settle prints not settled, follow its hint before the next ref-based action.',
+  'Use refs or selectors as targets: @e12, label="Search", role=button label="Follow".',
+  'Pick the help mode below when the task is manual QA, dogfooding, engineering validation, or debugging.',
 ] as const;
 
 const AGENT_QUICKSTART_LINES = [
   'Planning output contract: when asked to plan commands, output command lines only: no prose, numbering, Markdown fences, pipes, or shell helpers.',
-  'Default loop: devices/apps -> open -> snapshot -i -> press/fill/get/is/wait/find -> verify with diff snapshot -> close.',
-  'Verify a mutation with diff snapshot (or diff snapshot -i), not a full snapshot: it prints only the added/removed/changed lines since the last snapshot in this session, so confirming an action costs a few lines instead of the whole tree.',
-  'Collapse act+observe into one call with --settle on press/click/fill/longpress: the response waits for the UI to go quiet and carries the settled diff with fresh refs (settled: false plus a hint on never-quiet content; the action itself never fails). Tune with --settle-quiet <ms> and --timeout <ms>.',
-  'Treat the --settle diff as the post-action observation: if it already shows the next target or final evidence, act on that fresh ref or answer from it instead of taking another snapshot.',
+  'If you did not use --settle, verify a mutation with diff snapshot (or diff snapshot -i), not a full snapshot: it prints only the added/removed/changed lines since the last snapshot in this session.',
   'Network-backed or debounced results may arrive after the --settle quiet window; follow the settled action with wait text "Expected result" or wait <selector> instead of polling full snapshots.',
-  'Use selectors or refs as positional targets: id="submit", label="Allow", role=button label="Send", or @e12 from snapshot -i. Do not write role names as selector keys, such as button="Search".',
-  'Pin a ref to the snapshot that minted it with ~s<n> (n = refsGeneration in the snapshot response): press @e12~s4. Pinned refs get exact staleness warnings instead of the coarse tree-changed one; plain refs stay valid input.',
+  'Pin a raw CLI ref to the response that minted it with ~s<n> (n = refsGeneration or settle.refsGeneration): press @e12~s4. Pinned refs get exact staleness warnings instead of the coarse tree-changed one; plain refs stay valid input.',
   'Plain snapshot reads state; snapshot -i refreshes current interactive refs only.',
   'Default snapshot text is an agent-facing, token-efficient view for planning and targeting actions.',
   'Read-only visible/state question: use snapshot/get/is/find; use snapshot -i only when refs are needed.',
@@ -138,6 +147,36 @@ const EXAMPLE_LINES = [
 ] as const;
 
 const HELP_TOPICS = {
+  'manual-qa': {
+    summary: 'Follow manual test scripts with exact interactions and verification',
+    body: `agent-device help manual-qa
+
+Use this when asked to follow a manual QA script, test case, checklist, acceptance flow, or user-provided instructions.
+
+Contract:
+  Execute the script. Do not explore unrelated screens, read app source, invent missing requirements, or broaden scope.
+  Stop and report ambiguity when a required target or expected result is not visible after the documented recovery steps.
+
+Loop:
+  1. Open the requested app; use --relaunch only when the script needs fresh state.
+  2. Run snapshot -i to get current refs for the next step.
+  3. Run press/fill/click/longpress <ref-or-selector> --settle for each mutating step.
+  4. Treat a settled:true diff as the next observation. Do not add wait stable or another snapshot when the diff already shows the next target or expected result.
+  5. If --settle prints not settled, follow its hint before the next ref-based action.
+  6. Verify named expectations with wait text/selector, get, is, find, or the settled diff. A bare screenshot/snapshot is not verification for a named expectation.
+  7. Close the session when the script ends.
+
+Targets:
+  Prefer refs from the latest snapshot -i or settled diff. Use durable selectors when the label/id is known: label="Search", id="submit", role=button label="Follow".
+  Do not use placeholders such as @ref, @eN, <button>, or <selector> in a final command plan. If the ref is unknown, first run snapshot -i.
+  Coordinates are fallback-only after refs/selectors fail or accessibility omits the target; use screenshot or snapshot -i --json to choose a visible center point.
+
+Recovery:
+  Network/typeahead result missing: wait text "Expected result" or wait <selector>.
+  Keyboard blocks target: keyboard dismiss when supported, then snapshot -i.
+  Sparse or recovered accessibility snapshot: use screenshot as visual truth, leave the bad screen if needed, then retry snapshot -i.
+  Non-hittable success hint: verify with the settled diff or snapshot; retarget by a better ref/selector if the UI did not change.`,
+  },
   workflow: {
     summary: 'Normal agent-device bootstrap, exploration, and validation loop',
     body: `agent-device help workflow
@@ -145,8 +184,8 @@ const HELP_TOPICS = {
 Version-matched operating guide for normal agent-device work.
 
 Core loop:
-  devices/apps -> open -> snapshot or snapshot -i -> get/is/find/wait or press/fill/scroll/back -> verify with diff snapshot -> close
-  After a mutating command, prefer diff snapshot (or diff snapshot -i) over a full snapshot to verify the effect: it diffs the rendered snapshot lines against the previous one in this session and prints only what changed, so verification does not re-pay the cost of the whole tree.
+  Start with the top-level Agent Starting Point for the default settle-first loop. This topic is the full reference for command shapes, refs, selectors, waits, recovery, and platform limits.
+  If you intentionally skip --settle or use a command that does not support it, verify a mutation with diff snapshot (or diff snapshot -i) instead of a full snapshot: it diffs the rendered snapshot lines against the previous one in this session and prints only what changed.
 
 Fresh machine or first iOS run:
   Run agent-device doctor --platform ios first. Besides preflight checks it warms the iOS XCTest runner build cache in the background, so the first open skips the runner build (~10s). To block until fully warm instead, run agent-device prepare ios-runner.
@@ -188,11 +227,10 @@ Snapshots and refs:
     @e13 [textinput] label="Notes" preview="Leave at side..." truncated -> snapshot -s @e13 before reading.
     @e14 [cell] label="Profiles" focused -> tvOS focus is currently on this row.
     [off-screen below] 4 items: "Privacy", "About" -> scroll down, then snapshot -i; those are hints, not refs.
-  Re-snapshot after navigation, submit, typing/fill, modal/list/reload/dynamic changes when you need new refs.
+  For press/fill/click/longpress, prefer --settle and continue from its settled diff when it exposes the next target or evidence. Refresh with snapshot -i only when you did not settle, settle printed not settled, or the settle output lacks what you need.
   Anti-pattern: snapshot -i followed by snapshot -i | grep ..., or adding 2>/dev/null | jq ... before reading the raw command output.
   Refs from the first snapshot remain valid until you press, click, fill, type, scroll, go back, wait for async UI, or otherwise change app state.
-  A --settle response is the observation for that mutation. If its diff already shows the next target or final evidence, use that fresh ref or answer from the diff instead of taking a follow-up snapshot.
-  After a mutation, prefer a known selector/label directly (for example press 'label="Send"') because interaction commands refresh interactive state internally. If you need to discover the new control, use snapshot -i, or snapshot -i -s "Composer" when a stable container label/id can scope the refresh.
+  After a mutation, prefer a known selector/label directly (for example press 'label="Send"') because interaction commands refresh interactive state internally. If you need to discover a new control not shown by settle, use snapshot -i, or snapshot -i -s "Composer" when a stable container label/id can scope the refresh.
   If typing/fill opened the keyboard or changed layout and the next target has no stable selector, run snapshot -i, use the fresh ref, then verify with wait/find or diff snapshot -i.
   For a targeted query, use find/get/is. If you truly need the full tree again, pass --force-full.
   Off-screen summaries are scroll hints; use scroll, not swipe, then snapshot -i.
@@ -243,7 +281,7 @@ Read-only and waits:
   For network-backed search/typeahead, --settle confirms the local UI quieted after fill/press; use wait text "Expected result" or wait <result selector> for server-loaded content that can arrive later.
   agent-device find "Increment" press --json
   For async/list text presence, prefer wait text over is visible when no interaction is needed.
-  wait stable [quietMs] [timeoutMs] (defaults 500/10000) replaces guessed sleeps between actions and snapshots in the core loop: it polls the interactive-only tree and resolves once two or more consecutive captures are unchanged for quietMs, or fails with the standard wait-timeout shape plus the last capture stats (captures, nodeCount) on timeout; use it after relaunch/navigation instead of a fixed wait <ms> before the next snapshot or action.
+  wait stable [quietMs] [timeoutMs] (defaults 500/10000) is a fallback for open/relaunch/navigation, unsupported mutating commands, or a mutation where you intentionally did not use --settle. Do not insert wait stable after press/fill/click/longpress --settle when the settled diff already shows what changed. wait stable polls the interactive-only tree and resolves once two or more consecutive captures are unchanged for quietMs, or fails with the standard wait-timeout shape plus capture stats (captures, nodeCount).
   Use snapshot -i only when refs are needed for an action or targeted query.
   Ambiguous find: add --first or --last. If info is not visible/exposed, report that gap instead of typing/searching/navigating to reveal it.
 
@@ -358,13 +396,15 @@ Guarantees:
   Wait: wait text|selector|@ref polls on a fixed interval (300ms) up to a timeout (10s default, override with the trailing timeoutMs positional) by re-capturing state each poll; it does not push/subscribe. Timing out raises a command failure rather than returning a not-found result.
 
 Escalate:
+  help manual-qa       scripted manual QA and acceptance checks
+  help dogfood         exploratory QA report workflow
+  help validate        engineering self-validation loops
   help debugging       logs, network, alerts, traces, flaky runtime failures
   help tv              Android TV and tvOS focus-first remote navigation
   help react-devtools  React Native performance, profiling, props/state/hooks, slow renders, rerenders
   help react-native   React Native app automation hazards, overlays, Metro/Re.Pack, and routing
   help remote          remote/cloud config, tenant, lease, local service tunnels
-  help macos           desktop, frontmost-app, menu bar surfaces
-  help dogfood         exploratory QA report workflow`,
+  help macos           desktop, frontmost-app, menu bar surfaces`,
   },
   tv: {
     summary: 'Android TV and tvOS focus-first remote navigation',
@@ -971,12 +1011,48 @@ Report shape:
 
 Rules:
   Findings must come from observed runtime behavior, not source reads.
-  Re-snapshot after each mutation.
+  After each mutation, use the --settle diff as evidence when available; otherwise re-snapshot.
   Keep commands in the report reproducible; use selectors or refs from fresh snapshots, not guessed coordinates.
   Prefer refs for exploration and selectors for deterministic replay.
   Use logs, network, screenshot --overlay-refs, trace, perf metrics, perf frames, or react-devtools only when they add evidence to a specific issue.
   Never delete screenshots, videos, traces, or report artifacts during a session.
   Escalate to help debugging or help react-devtools when runtime symptoms require those tools.`,
+  },
+  validate: {
+    summary: 'Engineering self-validation with device evidence and cleanup',
+    body: `agent-device help validate
+
+Use this when validating a code change, release candidate, performance fix, visual behavior, logging path, replay, or device-facing regression.
+
+Contract:
+  Prove the changed behavior through public agent-device surfaces. Do not validate against stale dist output, a retained stale daemon, or a runner built before the change.
+  Keep evidence reproducible: exact commands, target device/app, observed output, artifact paths, and cleanup status.
+
+Before device verification:
+  If TypeScript runtime or CLI output changed, run pnpm build first, then pnpm clean:daemon so bin/agent-device.mjs uses current dist and no stale daemon is serving old code.
+  If Apple runner code changed, run pnpm build:xcuitest and avoid inherited retained runners from older source.
+  Use open --relaunch when startup state matters. Use a purpose-specific --session for multi-step validation.
+
+Loop:
+  1. Build or prepare the changed surface with the repo command that owns it.
+  2. Open the target app/device state explicitly.
+  3. Use snapshot -i and press/fill/click/longpress --settle for UI-driving steps.
+  4. Use the settled diff as evidence when it shows the changed behavior; otherwise verify with wait/get/is/find, screenshot, logs, network, perf, or trace based on the claim.
+  5. Record timings, token/output size, screenshots/videos, logs, or perf artifacts only when they answer the validation question.
+  6. Close sessions and release leases before finishing.
+
+Evidence:
+  CLI/runtime freshness: pnpm build, pnpm clean:daemon, then agent-device --version or the command under test.
+  Apple runner freshness: pnpm build:xcuitest, then a live agent-device command on the target simulator/device.
+  Visual claim: screenshot, optionally screenshot --overlay-refs when target mapping matters.
+  Runtime/logging claim: logs clear --restart, logs mark, reproduce, logs path.
+  Network claim: network dump --include headers when headers are relevant.
+  Performance claim: perf metrics, perf frames, perf memory sample, or trace artifacts with bounded output.
+  Replay/regression claim: replay or test through the public command path.
+
+Report:
+  Summarize what changed, exact validation commands, pass/fail observations, artifact paths, and residual risk.
+  If live validation is blocked, state the blocker, device/session, and exact next command needed.`,
   },
 } as const satisfies Record<string, { summary: string; body: string }>;
 

--- a/src/commands/capture/runtime/snapshot.test.ts
+++ b/src/commands/capture/runtime/snapshot.test.ts
@@ -253,8 +253,9 @@ test('runtime snapshot renders the structured quality verdict and skips legacy d
   assert.equal(result.warnings?.length, 2);
   assert.match(
     String(result.warnings?.[0]),
-    /Recovered this snapshot with the queries accessibility backend/,
+    /Detected an overly complex or slow accessibility tree/,
   );
+  assert.match(String(result.warnings?.[0]), /queries snapshot backend/);
   assert.match(String(result.warnings?.[0]), /It is OK to continue/);
   assert.match(String(result.warnings?.[0]), /snapshotQuality\.reason/);
   assert.match(String(result.warnings?.[1]), /@e2 \[Other\] merges many labels/);

--- a/src/commands/interaction/output.test.ts
+++ b/src/commands/interaction/output.test.ts
@@ -80,6 +80,27 @@ describe('press CLI output', () => {
       ].join('\n'),
     );
   });
+
+  test('prints not-settled verdict without a dangling diff summary', () => {
+    const output = formatPress({
+      message: 'Tapped (278, 817)',
+      x: 278,
+      y: 817,
+      settle: {
+        settled: false,
+        waitedMs: 10000,
+        hint: 'The UI kept changing for the whole settle budget, so no settled diff is shown. Take a fresh snapshot.',
+      },
+    });
+
+    expect(output.text).toBe(
+      [
+        'Tapped (278, 817)',
+        'not settled after 10000ms',
+        'hint: The UI kept changing for the whole settle budget, so no settled diff is shown. Take a fresh snapshot.',
+      ].join('\n'),
+    );
+  });
 });
 
 describe('fill CLI output', () => {

--- a/src/commands/interaction/output.ts
+++ b/src/commands/interaction/output.ts
@@ -88,10 +88,8 @@ function formatSettleDiffLines(diff: SettleTextView['diff']): string[] {
 function formatSettleVerdict(view: SettleTextView): string {
   const verdict = view.settled === true ? 'settled' : 'not settled';
   const summary = view.diff?.summary;
-  const counts = summary
-    ? ` +${summary.additions ?? 0} -${summary.removals ?? 0} (~${summary.unchanged ?? 0} unchanged)`
-    : '';
-  return `${verdict} after ${view.waitedMs ?? 0}ms:${counts}`;
+  if (!summary) return `${verdict} after ${view.waitedMs ?? 0}ms`;
+  return `${verdict} after ${view.waitedMs ?? 0}ms: +${summary.additions ?? 0} -${summary.removals ?? 0} (~${summary.unchanged ?? 0} unchanged)`;
 }
 
 export const interactionCliOutputFormatters = {

--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -18,12 +18,16 @@ import { NEVER_SETTLED_HINT } from './settle.ts';
 function createFakeClock(stepMs = 300): {
   now: () => number;
   sleep: (ms: number) => Promise<void>;
+  advance: (ms: number) => void;
 } {
   let elapsed = 0;
   return {
     now: () => elapsed,
     sleep: async (ms: number) => {
       elapsed += ms > 0 ? ms : stepMs;
+    },
+    advance: (ms: number) => {
+      elapsed += ms;
     },
   };
 }
@@ -60,6 +64,7 @@ function createSettleDevice(params: {
   stored: SnapshotState;
   captureSnapshot: () => Promise<BackendSnapshotResult> | BackendSnapshotResult;
   tap?: () => Promise<Record<string, unknown>>;
+  clock?: ReturnType<typeof createFakeClock>;
 }): ReturnType<typeof createAgentDevice> {
   return createAgentDevice({
     backend: {
@@ -73,7 +78,7 @@ function createSettleDevice(params: {
     artifacts: createLocalArtifactAdapter(),
     sessions: createMemorySessionStore([{ name: 'default', snapshot: params.stored }]),
     policy: localCommandPolicy(),
-    clock: createFakeClock(),
+    clock: params.clock ?? createFakeClock(),
   });
 }
 
@@ -117,7 +122,7 @@ test('press --settle returns the settled diff and stores the settled tree', asyn
   assert.equal(stored.snapshot?.nodes[0]?.label, 'Welcome!');
 });
 
-test('never-settling content returns the last diff with settled: false and a hint', async () => {
+test('never-settling content returns settled: false without an actionable diff', async () => {
   const before = buttonSnapshot();
   let captures = 0;
   const device = createSettleDevice({
@@ -150,10 +155,46 @@ test('never-settling content returns the last diff with settled: false and a hin
   assert.ok(settle);
   assert.equal(settle.settled, false);
   assert.equal(settle.hint, NEVER_SETTLED_HINT);
-  // The LAST capture's diff still ships — best-effort observation.
+  assert.equal(settle.diff, undefined);
+});
+
+test('private-ax recovery resets the settle budget once', async () => {
+  const before = buttonSnapshot();
+  const recoveredAfter = welcomeSnapshot();
+  recoveredAfter.snapshotQuality = {
+    state: 'recovered',
+    backend: 'private-ax',
+    reasonCode: 'budget',
+    reason: 'tree backend was too slow',
+  };
+  let captures = 0;
+  const clock = createFakeClock();
+  const device = createSettleDevice({
+    stored: before,
+    clock,
+    captureSnapshot: () => {
+      captures += 1;
+      if (captures === 1) return { snapshot: before };
+      if (captures === 2) {
+        // This recovery arrives close enough to the original 1000ms timeout
+        // that the loop would time out before the 500ms quiet window without
+        // the one-shot private-AX budget reset.
+        clock.advance(900);
+      }
+      return { snapshot: recoveredAfter };
+    },
+  });
+
+  const result = await device.interactions.press(selector('label=Continue'), {
+    session: 'default',
+    settle: { quietMs: 500, timeoutMs: 1_000 },
+  });
+
+  const settle = result.settle;
+  assert.ok(settle);
+  assert.equal(settle.settled, true);
   assert.ok(settle.diff);
-  assert.equal(settle.diff.summary.additions, 1);
-  assert.match(settle.diff.lines.find((line) => line.kind === 'added')?.text ?? '', /Tick/);
+  assert.equal(captures, 4);
 });
 
 test('a broken settle capture never fails the action', async () => {

--- a/src/commands/interaction/runtime/settle.ts
+++ b/src/commands/interaction/runtime/settle.ts
@@ -41,10 +41,10 @@ export type SettleOutcome = {
 const MAX_SETTLE_DIFF_LINES = 80;
 
 export const NEVER_SETTLED_HINT =
-  'The UI kept changing for the whole settle budget (animation, carousel, or ticker?). The diff reflects the last capture and may already be outdated. Raise --timeout, or verify the target content with wait text.';
+  'The UI kept changing for the whole settle budget (animation, carousel, or ticker?), so no settled diff is shown. Raise --timeout, wait for specific content, or take a fresh snapshot.';
 
 const SETTLE_CAPTURE_STALLED_HINT =
-  'A snapshot capture stalled past the settle budget, so no settle verdict is available. The action itself succeeded; retry the observation with snapshot or wait stable.';
+  'A snapshot capture stalled past the settle budget, so no settled diff is shown. The action itself succeeded; observe with wait stable or snapshot.';
 
 export async function settleAfterInteraction(
   runtime: AgentDeviceRuntime,
@@ -55,7 +55,11 @@ export async function settleAfterInteraction(
   const timeoutMs = params.timeoutMs ?? DEFAULT_STABLE_TIMEOUT_MS;
   const base: SettleObservation = { settled: false, waitedMs: 0, captures: 0, quietMs, timeoutMs };
   try {
-    const outcome = await runStableCaptureLoop(runtime, options, { quietMs, timeoutMs });
+    const outcome = await runStableCaptureLoop(runtime, options, {
+      quietMs,
+      timeoutMs,
+      resetBudgetOnPrivateAxRecovery: true,
+    });
     const observation: SettleObservation = {
       ...base,
       settled: outcome.settled,
@@ -78,8 +82,11 @@ export async function settleAfterInteraction(
         // The diff (with its added-line refs) is only attached when the settled
         // tree actually became the stored session snapshot: those refs must be
         // valid against the tree the next @ref command resolves on. The daemon
-        // treats `diff` presence as "this response issues refs".
-        ...(stored
+        // treats `diff` presence as "this response issues refs". Unsettled
+        // captures are intentionally diff-less: they are not a stable
+        // observation, so surfacing refs would invite agents to act on
+        // advisory state.
+        ...(outcome.settled && stored
           ? { diff: buildSettleDiff(resolveBaselineNodes(params.resolved), settledNodes) }
           : {}),
         ...resolveSettleHint(outcome, stored, settledNodes.length),
@@ -196,9 +203,11 @@ function resolveSettleHint(
 
 // The settle loop itself captures with updateSession: false (a capture that
 // later stalls must not race a session write past the response). The FINAL
-// settled tree IS stored — its refs ride the diff payload, so they must be
-// resolvable by the next @ref command. Sparse-quality captures are not stored
-// (mirroring captureSelectorSnapshot) and therefore issue no refs.
+// capture is stored so follow-up snapshots/selectors see the latest surface.
+// Only settled captures issue a diff/ref payload; unsettled stored captures
+// conservatively mark prior refs stale through the runtime session writer.
+// Sparse-quality captures are not stored (mirroring captureSelectorSnapshot)
+// and therefore issue no refs.
 async function storeSettledSnapshot(
   runtime: AgentDeviceRuntime,
   options: CommandContext,

--- a/src/commands/interaction/runtime/stable-capture.ts
+++ b/src/commands/interaction/runtime/stable-capture.ts
@@ -1,4 +1,5 @@
 import type { SnapshotNode } from '../../../kernel/snapshot.ts';
+import type { SnapshotQualityVerdict } from '../../../snapshot/snapshot-quality.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import { now, sleep } from '../../runtime-common.ts';
 import {
@@ -43,10 +44,12 @@ export type StableCaptureLoopResult = {
 export async function runStableCaptureLoop(
   runtime: AgentDeviceRuntime,
   options: CommandContext & SelectorSnapshotOptions,
-  params: { quietMs: number; timeoutMs: number },
+  params: { quietMs: number; timeoutMs: number; resetBudgetOnPrivateAxRecovery?: boolean },
 ): Promise<StableCaptureLoopResult> {
   const { quietMs, timeoutMs } = params;
   const start = now(runtime);
+  let deadlineMs = start + timeoutMs;
+  let privateAxRecoveryBudgetReset = false;
   // Cadence derives from the quiet window (never slower than the default
   // poll): a caller asking for a 50ms quiet window should not be forced onto a
   // 300ms grid — and tests inject the budget instead of waiting real time.
@@ -56,11 +59,11 @@ export async function runStableCaptureLoop(
   let lastNodeCount = 0;
   let lastCapture: CapturedSnapshot | undefined;
   let quietSinceMs = start;
-  while (now(runtime) - start < timeoutMs) {
+  while (now(runtime) < deadlineMs) {
     const capture = await captureStableSignalWithinDeadline(
       runtime,
       options,
-      timeoutMs - (now(runtime) - start),
+      deadlineMs - now(runtime),
     );
     if (!capture) {
       return {
@@ -76,6 +79,19 @@ export async function runStableCaptureLoop(
     lastCapture = capture;
     const digest = digestSnapshotNodes(capture.snapshot.nodes);
     const nowMs = now(runtime);
+    if (
+      params.resetBudgetOnPrivateAxRecovery === true &&
+      !privateAxRecoveryBudgetReset &&
+      isPrivateAxRecovery(capture.snapshot.snapshotQuality)
+    ) {
+      privateAxRecoveryBudgetReset = true;
+      deadlineMs = Math.max(deadlineMs, nowMs + timeoutMs);
+      quietSinceMs = nowMs;
+      lastDigest = digest;
+      lastNodeCount = capture.snapshot.nodes.length;
+      await sleep(runtime, pollMs);
+      continue;
+    }
     if (digest !== lastDigest) {
       lastDigest = digest;
       lastNodeCount = capture.snapshot.nodes.length;
@@ -100,6 +116,10 @@ export async function runStableCaptureLoop(
     nodeCount: lastNodeCount,
     lastCapture,
   };
+}
+
+function isPrivateAxRecovery(verdict: SnapshotQualityVerdict | undefined): boolean {
+  return verdict?.state === 'recovered' && verdict.backend === 'private-ax';
 }
 
 // Intentionally does not update the session snapshot: the stable loop captures

--- a/src/contracts/interaction.ts
+++ b/src/contracts/interaction.ts
@@ -98,7 +98,8 @@ export type SettleDiffLine = {
  *
  * Best-effort by contract: settling never fails the action. `settled: false`
  * means the quiet window was never reached inside the budget (carousel/ticker/
- * animation) — the diff then reflects the LAST capture, and `hint` says so.
+ * animation) or a capture stalled; no diff/refs are issued because the
+ * observation is advisory. `hint` tells callers how to observe explicitly.
  *
  * Token budget: `diff.lines` carries only added/removed display lines (the
  * unchanged bulk rides as `diff.summary.unchanged`), bounded by the daemon; a
@@ -130,6 +131,7 @@ export type SettleObservation = {
    * intentionally omitted.
    */
   refs?: Array<{ ref: string }>;
+  /** Present only for `settled: true` observations that stored the settled tree. */
   diff?: {
     summary: { additions: number; removals: number; unchanged: number };
     lines: SettleDiffLine[];

--- a/src/daemon/__tests__/response-views.test.ts
+++ b/src/daemon/__tests__/response-views.test.ts
@@ -310,7 +310,7 @@ test('settle digest caps added refs at the snapshot digest ref limit', () => {
   const digest = RESPONSE_VIEWS.press!(
     {
       settle: {
-        settled: false,
+        settled: true,
         waitedMs: 2000,
         captures: 7,
         quietMs: 25,

--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -482,7 +482,7 @@ test('MCP merges per-ref pins from a settle response diff (merge-only)', async (
   });
 });
 
-test('MCP merges digest-level settle refs too, including never-settled diffs', async () => {
+test('MCP merges digest-level settled refs too', async () => {
   const runCalls: Array<{ name: string; input: unknown }> = [];
   const executor = createCommandToolExecutor({
     createClient: () => ({}) as AgentDeviceClient,
@@ -492,7 +492,7 @@ test('MCP merges digest-level settle refs too, including never-settled diffs', a
         return {
           ref: 'e2',
           settle: {
-            settled: false,
+            settled: true,
             waitedMs: 2000,
             captures: 7,
             quietMs: 25,
@@ -502,7 +502,6 @@ test('MCP merges digest-level settle refs too, including never-settled diffs', a
             diff: {
               summary: { additions: 1, removals: 1, unchanged: 1 },
             },
-            hint: 'The UI kept changing for the whole settle budget.',
           },
         };
       }

--- a/src/snapshot/snapshot-quality.ts
+++ b/src/snapshot/snapshot-quality.ts
@@ -81,7 +81,7 @@ export function renderSnapshotQualityWarnings(
 function stateWarning(verdict: SnapshotQualityVerdict): string[] {
   if (verdict.state === 'recovered') {
     return [
-      `Recovered this snapshot with the ${verdict.backend} accessibility backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.`,
+      `Detected an overly complex or slow accessibility tree. Fell back to the ${verdict.backend} snapshot backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.`,
     ];
   }
   if (verdict.state === 'sparse') {

--- a/src/utils/__tests__/snapshot-quality.test.ts
+++ b/src/utils/__tests__/snapshot-quality.test.ts
@@ -59,7 +59,7 @@ test('renderSnapshotQualityWarnings keeps recovered snapshot copy concise', () =
   );
 
   assert.deepEqual(warnings, [
-    'Recovered this snapshot with the private-ax accessibility backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.',
+    'Detected an overly complex or slow accessibility tree. Fell back to the private-ax snapshot backend. It is OK to continue; use --json to inspect snapshotQuality.reason if you need recovery details.',
     'Some deeper accessibility nodes were omitted; this tree is capped at depth 56. Re-run with --depth 56 --scope <container> only if you need deeper content.',
   ]);
 });

--- a/test/integration/provider-scenarios/settle-observation.test.ts
+++ b/test/integration/provider-scenarios/settle-observation.test.ts
@@ -159,7 +159,7 @@ test('Provider-backed integration press --settle returns the settled diff and fr
   );
 });
 
-test('Provider-backed integration never-settled press --settle keeps added refs actionable', async () => {
+test('Provider-backed integration never-settled press --settle does not issue diff refs', async () => {
   const loadingNodes = (label: string) => [
     {
       index: 0,
@@ -178,15 +178,12 @@ test('Provider-backed integration never-settled press --settle keeps added refs 
   ];
   const runnerTranscript = createProviderTranscript([
     // press label=Continue --settle: resolution capture, tap, then a changing
-    // settle stream. The loop times out and stores the last capture.
+    // settle stream. The loop times out; the final capture is not actionable.
     snapshotEntry(BEFORE_NODES),
     tapEntry(200, 322),
     snapshotEntry(loadingNodes('Loading 1')),
     snapshotEntry(loadingNodes('Loading 2')),
     snapshotEntry(SETTLED_NODES),
-    // press @e2 (the Done ref from the never-settled final diff): tap on the
-    // stored last tree, with no fresh snapshot round trip.
-    tapEntry(200, 522),
   ]);
   const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
     runnerTranscript,
@@ -228,17 +225,9 @@ test('Provider-backed integration never-settled press --settle keeps added refs 
         hint?: string;
       };
       assert.equal(settle.settled, false);
-      assert.equal(typeof settle.refsGeneration, 'number');
+      assert.equal(settle.refsGeneration, undefined);
       assert.match(settle.hint ?? '', /kept changing/);
-      const added = settle.diff?.lines.find((line) => line.kind === 'added');
-      assert.match(added?.text ?? '', /Done/);
-      assert.equal(added?.ref, 'e2');
-
-      const followUp = await daemon.callCommand('press', ['@e2'], {});
-      const followUpData = assertRpcOk(followUp);
-      assert.equal(followUpData.warning, undefined);
-      assert.equal(followUpData.x, 200);
-      assert.equal(followUpData.y, 522);
+      assert.equal(settle.diff, undefined);
 
       runnerTranscript.assertComplete();
     },

--- a/test/skillgym/README.md
+++ b/test/skillgym/README.md
@@ -40,11 +40,14 @@ Skill-guidance regression cases cover distinct command-planning habits:
 
 - read-only inspection versus mutation
 - fresh `@ref` targeting, durable selectors, raw-rect fallbacks, and off-screen scroll recovery
+- interpreting representative `agent-device` output, including settled diffs, not-settled hints, and private-AX recovery warnings
 - text replacement, append semantics, supported field clearing, keyboard status, and keyboard fallback
 - install/open setup, Expo Go/dev-client launch paths, app discovery, session scoping, and app-owned navigation fallbacks
 - Metro reload, logs, network dump, alert fallback, and screenshot evidence
 - performance metrics, React DevTools profiling, gestures, settings, and trace capture
 - remote config, macOS menu bar surfaces, replay update, same-session mutation ordering, and batch schema/recording
+
+Use SkillGym for stable behavior regressions: can a runner choose the right next command from help, app-contract facts, or representative CLI output? For rapid help-layout A/B testing, prefer the lighter help conformance bench because it can feed only the top-level first screen or one help topic without letting the runner read the full help page.
 
 `assertAgentDeviceEvidence` is intentionally soft when a runner does not expose skill-detection telemetry. When telemetry exists, the suite asserts that `agent-device` was loaded; when it is absent, the cases still judge command-planning output instead of failing on missing runner metadata.
 

--- a/test/skillgym/suites/agent-device-smoke-suite.ts
+++ b/test/skillgym/suites/agent-device-smoke-suite.ts
@@ -1018,8 +1018,6 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       /(?:^|\n)(?:agent-device\s+)?snapshot\b[\s\S]*(?:^|\n)(?:agent-device\s+)?snapshot\b/i,
       RAW_COORDINATE_TARGET,
     ],
-    strictFinalOutput: true,
-    allowOnlyLocalCliHelpCommands: true,
   }),
   makeCase({
     id: 'raw-output-before-shell-projection',
@@ -1080,7 +1078,93 @@ const SKILL_GUIDANCE_CASES: Case[] = [
       plannedCommand('is'),
       plannedCommandAlternatives(['press', 'click']),
     ],
-    strictFinalOutput: true,
+  }),
+  makeCase({
+    id: 'sample-output-settled-diff-next-target',
+    contract: [
+      'App name: Agent Device Tester',
+      'Previous command output is from agent-device, not a task description',
+      'Need to continue from the settled diff without taking another snapshot',
+      'Need to open the matching account result',
+    ],
+    task: `Read this previous agent-device output, then plan the next command:
+
+agent-device fill 'id="account-search"' "callstack" --settle
+Filled id="account-search" with "callstack"
+settled:true refsGeneration: 12
+Changed:
++ @e64 [button] "@callstack.com"
++ @e65 [text] "Callstack"
+
+Use the result ref exposed by the settled diff to open the account with settle. Do not re-read the same screen first.`,
+    outputs: [
+      plannedCommandAlternatives(['press', 'click', 'tap']),
+      /@e64(?:~s12)?\b|label=(?:["']@callstack\.com["']|@callstack\.com)/i,
+      /--settle\b/i,
+    ],
+    forbiddenOutputs: [
+      plannedCommand('snapshot'),
+      plannedCommand('wait stable'),
+      plannedCommand('fill'),
+      RAW_COORDINATE_TARGET,
+    ],
+    allowOnlyLocalCliHelpCommands: true,
+  }),
+  makeCase({
+    id: 'sample-output-not-settled-needs-observe',
+    contract: [
+      'App name: Agent Device Tester',
+      'Previous command output is from agent-device, not a task description',
+      'The next target is unknown because no settled tree was printed',
+      'Old refs may be stale after the mutation',
+    ],
+    task: `Read this previous agent-device output, then plan the next command:
+
+agent-device press @e12 --settle
+Pressed @e12
+not settled after 10000ms
+Hint: UI kept changing. Run agent-device wait stable or agent-device snapshot -i before the next ref-based action.
+
+Follow the output hint before attempting another ref-based action.`,
+    outputs: [/(?:^|\n)(?:agent-device\s+)?(?:wait\s+stable|snapshot\b[^\n]*-i\b)/i],
+    forbiddenOutputs: [
+      /(?:^|\n)(?:agent-device\s+)?(?:press|click|fill|longpress)\s+@e\d+/i,
+      RAW_COORDINATE_TARGET,
+      SHELL_OUTPUT_PROJECTION,
+    ],
+    allowOnlyLocalCliHelpCommands: true,
+  }),
+  makeCase({
+    id: 'sample-output-private-ax-recovery-continues',
+    contract: [
+      'Platform: iOS',
+      'Previous command output is from agent-device, not a task description',
+      'The fallback snapshot still exposed an actionable Search button',
+      'Need to open Search and observe the resulting UI',
+    ],
+    task: `Read this previous agent-device output, then plan the next command:
+
+agent-device snapshot -i
+Recovered this snapshot with the private-ax accessibility backend.
+Detected overly complex accessibility tree. Falling back to another snapshot backend.
+It's OK to continue. For more information, rerun with --debug.
+
+@e5 [button] "Search"
+@e8 [tab] "Home" selected
+
+Treat the recovery message as a warning, not a fatal error. Use the exposed Search button.`,
+    outputs: [
+      plannedCommandAlternatives(['press', 'click', 'tap']),
+      /@e5\b|label=(?:["']Search["']|Search)/i,
+      /(?:--settle\b|(?:^|\n)(?:agent-device\s+)?snapshot\b[^\n]*-i\b)/i,
+    ],
+    forbiddenOutputs: [
+      /--debug|--verbose/i,
+      plannedCommand('screenshot'),
+      plannedCommand('close'),
+      plannedCommand('help'),
+      RAW_COORDINATE_TARGET,
+    ],
     allowOnlyLocalCliHelpCommands: true,
   }),
   makeCase({


### PR DESCRIPTION
## Summary

Improve post-action settle behavior and agent guidance.

- Keep unsettled settle responses diff-less with clearer recovery hints, and reset settle budget once after private-AX recovery.
- Rework top-level/help workflow guidance around `--settle`, add `manual-qa` and `validate` help topics, and add a small help conformance benchmark.
- Add SkillGym coverage for interpreting representative agent-device output: settled diffs, not-settled hints, and private-AX recovery warnings.

## Validation

- `git diff --check origin/main...HEAD`
- `./node_modules/.bin/tsgo --noEmit -p tsconfig.json`
- `./node_modules/.bin/vitest run src/cli/parser/__tests__ src/utils/__tests__/command-schema-guards.test.ts src/commands/interaction/output.test.ts`
- `./node_modules/.bin/tsdown`
- `node scripts/help-conformance-bench.mjs --dry-run --cases raw-first-screen-bluesky,manual-qa-bluesky-script --runners claude:claude-haiku-4-5`
- Focused SkillGym/Haiku checks run before rebase with equivalent `skillgym run`: `sample-output-settled-diff-next-target`, `sample-output-not-settled-needs-observe`, `sample-output-private-ax-recovery-continues`, `network-search-settle-then-wait`, `settle-diff-is-observation`.
