### PR TITLE
fix: narrow client result contracts

### DIFF
--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,9 +1,60 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
-import { createAgentDeviceClient, type AgentDeviceClientConfig } from '../client/client.ts';
+import {
+  createAgentDeviceClient,
+  type AgentDeviceClient,
+  type AgentDeviceClientConfig,
+  type PrepareCommandResult,
+  type PushCommandResult,
+  type TriggerAppEventCommandResult,
+  type WaitCommandResult,
+} from '../client/client.ts';
 import { runCommand } from '../commands/command-surface.ts';
+import type { CommandResult } from '../core/command-descriptor/command-result.ts';
 import type { DaemonRequest, DaemonResponse, DaemonResponseData } from '../kernel/contracts.ts';
 import { AppError } from '../kernel/errors.ts';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+const closedProjectionResponses: Record<string, DaemonResponseData> = {
+  wait: { waitedMs: 25, text: 'Ready' },
+  prepare: {
+    action: 'ios-runner',
+    platform: 'ios',
+    deviceId: 'SIM-001',
+    deviceName: 'iPhone 16',
+    kind: 'simulator',
+    durationMs: 30,
+    runner: { uptimeMs: 42 },
+    cache: 'exact',
+    artifact: 'valid',
+    buildMs: 10,
+    connectMs: 20,
+    healthCheckMs: 10,
+    xctestrunPath: '/tmp/AgentDevice.xctestrun',
+    timing: {
+      totalMs: 30,
+      additiveParts: { buildMs: 10, connectAfterBuildMs: 10, healthCheckMs: 10 },
+      containment: { connectMs: ['buildMs'], healthCheckMs: [] },
+      note: 'Use additiveParts.',
+    },
+    message: 'Prepared Apple runner: iPhone 16',
+  },
+  push: {
+    platform: 'android',
+    package: 'com.example.demo',
+    action: 'com.example.demo.TEST_PUSH',
+    extrasCount: 1,
+    message: 'Pushed notification to com.example.demo',
+  },
+  'trigger-app-event': {
+    event: 'screenshot_taken',
+    eventUrl: 'demo://agent-device/event?name=screenshot_taken',
+    transport: 'deep-link',
+    message: 'Triggered app event: screenshot_taken',
+  },
+};
 
 function createTransport(
   handler: (req: Omit<DaemonRequest, 'token'>) => Promise<DaemonResponse> | DaemonResponse,
@@ -33,6 +84,43 @@ function createTransport(
       return await handler(req);
     },
   };
