### PR TITLE
fix: alias launch/relaunch to open and suggest canonical commands for unknown names

### DIFF
--- a/src/__tests__/cli-help.test.ts
+++ b/src/__tests__/cli-help.test.ts
@@ -211,6 +211,25 @@ test('tap dispatches as press with positionals and flags preserved', async () =>
   assert.deepEqual(result.calls[0]?.positionals, ['@e3']);
 });
 
+test('relaunch dispatches as open with the relaunch flag injected', async () => {
+  const result = await runCliCapture(['relaunch', 'com.example.app', '--json']);
+  assert.doesNotMatch(result.stderr, /Unknown command/);
+  // Canonicalization: the daemon call must record open, never relaunch.
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.command, 'open');
+  assert.deepEqual(result.calls[0]?.positionals, ['com.example.app']);
+  assert.equal(result.calls[0]?.flags?.relaunch, true);
+});
+
+test('launch dispatches as a plain open without forcing a relaunch', async () => {
+  const result = await runCliCapture(['launch', 'com.example.app', '--json']);
+  assert.doesNotMatch(result.stderr, /Unknown command/);
+  assert.equal(result.calls.length, 1);
+  assert.equal(result.calls[0]?.command, 'open');
+  assert.deepEqual(result.calls[0]?.positionals, ['com.example.app']);
+  assert.notEqual(result.calls[0]?.flags?.relaunch, true);
+});
+
 // From #1052 (credit: @vku2018): the alias must compose with the bare-ref
 // hint — `tap e3` normalizes to press, then gets the @e3 suggestion.
 test('tap with a bare ref gets the @ref hint, not an unknown-command error', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { parseRawArgs, usage, usageForCommand } from './cli/parser/args.ts';
+import { suggestCommandFor } from './cli/parser/command-suggestions.ts';
 import { asAppError, AppError, normalizeError } from './kernel/errors.ts';
 import { printHumanError, printJson } from './utils/output.ts';
 import { readVersion } from './utils/version.ts';
@@ -146,7 +147,7 @@ export async function runCli(argv: string[], deps: CliDeps = DEFAULT_CLI_DEPS): 
           process.stdout.write(commandHelp);
           process.exit(0);
         }
-        printHumanError(new AppError('INVALID_ARGS', `Unknown command: ${helpTarget}`));
+        printHumanError(new AppError('INVALID_ARGS', formatUnknownHelpTargetMessage(helpTarget)));
         process.stdout.write(`${await usage()}\n`);
         process.exit(1);
       }
@@ -460,6 +461,13 @@ function isDebugRequested(argv: string[]): boolean {
   } catch {
     return argv.includes('--debug') || argv.includes('-v') || argv.includes('--verbose');
   }
+}
+
+function formatUnknownHelpTargetMessage(helpTarget: string): string {
+  const hint = suggestCommandFor(helpTarget);
+  return hint
+    ? `Unknown command: ${helpTarget}. Did you mean ${hint}?`
+    : `Unknown command: ${helpTarget}`;
 }
 
 function formatUnhandledCommandMessage(command: string): string {

--- a/src/cli/parser/__tests__/args-parse-session.test.ts
+++ b/src/cli/parser/__tests__/args-parse-session.test.ts
@@ -891,3 +891,51 @@ test('apps defaults to user-installed filter and allows overrides', () => {
     /Unknown flag: --user-installed/,
   );
 });
+
+// `relaunch` and `launch` are true command aliases for open (like tap ->
+// press): normalization is pre-dispatch, so command identity stays `open`
+// everywhere downstream (daemon requests, telemetry).
+test('relaunch is a true alias for open with --relaunch injected', () => {
+  const parsed = parseArgs(['relaunch', 'com.example.app'], { strictFlags: true });
+  assert.equal(parsed.command, 'open');
+  assert.deepEqual(parsed.positionals, ['com.example.app']);
+  assert.equal(parsed.flags.relaunch, true);
+});
+
+test('launch is a true alias for a plain open without --relaunch', () => {
+  // Aliasing launch to a forced restart would silently destroy app state.
+  const parsed = parseArgs(['launch', 'com.example.app'], { strictFlags: true });
+  assert.equal(parsed.command, 'open');
+  assert.deepEqual(parsed.positionals, ['com.example.app']);
+  assert.equal(parsed.flags.relaunch, undefined);
+});
+
+test('relaunch with an explicit --relaunch stays idempotent', () => {
+  const parsed = parseArgs(['relaunch', 'com.example.app', '--relaunch'], { strictFlags: true });
+  assert.equal(parsed.command, 'open');
+  assert.deepEqual(parsed.positionals, ['com.example.app']);
+  assert.equal(parsed.flags.relaunch, true);
+});
+
+test('command aliases normalize case-insensitively', () => {
+  const relaunch = parseArgs(['RELAUNCH', 'com.example.app'], { strictFlags: true });
+  assert.equal(relaunch.command, 'open');
+  assert.equal(relaunch.flags.relaunch, true);
+
+  const launch = parseArgs(['Launch', 'com.example.app'], { strictFlags: true });
+  assert.equal(launch.command, 'open');
+  assert.equal(launch.flags.relaunch, undefined);
+
+  const tap = parseArgs(['TAP', '@e3'], { strictFlags: true });
+  assert.equal(tap.command, 'press');
+  assert.deepEqual(tap.positionals, ['@e3']);
+});
+
+test('relaunch passes non-command args through to open validation untouched', () => {
+  // URL targets parse fine here; the daemon's existing "open --relaunch does
+  // not support URL targets" guidance owns the semantic rejection.
+  const parsed = parseArgs(['relaunch', 'rne://url'], { strictFlags: true });
+  assert.equal(parsed.command, 'open');
+  assert.deepEqual(parsed.positionals, ['rne://url']);
+  assert.equal(parsed.flags.relaunch, true);
+});

