### PR TITLE
fix: point unknown selector keys at role=/label= forms

### DIFF
--- a/src/core/interaction-positionals.test.ts
+++ b/src/core/interaction-positionals.test.ts
@@ -28,6 +28,15 @@ test('readInteractionTargetFromPositionals points a role word used as a key at r
   );
 });
 
+test('readInteractionTargetFromPositionals folds unquoted multi-word values into the suggestion', () => {
+  // An unquoted value splits across positionals; the hint must keep the full text, not just
+  // the fragment attached to the key.
+  assertInvalidArgs(
+    () => readInteractionTargetFromPositionals(['button=Push', 'Article']),
+    'Did you mean role=button label="Push Article"?',
+  );
+});
+
 test('readInteractionTargetFromPositionals points an unknown non-role key at label=', () => {
   assertInvalidArgs(
     () => readInteractionTargetFromPositionals(['color="red"']),
@@ -69,6 +78,11 @@ test('readInteractionTargetFromPositionals still resolves @refs and valid select
 test('readFillTargetFromPositionals points a role word used as a key at role=/label= too', () => {
   assertInvalidArgs(
     () => readFillTargetFromPositionals(['button="Push Article"', 'hello']),
+    'Did you mean role=button label="Push Article"?',
+  );
+  // Fill treats the first two positionals as the target; an unquoted split value folds back in.
+  assertInvalidArgs(
+    () => readFillTargetFromPositionals(['button=Push', 'Article', 'hello']),
     'Did you mean role=button label="Push Article"?',
   );
 });

--- a/src/core/interaction-positionals.test.ts
+++ b/src/core/interaction-positionals.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  readFillTargetFromPositionals,
+  readInteractionTargetFromPositionals,
+} from './interaction-positionals.ts';
+
+function assertInvalidArgs(fn: () => unknown, messageFragment: string) {
+  assert.throws(fn, (error: unknown) => {
+    assert.ok(error instanceof Error);
+    assert.equal((error as { code?: unknown }).code, 'INVALID_ARGS');
+    assert.ok(
+      error.message.includes(messageFragment),
+      `expected error message to include ${JSON.stringify(messageFragment)}, got ${JSON.stringify(error.message)}`,
+    );
+    return true;
+  });
+}
+
+test('readInteractionTargetFromPositionals points a role word used as a key at role=/label=', () => {
+  assertInvalidArgs(
+    () => readInteractionTargetFromPositionals(['button="Push Article"']),
+    'Unknown selector key "button". Supported:',
+  );
+  assertInvalidArgs(
+    () => readInteractionTargetFromPositionals(['button="Push Article"']),
+    'Did you mean role=button label="Push Article"?',
+  );
+});
+
+test('readInteractionTargetFromPositionals points an unknown non-role key at label=', () => {
+  assertInvalidArgs(
+    () => readInteractionTargetFromPositionals(['color="red"']),
+    'Unknown selector key "color". Supported:',
+  );
+  assertInvalidArgs(
+    () => readInteractionTargetFromPositionals(['color="red"']),
+    'Did you mean label="red"?',
+  );
+  // Non-role keys never get the role= suggestion.
+  assert.throws(
+    () => readInteractionTargetFromPositionals(['color="red"']),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.ok(!error.message.includes('role='));
+      return true;
+    },
+  );
+});
+
+test('readInteractionTargetFromPositionals keeps existing behavior for a known key with a bad value', () => {
+  assertInvalidArgs(
+    () => readInteractionTargetFromPositionals(['visible=maybe']),
+    'is not a @ref, selector, or "x y" point',
+  );
+});
+
+test('readInteractionTargetFromPositionals still parses "x y" points', () => {
+  assert.deepEqual(readInteractionTargetFromPositionals(['10', '20']), { x: 10, y: 20 });
+});
+
+test('readInteractionTargetFromPositionals still resolves @refs and valid selectors', () => {
+  assert.deepEqual(readInteractionTargetFromPositionals(['@e5']), { ref: '@e5' });
+  assert.deepEqual(readInteractionTargetFromPositionals(['text="Sign in"']), {
+    selector: 'text="Sign in"',
+  });
+});
+
+test('readFillTargetFromPositionals points a role word used as a key at role=/label= too', () => {
+  assertInvalidArgs(
+    () => readFillTargetFromPositionals(['button="Push Article"', 'hello']),
+    'Did you mean role=button label="Push Article"?',
+  );
+});
+
+test('readFillTargetFromPositionals still parses "x y" points and selectors', () => {
+  assert.deepEqual(readFillTargetFromPositionals(['10', '20', 'hi']), {
+    kind: 'point',
+    target: { x: 10, y: 20 },
+    text: 'hi',
+  });
+  assert.deepEqual(readFillTargetFromPositionals(['id="field-email"', 'qa@example.com']), {
+    kind: 'selector',
+    target: { selector: 'id="field-email"' },
+    text: 'qa@example.com',
+  });
+});

--- a/src/core/interaction-positionals.ts
+++ b/src/core/interaction-positionals.ts
@@ -1,5 +1,11 @@
 import { AppError } from '../kernel/errors.ts';
-import { isSelectorToken, splitSelectorFromArgs } from '../utils/selectors-parse.ts';
+import {
+  detectUnknownSelectorKeyToken,
+  isRoleHintWord,
+  isSelectorToken,
+  SELECTOR_KEY_NAMES,
+  splitSelectorFromArgs,
+} from '../utils/selectors-parse.ts';
 
 type PositionalInteractionTarget =
   | { x: number; y: number }
@@ -75,10 +81,23 @@ export function readFillTargetFromPositionals(positionals: string[]): DecodedFil
 }
 
 function readPointTarget(positionals: string[]): { x: number; y: number } {
+  const unknownKey = detectUnknownSelectorKeyToken(positionals[0] ?? '');
+  if (unknownKey) {
+    throw new AppError('INVALID_ARGS', formatUnknownSelectorKeyFailure(unknownKey));
+  }
   const x = Number(positionals[0]);
   const y = Number(positionals[1]);
   if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
   throw new AppError('INVALID_ARGS', formatTargetParseFailure(positionals));
+}
+
+function formatUnknownSelectorKeyFailure(unknownKey: { key: string; value: string }): string {
+  const { key, value } = unknownKey;
+  const supported = SELECTOR_KEY_NAMES.join(', ');
+  const hint = isRoleHintWord(key)
+    ? `Did you mean role=${key} label=${quoteSelectorValue(value)}?`
+    : `Did you mean label=${quoteSelectorValue(value)}?`;
+  return `Unknown selector key "${key}". Supported: ${supported}. ${hint}`;
 }
 
 function formatTargetParseFailure(positionals: string[]): string {

--- a/src/core/interaction-positionals.ts
+++ b/src/core/interaction-positionals.ts
@@ -81,14 +81,31 @@ export function readFillTargetFromPositionals(positionals: string[]): DecodedFil
 }
 
 function readPointTarget(positionals: string[]): { x: number; y: number } {
-  const unknownKey = detectUnknownSelectorKeyToken(positionals[0] ?? '');
+  const firstPositional = positionals[0] ?? '';
+  const unknownKey = detectUnknownSelectorKeyToken(firstPositional);
   if (unknownKey) {
-    throw new AppError('INVALID_ARGS', formatUnknownSelectorKeyFailure(unknownKey));
+    // An unquoted multi-word value arrives split across positionals (button=Push Article), so
+    // fold the trailing tokens back into the suggested value like mergeRestIntoSelectorValue.
+    // A fully quoted value (button="Push Article") is complete; trailing tokens are not part of it.
+    const value = hasCompleteQuotedValue(firstPositional)
+      ? unknownKey.value
+      : [unknownKey.value, ...positionals.slice(1)].join(' ').trim();
+    throw new AppError(
+      'INVALID_ARGS',
+      formatUnknownSelectorKeyFailure({ key: unknownKey.key, value }),
+    );
   }
   const x = Number(positionals[0]);
   const y = Number(positionals[1]);
   if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
   throw new AppError('INVALID_ARGS', formatTargetParseFailure(positionals));
+}
+
+function hasCompleteQuotedValue(token: string): boolean {
+  const valueRaw = token.slice(token.indexOf('=') + 1).trim();
+  if (valueRaw.length < 2) return false;
+  const first = valueRaw[0];
+  return (first === '"' || first === "'") && valueRaw.endsWith(first);
 }
 
 function formatUnknownSelectorKeyFailure(unknownKey: { key: string; value: string }): string {

--- a/src/utils/__tests__/selectors-parse-unknown-key.test.ts
+++ b/src/utils/__tests__/selectors-parse-unknown-key.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  detectUnknownSelectorKeyToken,
+  isRoleHintWord,
+  SELECTOR_KEY_NAMES,
+} from '../selectors-parse.ts';
+
+test('detectUnknownSelectorKeyToken flags a role word used as a selector key', () => {
+  assert.deepEqual(detectUnknownSelectorKeyToken('button="Push Article"'), {
+    key: 'button',
+    value: 'Push Article',
+  });
+});
+
+test('detectUnknownSelectorKeyToken flags any non-recognized key, lowercased', () => {
+  assert.deepEqual(detectUnknownSelectorKeyToken('Color="red"'), { key: 'color', value: 'red' });
+  assert.deepEqual(detectUnknownSelectorKeyToken('unquoted=value'), {
+    key: 'unquoted',
+    value: 'value',
+  });
+});
+
+test('detectUnknownSelectorKeyToken returns null for recognized selector keys', () => {
+  assert.equal(detectUnknownSelectorKeyToken('id="submit"'), null);
+  assert.equal(detectUnknownSelectorKeyToken('role=button'), null);
+  assert.equal(detectUnknownSelectorKeyToken('visible=maybe'), null);
+});
+
+test('detectUnknownSelectorKeyToken returns null without an "=", an empty key, or an empty value', () => {
+  assert.equal(detectUnknownSelectorKeyToken('10'), null);
+  assert.equal(detectUnknownSelectorKeyToken('=value'), null);
+  assert.equal(detectUnknownSelectorKeyToken('button='), null);
+  assert.equal(detectUnknownSelectorKeyToken('button=""'), null);
+});
+
+test('isRoleHintWord recognizes common accessibility role words, case-insensitively', () => {
+  assert.equal(isRoleHintWord('button'), true);
+  assert.equal(isRoleHintWord('Button'), true);
+  assert.equal(isRoleHintWord('textfield'), true);
+  assert.equal(isRoleHintWord('color'), false);
+  assert.equal(isRoleHintWord('unquoted'), false);
+});
+
+test('SELECTOR_KEY_NAMES lists the recognized selector keys and excludes role words', () => {
+  assert.ok(SELECTOR_KEY_NAMES.includes('id'));
+  assert.ok(SELECTOR_KEY_NAMES.includes('role'));
+  assert.ok(SELECTOR_KEY_NAMES.includes('label'));
+  assert.ok(SELECTOR_KEY_NAMES.includes('visible'));
+  assert.equal((SELECTOR_KEY_NAMES as readonly string[]).includes('button'), false);
+});

--- a/src/utils/__tests__/selectors-parse-unknown-key.test.ts
+++ b/src/utils/__tests__/selectors-parse-unknown-key.test.ts
@@ -32,6 +32,7 @@ test('detectUnknownSelectorKeyToken returns null without an "=", an empty key, o
   assert.equal(detectUnknownSelectorKeyToken('=value'), null);
   assert.equal(detectUnknownSelectorKeyToken('button='), null);
   assert.equal(detectUnknownSelectorKeyToken('button=""'), null);
+  assert.equal(detectUnknownSelectorKeyToken('button="   "'), null);
 });
 
 test('isRoleHintWord recognizes common accessibility role words, case-insensitively', () => {

--- a/src/utils/selectors-parse.ts
+++ b/src/utils/selectors-parse.ts
@@ -55,16 +55,17 @@ const ALL_KEYS = new Set<SelectorKey>([...TEXT_KEYS, ...BOOLEAN_KEYS]);
 export const SELECTOR_KEY_NAMES: readonly SelectorKey[] = [...ALL_KEYS];
 
 // Role/element-type words that show up as accessibility roles, not selector keys (e.g. the
-// `button` in `button="Push Article"`). Mirrors the vocabulary of ROLE_LABELS in
-// src/snapshot/snapshot-lines.ts, kept as a local copy to avoid a utils/ -> snapshot/ layering
-// dependency (scripts/layering/check.ts). Drifts silently if ROLE_LABELS grows; that's fine here
-// since this is only used to sharpen a hint, not to validate anything.
+// `button` in `button="Push Article"`). Superset of the ROLE_LABELS vocabulary in
+// src/snapshot/snapshot-lines.ts (plus a few common role words like list/tab/alert/dialog/header,
+// minus valid selector keys such as `text`, which ALL_KEYS short-circuits before this set is
+// consulted), kept as a local copy to avoid a utils/ -> snapshot/ layering dependency
+// (scripts/layering/check.ts). Drifts silently if ROLE_LABELS grows; that's fine here since this
+// is only used to sharpen a hint, not to validate anything.
 const ROLE_HINT_WORDS = new Set([
   'button',
   'imagebutton',
   'link',
   'cell',
-  'text',
   'statictext',
   'checkedtextview',
   'textfield',
@@ -163,7 +164,8 @@ export function isSelectorToken(token: string): boolean {
  * Detects a `key=value` token whose key is not a recognized selector key, e.g.
  * `button="Push Article"`. Returns the lowercased key and unquoted value so callers can build a
  * targeted "did you mean role=/label=" hint instead of treating the whole token as free text.
- * Returns null for tokens without an `=`, an empty key, an empty value, or a recognized key.
+ * Returns null for tokens without an `=`, an empty key, an empty or whitespace-only value, or a
+ * recognized key.
  */
 export function detectUnknownSelectorKeyToken(
   token: string,
@@ -176,7 +178,7 @@ export function detectUnknownSelectorKeyToken(
   if (ALL_KEYS.has(key as SelectorKey)) return null;
   const valueRaw = trimmed.slice(equalsIdx + 1).trim();
   if (!valueRaw) return null;
-  const value = unquote(valueRaw);
+  const value = unquote(valueRaw).trim();
   if (!value) return null;
   return { key, value };
 }

--- a/src/utils/selectors-parse.ts
+++ b/src/utils/selectors-parse.ts
@@ -50,6 +50,68 @@ const BOOLEAN_KEYS = new Set<SelectorKey>([
   'hittable',
 ]);
 const ALL_KEYS = new Set<SelectorKey>([...TEXT_KEYS, ...BOOLEAN_KEYS]);
+
+/** Selector key names accepted on the left of `key=value`, for error messages. */
+export const SELECTOR_KEY_NAMES: readonly SelectorKey[] = [...ALL_KEYS];
+
+// Role/element-type words that show up as accessibility roles, not selector keys (e.g. the
+// `button` in `button="Push Article"`). Mirrors the vocabulary of ROLE_LABELS in
+// src/snapshot/snapshot-lines.ts, kept as a local copy to avoid a utils/ -> snapshot/ layering
+// dependency (scripts/layering/check.ts). Drifts silently if ROLE_LABELS grows; that's fine here
+// since this is only used to sharpen a hint, not to validate anything.
+const ROLE_HINT_WORDS = new Set([
+  'button',
+  'imagebutton',
+  'link',
+  'cell',
+  'text',
+  'statictext',
+  'checkedtextview',
+  'textfield',
+  'textbox',
+  'edittext',
+  'textarea',
+  'switch',
+  'slider',
+  'image',
+  'imageview',
+  'webview',
+  'framelayout',
+  'linearlayout',
+  'relativelayout',
+  'constraintlayout',
+  'viewgroup',
+  'view',
+  'listview',
+  'recyclerview',
+  'collectionview',
+  'list',
+  'searchfield',
+  'segmentedcontrol',
+  'group',
+  'window',
+  'checkbox',
+  'radio',
+  'menuitem',
+  'toolbar',
+  'scrollarea',
+  'scrollview',
+  'nestedscrollview',
+  'table',
+  'application',
+  'navigationbar',
+  'tabbar',
+  'tab',
+  'alert',
+  'dialog',
+  'header',
+]);
+
+/** Whether `key` looks like an accessibility role word rather than a selector key. */
+export function isRoleHintWord(key: string): boolean {
+  return ROLE_HINT_WORDS.has(key.trim().toLowerCase());
+}
+
 const SIMPLE_ESCAPE_REPLACEMENTS = new Map<string, string>([
   ['"', '"'],
   ["'", "'"],
@@ -95,6 +157,28 @@ export function isSelectorToken(token: string): boolean {
     return ALL_KEYS.has(key);
   }
   return ALL_KEYS.has(trimmed.toLowerCase() as SelectorKey);
+}
+
+/**
+ * Detects a `key=value` token whose key is not a recognized selector key, e.g.
+ * `button="Push Article"`. Returns the lowercased key and unquoted value so callers can build a
+ * targeted "did you mean role=/label=" hint instead of treating the whole token as free text.
+ * Returns null for tokens without an `=`, an empty key, an empty value, or a recognized key.
+ */
+export function detectUnknownSelectorKeyToken(
+  token: string,
+): { key: string; value: string } | null {
+  const trimmed = token.trim();
+  const equalsIdx = trimmed.indexOf('=');
+  if (equalsIdx === -1) return null;
+  const key = trimmed.slice(0, equalsIdx).trim().toLowerCase();
+  if (!key) return null;
+  if (ALL_KEYS.has(key as SelectorKey)) return null;
+  const valueRaw = trimmed.slice(equalsIdx + 1).trim();
+  if (!valueRaw) return null;
+  const value = unquote(valueRaw);
+  if (!value) return null;
+  return { key, value };
 }
 
 export function splitSelectorFromArgs(


### PR DESCRIPTION
## Problem

`press 'button="Push Article"'` errors with a suggestion to use `text="button=\"Push Article\""` — nonsense, since it just re-wraps the entire malformed token. The real problem is that `button` isn't a selector key (`role=button label="..."` is the correct form, per the existing warning in `agent-device help` under Selectors), but nothing in the parse path detects that a `key=value` shaped token has an *unrecognized key* specifically — it's all lumped into "not a @ref, selector, or x/y point".

### Trace
- `isSelectorToken` (`src/utils/selectors-parse.ts`) returns `false` for `button="..."` because `button` isn't in `ALL_KEYS`.
- `splitSelectorFromArgs` therefore returns `null`.
- `readPointTarget` (`src/core/interaction-positionals.ts`) falls through to `formatTargetParseFailure`, which wraps the *whole raw token* — key and all — in `text=`.

## Approach

- `src/utils/selectors-parse.ts`: added `detectUnknownSelectorKeyToken(token)`, which recognizes a `key=value`-shaped token whose key is *not* in `ALL_KEYS` (reusing the existing `unquote` helper for quoted/unquoted values) and returns `{ key, value }`. Exported `SELECTOR_KEY_NAMES` (the `ALL_KEYS` list) for the error message. Added a local `ROLE_HINT_WORDS` set + `isRoleHintWord(key)` mirroring the role vocabulary in `ROLE_LABELS` (`src/snapshot/snapshot-lines.ts`) — kept as a local copy (with a drift-risk comment) to avoid a `utils/` → `snapshot/` layering dependency.
- `src/core/interaction-positionals.ts`: at the top of `readPointTarget`, before the numeric parse, call `detectUnknownSelectorKeyToken` on `positionals[0]`. If it hits, throw `INVALID_ARGS` with a targeted hint: `role=<key> label=<quoted value>` when the key looks like a role word, else just `label=<quoted value>`. Numbers never contain `=`, so this can't intercept `x y` point targets.
- Checked `src/core/wait-positionals.ts` for an analogous point-fallback path — there isn't one (unmatched args there silently become `wait text ...`, they don't throw), so no change was needed there.
- Suggestion-only: this still throws `INVALID_ARGS`; it never auto-executes a guess, consistent with the repo's ambiguous-target rejection convention.

## Before / after

```
$ agent-device press 'button="Push Article"'

# before
Target "button="Push Article"" is not a @ref, selector, or "x y" point. To match by visible
text, use text="button=\"Push Article\"" (or label=/id=/role=), or pass an @ref from snapshot.

# after
Unknown selector key "button". Supported: id, role, text, label, value, appname, windowtitle,
visible, hidden, editable, selected, focused, enabled, hittable. Did you mean role=button
label="Push Article"?
```

For a non-role unknown key, e.g. `press 'color="red"'`:
```
Unknown selector key "color". Supported: ...same list.... Did you mean label="red"?
```

## Test plan

- [x] New unit tests: `src/utils/__tests__/selectors-parse-unknown-key.test.ts` (`detectUnknownSelectorKeyToken`, `isRoleHintWord`, `SELECTOR_KEY_NAMES`)
- [x] New unit tests: `src/core/interaction-positionals.test.ts` — role-word key → `role=` suggestion, non-role unknown key → `label=` suggestion (and asserts no `role=` leaks in), known key with a bad value (`visible=maybe`) keeps existing behavior, `press 10 20`-style point parsing still works, `@e5` and valid selectors unaffected, and the same coverage for `readFillTargetFromPositionals`'s point-fallback path.
- [x] `pnpm run typecheck`, `pnpm run lint`, `pnpm run format:check` all pass.
- [x] `node --experimental-strip-types scripts/layering/check.ts` — OK, DAG intact.
- [x] Broader sweep (`src/utils/__tests__`, `src/core/__tests__`, `src/commands/interaction/**`, selector/maestro tests): 645 tests pass.
- [x] Full `pnpm run test`: 3433/3434 pass. The 1 failure (`runner-xctestrun.test.ts`, a stale `packageVersion` comparison) reproduces identically on a clean `origin/main` with none of this PR's changes (verified via `git stash`) — pre-existing, caused by the recent `0.19.1` version-bump commit, unrelated to this change. Flagged separately.

## Gaps

- The `runner-xctestrun.test.ts` package-version test flake noted above is out of scope for this PR and tracked separately.