+}
+
+test('client exposes narrowed result types for closed daemon projections', async () => {
+  const setup = createTransport(async (req) => closedProjectionResponse(req.command));
+  const client = createAgentDeviceClient(setup.config, { transport: setup.transport });
+
+  const waitResult = await client.command.wait({ durationMs: 25 });
+  const prepareResult = await client.command.prepare({ action: 'ios-runner' });
+  const pushResult = await client.apps.push({
+    app: 'com.example.demo',
+    payload: { extras: { source: 'test' } },
+  });
+  const triggerResult = await client.apps.triggerEvent({ event: 'screenshot_taken' });
+
+  const waitType: Equal<typeof waitResult, WaitCommandResult> = true;
+  const prepareType: Equal<typeof prepareResult, PrepareCommandResult> = true;
+  const pushType: Equal<typeof pushResult, PushCommandResult> = true;
+  const triggerType: Equal<typeof triggerResult, TriggerAppEventCommandResult> = true;
+  const clientWaitType: Equal<
+    Awaited<ReturnType<AgentDeviceClient['command']['wait']>>,
+    CommandResult<'wait'>
+  > = true;
+
+  assert.deepEqual(
+    [waitType, prepareType, pushType, triggerType, clientWaitType],
+    [true, true, true, true, true],
+  );
+  assert.deepEqual(waitResult, { waitedMs: 25, text: 'Ready' });
+  assert.equal(prepareResult.timing.additiveParts.connectAfterBuildMs, 10);
+  assert.equal(pushResult.platform, 'android');
+  assert.equal(triggerResult.transport, 'deep-link');
+});
+
+function closedProjectionResponse(command: string): DaemonResponse {
+  const data = closedProjectionResponses[command];
+  if (!data) throw new Error(`Unexpected command: ${command}`);
+  return { ok: true, data };
 }
 
 test('apps.open resolves session device identifiers from open response', async () => {

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -1,5 +1,6 @@
 import type { AlertAction, AlertInfo } from './alert-contract.ts';
 import type { AppsFilter } from './contracts/app-inventory.ts';
+import type { JsonObject } from './contracts/json.ts';
 import type { Point, SnapshotNode, SnapshotOptions, SnapshotState } from './kernel/snapshot.ts';
 import type { NetworkIncludeMode } from './kernel/contracts.ts';
 import type { DeviceTarget, Platform, PlatformSelector, PublicPlatform } from './kernel/device.ts';
@@ -225,7 +226,7 @@ export type BackendAppState = {
 export type BackendPushInput =
   | {
       kind: 'json';
-      payload: Record<string, unknown>;
+      payload: JsonObject;
     }
   | {
       kind: 'file';
@@ -234,7 +235,7 @@ export type BackendPushInput =
 
 export type BackendAppEvent = {
   name: string;
-  payload?: Record<string, unknown>;
+  payload?: JsonObject;
 };
 
 export type BackendDeviceFilter = {

--- a/src/client/client-types.ts
+++ b/src/client/client-types.ts
@@ -51,6 +51,7 @@ export type { TargetShutdownResult } from '../target-shutdown-contract.ts';
 import type { PerfAction, PerfArea, PerfKind, PerfSubject } from '../contracts/perf.ts';
 import type { AlertAction, AlertInfo } from '../alert-contract.ts';
 import type { DebugSymbolsOptions, DebugSymbolsResult } from '../contracts/debug-symbols.ts';
+import type { JsonObject } from '../contracts/json.ts';
 import type {
   CloudProviderProfileFields,
   RemoteConnectionProfileFields,
@@ -76,6 +77,11 @@ export type {
 export type { ClipboardCommandResult } from '../contracts/clipboard.ts';
 export type { AppStateCommandResult } from '../contracts/app-state.ts';
 export type { KeyboardCommandResult } from '../contracts/keyboard.ts';
+export type { WaitCommandResult } from '../contracts/wait.ts';
+export type { PrepareCommandResult } from '../contracts/prepare.ts';
+export type { PushCommandResult } from '../contracts/push.ts';
+export type { TriggerAppEventCommandResult } from '../contracts/app-events.ts';
+export type { JsonObject, JsonPrimitive, JsonValue } from '../contracts/json.ts';
 
 export type AgentDeviceDaemonTransport = (
   req: Omit<DaemonRequest, 'token'>,
@@ -561,7 +567,7 @@ export type ViewportCommandOptions = DeviceCommandBaseOptions & {
 };
 
 export type AgentDeviceCommandClient = {
-  wait: (options: WaitCommandOptions) => Promise<CommandRequestResult>;
+  wait: (options: WaitCommandOptions) => Promise<CommandResult<'wait'>>;
   alert: (options?: AlertCommandOptions) => Promise<CommandRequestResult>;
   appState: (options?: AppStateCommandOptions) => Promise<CommandResult<'appstate'>>;
   back: (options?: BackCommandOptions) => Promise<CommandResult<'back'>>;
@@ -577,7 +583,7 @@ export type AgentDeviceCommandClient = {
    * JSON prepare results include timing.additiveParts for additive wall-clock phases.
    * Top-level buildMs/connectMs/healthCheckMs are diagnostics and may overlap.
    */
-  prepare: (options: PrepareCommandOptions) => Promise<CommandRequestResult>;
+  prepare: (options: PrepareCommandOptions) => Promise<CommandResult<'prepare'>>;
   viewport: (options: ViewportCommandOptions) => Promise<CommandResult<'viewport'>>;
 };
 
@@ -628,12 +634,12 @@ export type DeviceShutdownOptions = DeviceCommandBaseOptions;
 
 export type AppPushOptions = DeviceCommandBaseOptions & {
   app: string;
-  payload: string | Record<string, unknown>;
+  payload: string | JsonObject;
 };
 
 export type AppTriggerEventOptions = DeviceCommandBaseOptions & {
   event: string;
-  payload?: Record<string, unknown>;
+  payload?: JsonObject;
 };
 
 export type CaptureDiffOptions = DeviceCommandBaseOptions &
@@ -1047,8 +1053,8 @@ export type AgentDeviceClient = {
     list: (options?: AppListOptions) => Promise<string[]>;
     open: (options: AppOpenOptions) => Promise<AppOpenResult>;
     close: (options?: AppCloseOptions) => Promise<AppCloseResult>;
-    push: (options: AppPushOptions) => Promise<CommandRequestResult>;
-    triggerEvent: (options: AppTriggerEventOptions) => Promise<CommandRequestResult>;
+    push: (options: AppPushOptions) => Promise<CommandResult<'push'>>;
+    triggerEvent: (options: AppTriggerEventOptions) => Promise<CommandResult<'trigger-app-event'>>;
   };
   materializations: {
     release: (options: MaterializationReleaseOptions) => Promise<MaterializationReleaseResult>;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -117,12 +117,13 @@ export function createAgentDeviceClient(
 
   return {
     command: {
-      wait: async (options) => await executeCommand('wait', options),
+      wait: async (options) => await executeCommand<CommandResult<'wait'>>('wait', options),
       alert: async (options = {}) => await executeCommand('alert', options),
       ...projectedSystemCommands,
       reactNative: async (options) => await executeCommand('react-native', options),
       doctor: async (options = {}) => await executeCommand('doctor', options),
-      prepare: async (options) => await executeCommand('prepare', options),
+      prepare: async (options) =>
+        await executeCommand<CommandResult<'prepare'>>('prepare', options),
       viewport: async (options) =>
         await executeCommand<CommandResult<'viewport'>>('viewport', options),
     },
@@ -226,8 +227,9 @@ export function createAgentDeviceClient(
           identifiers: { session },
         };
       },
-      push: async (options) => await executeCommand('push', options),
-      triggerEvent: async (options) => await executeCommand('trigger-app-event', options),
+      push: async (options) => await executeCommand<CommandResult<'push'>>('push', options),
+      triggerEvent: async (options) =>
+        await executeCommand<CommandResult<'trigger-app-event'>>('trigger-app-event', options),
     },
     materializations: {
       release: async (options: MaterializationReleaseOptions) =>

--- a/src/commands/__tests__/command-surface-metadata.test.ts
+++ b/src/commands/__tests__/command-surface-metadata.test.ts
@@ -54,6 +54,16 @@ test('common command input accepts web platform selector', () => {
   assert.equal(input.platform, 'web');
 });
 
+test('trigger-app-event rejects non-object payloads at command input read time', () => {
+  const metadata = listCommandMetadata().find((entry) => entry.name === 'trigger-app-event');
+  if (!metadata) throw new Error('Expected trigger-app-event command metadata');
+
+  assert.throws(
+    () => metadata.readInput({ event: 'screenshot_taken', payload: 'not-json-object' }),
+    /Expected payload to be an object\./,
+  );
+});
+
 test('command response data transforms reference command input fields', () => {
   const metadataByName = new Map<string, ReturnType<typeof listCommandMetadata>[number]>(
     listCommandMetadata().map((metadata) => [metadata.name, metadata] as const),

--- a/src/commands/management/push.ts
+++ b/src/commands/management/push.ts
@@ -1,10 +1,12 @@
 import { PUBLIC_COMMANDS } from '../../command-catalog.ts';
 import type { AppPushOptions, AppTriggerEventOptions } from '../../client/client-types.ts';
+import type { JsonObject } from '../../contracts/json.ts';
 import type { CommandSchemaOverride } from '../../utils/cli-command-schema-types.ts';
 import {
   jsonSchemaField,
   looseObjectField,
   looseObjectSchema,
+  type CommandField,
   requiredField,
   stringField,
   stringSchema,
@@ -23,7 +25,7 @@ import { defineFieldCommandMetadata } from '../field-command-contract.ts';
 const pushCommandMetadata = defineFieldCommandMetadata('push', 'Deliver a push payload.', {
   app: requiredField(stringField()),
   payload: requiredField(
-    jsonSchemaField<string | Record<string, unknown>>({
+    jsonSchemaField<string | JsonObject>({
       oneOf: [stringSchema(), looseObjectSchema()],
     }),
   ),
@@ -34,7 +36,7 @@ const triggerAppEventCommandMetadata = defineFieldCommandMetadata(
   'Trigger an app-defined event.',
   {
     event: requiredField(stringField()),
-    payload: looseObjectField(),
+    payload: jsonObjectField(),
   },
 );
 
@@ -112,4 +114,8 @@ function pushPositionals(input: AppPushOptions): string[] {
 
 function triggerEventPositionals(input: AppTriggerEventOptions): string[] {
   return [input.event, ...(input.payload ? [JSON.stringify(input.payload)] : [])];
+}
+
+function jsonObjectField(): CommandField<JsonObject> {
+  return looseObjectField() as CommandField<JsonObject>;
 }

--- a/src/commands/management/runtime/apps.test.ts
+++ b/src/commands/management/runtime/apps.test.ts
@@ -6,6 +6,7 @@ import type {
   BackendOpenTarget,
   BackendPushInput,
 } from '../../../backend.ts';
+import type { JsonObject } from '../../../contracts/json.ts';
 import { createLocalArtifactAdapter } from '../../../io.ts';
 import {
   createAgentDevice,
@@ -108,7 +109,7 @@ test('runtime app push rejects local payload paths under restricted policy', asy
   assert.equal(pushCalled, false);
 });
 
-test('runtime app commands validate JSON payloads', async () => {
+test('runtime app commands reject invalid event names', async () => {
   const device = createAgentDevice({
     backend: createAppsBackend([]),
     artifacts: createLocalArtifactAdapter(),
@@ -119,11 +120,16 @@ test('runtime app commands validate JSON payloads', async () => {
     () => device.apps.triggerEvent({ name: 'bad event' }),
     /Invalid apps\.triggerEvent name/,
   );
+});
+
+test('runtime app push validates JSON payloads', async () => {
+  const device = createAppsRuntimeDevice();
+
   await assert.rejects(
     () =>
       device.apps.push({
         app: 'com.example.app',
-        input: { kind: 'json', payload: [] as unknown as Record<string, unknown> },
+        input: { kind: 'json', payload: [] as unknown as JsonObject },
       }),
     /JSON payload must be a JSON object/,
   );
@@ -133,7 +139,7 @@ test('runtime app commands validate JSON payloads', async () => {
         app: 'com.example.app',
         input: {
           kind: 'json',
-          payload: { count: 1n } as unknown as Record<string, unknown>,
+          payload: { count: 1n } as unknown as JsonObject,
         },
       }),
     /JSON payload must be JSON-serializable/,
@@ -144,7 +150,7 @@ test('runtime app commands validate JSON payloads', async () => {
         app: 'com.example.app',
         input: {
           kind: 'json',
-          payload: { toJSON: () => undefined } as unknown as Record<string, unknown>,
+          payload: { toJSON: () => undefined } as unknown as JsonObject,
         },
       }),
     /JSON payload must be JSON-serializable/,
@@ -162,9 +168,22 @@ test('runtime app commands validate JSON payloads', async () => {
   );
   await assert.rejects(
     () =>
+      device.apps.push({
+        app: 'com.example.app',
+        input: undefined as unknown as Parameters<typeof device.apps.push>[0]['input'],
+      }),
+    /apps\.push requires an input/,
+  );
+});
+
+test('runtime app events validate JSON payloads', async () => {
+  const device = createAppsRuntimeDevice();
+
+  await assert.rejects(
+    () =>
       device.apps.triggerEvent({
         name: 'example.ready',
-        payload: { count: 1n } as unknown as Record<string, unknown>,
+        payload: { count: 1n } as unknown as JsonObject,
       }),
     /payload for "example.ready" must be JSON-serializable/,
   );
@@ -172,7 +191,7 @@ test('runtime app commands validate JSON payloads', async () => {
     () =>
       device.apps.triggerEvent({
         name: 'example.ready',
-        payload: { toJSON: () => undefined } as unknown as Record<string, unknown>,
+        payload: { toJSON: () => undefined } as unknown as JsonObject,
       }),
     /payload for "example.ready" must be JSON-serializable/,
   );
@@ -184,15 +203,15 @@ test('runtime app commands validate JSON payloads', async () => {
       }),
     /payload for "example.ready" exceeds 8192 bytes/,
   );
-  await assert.rejects(
-    () =>
-      device.apps.push({
-        app: 'com.example.app',
-        input: undefined as unknown as Parameters<typeof device.apps.push>[0]['input'],
-      }),
-    /apps\.push requires an input/,
-  );
 });
+
+function createAppsRuntimeDevice() {
+  return createAgentDevice({
+    backend: createAppsBackend([]),
+    artifacts: createLocalArtifactAdapter(),
+    policy: localCommandPolicy(),
+  });
+}
 
 function createAppsBackend(calls: unknown[]): AgentDeviceBackend {
   return {

--- a/src/commands/management/runtime/apps.ts
+++ b/src/commands/management/runtime/apps.ts
@@ -6,6 +6,7 @@ import type {
   BackendOpenTarget,
   BackendPushInput,
 } from '../../../backend.ts';
+import type { JsonObject } from '../../../contracts/json.ts';
 import type { FileInputRef } from '../../../io.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import { assertResolvedAppsFilter } from '../app-inventory-contract.ts';
@@ -66,7 +67,7 @@ export type GetAppStateCommandResult = {
 export type AppPushInput =
   | {
       kind: 'json';
-      payload: Record<string, unknown>;
+      payload: JsonObject;
     }
   | FileInputRef;
 
@@ -83,13 +84,13 @@ export type PushAppCommandResult = {
 
 export type TriggerAppEventCommandOptions = CommandContext & {
   name: string;
-  payload?: Record<string, unknown>;
+  payload?: JsonObject;
 };
 
 export type TriggerAppEventCommandResult = {
   kind: 'appEventTriggered';
   name: string;
-  payload?: Record<string, unknown>;
+  payload?: JsonObject;
 } & BackendResultEnvelope;
 
 export const openAppCommand: RuntimeCommand<OpenAppCommandOptions, OpenAppCommandResult> = async (
@@ -322,16 +323,12 @@ function requireAppEventName(name: string): string {
   return normalized;
 }
 
-function assertPayload(payload: Record<string, unknown> | undefined, field: string): void {
+function assertPayload(payload: JsonObject | undefined, field: string): void {
   if (payload === undefined) return;
   validateJsonObjectPayload(payload, field, MAX_APP_EVENT_PAYLOAD_BYTES);
 }
 
-function validateJsonObjectPayload(
-  payload: Record<string, unknown>,
-  field: string,
-  maxBytes: number,
-): void {
+function validateJsonObjectPayload(payload: JsonObject, field: string, maxBytes: number): void {
   assertJsonObject(payload, field);
   const payloadBytes = Buffer.byteLength(stringifyJsonObject(payload, field), 'utf8');
   if (payloadBytes > maxBytes) {
@@ -339,13 +336,13 @@ function validateJsonObjectPayload(
   }
 }
 
-function assertJsonObject(payload: Record<string, unknown>, field: string): void {
+function assertJsonObject(payload: JsonObject, field: string): void {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
     throw new AppError('INVALID_ARGS', `${field} must be a JSON object`);
   }
 }
 
-function stringifyJsonObject(payload: Record<string, unknown>, field: string): string {
+function stringifyJsonObject(payload: JsonObject, field: string): string {
   try {
     const serialized = JSON.stringify(payload);
     if (typeof serialized !== 'string') {

--- a/src/contracts/app-events.ts
+++ b/src/contracts/app-events.ts
@@ -1,0 +1,6 @@
+export type TriggerAppEventCommandResult = {
+  event: string;
+  eventUrl: string;
+  transport: 'deep-link';
+  message: string;
+};

--- a/src/contracts/json.ts
+++ b/src/contracts/json.ts
@@ -1,0 +1,3 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };

--- a/src/contracts/prepare.ts
+++ b/src/contracts/prepare.ts
@@ -1,0 +1,41 @@
+import type { DeviceKind, PublicPlatform } from '../kernel/device.ts';
+import type { JsonObject } from './json.ts';
+
+export type PrepareIosRunnerCacheKind = 'exact' | 'restore-key' | 'miss' | 'external';
+export type PrepareIosRunnerArtifactState = 'valid' | 'rebuilt';
+
+export type PrepareIosRunnerTiming = {
+  totalMs: number;
+  additiveParts: {
+    buildMs?: number;
+    connectAfterBuildMs: number;
+    healthCheckMs: number;
+  };
+  containment: { connectMs?: ['buildMs']; healthCheckMs: [] };
+  note: string;
+};
+
+/**
+ * Public daemon result for `prepare ios-runner`. The runner-local prepare result
+ * is projected by `prepareIosRunnerResponseData` with device identity and timing
+ * guidance before it reaches the client.
+ */
+export type PrepareCommandResult = {
+  action: 'ios-runner';
+  platform: PublicPlatform;
+  deviceId: string;
+  deviceName: string;
+  kind: DeviceKind;
+  durationMs: number;
+  runner: JsonObject;
+  cache?: PrepareIosRunnerCacheKind;
+  artifact?: PrepareIosRunnerArtifactState;
+  buildMs?: number;
+  connectMs: number;
+  healthCheckMs: number;
+  xctestrunPath?: string;
+  recoveryReason?: string;
+  failureReason?: string;
+  timing: PrepareIosRunnerTiming;
+  message: string;
+};

--- a/src/contracts/push.ts
+++ b/src/contracts/push.ts
@@ -1,0 +1,13 @@
+export type PushCommandResult =
+  | {
+      platform: 'ios';
+      bundleId: string;
+      message: string;
+    }
+  | {
+      platform: 'android';
+      package: string;
+      action: string;
+      extrasCount: number;
+      message: string;
+    };

--- a/src/contracts/wait.ts
+++ b/src/contracts/wait.ts
@@ -1,0 +1,16 @@
+/**
+ * Public daemon result for `wait`. The runtime-local result carries a `kind`
+ * discriminant, but `toDaemonWaitData` intentionally projects the normal daemon
+ * payload to this compact shape. The direct iOS selector fast path may still
+ * include `kind: 'selector'` additively.
+ */
+export type WaitCommandResult = {
+  waitedMs: number;
+  kind?: 'selector';
+  text?: string;
+  selector?: string;
+  captures?: number;
+  nodeCount?: number;
+  hint?: string;
+  warning?: string;
+};

--- a/src/core/app-events.ts
+++ b/src/core/app-events.ts
@@ -1,5 +1,6 @@
 import { isIosFamily, isMacOs, publicPlatformString, type DeviceInfo } from '../kernel/device.ts';
 import { AppError } from '../kernel/errors.ts';
+import type { JsonObject } from '../contracts/json.ts';
 
 type AppEventDevice = Pick<DeviceInfo, 'platform' | 'appleOs'>;
 
@@ -7,7 +8,7 @@ const APP_EVENT_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
 const MAX_APP_EVENT_PAYLOAD_BYTES = 8 * 1024;
 const MAX_APP_EVENT_URL_LENGTH = 4 * 1024;
 
-type AppEventPayload = Record<string, unknown> | undefined;
+type AppEventPayload = JsonObject | undefined;
 
 export function parseTriggerAppEventArgs(positionals: string[]): {
   eventName: string;
@@ -85,7 +86,7 @@ function parseTriggerEventPayload(
         `trigger-app-event payload for "${eventName}" exceeds ${MAX_APP_EVENT_PAYLOAD_BYTES} bytes`,
       );
     }
-    return parsed as Record<string, unknown>;
+    return parsed as JsonObject;
   } catch (error) {
     if (error instanceof AppError) throw error;
     throw new AppError('INVALID_ARGS', `Invalid trigger-app-event payload JSON: ${payloadArg}`);

--- a/src/core/command-descriptor/__tests__/command-result.test.ts
+++ b/src/core/command-descriptor/__tests__/command-result.test.ts
@@ -16,6 +16,10 @@ import type {
 import type { ClipboardCommandResult } from '../../../contracts/clipboard.ts';
 import type { AppStateCommandResult } from '../../../contracts/app-state.ts';
 import type { KeyboardCommandResult } from '../../../contracts/keyboard.ts';
+import type { WaitCommandResult } from '../../../contracts/wait.ts';
+import type { PrepareCommandResult } from '../../../contracts/prepare.ts';
+import type { PushCommandResult } from '../../../contracts/push.ts';
+import type { TriggerAppEventCommandResult } from '../../../contracts/app-events.ts';
 import type { CommandResult, CommandResultMap } from '../command-result.ts';
 
 /**
@@ -42,6 +46,13 @@ test('seeded CommandResult entries resolve to their existing contract result typ
   const appstate: Equal<CommandResult<'appstate'>, AppStateCommandResult> = true;
   const keyboard: Equal<CommandResult<'keyboard'>, KeyboardCommandResult> = true;
   const tvRemote: Equal<CommandResult<'tv-remote'>, TvRemoteCommandResult> = true;
+  const wait: Equal<CommandResult<'wait'>, WaitCommandResult> = true;
+  const prepare: Equal<CommandResult<'prepare'>, PrepareCommandResult> = true;
+  const push: Equal<CommandResult<'push'>, PushCommandResult> = true;
+  const triggerAppEvent: Equal<
+    CommandResult<'trigger-app-event'>,
+    TriggerAppEventCommandResult
+  > = true;
   expect([
     press,
     fill,
@@ -57,7 +68,30 @@ test('seeded CommandResult entries resolve to their existing contract result typ
     appstate,
     keyboard,
     tvRemote,
-  ]).toEqual([true, true, true, true, true, true, true, true, true, true, true, true, true, true]);
+    wait,
+    prepare,
+    push,
+    triggerAppEvent,
+  ]).toEqual([
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+  ]);
 });
 
 test('unmigrated commands fall back to the untyped Record bag, keeping the union total', () => {
@@ -84,6 +118,10 @@ test('CommandResultMap is seeded only from already-existing contract result type
     | 'appstate'
     | 'keyboard'
     | 'tv-remote'
+    | 'wait'
+    | 'prepare'
+    | 'push'
+    | 'trigger-app-event'
   > = true;
   expect(keys).toBe(true);
 });

--- a/src/core/command-descriptor/command-result.ts
+++ b/src/core/command-descriptor/command-result.ts
@@ -15,6 +15,10 @@ import type {
 import type { ClipboardCommandResult } from '../../contracts/clipboard.ts';
 import type { AppStateCommandResult } from '../../contracts/app-state.ts';
 import type { KeyboardCommandResult } from '../../contracts/keyboard.ts';
+import type { WaitCommandResult } from '../../contracts/wait.ts';
+import type { PrepareCommandResult } from '../../contracts/prepare.ts';
+import type { PushCommandResult } from '../../contracts/push.ts';
+import type { TriggerAppEventCommandResult } from '../../contracts/app-events.ts';
 
 /**
  * The additive typed-result spine (ADR-0008, Phase 1 step 6).
@@ -31,7 +35,8 @@ import type { KeyboardCommandResult } from '../../contracts/keyboard.ts';
  * interaction trio. Batch 3 adds `clipboard` (a closed `read`/`write` union) and
  * `appstate` (a closed `platform` union — Apple session state with the iOS-only
  * device locators, or Android package/activity). Batch 4 adds `keyboard` (a
- * closed flat shape). Each entry is grounded in a
+ * closed flat shape). Batch 5 adds the compact daemon projections for `wait`,
+ * `prepare`, `push`, and `trigger-app-event`. Each entry is grounded in a
  * re-read of the handler's literal return; see the per-type docstrings.
  */
 export interface CommandResultMap {
@@ -49,6 +54,10 @@ export interface CommandResultMap {
   appstate: AppStateCommandResult;
   keyboard: KeyboardCommandResult;
   'tv-remote': TvRemoteCommandResult;
+  wait: WaitCommandResult;
+  prepare: PrepareCommandResult;
+  push: PushCommandResult;
+  'trigger-app-event': TriggerAppEventCommandResult;
 }
 
 /**

--- a/src/core/dispatch-payload.ts
+++ b/src/core/dispatch-payload.ts
@@ -1,10 +1,9 @@
 import { promises as fs } from 'node:fs';
 import { AppError } from '../kernel/errors.ts';
 import { resolvePayloadInput } from '../utils/payload-input.ts';
+import type { JsonObject } from '../contracts/json.ts';
 
-export async function readNotificationPayload(
-  payloadArg: string,
-): Promise<Record<string, unknown>> {
+export async function readNotificationPayload(payloadArg: string): Promise<JsonObject> {
   const source = resolvePayloadInput(payloadArg, { subject: 'Push payload' });
   const payloadText =
     source.kind === 'inline' ? source.text : await readPushPayloadFile(source.path);
@@ -13,7 +12,7 @@ export async function readNotificationPayload(
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       throw new AppError('INVALID_ARGS', 'push payload must be a JSON object');
     }
-    return parsed as Record<string, unknown>;
+    return parsed as JsonObject;
   } catch (error) {
     if (error instanceof AppError) throw error;
     throw new AppError('INVALID_ARGS', `Invalid push payload JSON: ${payloadArg}`);

--- a/src/daemon/selector-runtime.ts
+++ b/src/daemon/selector-runtime.ts
@@ -373,7 +373,7 @@ async function dispatchDirectIosSelectorWait(
     selectorChain: [selector.raw],
   };
   recordIfSession(params.sessionStore, params.sessionName, params.req, payload);
-  const response: DaemonResponse = { ok: true, data: payload };
+  const response: DaemonResponse = { ok: true, data: stripSelectorChain(payload) };
   return await maybeWaitTimeoutSurfaceResponse(
     { req: params.req, logPath: params.logPath, session: params.session, device: params.device },
     response,

--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import type { AgentDeviceClient } from '../../client/client-types.ts';
 import { createCommandToolExecutor, listCommandTools } from '../command-tools.ts';
+import { COMMAND_OUTPUT_SCHEMAS } from '../command-output-schemas.ts';
 
 test('MCP command tool executor hides client creation behind an execution adapter', async () => {
   const client = {} as AgentDeviceClient;
@@ -234,10 +235,9 @@ test('MCP responseLevel rejects unknown values at the boundary', async () => {
   );
 });
 
-test('MCP typed commands advertise an outputSchema with the contract discriminant', () => {
+test('MCP keyboard outputSchema advertises flat contract discriminants', () => {
   const tools = listCommandTools();
 
-  // keyboard is a flat closed shape: platform + action discriminants at the top.
   const keyboard = tools.find((tool) => tool.name === 'keyboard');
   assert.ok(keyboard);
   assert.ok(keyboard.outputSchema);
@@ -250,8 +250,11 @@ test('MCP typed commands advertise an outputSchema with the contract discriminan
     (keyboard.outputSchema.properties?.platform as { enum?: unknown[] } | undefined)?.enum,
     ['android', 'ios'],
   );
+});
 
-  // clipboard is a discriminated union on `action`, modeled as oneOf branches.
+test('MCP clipboard outputSchema advertises action union branches', () => {
+  const tools = listCommandTools();
+
   const clipboard = tools.find((tool) => tool.name === 'clipboard');
   assert.ok(clipboard);
   assert.ok(clipboard.outputSchema);
@@ -259,6 +262,10 @@ test('MCP typed commands advertise an outputSchema with the contract discriminan
     (branch) => (branch.properties?.action as { const?: unknown } | undefined)?.const,
   );
   assert.deepEqual(clipboardActions, ['read', 'write']);
+});
+
+test('MCP tv remote outputSchema advertises button values', () => {
+  const tools = listCommandTools();
 
   const tvRemote = tools.find((tool) => tool.name === 'tv-remote');
   assert.ok(tvRemote);
@@ -267,6 +274,29 @@ test('MCP typed commands advertise an outputSchema with the contract discriminan
     (tvRemote.outputSchema.properties?.button as { enum?: unknown[] } | undefined)?.enum,
     ['up', 'down', 'left', 'right', 'select', 'menu', 'home', 'back'],
   );
+});
+
+test('MCP newly typed outputSchemas advertise public contract keys', () => {
+  const tools = listCommandTools();
+
+  const wait = tools.find((tool) => tool.name === 'wait');
+  assert.ok(wait);
+  assert.ok(wait.outputSchema);
+  assert.deepEqual(wait.outputSchema.required, ['waitedMs']);
+
+  const triggerAppEvent = tools.find((tool) => tool.name === 'trigger-app-event');
+  assert.ok(triggerAppEvent);
+  assert.ok(triggerAppEvent.outputSchema);
+  assert.equal(
+    (triggerAppEvent.outputSchema.properties?.transport as { const?: unknown } | undefined)?.const,
+    'deep-link',
+  );
+});
+
+test('MCP prepare outputSchema stays complete for the typed non-exposed command', () => {
+  const prepareSchema = COMMAND_OUTPUT_SCHEMAS.prepare;
+  assert.ok(prepareSchema.required?.includes('runner'));
+  assert.ok(prepareSchema.required?.includes('timing'));
 });
 
 test('MCP untyped tools stay byte-identical: no outputSchema key', () => {

--- a/src/mcp/command-output-schemas.ts
+++ b/src/mcp/command-output-schemas.ts
@@ -266,6 +266,111 @@ export const COMMAND_OUTPUT_SCHEMAS = {
     ['action', 'button', 'message'],
   ),
 
+  // src/contracts/wait.ts — compact public daemon projection.
+  wait: objectSchema(
+    {
+      waitedMs: numberSchema(),
+      kind: constSchema('selector'),
+      text: stringSchema(),
+      selector: stringSchema(),
+      captures: numberSchema(),
+      nodeCount: numberSchema(),
+      hint: stringSchema(),
+      warning: stringSchema(),
+    },
+    ['waitedMs'],
+  ),
+
+  // src/contracts/prepare.ts — prepare is not MCP-exposed, but the schema stays
+  // map-complete with CommandResultMap.
+  prepare: objectSchema(
+    {
+      action: constSchema('ios-runner'),
+      platform: enumSchema(PLATFORMS),
+      deviceId: stringSchema(),
+      deviceName: stringSchema(),
+      kind: enumSchema(DEVICE_KINDS),
+      durationMs: numberSchema(),
+      runner: objectSchema({}, []),
+      cache: enumSchema(['exact', 'restore-key', 'miss', 'external']),
+      artifact: enumSchema(['valid', 'rebuilt']),
+      buildMs: numberSchema(),
+      connectMs: numberSchema(),
+      healthCheckMs: numberSchema(),
+      xctestrunPath: stringSchema(),
+      recoveryReason: stringSchema(),
+      failureReason: stringSchema(),
+      timing: objectSchema(
+        {
+          totalMs: numberSchema(),
+          additiveParts: objectSchema(
+            {
+              buildMs: numberSchema(),
+              connectAfterBuildMs: numberSchema(),
+              healthCheckMs: numberSchema(),
+            },
+            ['connectAfterBuildMs', 'healthCheckMs'],
+          ),
+          containment: objectSchema(
+            {
+              connectMs: { type: 'array', items: constSchema('buildMs') },
+              healthCheckMs: { type: 'array', items: stringSchema() },
+            },
+            ['healthCheckMs'],
+          ),
+          note: stringSchema(),
+        },
+        ['totalMs', 'additiveParts', 'containment', 'note'],
+      ),
+      message: stringSchema(),
+    },
+    [
+      'action',
+      'platform',
+      'deviceId',
+      'deviceName',
+      'kind',
+      'durationMs',
+      'runner',
+      'connectMs',
+      'healthCheckMs',
+      'timing',
+      'message',
+    ],
+  ),
+
+  // src/contracts/push.ts — discriminated union on public platform.
+  push: {
+    type: 'object',
+    oneOf: [
+      objectSchema(
+        { platform: constSchema('ios'), bundleId: stringSchema(), message: stringSchema() },
+        ['platform', 'bundleId', 'message'],
+      ),
+      objectSchema(
+        {
+          platform: constSchema('android'),
+          package: stringSchema(),
+          action: stringSchema(),
+          extrasCount: numberSchema(),
+          message: stringSchema(),
+        },
+        ['platform', 'package', 'action', 'extrasCount', 'message'],
+      ),
+    ],
+  },
+
+  // src/contracts/app-events.ts
+  'trigger-app-event': objectSchema(
+    {
+      event: stringSchema(),
+      eventUrl: stringSchema(),
+      transport: constSchema('deep-link'),
+      message: stringSchema(),
+    },
+    ['event', 'eventUrl', 'transport', 'message'],
+  ),
+
   // src/contracts/clipboard.ts — discriminated union on `action`.
   clipboard: {
     type: 'object',

--- a/test/integration/provider-scenarios/android-lifecycle.test.ts
+++ b/test/integration/provider-scenarios/android-lifecycle.test.ts
@@ -491,6 +491,7 @@ async function runAndroidSetupAndInstallWorkflow(
     },
     ...selection,
   });
+  assert.equal(push.platform, 'android');
   assert.equal(push.package, 'com.example.demo');
   assert.equal(push.action, 'com.example.demo.PUSH');
   assert.equal(push.extrasCount, 3);

--- a/test/integration/provider-scenarios/interaction-direct-selector-fallback.test.ts
+++ b/test/integration/provider-scenarios/interaction-direct-selector-fallback.test.ts
@@ -133,6 +133,31 @@ async function withDirectSelectorScenario(
   );
 }
 
+test('Provider-backed direct iOS selector wait strips selectorChain from the public response', async () => {
+  const transcript = createProviderTranscript([
+    {
+      command: 'ios.runner.querySelector',
+      deviceId: DEVICE_ID,
+      platform: 'apple',
+      request: {
+        command: 'querySelector',
+        selectorKey: 'label',
+        selectorValue: 'Continue',
+        appBundleId: APP,
+      },
+      result: { found: true, node: { label: 'Continue' } },
+    },
+  ]);
+
+  await withDirectSelectorScenario(transcript, async (daemon) => {
+    const wait = await daemon.callCommand('wait', ['label="Continue"']);
+    const data = assertRpcOk(wait);
+    assert.equal(data.kind, 'selector');
+    assert.equal(data.selector, 'label="Continue"');
+    assert.equal('selectorChain' in data, false);
+  });
+});
+
 test('Provider-backed integration runner AMBIGUOUS_MATCH falls back to runtime disambiguation', async () => {
   const transcript = createProviderTranscript([
     // Direct selector tap attempt fails with the runner's semantic shape.


### PR DESCRIPTION
## Summary

Narrow Node client result types for closed daemon projections from #1153.

Adds public contracts for wait, prepare, push, and trigger-app-event, wires them into CommandResultMap and MCP output schemas, and tightens JSON payload typing for push/app-event payloads.

Closes #1153

## Validation

- pnpm typecheck
- pnpm format
- pnpm exec vitest run src/core/command-descriptor/__tests__/command-result.test.ts src/mcp/__tests__/command-tools.test.ts src/__tests__/client.test.ts src/commands/management/runtime/apps.test.ts src/commands/management/index.test.ts src/core/dispatch-payload.test.ts src/core/__tests__/dispatch-trigger-app-event.test.ts
- git diff --check