--- a/src/cli/parser/__tests__/command-suggestions.test.ts
+++ b/src/cli/parser/__tests__/command-suggestions.test.ts
@@ -43,17 +43,17 @@ test('the keyboard dismiss example uses a real keyboard action', () => {
   assert.doesNotThrow(() => keyboardCliReader(['dismiss'], baseFlags));
 });
 
-test('relaunch suggests the canonical open --relaunch shape', () => {
-  assert.throws(
-    () => parseArgs(['relaunch', 'com.example.app']),
-    (error: unknown) =>
-      error instanceof AppError &&
-      error.code === 'INVALID_ARGS' &&
-      error.message === 'Unknown command: relaunch. Did you mean open <app> --relaunch?',
-  );
+// `launch`/`relaunch` (and `tap`) are true aliases normalized before the
+// unknown-command check, so they must never appear in the suggestion map —
+// a stale entry there would be dead code masking the alias.
+test('true aliases are not listed in the curated suggestion map', () => {
+  const guesses = new Set(listCommandAliasSuggestionEntries().map(([guess]) => guess));
+  for (const alias of ['launch', 'relaunch', 'tap']) {
+    assert.ok(!guesses.has(alias), `"${alias}" is a true alias and must not be a suggestion`);
+  }
 });
 
-for (const guess of ['launch', 'start', 'restart']) {
+for (const guess of ['start', 'restart']) {
   test(`${guess} suggests the canonical open --relaunch shape`, () => {
     assert.throws(
       () => parseArgs([guess, 'com.example.app']),
@@ -110,10 +110,10 @@ test('screencap and capture suggest screenshot', () => {
 });
 
 test('curated suggestions are case-insensitive', () => {
-  assert.equal(suggestCommandFor('RELAUNCH'), 'open <app> --relaunch');
-  assert.equal(suggestCommandFor('Relaunch'), 'open <app> --relaunch');
-  assert.equal(suggestCommandFor('TAP'), 'press');
+  assert.equal(suggestCommandFor('RESTART'), 'open <app> --relaunch');
+  assert.equal(suggestCommandFor('Restart'), 'open <app> --relaunch');
   assert.equal(suggestCommandFor('Touch'), 'press');
+  assert.equal(suggestCommandFor('DISMISS'), 'keyboard dismiss');
 });
 
 test('known command names in the wrong case suggest their lowercase form', () => {

--- a/src/cli/parser/__tests__/command-suggestions.test.ts
+++ b/src/cli/parser/__tests__/command-suggestions.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { isKnownCliCommandName } from '../../../command-catalog.ts';
+import { keyboardCliReader } from '../../../commands/system/index.ts';
 import { AppError } from '../../../kernel/errors.ts';
 import { parseArgs } from '../args.ts';
+import type { CliFlags } from '../cli-flags.ts';
 import { listCommandAliasSuggestionEntries, suggestCommandFor } from '../command-suggestions.ts';
 
 // Guards against the curated alias map drifting to a command that no longer
@@ -19,6 +21,26 @@ test('every curated alias suggestion target resolves to a registered command', (
       `alias suggestion example for "${guess}" ("${suggestion.example}") must start with its command ("${suggestion.command}")`,
     );
   }
+});
+
+// Guards the full example shapes, not just the leading command token: every
+// example must parse as a valid invocation (placeholders substituted), so a
+// renamed flag (e.g. open --relaunch) or a dropped subcommand fails here.
+test('every curated alias suggestion example parses as a valid invocation', () => {
+  for (const [guess, suggestion] of listCommandAliasSuggestionEntries()) {
+    const tokens = suggestion.example
+      .split(' ')
+      .map((token) => (token.startsWith('<') ? 'com.example.app' : token));
+    assert.doesNotThrow(
+      () => parseArgs(tokens, { strictFlags: true }),
+      `alias suggestion example for "${guess}" ("${suggestion.example}") no longer parses`,
+    );
+  }
+});
+
+test('the keyboard dismiss example uses a real keyboard action', () => {
+  const baseFlags: CliFlags = { json: false, help: false, version: false };
+  assert.doesNotThrow(() => keyboardCliReader(['dismiss'], baseFlags));
 });
 
 test('relaunch suggests the canonical open --relaunch shape', () => {
@@ -87,6 +109,18 @@ test('screencap and capture suggest screenshot', () => {
   }
 });
 
+test('curated suggestions are case-insensitive', () => {
+  assert.equal(suggestCommandFor('RELAUNCH'), 'open <app> --relaunch');
+  assert.equal(suggestCommandFor('Relaunch'), 'open <app> --relaunch');
+  assert.equal(suggestCommandFor('TAP'), 'press');
+  assert.equal(suggestCommandFor('Touch'), 'press');
+});
+
+test('known command names in the wrong case suggest their lowercase form', () => {
+  assert.equal(suggestCommandFor('OPEN'), 'open');
+  assert.equal(suggestCommandFor('Press'), 'press');
+});
+
 test('nonsense command names fall back to nearest-name suggestion or a plain error, never a crash', () => {
   assert.throws(
     () => parseArgs(['frobnicate']),
@@ -104,6 +138,28 @@ test('near-miss typos of real commands are suggested via edit distance', () => {
       error instanceof AppError &&
       error.code === 'INVALID_ARGS' &&
       error.message === 'Unknown command: presss. Did you mean press?',
+  );
+});
+
+test('a prefix match wins outright instead of bundling weaker edit-distance ties', () => {
+  // Without the prefix rule, `clos` would suggest "one of: close, logs".
+  assert.throws(
+    () => parseArgs(['clos']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: clos. Did you mean close?',
+  );
+});
+
+test('1-2 character tokens never get a nearest-name suggestion', () => {
+  // `ls` is one edit from `is`, but suggesting `is` would be a false positive.
+  assert.throws(
+    () => parseArgs(['ls']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: ls',
   );
 });
 

--- a/src/cli/parser/__tests__/command-suggestions.test.ts
+++ b/src/cli/parser/__tests__/command-suggestions.test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { isKnownCliCommandName } from '../../../command-catalog.ts';
+import { AppError } from '../../../kernel/errors.ts';
+import { parseArgs } from '../args.ts';
+import { listCommandAliasSuggestionEntries, suggestCommandFor } from '../command-suggestions.ts';
+
+// Guards against the curated alias map drifting to a command that no longer
+// exists (renamed, removed, gated) in the live command registry.
+test('every curated alias suggestion target resolves to a registered command', () => {
+  for (const [guess, suggestion] of listCommandAliasSuggestionEntries()) {
+    assert.ok(
+      isKnownCliCommandName(suggestion.command),
+      `alias suggestion for "${guess}" points at unregistered command "${suggestion.command}"`,
+    );
+    assert.ok(
+      suggestion.example === suggestion.command ||
+        suggestion.example.startsWith(`${suggestion.command} `),
+      `alias suggestion example for "${guess}" ("${suggestion.example}") must start with its command ("${suggestion.command}")`,
+    );
+  }
+});
+
+test('relaunch suggests the canonical open --relaunch shape', () => {
+  assert.throws(
+    () => parseArgs(['relaunch', 'com.example.app']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: relaunch. Did you mean open <app> --relaunch?',
+  );
+});
+
+for (const guess of ['launch', 'start', 'restart']) {
+  test(`${guess} suggests the canonical open --relaunch shape`, () => {
+    assert.throws(
+      () => parseArgs([guess, 'com.example.app']),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'INVALID_ARGS' &&
+        error.message.includes('Did you mean open <app> --relaunch?'),
+    );
+  });
+}
+
+test('touch suggests press', () => {
+  assert.throws(
+    () => parseArgs(['touch', '100', '200']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: touch. Did you mean press?',
+  );
+});
+
+test('dismiss suggests keyboard dismiss', () => {
+  assert.throws(
+    () => parseArgs(['dismiss']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: dismiss. Did you mean keyboard dismiss?',
+  );
+});
+
+test('input and settext suggest fill', () => {
+  for (const guess of ['input', 'settext', 'entertext']) {
+    assert.throws(
+      () => parseArgs([guess, '@e1', 'hello']),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'INVALID_ARGS' &&
+        error.message === `Unknown command: ${guess}. Did you mean fill?`,
+    );
+  }
+});
+
+test('screencap and capture suggest screenshot', () => {
+  for (const guess of ['screencap', 'capture']) {
+    assert.throws(
+      () => parseArgs([guess]),
+      (error: unknown) =>
+        error instanceof AppError &&
+        error.code === 'INVALID_ARGS' &&
+        error.message === `Unknown command: ${guess}. Did you mean screenshot?`,
+    );
+  }
+});
+
+test('nonsense command names fall back to nearest-name suggestion or a plain error, never a crash', () => {
+  assert.throws(
+    () => parseArgs(['frobnicate']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: frobnicate',
+  );
+});
+
+test('near-miss typos of real commands are suggested via edit distance', () => {
+  assert.throws(
+    () => parseArgs(['presss', '100', '200']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: presss. Did you mean press?',
+  );
+});
+
+test('suggestCommandFor never throws for arbitrary input', () => {
+  const inputs = ['', ' ', '@#$%', 'a'.repeat(200), 'RELAUNCH', 'Relaunch'];
+  for (const input of inputs) {
+    assert.doesNotThrow(() => suggestCommandFor(input));
+  }
+});
+
+test('unknown flag that looks like an app/bundle id hints at the open positional', () => {
+  assert.throws(
+    () => parseArgs(['launch', '--bundle-id', 'com.example.app']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message ===
+        'Unknown flag: --bundle-id. The app or bundle id is a positional argument, e.g. open <app> --relaunch.',
+  );
+});
+
+test('unrelated unknown flags are unaffected', () => {
+  assert.throws(
+    () => parseArgs(['press', '100', '200', '--not-a-real-flag']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown flag: --not-a-real-flag',
+  );
+});

--- a/src/cli/parser/args.ts
+++ b/src/cli/parser/args.ts
@@ -44,6 +44,7 @@ export function parseArgs(argv: string[], options?: FinalizeArgsOptions): Parsed
 export function parseRawArgs(argv: string[]): RawParsedArgs {
   const flags: CliFlags = { json: false, help: false, version: false };
   let command: string | null = null;
+  let rawCommand: string | null = null;
   const positionals: string[] = [];
   const warnings: string[] = [];
   const providedFlags: ParsedFlagRecord[] = [];
@@ -56,8 +57,10 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
       continue;
     }
     if (!parseFlags) {
-      if (!command) command = normalizeCommandAlias(arg);
-      else positionals.push(arg);
+      if (!command) {
+        rawCommand = arg;
+        command = normalizeCommandAlias(arg);
+      } else positionals.push(arg);
       continue;
     }
     if (shouldPreservePostCommandArgs(command)) {
@@ -67,8 +70,10 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
     const isLongFlag = arg.startsWith('--');
     const isShortFlag = arg.startsWith('-') && arg.length > 1;
     if (!isLongFlag && !isShortFlag) {
-      if (!command) command = normalizeCommandAlias(arg);
-      else positionals.push(arg);
+      if (!command) {
+        rawCommand = arg;
+        command = normalizeCommandAlias(arg);
+      } else positionals.push(arg);
       continue;
     }
 
@@ -106,7 +111,18 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
     providedFlags.push({ key: definition.key, token });
   }
 
+  applyAliasImpliedFlags(rawCommand, flags);
   return { command, positionals, flags, warnings, providedFlags };
+}
+
+// `relaunch <app>` is a true alias for `open <app> --relaunch`: the command
+// token normalizes to open and the flag is injected here. Setting the flag is
+// idempotent with an explicit --relaunch; everything else passes through to
+// open's normal validation.
+function applyAliasImpliedFlags(rawCommand: string | null, flags: CliFlags): void {
+  if (rawCommand?.toLowerCase() === 'relaunch') {
+    flags.relaunch = true;
+  }
 }
 
 function isLegacyIgnoredSnapshotShortFlag(command: string | null, token: string): boolean {
@@ -369,9 +385,17 @@ export async function usageForCommand(command: string): Promise<string | null> {
   return buildCommandUsageText(normalizeCommandAlias(command));
 }
 
+// Alias matching is case-insensitive (`TAP`, `Relaunch`) so agent-typed case
+// variants normalize instead of erroring. Non-alias tokens pass through
+// unchanged, keeping the user's original casing in unknown-command errors.
 function normalizeCommandAlias(command: string): string {
-  if (command === 'long-press') return 'longpress';
-  if (command === 'metrics') return 'perf';
-  if (command === 'tap') return 'press';
+  const normalized = command.toLowerCase();
+  if (normalized === 'long-press') return 'longpress';
+  if (normalized === 'metrics') return 'perf';
+  if (normalized === 'tap') return 'press';
+  // `launch` maps to a plain open: forcing --relaunch here would silently
+  // destroy app state. `relaunch` additionally injects --relaunch via
+  // applyAliasImpliedFlags in parseRawArgs.
+  if (normalized === 'launch' || normalized === 'relaunch') return 'open';
   return command;
 }

--- a/src/cli/parser/args.ts
+++ b/src/cli/parser/args.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/command-schema.ts';
 import { isFlagSupportedForCommand } from '../../utils/cli-option-schema.ts';
 import { isKnownCliCommandName } from '../../command-catalog.ts';
+import { formatUnknownFlagMessage, suggestCommandFor } from './command-suggestions.ts';
 
 type ParsedArgs = {
   command: string | null;
@@ -86,7 +87,7 @@ export function parseRawArgs(argv: string[]): RawParsedArgs {
         else positionals.push(arg);
         continue;
       }
-      throw new AppError('INVALID_ARGS', `Unknown flag: ${token}`);
+      throw new AppError('INVALID_ARGS', formatUnknownFlagMessage(token));
     }
 
     const parsed = parseFlagValue(definition, token, inlineValue, argv[i + 1]);
@@ -153,7 +154,7 @@ export function finalizeParsedArgs(
   // This ensures "Unknown command" errors take precedence over flag validation errors
   // However, skip this check if --help is provided, since cli.ts will handle it gracefully
   if (parsed.command && !isKnownCliCommandName(parsed.command) && !flags.help) {
-    const hint = getCommandAliasSuggestion(parsed.command);
+    const hint = suggestCommandFor(parsed.command);
     const message = hint
       ? `Unknown command: ${parsed.command}. Did you mean ${hint}?`
       : `Unknown command: ${parsed.command}`;
@@ -343,14 +344,6 @@ function normalizeParsedCommandAliases(parsed: ParsedArgs): ParsedArgs {
     };
   }
   return parsed;
-}
-
-const COMMAND_ALIAS_SUGGESTIONS: Record<string, string> = {
-  tap: 'press or click',
-};
-
-function getCommandAliasSuggestion(command: string): string | undefined {
-  return COMMAND_ALIAS_SUGGESTIONS[command];
 }
 
 function formatUnsupportedFlagMessage(command: string | null, unsupported: string[]): string {

--- a/src/cli/parser/command-suggestions.ts
+++ b/src/cli/parser/command-suggestions.ts
@@ -4,14 +4,17 @@ import { listCliCommandNames } from '../../command-catalog.ts';
  * Curated guess -> canonical command mapping for unknown CLI command names.
  *
  * Agents (and humans) commonly guess command names that don't exist under that
- * spelling, such as `relaunch` instead of `open <app> --relaunch`. Keys must be
+ * spelling, such as `restart` instead of `open <app> --relaunch`. Keys must be
  * lowercase (lookups lowercase the input token first). Each entry's `command`
  * must resolve to a real, registered CLI command name, and each `example` must
  * parse as a valid invocation of it; the registry-drift tests in
  * `src/cli/parser/__tests__/command-suggestions.test.ts` fail the build on drift.
  *
- * `tap` is normalized to `press` as a true alias before the unknown-command
- * check runs, so its entry here only catches case variants such as `TAP`.
+ * True aliases (`tap` -> press, `launch`/`relaunch` -> open) are normalized
+ * case-insensitively in `normalizeCommandAlias` (args.ts) before the
+ * unknown-command check runs, so they never reach this map and must not be
+ * listed here. `start`/`restart` stay suggestion-only: `start` is genuinely
+ * ambiguous, so a hint beats silently guessing.
  */
 type CommandAliasSuggestion = {
   /** Canonical command name this guess should have used. */
@@ -23,11 +26,8 @@ type CommandAliasSuggestion = {
 const OPEN_RELAUNCH_EXAMPLE = 'open <app> --relaunch';
 
 const COMMAND_ALIAS_SUGGESTIONS: Record<string, CommandAliasSuggestion> = {
-  launch: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
-  relaunch: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
   start: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
   restart: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
-  tap: { command: 'press', example: 'press' },
   touch: { command: 'press', example: 'press' },
   input: { command: 'fill', example: 'fill' },
   settext: { command: 'fill', example: 'fill' },

--- a/src/cli/parser/command-suggestions.ts
+++ b/src/cli/parser/command-suggestions.ts
@@ -4,10 +4,14 @@ import { listCliCommandNames } from '../../command-catalog.ts';
  * Curated guess -> canonical command mapping for unknown CLI command names.
  *
  * Agents (and humans) commonly guess command names that don't exist under that
- * spelling, such as `relaunch` instead of `open <app> --relaunch`. Each entry's
- * `command` must resolve to a real, registered CLI command name; the
- * "alias suggestion targets exist" test in
- * `src/cli/parser/__tests__/command-suggestions.test.ts` fails the build on drift.
+ * spelling, such as `relaunch` instead of `open <app> --relaunch`. Keys must be
+ * lowercase (lookups lowercase the input token first). Each entry's `command`
+ * must resolve to a real, registered CLI command name, and each `example` must
+ * parse as a valid invocation of it; the registry-drift tests in
+ * `src/cli/parser/__tests__/command-suggestions.test.ts` fail the build on drift.
+ *
+ * `tap` is normalized to `press` as a true alias before the unknown-command
+ * check runs, so its entry here only catches case variants such as `TAP`.
  */
 type CommandAliasSuggestion = {
   /** Canonical command name this guess should have used. */
@@ -16,11 +20,14 @@ type CommandAliasSuggestion = {
   example: string;
 };
 
+const OPEN_RELAUNCH_EXAMPLE = 'open <app> --relaunch';
+
 const COMMAND_ALIAS_SUGGESTIONS: Record<string, CommandAliasSuggestion> = {
-  launch: { command: 'open', example: 'open <app> --relaunch' },
-  relaunch: { command: 'open', example: 'open <app> --relaunch' },
-  start: { command: 'open', example: 'open <app> --relaunch' },
-  restart: { command: 'open', example: 'open <app> --relaunch' },
+  launch: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
+  relaunch: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
+  start: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
+  restart: { command: 'open', example: OPEN_RELAUNCH_EXAMPLE },
+  tap: { command: 'press', example: 'press' },
   touch: { command: 'press', example: 'press' },
   input: { command: 'fill', example: 'fill' },
   settext: { command: 'fill', example: 'fill' },
@@ -34,29 +41,42 @@ export function listCommandAliasSuggestionEntries(): Array<[string, CommandAlias
   return Object.entries(COMMAND_ALIAS_SUGGESTIONS);
 }
 
-function getCuratedCommandSuggestion(command: string): string | undefined {
-  return COMMAND_ALIAS_SUGGESTIONS[command]?.example;
-}
-
 const NEAREST_COMMAND_SUGGESTION_LIMIT = 3;
 
 /**
- * Nearest registered command names for an unrecognized command, ranked by a
- * prefix-aware edit distance. Names are derived from the live command
- * descriptor registry (via `listCliCommandNames`), never hardcoded, so the
- * suggestion list can't drift from what the CLI actually supports.
+ * Nearest registered command names for an unrecognized (lowercased) command
+ * token. Names are derived from the live command descriptor registry (via
+ * `listCliCommandNames`), never hardcoded, so the suggestion list can't drift
+ * from what the CLI actually supports.
+ *
+ * Precision rules: 1-2 character tokens never get a suggestion, exact prefix
+ * matches win outright, and otherwise only ties at the minimum edit distance
+ * are kept so a strong match is not bundled with a coincidental weak one.
  */
-export function getNearestCommandNames(command: string): string[] {
+function getNearestCommandNames(command: string): string[] {
+  if (command.length <= 2) return [];
   const names = listCliCommandNames();
+  const prefixMatches = names.filter((name) => name.startsWith(command));
+  if (prefixMatches.length > 0) {
+    return prefixMatches
+      .sort((a, b) => a.length - b.length || a.localeCompare(b))
+      .slice(0, NEAREST_COMMAND_SUGGESTION_LIMIT);
+  }
+  const threshold = nearestMatchThreshold(command);
   const scored = names
     .map((name) => ({ name, distance: commandNameDistance(command, name) }))
-    .filter((entry) => entry.distance <= nearestMatchThreshold(command))
-    .sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name));
-  return scored.slice(0, NEAREST_COMMAND_SUGGESTION_LIMIT).map((entry) => entry.name);
+    .filter((entry) => entry.distance <= threshold);
+  if (scored.length === 0) return [];
+  const best = Math.min(...scored.map((entry) => entry.distance));
+  return scored
+    .filter((entry) => entry.distance === best)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .slice(0, NEAREST_COMMAND_SUGGESTION_LIMIT)
+    .map((entry) => entry.name);
 }
 
 function nearestMatchThreshold(command: string): number {
-  if (command.length <= 3) return 1;
+  if (command.length < 4) return 1;
   if (command.length <= 6) return 2;
   return 3;
 }
@@ -91,12 +111,14 @@ function levenshteinDistance(a: string, b: string): number {
 /**
  * Builds the "Did you mean ...?" fragment for an unknown command, or
  * `undefined` when neither the curated alias map nor the nearest-name
- * fallback has a confident suggestion.
+ * fallback has a confident suggestion. Matching is case-insensitive so
+ * `RELAUNCH` and `Touch` get the same hint as their lowercase forms.
  */
 export function suggestCommandFor(command: string): string | undefined {
-  const curated = getCuratedCommandSuggestion(command);
+  const normalized = command.toLowerCase();
+  const curated = COMMAND_ALIAS_SUGGESTIONS[normalized]?.example;
   if (curated) return curated;
-  const nearest = getNearestCommandNames(command);
+  const nearest = getNearestCommandNames(normalized);
   if (nearest.length === 0) return undefined;
   if (nearest.length === 1) return nearest[0];
   return `one of: ${nearest.join(', ')}`;
@@ -121,7 +143,7 @@ const POSITIONAL_APP_FLAG_GUESSES = new Set([
 
 export function formatUnknownFlagMessage(token: string): string {
   if (POSITIONAL_APP_FLAG_GUESSES.has(token.toLowerCase())) {
-    return `Unknown flag: ${token}. The app or bundle id is a positional argument, e.g. open <app> --relaunch.`;
+    return `Unknown flag: ${token}. The app or bundle id is a positional argument, e.g. ${OPEN_RELAUNCH_EXAMPLE}.`;
   }
   return `Unknown flag: ${token}`;
 }

--- a/src/cli/parser/command-suggestions.ts
+++ b/src/cli/parser/command-suggestions.ts
@@ -1,0 +1,127 @@
+import { listCliCommandNames } from '../../command-catalog.ts';
+
+/**
+ * Curated guess -> canonical command mapping for unknown CLI command names.
+ *
+ * Agents (and humans) commonly guess command names that don't exist under that
+ * spelling, such as `relaunch` instead of `open <app> --relaunch`. Each entry's
+ * `command` must resolve to a real, registered CLI command name; the
+ * "alias suggestion targets exist" test in
+ * `src/cli/parser/__tests__/command-suggestions.test.ts` fails the build on drift.
+ */
+type CommandAliasSuggestion = {
+  /** Canonical command name this guess should have used. */
+  command: string;
+  /** Full example invocation shown to the user. */
+  example: string;
+};
+
+const COMMAND_ALIAS_SUGGESTIONS: Record<string, CommandAliasSuggestion> = {
+  launch: { command: 'open', example: 'open <app> --relaunch' },
+  relaunch: { command: 'open', example: 'open <app> --relaunch' },
+  start: { command: 'open', example: 'open <app> --relaunch' },
+  restart: { command: 'open', example: 'open <app> --relaunch' },
+  touch: { command: 'press', example: 'press' },
+  input: { command: 'fill', example: 'fill' },
+  settext: { command: 'fill', example: 'fill' },
+  entertext: { command: 'fill', example: 'fill' },
+  screencap: { command: 'screenshot', example: 'screenshot' },
+  capture: { command: 'screenshot', example: 'screenshot' },
+  dismiss: { command: 'keyboard', example: 'keyboard dismiss' },
+};
+
+export function listCommandAliasSuggestionEntries(): Array<[string, CommandAliasSuggestion]> {
+  return Object.entries(COMMAND_ALIAS_SUGGESTIONS);
+}
+
+function getCuratedCommandSuggestion(command: string): string | undefined {
+  return COMMAND_ALIAS_SUGGESTIONS[command]?.example;
+}
+
+const NEAREST_COMMAND_SUGGESTION_LIMIT = 3;
+
+/**
+ * Nearest registered command names for an unrecognized command, ranked by a
+ * prefix-aware edit distance. Names are derived from the live command
+ * descriptor registry (via `listCliCommandNames`), never hardcoded, so the
+ * suggestion list can't drift from what the CLI actually supports.
+ */
+export function getNearestCommandNames(command: string): string[] {
+  const names = listCliCommandNames();
+  const scored = names
+    .map((name) => ({ name, distance: commandNameDistance(command, name) }))
+    .filter((entry) => entry.distance <= nearestMatchThreshold(command))
+    .sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name));
+  return scored.slice(0, NEAREST_COMMAND_SUGGESTION_LIMIT).map((entry) => entry.name);
+}
+
+function nearestMatchThreshold(command: string): number {
+  if (command.length <= 3) return 1;
+  if (command.length <= 6) return 2;
+  return 3;
+}
+
+function commandNameDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.startsWith(b) || b.startsWith(a)) {
+    return Math.abs(a.length - b.length);
+  }
+  return levenshteinDistance(a, b);
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const distances: number[][] = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let i = 0; i < rows; i += 1) distances[i]![0] = i;
+  for (let j = 0; j < cols; j += 1) distances[0]![j] = j;
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      distances[i]![j] = Math.min(
+        distances[i - 1]![j]! + 1,
+        distances[i]![j - 1]! + 1,
+        distances[i - 1]![j - 1]! + cost,
+      );
+    }
+  }
+  return distances[rows - 1]![cols - 1]!;
+}
+
+/**
+ * Builds the "Did you mean ...?" fragment for an unknown command, or
+ * `undefined` when neither the curated alias map nor the nearest-name
+ * fallback has a confident suggestion.
+ */
+export function suggestCommandFor(command: string): string | undefined {
+  const curated = getCuratedCommandSuggestion(command);
+  if (curated) return curated;
+  const nearest = getNearestCommandNames(command);
+  if (nearest.length === 0) return undefined;
+  if (nearest.length === 1) return nearest[0];
+  return `one of: ${nearest.join(', ')}`;
+}
+
+// Unknown flag names that read like an app/bundle identity concept. `open` (and
+// the commands the curated map above points agents toward) take the app or
+// bundle id as a positional argument, not a flag, so a bare "Unknown flag"
+// error leaves agents guessing. Kept intentionally narrow to avoid false
+// positives on unrelated unknown flags.
+const POSITIONAL_APP_FLAG_GUESSES = new Set([
+  '--bundle-id',
+  '--bundleid',
+  '--bundle',
+  '--package',
+  '--package-name',
+  '--packagename',
+  '--app-id',
+  '--appid',
+  '--pkg',
+]);
+
+export function formatUnknownFlagMessage(token: string): string {
+  if (POSITIONAL_APP_FLAG_GUESSES.has(token.toLowerCase())) {
+    return `Unknown flag: ${token}. The app or bundle id is a positional argument, e.g. open <app> --relaunch.`;
+  }
+  return `Unknown flag: ${token}`;
+}


### PR DESCRIPTION
## Problem

In a July 2026 benchmark, claude-haiku burned 5 turns across runs trying to
relaunch an installed app:

1. `launch --bundle-id <app>` — the QA task said "Relaunch the installed app"
2. `relaunch <app>`
3. `help relaunch`

The correct shape is `open <bundleId> --relaunch`, but the CLI's errors gave
no hint toward it:

```
$ agent-device relaunch com.example.app
Error (INVALID_ARGS): Unknown command: relaunch
Hint: Check command arguments and run --help for usage examples.

$ agent-device launch --bundle-id com.example.app
Error (INVALID_ARGS): Unknown flag: --bundle-id
Hint: Check command arguments and run --help for usage examples.
```

## Approach

Two layers: **true aliases** for the two crisp names, and **suggestions** as
fallback for the fuzzy rest.

### True aliases: `launch` / `relaunch` → `open`

Following the existing `tap` → `press` precedent (normalized in
`normalizeCommandAlias` before parsing, hidden — not added to help or the
command catalog):

- `relaunch <app>` → `open <app>` with `--relaunch` injected. Injection is
  idempotent with an explicit `--relaunch`, and only the command token is
  normalized — everything else passes through to open's normal validation
  (e.g. `relaunch rne://url` surfaces the daemon's existing
  "open --relaunch does not support URL targets" guidance).
- `launch <app>` → plain `open <app>` (**no** `--relaunch` — aliasing launch
  to a force-restart would silently destroy app state).
- Alias matching is case-insensitive (`TAP`, `RELAUNCH`, `Launch` all
  normalize), so agent-typed case variants work too.
- Normalization is pre-dispatch, so command identity stays `open` in daemon
  requests and telemetry — asserted at the daemon boundary by dispatch-level
  tests (`calls[0].command === 'open'`, `flags.relaunch === true`).
- `help relaunch` / `help launch` now show open's usage instead of erroring.

### Suggestions for the rest (`src/cli/parser/command-suggestions.ts`)

Wired into the "Unknown command" check in `src/cli/parser/args.ts` and the
`help <unknown>` path in `src/cli.ts`:

- **Curated map**: `start`/`restart` → `open <app> --relaunch` (`start` is
  genuinely ambiguous, so a hint beats silently guessing — kept
  suggestion-only by design), `touch` → `press`, `input`/`settext`/
  `entertext` → `fill`, `screencap`/`capture` → `screenshot`, `dismiss` →
  `keyboard dismiss`. Registry-drift tests assert every target resolves to a
  registered command **and** every example parses as a valid invocation
  (placeholders substituted), so a renamed `--relaunch` flag or dropped
  keyboard action fails the suite. A companion test asserts true aliases
  (`launch`/`relaunch`/`tap`) are *not* in the map — a stale entry there
  would be dead code masking the alias.
- **Nearest-name fallback**: prefix-aware Levenshtein over
  `listCliCommandNames()` (derived from the command descriptor registry,
  never hardcoded). Precision rules: exact prefix matches win outright
  (`clos` → only `close`), otherwise only ties at the minimum distance are
  kept, and 1-2 character tokens never get a suggestion (`ls` doesn't
  suggest `is`). Case-insensitive; falls back to the plain error when
  nothing is close — never guesses wildly, never crashes.
- **Unknown-flag hint**: a narrow curated set of app/bundle-id-shaped flag
  guesses (`--bundle-id`, `--package`, `--app-id`, ...) gets a hint that the
  app/bundle id is a positional on `open`.

Suggestions are strictly display text on the existing `INVALID_ARGS`
`AppError` — nothing auto-executes; aliases only normalize to a command the
user unambiguously meant.

## Before / after

```
$ agent-device relaunch com.example.app
- Error (INVALID_ARGS): Unknown command: relaunch
+ (works: runs open com.example.app --relaunch)

$ agent-device launch com.example.app
- Error (INVALID_ARGS): Unknown command: launch
+ (works: runs open com.example.app — no forced restart)

$ agent-device help relaunch
- Error (INVALID_ARGS): Unknown command: relaunch
+ (shows open's usage)

$ agent-device launch --bundle-id com.example.app
- Error (INVALID_ARGS): Unknown flag: --bundle-id
+ Error (INVALID_ARGS): Unknown flag: --bundle-id. The app or bundle id is a positional argument, e.g. open <app> --relaunch.

$ agent-device start com.example.app
+ Error (INVALID_ARGS): Unknown command: start. Did you mean open <app> --relaunch?

$ agent-device dismiss
+ Error (INVALID_ARGS): Unknown command: dismiss. Did you mean keyboard dismiss?

$ agent-device presss 100 200
+ Error (INVALID_ARGS): Unknown command: presss. Did you mean press?

$ agent-device frobnicate
Error (INVALID_ARGS): Unknown command: frobnicate   (unchanged: no confident nearest match)
```

All three of the benchmark's wasted-turn shapes now resolve on the first try.

## Gaps / deferred

- The `Unknown flag` fix is intentionally narrow (a curated flag-name set),
  not a generic fuzzy matcher — flag validation is sequenced ahead of
  command validation, so making it command-aware felt riskier than the
  payoff warranted.
- Aliases are CLI-parse-level only (like `tap`): batch steps and MCP tool
  names are separate surfaces and unchanged.

## Test plan

- `src/cli/parser/__tests__/args-parse-session.test.ts`: `relaunch` → open
  + `relaunch: true`; `launch` → open without it; explicit `--relaunch`
  idempotent; `RELAUNCH`/`Launch`/`TAP` case variants; URL pass-through.
- `src/__tests__/cli-help.test.ts`: dispatch-level daemon-call identity for
  both aliases (command records `open`, never `relaunch`/`launch`).
- `src/cli/parser/__tests__/command-suggestions.test.ts` (19 tests):
  registry parity + example-parses drift guards, aliases-not-in-map guard,
  `start`/`restart`/`touch`/`dismiss`/fill/screenshot suggestions,
  case-insensitivity, prefix-beats-ties (`clos`), short-token cutoff (`ls`),
  nonsense fallback, `--bundle-id` hint, unrelated flags unaffected.
- Full gate: `pnpm typecheck`, `pnpm lint`, layering guard, `pnpm build`,
  `pnpm format:check`, `pnpm fallow` (audit vs merge-base: no issues), and
  the full `pnpm test:unit` suite — **379 files, 3447/3447 tests pass**
  (the previously failing `runner-xctestrun` test is fixed by #1170, which
  this branch is rebased on).