### PR TITLE
fix: harden iOS XCTest recovery paths

### DIFF
--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Interaction.swift
@@ -51,28 +51,6 @@ extension RunnerTests {
     let usedNonHittableFallback: Bool
   }
 
-  // MARK: - Navigation Gestures
-
-  func tapInAppBackControl(app: XCUIApplication) -> Bool {
-#if os(macOS)
-    if let back = macOSNavigationBackElement(app: app) {
-      tapElementCenter(app: app, element: back)
-      return true
-    }
-    return false
-#elseif os(tvOS)
-    _ = pressTvRemote(.menu)
-    return true
-#else
-    let buttons = app.navigationBars.buttons.allElementsBoundByIndex
-    if let back = buttons.first(where: { $0.isHittable }) {
-      back.tap()
-      return true
-    }
-    return false
-#endif
-  }
-
   func performBackGesture(app: XCUIApplication) {
     if pressTvRemote(.menu) {
       return
@@ -1374,27 +1352,6 @@ extension RunnerTests {
 #endif
   }
 #endif
-
-  private func tapElementCenter(app: XCUIApplication, element: XCUIElement) {
-    let frame = element.frame
-    if !frame.isEmpty {
-      _ = tapAt(app: app, x: frame.midX, y: frame.midY)
-      return
-    }
-#if !os(tvOS)
-    element.tap()
-#endif
-  }
-
-  private func macOSNavigationBackElement(app: XCUIApplication) -> XCUIElement? {
-    let predicate = NSPredicate(
-      format: "identifier == %@ OR label == %@",
-      "go back",
-      "Back"
-    )
-    let element = app.descendants(matching: .any).matching(predicate).firstMatch
-    return element.exists ? element : nil
-  }
 
 #if AGENT_DEVICE_RUNNER_UNIT_TESTS
   // Identity in portrait/unknown, 90° per landscape, 180° upside-down.

--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Navigation.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Navigation.swift
@@ -1,0 +1,239 @@
+import XCTest
+
+extension RunnerTests {
+  static let navigationBackKeywords = ["back", "close", "cancel"]
+  static let navigationFallbackVerificationDelay: TimeInterval = 0.25
+
+  func tapInAppBackControl(app: XCUIApplication) -> Bool {
+#if os(macOS)
+    if let back = macOSNavigationBackElement(app: app) {
+      tapElementCenter(app: app, element: back)
+      return true
+    }
+    return false
+#elseif os(tvOS)
+    _ = pressTvRemote(.menu)
+    return true
+#else
+    let buttons = app.navigationBars.buttons.allElementsBoundByIndex
+    if let back = buttons.first(where: { $0.isHittable }) {
+      back.tap()
+      return true
+    }
+    if isSnapshotXCTestChannelPenalized(bundleId: currentBundleId) {
+      NSLog("AGENT_DEVICE_RUNNER_IN_APP_BACK_SKIPPED_XCTEST_ENUMERATION bundle=%@", currentBundleId ?? "")
+    } else if let back = topNavigationBackElement(app: app) {
+      tapElementCenter(app: app, element: back)
+      return true
+    }
+    return tapTopLeadingNavigationFallback(app: app)
+#endif
+  }
+
+  private func tapElementCenter(app: XCUIApplication, element: XCUIElement) {
+    let frame = element.frame
+    if !frame.isEmpty {
+      _ = tapAt(app: app, x: frame.midX, y: frame.midY)
+      return
+    }
+#if !os(tvOS)
+    element.tap()
+#endif
+  }
+
+  private func topNavigationBackElement(app: XCUIApplication) -> XCUIElement? {
+#if os(iOS)
+    let frame = onScreenWindowFrame(app: app)
+    let candidates = app.buttons.matching(Self.navigationBackPredicate()).allElementsBoundByIndex.compactMap {
+      element -> (XCUIElement, Int)? in
+      guard element.exists, element.isHittable else { return nil }
+      guard Self.isTopNavigationControlFrame(element.frame, in: frame) else { return nil }
+      guard let rank = Self.navigationBackControlRank(
+        label: element.label,
+        identifier: element.identifier
+      ) else {
+        return nil
+      }
+      return (element, rank)
+    }
+    return candidates.sorted { lhs, rhs in
+      if lhs.1 != rhs.1 { return lhs.1 < rhs.1 }
+      let leftFrame = lhs.0.frame
+      let rightFrame = rhs.0.frame
+      if leftFrame.minY != rightFrame.minY { return leftFrame.minY < rightFrame.minY }
+      return leftFrame.minX < rightFrame.minX
+    }.first?.0
+#else
+    return nil
+#endif
+  }
+
+  static func navigationBackPredicate() -> NSPredicate {
+    let clauses = navigationBackKeywords.flatMap { _ in
+      ["label CONTAINS[c] %@", "identifier CONTAINS[c] %@"]
+    }.joined(separator: " OR ")
+    let arguments = navigationBackKeywords.flatMap { [$0, $0] }
+    return NSPredicate(format: clauses, argumentArray: arguments)
+  }
+
+  static func navigationBackControlRank(label: String, identifier: String) -> Int? {
+    let text = "\(label) \(identifier)".lowercased()
+    return navigationBackKeywords.firstIndex { text.contains($0) }
+  }
+
+  static func isTopNavigationControlFrame(_ candidate: CGRect, in window: CGRect) -> Bool {
+    guard
+      candidate.width.isFinite,
+      candidate.height.isFinite,
+      window.width.isFinite,
+      window.height.isFinite,
+      candidate.width > 0,
+      candidate.height > 0,
+      window.width > 0,
+      window.height > 0
+    else {
+      return false
+    }
+    // Accept the compact navigation/search header band without matching deep content controls.
+    let maxY = window.minY + min(max(window.height * 0.22, 96), 180)
+    return candidate.midY >= window.minY && candidate.midY <= maxY
+  }
+
+  static func topLeadingNavigationFallbackPoint(in frame: CGRect) -> CGPoint? {
+    guard frame.width.isFinite, frame.height.isFinite, frame.width > 0, frame.height > 0 else {
+      return nil
+    }
+    // Aim at the standard leading navigation slot, bounded for compact and tablet widths.
+    let xOffset = min(max(frame.width * 0.08, 28), 44)
+    // Sit below the status/dynamic-island region and inside common custom RN search headers.
+    let yOffset = min(max(frame.height * 0.155, 56), 132)
+    return CGPoint(x: frame.minX + xOffset, y: frame.minY + yOffset)
+  }
+
+  private func tapTopLeadingNavigationFallback(app: XCUIApplication) -> Bool {
+#if os(iOS)
+    let frame = onScreenWindowFrame(app: app)
+    guard let point = Self.topLeadingNavigationFallbackPoint(in: frame) else {
+      return false
+    }
+    let before = captureNavigationFallbackVisualState()
+    let context = synthesizedCoordinateContext(
+      policy: synthesizedGesturePolicy(.coordinateTap)
+    )?.withReferenceFrame(frame)
+    let synthesized = performGesture(app, idleTimeout: false) {
+      synthesizedTapAt(app: app, x: point.x, y: point.y, context: context)
+    }
+    if case .performed = synthesized.outcome {
+      return didNavigationFallbackChangeVisualState(before: before)
+    }
+    let fallback = performGesture(app) {
+      tapAt(app: app, x: point.x, y: point.y)
+    }
+    if case .performed = fallback.outcome {
+      return didNavigationFallbackChangeVisualState(before: before)
+    }
+#endif
+    return false
+  }
+
+  private func captureNavigationFallbackVisualState() -> Data? {
+#if os(iOS)
+    runnerPngData(for: XCUIScreen.main.screenshot().image)
+#else
+    return nil
+#endif
+  }
+
+  private func didNavigationFallbackChangeVisualState(before: Data?) -> Bool {
+    sleepFor(Self.navigationFallbackVerificationDelay)
+    let after = captureNavigationFallbackVisualState()
+    let changed = Self.didNavigationFallbackChangeVisualState(before: before, after: after)
+    if !changed {
+      NSLog("AGENT_DEVICE_RUNNER_IN_APP_BACK_FALLBACK_NO_STATE_CHANGE")
+    }
+    return changed
+  }
+
+  static func didNavigationFallbackChangeVisualState(before: Data?, after: Data?) -> Bool {
+    guard let before, let after else { return false }
+    return before != after
+  }
+
+  private func macOSNavigationBackElement(app: XCUIApplication) -> XCUIElement? {
+    let predicate = NSPredicate(
+      format: "identifier == %@ OR label == %@",
+      "go back",
+      "Back"
+    )
+    let element = app.descendants(matching: .any).matching(predicate).firstMatch
+    return element.exists ? element : nil
+  }
+
+#if AGENT_DEVICE_RUNNER_UNIT_TESTS
+  func testTopLeadingNavigationFallbackPointTargetsHeaderControlBand() throws {
+    let point = try XCTUnwrap(
+      Self.topLeadingNavigationFallbackPoint(
+        in: CGRect(x: 0, y: 0, width: 430, height: 932)
+      )
+    )
+
+    XCTAssertEqual(point.x, 34.4, accuracy: 0.01)
+    XCTAssertEqual(point.y, 132, accuracy: 0.01)
+  }
+
+  func testTopLeadingNavigationFallbackPointRejectsInvalidFrame() {
+    XCTAssertNil(Self.topLeadingNavigationFallbackPoint(in: .infinite))
+    XCTAssertNil(Self.topLeadingNavigationFallbackPoint(in: .zero))
+  }
+
+  func testNavigationBackControlRankPrefersBackThenCloseThenCancel() {
+    XCTAssertEqual(Self.navigationBackControlRank(label: "Back", identifier: ""), 0)
+    XCTAssertEqual(Self.navigationBackControlRank(label: "Close", identifier: ""), 1)
+    XCTAssertEqual(Self.navigationBackControlRank(label: "Cancel search", identifier: ""), 2)
+    XCTAssertNil(Self.navigationBackControlRank(label: "Search for more feeds", identifier: ""))
+  }
+
+  func testNavigationBackPredicateUsesTheSharedKeywordTable() {
+    let predicate = Self.navigationBackPredicate()
+
+    XCTAssertTrue(predicate.evaluate(with: ["label": "Back", "identifier": ""]))
+    XCTAssertTrue(predicate.evaluate(with: ["label": "", "identifier": "close-button"]))
+    XCTAssertFalse(predicate.evaluate(with: ["label": "Search for more feeds", "identifier": ""]))
+  }
+
+  func testTopNavigationControlFrameAcceptsOnlyHeaderBand() {
+    let window = CGRect(x: 0, y: 0, width: 430, height: 932)
+
+    XCTAssertTrue(
+      Self.isTopNavigationControlFrame(
+        CGRect(x: 340, y: 84, width: 72, height: 44),
+        in: window
+      )
+    )
+    XCTAssertFalse(
+      Self.isTopNavigationControlFrame(
+        CGRect(x: 20, y: 760, width: 72, height: 44),
+        in: window
+      )
+    )
+    XCTAssertFalse(Self.isTopNavigationControlFrame(.infinite, in: window))
+  }
+
+  func testNavigationFallbackRequiresObservedVisualChange() {
+    XCTAssertTrue(
+      Self.didNavigationFallbackChangeVisualState(
+        before: Data([1, 2, 3]),
+        after: Data([1, 2, 4])
+      )
+    )
+    XCTAssertFalse(
+      Self.didNavigationFallbackChangeVisualState(
+        before: Data([1, 2, 3]),
+        after: Data([1, 2, 3])
+      )
+    )
+    XCTAssertFalse(Self.didNavigationFallbackChangeVisualState(before: nil, after: Data([1])))
+    XCTAssertFalse(Self.didNavigationFallbackChangeVisualState(before: Data([1]), after: nil))
+  }
+#endif
+}

--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+Snapshot.swift
@@ -571,7 +571,8 @@ extension RunnerTests {
   func makeSnapshotTraversalContext(
     app: XCUIApplication,
     options: SnapshotOptions,
-    captureDeadline: Date = .distantFuture
+    captureDeadline: Date = .distantFuture,
+    treeCaptureSliceBudgetOverride: TimeInterval? = nil
   ) throws -> SnapshotTraversalContext? {
     let (viewport, queryRoot) = try runMainThreadWork(
       command: nil,
@@ -584,7 +585,8 @@ extension RunnerTests {
       )
     }
 
-    let slice = min(treeCaptureSliceBudget, max(0.5, captureDeadline.timeIntervalSinceNow))
+    let treeSliceBudget = treeCaptureSliceBudgetOverride ?? treeCaptureSliceBudget
+    let slice = min(treeSliceBudget, max(0.5, captureDeadline.timeIntervalSinceNow))
     guard let rootSnapshot = try captureSnapshotRootBounded(queryRoot, sliceSeconds: slice) else {
       return nil
     }
@@ -600,7 +602,7 @@ extension RunnerTests {
     )
   }
 
-  static let treeCaptureTimeoutCode = "IOS_TREE_CAPTURE_TIMEOUT"
+  static let xCTestSnapshotTimeoutCode = "IOS_TREE_CAPTURE_TIMEOUT"
 
   func hasAbandonedTreeCapture() -> Bool {
     treeCaptureLock.lock()
@@ -611,7 +613,8 @@ extension RunnerTests {
   /// Runs the blocking tree-snapshot XPC on the main thread bounded by `sliceSeconds`. On
   /// timeout the XPC keeps running on main (it cannot be cancelled); the capture is marked
   /// abandoned so plans avoid XCTest-backed tiers until it drains, the tree backend is penalized
-  /// for this bundle, and the plan moves on to the private AX backend (#1105/#1122).
+  /// for this bundle, and the plan moves to the platform's independent recovery tier when one
+  /// exists (#1105/#1122).
   private func captureSnapshotRootBounded(
     _ element: XCUIElement,
     sliceSeconds: TimeInterval
@@ -628,7 +631,7 @@ extension RunnerTests {
         self.abandonedTreeCaptureCount += 1
         self.treeCaptureLock.unlock()
         NSLog("AGENT_DEVICE_RUNNER_TREE_CAPTURE_SLICE_TIMEOUT slice=%.1f", sliceSeconds)
-        self.penalizeSnapshotTreeBackend(
+        self.penalizeSnapshotXCTestChannel(
           bundleId: self.currentBundleId,
           reason: "tree_capture_slice_timeout"
         )
@@ -647,9 +650,9 @@ extension RunnerTests {
   private func treeCaptureTimeoutError(sliceSeconds: TimeInterval) -> () -> Error {
     {
       SnapshotCaptureFailure(
-        code: Self.treeCaptureTimeoutCode,
+        code: Self.xCTestSnapshotTimeoutCode,
         message: "the XCTest tree capture exceeded its \(Int(sliceSeconds))s time slice",
-        hint: "The capture plan recovers through the private AX backend on this screen."
+        hint: "The capture plan will avoid or tightly bound XCTest-backed snapshot tiers on this screen."
       )
     }
   }
@@ -657,7 +660,7 @@ extension RunnerTests {
   func snapshotMainThreadTimeoutError(_ operation: String) -> () -> Error {
     {
       SnapshotCaptureFailure(
-        code: Self.treeCaptureTimeoutCode,
+        code: Self.xCTestSnapshotTimeoutCode,
         message: "timed out while \(operation) on the XCTest main thread",
         hint: "The capture plan will skip XCTest-backed snapshot tiers while the previous main-thread work drains."
       )

--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests+SnapshotCapturePlan.swift
@@ -28,6 +28,40 @@ enum SnapshotBackendKind: String, CaseIterable {
   case recursiveTree = "tree"
   case querySweep = "queries"
   case privateAX = "private-ax"
+
+  var usesXCTestAccessibilityChannel: Bool {
+    switch self {
+    case .recursiveTree, .querySweep:
+      return true
+    case .privateAX:
+      return false
+    }
+  }
+
+  var isAvailableOnCurrentPlatform: Bool {
+    switch self {
+    case .recursiveTree, .querySweep:
+      return true
+    case .privateAX:
+      #if os(iOS) && targetEnvironment(simulator)
+        return true
+      #else
+        return false
+      #endif
+    }
+  }
+}
+
+enum SnapshotXCTestChannelPlanState: Equatable {
+  case normal
+  case deferredToIndependentBackend
+  case boundedXCTestProbe
+}
+
+struct EffectiveSnapshotCapturePlan {
+  let plan: [SnapshotBackendKind]
+  let xCTestChannelState: SnapshotXCTestChannelPlanState
+  let treeCaptureSliceBudgetOverride: TimeInterval?
 }
 
 /// What the plan runner does when every backend failed or stayed sparse.
@@ -52,6 +86,7 @@ extension RunnerTests {
   /// but chained recovery tiers must never stack past the 30s main-thread watchdog: when the
   /// budget is spent, remaining tiers are skipped and the best payload so far is returned.
   static let snapshotPlanBudget: TimeInterval = 20
+  static let penalizedXCTestProbeTreeSliceBudget: TimeInterval = 1
   static let collapsedLeafMinimumSegments = 10
 
   static func payloadNodeCount(_ payload: DataPayload?) -> Int {
@@ -63,48 +98,68 @@ extension RunnerTests {
   static let regularVisiblePlan: [SnapshotBackendKind] = [.recursiveTree, .querySweep, .privateAX]
   static let rawDiagnosticPlan: [SnapshotBackendKind] = [.recursiveTree, .privateAX]
 
-  // MARK: Tree-backend penalty (cross-attempt memory, #1105)
+  // MARK: XCTest accessibility channel penalty (cross-attempt memory, #1105/#1156)
   //
   // On some deep/dynamic screens the XCTest bulk snapshot no longer fails fast with
   // kAXErrorIllegalArgument (the #758 signature) — it grinds for many seconds first. One slow
   // grind is tolerable; re-grinding on every subsequent capture of the same screen buries the
-  // main thread past the execution watchdog. After a slow or abandoned tree capture, later
-  // plans for the same bundle lead with the private AX backend until the penalty expires.
+  // main thread past the execution watchdog. After a slow, timed-out, or abandoned XCTest-backed
+  // capture, later plans for the same bundle use non-XCTest recovery tiers until the penalty expires.
 
-  func penalizeSnapshotTreeBackend(bundleId: String?, reason: String) {
-    snapshotTreePenaltyLock.lock()
-    snapshotTreePenaltyBundleId = bundleId
-    snapshotTreePenaltyUntil = Date().addingTimeInterval(snapshotTreePenaltyDuration)
-    snapshotTreePenaltyLock.unlock()
+  func penalizeSnapshotXCTestChannel(bundleId: String?, reason: String) {
+    snapshotXCTestChannelPenaltyLock.lock()
+    snapshotXCTestChannelPenaltyBundleId = bundleId
+    snapshotXCTestChannelPenaltyUntil = Date().addingTimeInterval(snapshotXCTestChannelPenaltyDuration)
+    snapshotXCTestChannelPenaltyLock.unlock()
     NSLog(
-      "AGENT_DEVICE_RUNNER_SNAPSHOT_TREE_PENALIZED bundle=%@ reason=%@",
+      "AGENT_DEVICE_RUNNER_SNAPSHOT_XCTEST_CHANNEL_PENALIZED bundle=%@ reason=%@",
       bundleId ?? "",
       reason
     )
   }
 
-  func isSnapshotTreeBackendPenalized(bundleId: String?) -> Bool {
-    snapshotTreePenaltyLock.lock()
-    defer { snapshotTreePenaltyLock.unlock() }
-    guard Date() < snapshotTreePenaltyUntil else { return false }
+  func isSnapshotXCTestChannelPenalized(bundleId: String?) -> Bool {
+    snapshotXCTestChannelPenaltyLock.lock()
+    defer { snapshotXCTestChannelPenaltyLock.unlock() }
+    guard Date() < snapshotXCTestChannelPenaltyUntil else { return false }
     // A penalty recorded without a bundle id applies to whatever target is current.
-    guard let penalized = snapshotTreePenaltyBundleId else { return true }
+    guard let penalized = snapshotXCTestChannelPenaltyBundleId else { return true }
     return penalized == bundleId
   }
 
-  /// Pure plan-reorder rule: a penalized tree backend defers to the private AX backend on the
-  /// regular plan only. The raw diagnostic plan keeps tree-first errors, and unknown plans are
-  /// left untouched.
+  /// Pure plan-reorder rule: a penalized XCTest accessibility channel uses independent backends
+  /// when the platform has one, otherwise it keeps XCTest work on a short probe. The raw
+  /// diagnostic plan keeps tree-first errors, and unknown plans are left untouched.
   static func effectiveSnapshotCapturePlan(
     _ plan: [SnapshotBackendKind],
-    treePenalized: Bool
-  ) -> (plan: [SnapshotBackendKind], treeDeferred: Bool) {
-    guard treePenalized, plan == Self.regularVisiblePlan else { return (plan, false) }
-    return ([.privateAX, .querySweep, .recursiveTree], true)
+    xCTestChannelPenalized: Bool,
+    availableBackends: Set<SnapshotBackendKind> = Set(SnapshotBackendKind.allCases)
+  ) -> EffectiveSnapshotCapturePlan {
+    guard xCTestChannelPenalized, plan == Self.regularVisiblePlan else {
+      return EffectiveSnapshotCapturePlan(
+        plan: plan,
+        xCTestChannelState: .normal,
+        treeCaptureSliceBudgetOverride: nil
+      )
+    }
+    let availablePlan = plan.filter { availableBackends.contains($0) }
+    let recoveryPlan = availablePlan.filter { !$0.usesXCTestAccessibilityChannel }
+    if !recoveryPlan.isEmpty {
+      return EffectiveSnapshotCapturePlan(
+        plan: recoveryPlan,
+        xCTestChannelState: .deferredToIndependentBackend,
+        treeCaptureSliceBudgetOverride: nil
+      )
+    }
+    return EffectiveSnapshotCapturePlan(
+      plan: availablePlan.filter(\.usesXCTestAccessibilityChannel),
+      xCTestChannelState: .boundedXCTestProbe,
+      treeCaptureSliceBudgetOverride: Self.penalizedXCTestProbeTreeSliceBudget
+    )
   }
 
   func shouldSkipSnapshotBackendForAbandonedTreeCapture(_ kind: SnapshotBackendKind) -> Bool {
-    kind != .privateAX && hasAbandonedTreeCapture()
+    kind.usesXCTestAccessibilityChannel && hasAbandonedTreeCapture()
   }
 
   // MARK: Plan runner
@@ -120,22 +175,34 @@ extension RunnerTests {
     var axFailure: SnapshotCaptureFailure?
     let deadline = Date().addingTimeInterval(Self.snapshotPlanBudget)
 
-    // Reorder is gated to iOS simulators — the only place the private AX backend exists, so
-    // the deferred plan cannot degrade platforms where the tree backend is the strongest tier.
-    var treePenalized = false
-#if os(iOS) && targetEnvironment(simulator)
-    treePenalized = isSnapshotTreeBackendPenalized(bundleId: currentBundleId)
+    // Reorder is iOS-only because hostile screens can make XCTest tree/query work grind while
+    // the app remains visually responsive. Simulators can avoid that channel through private AX;
+    // physical devices have no independent semantic backend yet, so they use a bounded probe.
+    var xCTestChannelPenalized = false
+#if os(iOS)
+    xCTestChannelPenalized = isSnapshotXCTestChannelPenalized(bundleId: currentBundleId)
 #endif
-    let (effectivePlan, treeDeferred) = Self.effectiveSnapshotCapturePlan(
+    let effective = Self.effectiveSnapshotCapturePlan(
       plan,
-      treePenalized: treePenalized
+      xCTestChannelPenalized: xCTestChannelPenalized,
+      availableBackends: Set(SnapshotBackendKind.allCases.filter(\.isAvailableOnCurrentPlatform))
     )
-    if treeDeferred {
+    let effectivePlan = effective.plan
+    switch effective.xCTestChannelState {
+    case .normal:
+      break
+    case .deferredToIndependentBackend:
       firstFailure = (
-        "the XCTest tree backend was deferred after a recent slow capture on this screen",
+        "XCTest-backed snapshot tiers were deferred after recent slow accessibility work on this screen",
         "budget"
       )
-      NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_TREE_DEFERRED bundle=%@", currentBundleId ?? "")
+      NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_XCTEST_CHANNEL_DEFERRED bundle=%@", currentBundleId ?? "")
+    case .boundedXCTestProbe:
+      firstFailure = (
+        "XCTest-backed snapshot tiers are running with a short recovery probe after recent slow accessibility work on this screen",
+        "budget"
+      )
+      NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_XCTEST_CHANNEL_PROBE_BOUNDED bundle=%@", currentBundleId ?? "")
     }
 
     for kind in effectivePlan {
@@ -147,7 +214,7 @@ extension RunnerTests {
         break
       }
       // While an abandoned tree capture is still grinding inside testmanagerd, XCTest-backed
-      // tiers would block behind it; only the private AX backend stays responsive (#1105).
+      // tiers would block behind it; only independent backends stay responsive (#1105).
       if shouldSkipSnapshotBackendForAbandonedTreeCapture(kind) {
         NSLog("AGENT_DEVICE_RUNNER_SNAPSHOT_TIER_SKIPPED_XCTEST_OCCUPIED tier=%@", kind.rawValue)
         if firstFailure == nil {
@@ -161,15 +228,23 @@ extension RunnerTests {
       let capture: SnapshotBackendCapture
       let backendStartedAt = Date()
       do {
-        guard let result = try captureWithBackend(kind, app: app, options: options, deadline: deadline)
+        guard
+          let result = try captureWithBackend(
+            kind,
+            app: app,
+            options: options,
+            deadline: deadline,
+            treeCaptureSliceBudgetOverride: effective.treeCaptureSliceBudgetOverride
+          )
         else {
-          recordSlowTreeBackendIfNeeded(kind, startedAt: backendStartedAt)
+          recordSlowXCTestSnapshotBackendIfNeeded(kind, startedAt: backendStartedAt)
           continue
         }
         capture = result
-        recordSlowTreeBackendIfNeeded(kind, startedAt: backendStartedAt)
+        recordSlowXCTestSnapshotBackendIfNeeded(kind, startedAt: backendStartedAt)
       } catch let failure as SnapshotCaptureFailure {
-        recordSlowTreeBackendIfNeeded(kind, startedAt: backendStartedAt)
+        recordXCTestSnapshotBackendFailureIfNeeded(kind, failure: failure)
+        recordSlowXCTestSnapshotBackendIfNeeded(kind, startedAt: backendStartedAt)
         if Self.isAxSnapshotFailure(failure) { axFailure = failure }
         if firstFailure == nil {
           firstFailure = (failure.message, Self.isAxSnapshotFailure(failure) ? "ax-rejected" : "capture-failed")
@@ -190,7 +265,7 @@ extension RunnerTests {
         continue
       }
 
-      let recovered = kind != effectivePlan.first || treeDeferred
+      let recovered = kind != effectivePlan.first || effective.xCTestChannelState != .normal
       if recovered {
         NSLog(
           "AGENT_DEVICE_RUNNER_SNAPSHOT_RECOVERED backend=%@ reason=%@",
@@ -229,22 +304,33 @@ extension RunnerTests {
       best.map { stampedSnapshotPayload($0.capture, backend: $0.kind, state: "sparse", reason: firstFailure) }
       ?? stampedSnapshotPayload(
         SnapshotBackendCapture(payload: sparseTruncatedSnapshotPayload(), effectiveDepth: nil),
-        backend: plan.last ?? .recursiveTree,
+        backend: effectivePlan.last ?? plan.last ?? .recursiveTree,
         state: "sparse",
         reason: firstFailure
       )
     return fallbackPayload
   }
 
-  /// Marks the tree backend as penalized when a capture attempt ground past the slow-capture
+  /// Marks XCTest-backed snapshot tiers as penalized when one attempt ground past the slow-capture
   /// threshold — even a successful one: the next capture of this screen must not re-grind.
-  private func recordSlowTreeBackendIfNeeded(_ kind: SnapshotBackendKind, startedAt: Date) {
-    guard kind == .recursiveTree else { return }
+  private func recordSlowXCTestSnapshotBackendIfNeeded(_ kind: SnapshotBackendKind, startedAt: Date) {
+    guard kind.usesXCTestAccessibilityChannel else { return }
     let elapsed = Date().timeIntervalSince(startedAt)
-    guard elapsed > snapshotTreeSlowCaptureThreshold else { return }
-    penalizeSnapshotTreeBackend(
+    guard elapsed > snapshotXCTestSlowCaptureThreshold else { return }
+    penalizeSnapshotXCTestChannel(
       bundleId: currentBundleId,
-      reason: "slow_tree_capture_\(Int(elapsed * 1000))ms"
+      reason: "slow_\(kind.rawValue)_capture_\(Int(elapsed * 1000))ms"
+    )
+  }
+
+  private func recordXCTestSnapshotBackendFailureIfNeeded(
+    _ kind: SnapshotBackendKind,
+    failure: SnapshotCaptureFailure
+  ) {
+    guard kind.usesXCTestAccessibilityChannel, failure.code == Self.xCTestSnapshotTimeoutCode else { return }
+    penalizeSnapshotXCTestChannel(
+      bundleId: currentBundleId,
+      reason: "\(kind.rawValue)_backend_timeout"
     )
   }
 
@@ -252,7 +338,8 @@ extension RunnerTests {
     _ kind: SnapshotBackendKind,
     app: XCUIApplication,
     options: SnapshotOptions,
-    deadline: Date
+    deadline: Date,
+    treeCaptureSliceBudgetOverride: TimeInterval?
   ) throws -> SnapshotBackendCapture? {
     switch kind {
     case .recursiveTree:
@@ -260,7 +347,8 @@ extension RunnerTests {
         let context = try makeSnapshotTraversalContext(
           app: app,
           options: options,
-          captureDeadline: deadline
+          captureDeadline: deadline,
+          treeCaptureSliceBudgetOverride: treeCaptureSliceBudgetOverride
         )
       else {
         return nil
@@ -514,38 +602,65 @@ extension RunnerTests {
     )
   }
 
-  func testEffectiveSnapshotCapturePlanDefersTreeOnlyWhenPenalizedRegularPlan() {
-    let regular = Self.effectiveSnapshotCapturePlan(Self.regularVisiblePlan, treePenalized: true)
-    XCTAssertEqual(regular.plan, [.privateAX, .querySweep, .recursiveTree])
-    XCTAssertTrue(regular.treeDeferred)
+  func testEffectiveSnapshotCapturePlanDefersXCTestBackedTiersOnlyWhenPenalizedRegularPlan() {
+    let regular = Self.effectiveSnapshotCapturePlan(
+      Self.regularVisiblePlan,
+      xCTestChannelPenalized: true
+    )
+    XCTAssertEqual(regular.plan, [.privateAX])
+    XCTAssertEqual(regular.xCTestChannelState, .deferredToIndependentBackend)
+    XCTAssertNil(regular.treeCaptureSliceBudgetOverride)
 
-    let unpenalized = Self.effectiveSnapshotCapturePlan(Self.regularVisiblePlan, treePenalized: false)
+    let unpenalized = Self.effectiveSnapshotCapturePlan(
+      Self.regularVisiblePlan,
+      xCTestChannelPenalized: false
+    )
     XCTAssertEqual(unpenalized.plan, Self.regularVisiblePlan)
-    XCTAssertFalse(unpenalized.treeDeferred)
+    XCTAssertEqual(unpenalized.xCTestChannelState, .normal)
+    XCTAssertNil(unpenalized.treeCaptureSliceBudgetOverride)
 
     // The raw diagnostic plan preserves tree-first error propagation even under penalty.
-    let raw = Self.effectiveSnapshotCapturePlan(Self.rawDiagnosticPlan, treePenalized: true)
+    let raw = Self.effectiveSnapshotCapturePlan(
+      Self.rawDiagnosticPlan,
+      xCTestChannelPenalized: true
+    )
     XCTAssertEqual(raw.plan, Self.rawDiagnosticPlan)
-    XCTAssertFalse(raw.treeDeferred)
+    XCTAssertEqual(raw.xCTestChannelState, .normal)
+    XCTAssertNil(raw.treeCaptureSliceBudgetOverride)
   }
 
-  func testSnapshotTreeBackendPenaltyMatchesBundleAndExpires() {
+  func testEffectiveSnapshotCapturePlanUsesBoundedXCTestProbeWhenNoIndependentBackendRuns() {
+    let physicalDevicePlan = Self.effectiveSnapshotCapturePlan(
+      Self.regularVisiblePlan,
+      xCTestChannelPenalized: true,
+      availableBackends: [.recursiveTree, .querySweep]
+    )
+
+    XCTAssertEqual(physicalDevicePlan.plan, [.recursiveTree, .querySweep])
+    XCTAssertEqual(physicalDevicePlan.xCTestChannelState, .boundedXCTestProbe)
+    XCTAssertEqual(
+      physicalDevicePlan.treeCaptureSliceBudgetOverride,
+      Self.penalizedXCTestProbeTreeSliceBudget
+    )
+  }
+
+  func testSnapshotXCTestChannelPenaltyMatchesBundleAndExpires() {
     defer {
-      snapshotTreePenaltyBundleId = nil
-      snapshotTreePenaltyUntil = .distantPast
+      snapshotXCTestChannelPenaltyBundleId = nil
+      snapshotXCTestChannelPenaltyUntil = .distantPast
     }
 
-    penalizeSnapshotTreeBackend(bundleId: "xyz.blueskyweb.app", reason: "test")
-    XCTAssertTrue(isSnapshotTreeBackendPenalized(bundleId: "xyz.blueskyweb.app"))
-    XCTAssertFalse(isSnapshotTreeBackendPenalized(bundleId: "com.other.app"))
+    penalizeSnapshotXCTestChannel(bundleId: "xyz.blueskyweb.app", reason: "test")
+    XCTAssertTrue(isSnapshotXCTestChannelPenalized(bundleId: "xyz.blueskyweb.app"))
+    XCTAssertFalse(isSnapshotXCTestChannelPenalized(bundleId: "com.other.app"))
 
     // A penalty recorded without a bundle applies to any current target.
-    penalizeSnapshotTreeBackend(bundleId: nil, reason: "test")
-    XCTAssertTrue(isSnapshotTreeBackendPenalized(bundleId: "com.other.app"))
+    penalizeSnapshotXCTestChannel(bundleId: nil, reason: "test")
+    XCTAssertTrue(isSnapshotXCTestChannelPenalized(bundleId: "com.other.app"))
 
     // Expired penalties stop applying.
-    snapshotTreePenaltyUntil = Date(timeIntervalSinceNow: -1)
-    XCTAssertFalse(isSnapshotTreeBackendPenalized(bundleId: "com.other.app"))
+    snapshotXCTestChannelPenaltyUntil = Date(timeIntervalSinceNow: -1)
+    XCTAssertFalse(isSnapshotXCTestChannelPenalized(bundleId: "com.other.app"))
   }
 
   func testAbandonedTreeCaptureSkipsOnlyXCTestBackedSnapshotTiers() {

--- a/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
+++ b/apple-runner/AgentDeviceRunner/AgentDeviceRunnerUITests/RunnerTests.swift
@@ -68,21 +68,22 @@ final class RunnerTests: XCTestCase {
   // Past this age the runner stops claiming "busy, retry soon" and reports itself wedged so
   // the daemon recycles it — the only cure once the main thread is stuck for good.
   let mainThreadWedgeThreshold: TimeInterval = 120
-  // Sticky per-bundle hint: after the XCTest tree backend ground past its slice (or a snapshot
-  // was abandoned by the watchdog), later capture plans lead with the private AX backend
-  // instead of re-grinding the tree on the same screen class (#1105).
-  let snapshotTreePenaltyLock = NSLock()
-  var snapshotTreePenaltyBundleId: String?
-  var snapshotTreePenaltyUntil = Date.distantPast
-  let snapshotTreePenaltyDuration: TimeInterval = 120
-  // Bluesky-class screens grind ~4-8s before the tree backend fails; anything past this
-  // threshold marks the screen hostile so the next capture leads with private AX.
-  let snapshotTreeSlowCaptureThreshold: TimeInterval = 3
+  // Sticky per-bundle hint: after an XCTest-backed snapshot tier ground past its slice (or a
+  // snapshot was abandoned by the watchdog), later capture plans avoid the XCTest accessibility
+  // channel when an independent recovery backend exists, or use a bounded XCTest probe when it
+  // does not, for the same screen class (#1105/#1156).
+  let snapshotXCTestChannelPenaltyLock = NSLock()
+  var snapshotXCTestChannelPenaltyBundleId: String?
+  var snapshotXCTestChannelPenaltyUntil = Date.distantPast
+  let snapshotXCTestChannelPenaltyDuration: TimeInterval = 120
+  // Bluesky-class screens can grind ~4-8s before an XCTest-backed snapshot tier fails; anything
+  // past this threshold marks the screen hostile so the next capture uses non-XCTest recovery.
+  let snapshotXCTestSlowCaptureThreshold: TimeInterval = 3
   // The blocking XCTest tree snapshot XPC runs on the main thread with this slice so a
   // content-dependent grind (#1105: seconds to minutes on live Bluesky screens) cannot pin
   // the capture plan. On timeout the XPC keeps grinding on main; while any abandoned
-  // tree capture is outstanding, plans skip the XCTest-backed tiers (tree, query sweep) and
-  // use the private AX backend, which does not go through testmanagerd.
+  // tree capture is outstanding, plans skip XCTest-backed tiers (tree, query sweep) until the
+  // abandoned work drains.
   let treeCaptureLock = NSLock()
   var abandonedTreeCaptureCount = 0
   let treeCaptureSliceBudget: TimeInterval = 8

--- a/apple-runner/README.md
+++ b/apple-runner/README.md
@@ -28,7 +28,8 @@ Protocol and maintenance references:
 - `RunnerTests+Transport.swift`: TCP request handling and HTTP parsing/encoding.
 - `RunnerTests+CommandExecution.swift`: command dispatch (`execute*`) and command switch.
 - `RunnerTests+Lifecycle.swift`: activation/retry/stabilization and recording lifecycle helpers.
-- `RunnerTests+Interaction.swift`: tap/drag/swipe/type/back/home/rotate/app-switcher helpers.
+- `RunnerTests+Interaction.swift`: tap/drag/swipe/type/home/rotate/app-switcher helpers.
+- `RunnerTests+Navigation.swift`: back/navigation-control helpers.
 - `RunnerTests+Snapshot.swift`: fast/raw snapshot builders and include/filter helpers.
 - `RunnerTests+SystemModal.swift`: SpringBoard/system modal detection and modal snapshot shaping.
 - `RunnerTests+ScreenRecorder.swift`: nested `ScreenRecorder` implementation.
@@ -40,9 +41,11 @@ iOS snapshots have two explicit public capture modes:
 - full/raw snapshots use recursive XCTest snapshots for rich hierarchy and diagnostics;
 - interactive snapshots filter the same visible tree down to agent-facing refs.
 
-Some simulator apps expose accessibility trees that lower-level AX services can inspect but XCTest
-cannot serialize reliably. In those cases interactive snapshots may return a sparse root quickly,
-while full snapshots preserve the XCTest error. See
+Some iOS apps expose accessibility trees that lower-level AX services can inspect but XCTest cannot
+serialize reliably. In those cases interactive snapshots may return a sparse root quickly, while
+full snapshots preserve the XCTest error. A penalized simulator can recover through private AX;
+physical devices use a short XCTest probe because no non-XCTest semantic backend is available
+there. See
 [`../docs/adr/0004-ios-snapshot-backend-strategy.md`](../docs/adr/0004-ios-snapshot-backend-strategy.md)
 for the backend boundary and future simulator AX-service direction.
 

--- a/docs/adr/0004-ios-snapshot-backend-strategy.md
+++ b/docs/adr/0004-ios-snapshot-backend-strategy.md
@@ -21,11 +21,12 @@ runner has two durable snapshot needs:
   because it preserves hierarchy, static text, wrappers, scroll containers, and ancestry.
 
 These needs should not share one capture strategy blindly. Recursive `XCUIElement.snapshot()` is
-rich, but some real simulator app trees can make XCTest fail with `kAXErrorIllegalArgument` while
-the same app remains visually usable and can be inspected by lower-level simulator accessibility
-services. Bluesky is the current known example: Argent's `ax-service` can describe the screen, but
-XCTest recursive snapshots and typed `XCUIElementQuery` enumeration can degrade to no useful child
-nodes.
+rich, but some real app trees can make XCTest fail with `kAXErrorIllegalArgument` or main-thread
+timeouts while the same app remains visually usable. Bluesky is the current known example:
+lower-level accessibility services can describe simulator screens even when XCTest recursive
+snapshots and typed `XCUIElementQuery` enumeration degrade to no useful child nodes. Physical iOS
+devices can show the same XCTest accessibility-channel timeout shape even when no lower-level
+semantic backend is available.
 
 This is different from presentation filtering. The daemon's snapshot presentation can hide noisy
 or inaccessible nodes, but it cannot recover nodes that XCTest never returns. More filters,
@@ -50,11 +51,12 @@ strategies:
   carry the response, fail explicitly instead of silently truncating the tree at a hard node count.
   If XCTest reports a real AX serialization failure, preserve that error instead of pretending the
   UI is empty.
-- **Future simulator AX-service strategy**: treat Bluesky-class failures as evidence that XCTest is
+- **Future AX-service strategy**: treat Bluesky-class failures as evidence that XCTest is
   not a complete semantic snapshot backend. A robust semantic fix should add a host-side simulator
-  accessibility backend, similar in role to `idb` accessibility commands or Argent's `ax-service`,
+  accessibility backend, similar in role to existing simulator accessibility inspection tools,
   and normalize its output into the same `SnapshotNode` model. That backend can be simulator-only;
-  physical devices can continue using XCTest unless a supported lower-level API exists.
+  physical devices should use an equivalent non-XCTest semantic backend only if Apple exposes a
+  supported channel.
 
 The daemon should make degraded output observable. If an iOS interactive snapshot contains only the
 application root or another sparse shape, surface a structured quality verdict and warning so
@@ -67,18 +69,21 @@ snapshots. That was the correct diagnostic change, but it exposed apps whose acc
 XCTest cannot serialize.
 
 Later work moved recovery into the regular visible capture plan so healthy apps keep the fast
-recursive tree path while degraded simulator app classes can still return bounded, honest output
-when fallback query tiers are the only available source of visible controls.
+recursive tree path while degraded app classes can still return bounded, honest output when
+fallback tiers are the only available source of visible controls.
 
 Issue #1105 showed a second failure shape on the same app class: instead of failing fast with
 `kAXErrorIllegalArgument`, the recursive tree capture can grind for many seconds on
 heavy/animating screens before failing, pushing the chained plan past the runner's main-thread
 watchdog and burying the main queue under retries. The plan now carries its umbrella deadline
 into the query-sweep and private-AX tiers (later ladder rungs stop when the budget is spent),
-and a slow or watchdog-abandoned tree capture penalizes the tree backend for that bundle for a
-bounded window: subsequent regular plans lead with the private-AX backend
-(`effectiveSnapshotCapturePlan`), stamped as `recovered` with a `budget` reason so the deferral
-stays observable. The raw diagnostic plan is exempt — it keeps tree-first error propagation.
+and a slow, timed-out, or watchdog-abandoned XCTest-backed capture penalizes the XCTest
+accessibility channel for that bundle for a bounded window. Subsequent regular plans derive the
+next step from backend traits (`effectiveSnapshotCapturePlan`): when a runnable non-XCTest backend
+exists, they defer to that independent tier; when it does not, as on physical iOS devices today,
+they run a short XCTest probe instead of the full tree slice so healthy screens can recover without
+repeating the hostile-screen grind. The raw diagnostic plan is exempt — it keeps tree-first error
+propagation.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Fixes #1156.

Reframes iOS snapshot recovery around the XCTest accessibility channel instead of a simulator-only tree backend penalty. Regular snapshots now avoid all XCTest-backed tiers after slow or timed-out XCTest accessibility work and derive recovery from non-XCTest backend traits, while raw diagnostics keep tree-first behavior.

Improves `back --in-app` by trying native navigation buttons, then semantic top-band Back/Close/Cancel controls, before falling back to a bounded top-leading tap. This avoids false-positive coordinate success on React Native custom search headers.

## Validation

- `pnpm build`
- `pnpm build:xcuitest`
- `git diff --check`
- Verified on `thymikee-iphone` with Bluesky: snapshot Explore, focus search by ref, type `agent-device`, run `back --in-app`, and confirm the follow-up snapshot returned to Explore.