### PR TITLE
fix: make manual-qa help self-sufficient and slim routine help paths

### DIFF
--- a/src/cli/parser/__tests__/cli-help-topics.test.ts
+++ b/src/cli/parser/__tests__/cli-help-topics.test.ts
@@ -102,37 +102,31 @@ test('usage includes agent workflows, config, environment, and examples footers'
   assert.match(usageText, /agent-facing, token-efficient view for planning and targeting actions/);
   assert.match(usageText, /Truncated text\/input preview: expand first with snapshot -s @e12/);
   assert.match(usageText, /React Native apps: read help react-native/);
-  assert.match(usageText, /localhost URL opens with a port auto-configure host reachability/);
-  assert.match(usageText, /Expo Go\/dev clients: use the provided URL when given/);
-  assert.match(usageText, /open "Expo Go" <url> --platform ios/);
-  assert.match(usageText, /Do not use plain snapshot or snapshot --diff for this recovery check/);
-  assert.match(usageText, /Install flows: install\/install-from-source first/);
   assert.match(usageText, /use fill <target> <text> --settle to replace a field value/);
   assert.match(usageText, /Use type <text> only to append after focusing a field with press/);
   assert.match(usageText, /do not use fill <target> ""/);
-  assert.match(usageText, /Android IME capture: if fill says input was captured/);
   assert.match(usageText, /Implicit default sessions are scoped to the current worktree/);
   assert.match(usageText, /if a prompt names a Session, include --session <name>/);
   assert.match(usageText, /Run mutating commands serially within one session/);
   assert.match(usageText, /After mutation: refs are stale/);
   assert.match(usageText, /use its selector directly; otherwise refresh with snapshot -i/);
-  assert.match(usageText, /verify the action with diff snapshot -i or snapshot --diff/);
   assert.match(usageText, /fill <targetOrX> <yOrText> \[text\]\s+Replace text in/);
   assert.match(usageText, /type <text>\s+Append text to the focused field/);
-  assert.match(usageText, /Sparse or AX-unavailable snapshot/);
   assert.match(usageText, /macOS context menus use click <ref> --button secondary/);
   assert.match(
     usageText,
     /Remote lifecycle: use connect, then open, commands, close, and disconnect/,
   );
-  assert.match(usageText, /connect proxy --daemon-base-url <proxy-agent-device-url>/);
-  assert.match(usageText, /Device leases are automatic on open/);
-  assert.match(usageText, /expire after five minutes of inactivity/);
-  assert.match(usageText, /app-owned back uses back/);
-  assert.match(usageText, /Web browser sessions: read help web/);
+  // Deep topic-specific detail (Metro/Expo recovery, Android IME capture, coordinate
+  // fallback verification, sparse/AX recovery, direct-proxy flags, back/system-back
+  // wording, the full web command sequence) moved out of the bare-help Agent
+  // Quickstart section and now lives only in the owning topic (help react-native,
+  // help workflow, help remote, help web) so `agent-device help` alone stays small.
+  // Those topics assert the same content in their own usageForCommand tests below.
+  assert.match(usageText, /TV\/D-pad targets: read help tv\. Web browser sessions: read help web/);
   assert.match(
     usageText,
-    /open <url> --platform web -> snapshot -i -> click\/fill\/get\/is\/find\/wait\/screenshot -> close/,
+    /Routine QA loop with concrete command shapes: agent-device help manual-qa/,
   );
   assert.match(usageText, /Session state contains request diagnostics and runner\.log/);
   assert.match(usageText, /logs clear --restart\/mark\/path/);

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -82,36 +82,22 @@ const AGENT_QUICKSTART_LINES = [
   'Planning output contract: when asked to plan commands, output command lines only: no prose, numbering, Markdown fences, pipes, or shell helpers.',
   'If you did not use --settle, verify a mutation with diff snapshot (or diff snapshot -i), not a full snapshot: it prints only the added/removed/changed lines since the last snapshot in this session.',
   'Network-backed or debounced results may arrive after the --settle quiet window; follow the settled action with wait text "Expected result" or wait <selector> instead of polling full snapshots.',
-  'Pin a raw CLI ref to the response that minted it with ~s<n> (n = refsGeneration or settle.refsGeneration): press @e12~s4. Pinned refs get exact staleness warnings instead of the coarse tree-changed one; plain refs stay valid input.',
+  'Pin a raw CLI ref to the response that minted it with ~s<n> (n = refsGeneration): press @e12~s4; plain refs stay valid input.',
   'Plain snapshot reads state; snapshot -i refreshes current interactive refs only.',
   'Default snapshot text is an agent-facing, token-efficient view for planning and targeting actions.',
   'Read-only visible/state question: use snapshot/get/is/find; use snapshot -i only when refs are needed.',
-  'Anti-pattern: snapshot -i followed by snapshot -i | grep ... or hiding command output with 2>/dev/null | jq ...; inspect raw agent-device output first, since hints and errors are part of the planning contract.',
   'Truncated text/input preview: expand first with snapshot -s @e12, not get text.',
-  'React Native apps: read help react-native for Metro/Re.Pack, DevTools routing, and RN-specific blockers; use react-native dismiss-overlay for LogBox/RedBox overlays.',
-  'React Native JS memory leaks: read help cdp; use heap usage samples for a quick signal, then snapshot diff/leak-triplet for retained object proof.',
-  'Android RN/Expo/Re.Pack dev server: direct Android localhost URL opens with a port auto-configure host reachability.',
-  'Expo Go/dev clients: use the provided URL when given; on iOS use open "Expo Go" <url> --platform ios, then snapshot -i --platform ios to verify project UI. Do not use plain snapshot or snapshot --diff for this recovery check. Android URL opens infer the foreground package for logs/perf when possible.',
-  'Install flows: install/install-from-source first, then open the installed id with --relaunch.',
+  'React Native apps: read help react-native.',
   'Text fields: use fill <target> <text> --settle to replace a field value. Use type <text> only to append after focusing a field with press.',
   'Clearing text: do not use fill <target> ""; use a visible clear/reset control or report that clearing is unsupported.',
-  'Android IME capture: if fill says input was captured by the keyboard/IME, inspect keyboard state and switch/disable handwriting before retrying; do not loop fill/type.',
   'Implicit default sessions are scoped to the current worktree; if a prompt names a Session, include --session <name> on every command in that flow.',
   'Run mutating commands serially within one session; parallelize only read-only commands or separate sessions/devices.',
-  'Clipboard limits: iOS Allow Paste cannot be automated through XCUITest; prefill with clipboard write. Android non-ASCII should use fill/type, not raw adb input.',
   'After mutation: refs are stale. If the next target is known, use its selector directly; otherwise refresh with snapshot -i, scoped with -s when a stable container is known. Use press/click for taps.',
-  'Raw coordinates are fallback-only: use snapshot -i --json rects when iOS refs no-op or child refs are missing, then verify the action with diff snapshot -i or snapshot --diff.',
-  'Sparse or AX-unavailable snapshot: use screenshot for visual truth, press the visible coordinate to leave the bad screen, then retry AX with snapshot -i.',
   'macOS context menus use click <ref> --button secondary, then snapshot -i. Longpress is for mobile hold gestures, not macOS secondary-click menus.',
-  'Remote lifecycle: use connect, then open, commands, close, and disconnect. Cloud, remote-config, direct proxy, and limrun use the same flow.',
-  'Direct proxy: run agent-device connect proxy --daemon-base-url <proxy-agent-device-url> before using a shared Mac proxy. Device leases are automatic on open and expire after five minutes of inactivity.',
-  'Batch JSON steps use "command" and structured "input"; legacy "positionals"/"flags" steps still run in CLI but are deprecated until the next major version.',
-  'Navigation: app-owned back uses back; system back uses back --system.',
-  'TV targets are focus-first: read help tv; use tv-remote press up|down|left|right|select to move D-pad/remote focus, tv-remote longpress <button> for a held remote button, and activate focused controls before assuming press/click @ref works.',
-  'Web browser sessions: read help web; first slice is web setup if needed -> web doctor -> open <url> --platform web -> snapshot -i -> click/fill/get/is/find/wait/screenshot -> close.',
-  'Verification commands must name the expected text/selector; bare screenshots/snapshots are not enough.',
+  'Remote lifecycle: use connect, then open, commands, close, and disconnect. Read help remote for proxy, cloud, and device-cloud provider flows.',
+  'TV/D-pad targets: read help tv. Web browser sessions: read help web.',
   'Debug evidence: Session state contains request diagnostics and runner.log; use logs clear --restart/mark/path, trace, and network dump --include headers for app evidence.',
-  'Full operating guide: agent-device help workflow. Exploratory QA: agent-device help dogfood.',
+  'Routine QA loop with concrete command shapes: agent-device help manual-qa. Full operating guide: agent-device help workflow. Exploratory QA: agent-device help dogfood.',
 ] as const;
 
 const CONFIGURATION_LINES = [
@@ -137,10 +123,7 @@ const ENVIRONMENT_LINES = [
 const EXAMPLE_LINES = [
   'agent-device open Settings --platform ios',
   'agent-device open https://example.com --platform web',
-  'agent-device open TextEdit --platform macos',
   'agent-device snapshot -i',
-  'agent-device react-devtools get tree --depth 3',
-  'agent-device cdp memory usage sample --gc --label baseline',
   'agent-device fill @e3 "test@example.com"',
   'agent-device replay ./session.ad',
   'agent-device test ./suite --platform android',
@@ -165,6 +148,17 @@ Loop:
   5. If --settle prints not settled, follow its hint before the next ref-based action.
   6. Verify named expectations with wait text/selector, get, is, find, or the settled diff. A bare screenshot/snapshot is not verification for a named expectation.
   7. Close the session when the script ends.
+
+Command shapes:
+  agent-device open com.example.app --relaunch
+  agent-device open https://example.com/deep-link
+  agent-device snapshot -i
+  agent-device press @e12 --settle
+  agent-device press 'label="Follow"'
+  agent-device fill @e13 "qa@example.com" --settle
+  agent-device wait text "Order placed" 3000
+  agent-device close
+  --relaunch forces fresh app state; a deep link/URL open does not need it. Labels with an apostrophe or quote (label="Don't leave") are shell-quoting hazards: prefer the @ref from the latest snapshot/settle output over quoting the literal label.
 
 Targets:
   Prefer refs from the latest snapshot -i or settled diff. Use durable selectors when the label/id is known: label="Search", id="submit", role=button label="Follow".
@@ -687,7 +681,8 @@ This topic covers React Native-specific automation hazards and routes deeper
 questions to the owning help topic.
 
 Choose the next help topic:
-  Generic navigation, selectors, refs, verification, serial commands: help workflow.
+  Routine QA/dogfood/manual-test flow (open, snapshot -i, press/fill --settle, verify, close): help manual-qa; it has the concrete command shapes, so you should not need generic navigation help for a normal pass.
+  Deep exploration of navigation/selector/ref edge cases, or a serial-command question manual-qa does not answer: help workflow (full reference, larger read).
   Logs, network, diagnostics, traces, permission dialogs, or runtime failures: help debugging.
   Component tree, props/state/hooks, slow renders, rerenders, or render causes: help react-devtools.
   JS heap growth, heap snapshots, allocation hotspots, or retained-object leaks: help cdp.
@@ -763,7 +758,7 @@ Slow-flow investigation:
     body: `agent-device help physical-device
 
 Use this when the target is connected hardware instead of a simulator/emulator.
-For simulator/emulator workflows, use help workflow.
+For simulator/emulator flows, use help manual-qa for routine QA or help workflow for the full reference.
 
 Discovery:
   agent-device devices --platform ios
@@ -1170,6 +1165,13 @@ function renderFlagSection(title: string, definitions: FlagDefinition[]): string
   );
 }
 
+// Cap the alignment column so one long outlier label (for example a
+// combined tv-remote usage string) does not force padding whitespace onto
+// every other row. Rows whose label exceeds the cap fall back to a plain
+// two-space gap; they still read fine and every regex in the test suite
+// only requires \s{2,}, never an exact column width.
+const ALIGN_CAP = 26;
+
 function renderAlignedSection(
   title: string,
   items: ReadonlyArray<{ label: string; description: string }>,
@@ -1177,10 +1179,13 @@ function renderAlignedSection(
   if (items.length === 0) {
     return `${title}\n  (none)`;
   }
-  const maxLabelLength = Math.max(...items.map((item) => item.label.length)) + 2;
+  const columnWidth =
+    Math.max(...items.map((item) => Math.min(item.label.length, ALIGN_CAP))) + 2;
   const lines = [title];
   for (const item of items) {
-    lines.push(`  ${item.label.padEnd(maxLabelLength)}${item.description}`);
+    const label =
+      item.label.length <= ALIGN_CAP ? item.label.padEnd(columnWidth) : `${item.label}  `;
+    lines.push(`  ${label}${item.description}`);
   }
   return lines.join('\n');
 }
@@ -1234,6 +1239,7 @@ function buildHelpTopicUsageText(topicName: string): string | null {
 Related:
   agent-device help                  command list and global flags
   agent-device help <command>        command-specific flags
-  agent-device help workflow         normal app automation loop
+  agent-device help manual-qa        routine QA loop with concrete command shapes
+  agent-device help workflow         full app automation reference
 `;
 }

--- a/src/cli/parser/cli-help.ts
+++ b/src/cli/parser/cli-help.ts
@@ -222,6 +222,7 @@ Snapshots and refs:
   For press/fill/click/longpress, prefer --settle and continue from its settled diff when it exposes the next target or evidence. Refresh with snapshot -i only when you did not settle, settle printed not settled, or the settle output lacks what you need.
   Anti-pattern: snapshot -i followed by snapshot -i | grep ..., or adding 2>/dev/null | jq ... before reading the raw command output.
   Refs from the first snapshot remain valid until you press, click, fill, type, scroll, go back, wait for async UI, or otherwise change app state.
+  Pinned refs (@e12~s4, generation from refsGeneration or settle.refsGeneration) get exact staleness warnings instead of the coarse tree-changed one; plain refs stay valid input.
   After a mutation, prefer a known selector/label directly (for example press 'label="Send"') because interaction commands refresh interactive state internally. If you need to discover a new control not shown by settle, use snapshot -i, or snapshot -i -s "Composer" when a stable container label/id can scope the refresh.
   If typing/fill opened the keyboard or changed layout and the next target has no stable selector, run snapshot -i, use the fresh ref, then verify with wait/find or diff snapshot -i.
   For a targeted query, use find/get/is. If you truly need the full tree again, pass --force-full.
@@ -1179,8 +1180,7 @@ function renderAlignedSection(
   if (items.length === 0) {
     return `${title}\n  (none)`;
   }
-  const columnWidth =
-    Math.max(...items.map((item) => Math.min(item.label.length, ALIGN_CAP))) + 2;
+  const columnWidth = Math.max(...items.map((item) => Math.min(item.label.length, ALIGN_CAP))) + 2;
   const lines = [title];
   for (const item of items) {
     const label =


### PR DESCRIPTION
## Evidence

July 2026 benchmarks of gpt-5.4-mini/haiku/sonnet driving the CLI showed agents spending 14-41KB of tool output on help before a routine QA flow:

- Agents told to read `help manual-qa` + `help react-native` before a QA flow spent 14-41KB of tool output on help.
- One run read `help workflow` (31.7KB) because `help react-native` routed "generic navigation, selectors, refs, verification" there.
- Another ran bare `agent-device help` (16.3KB) mid-task.
- Several read per-command help (`help open/press/fill/close`) because `manual-qa` lacked concrete command shapes.
- Haiku guessed a phantom `relaunch` command because no shape showed `open <app> --relaunch`.
- One run failed shell-quoting on `label="Don't leave"`.

## Changes

1. **`help manual-qa`** now has a compact "Command shapes" block covering the whole routine QA loop (`open <bundleId> --relaunch`, `open <url>` deep link, `snapshot -i`, `press @eN --settle`, `press 'label="Text"'`, `fill @eN "text" --settle`, `wait text "..." <ms>`, `close`), plus one line on apostrophe/quote-label quoting hazards (prefer `@ref` from the latest snapshot/settle output). No per-command help reads should be needed for a normal pass.
2. **`help react-native`** no longer routes routine QA to `help workflow`. The routing block now sends routine flows to `help manual-qa` and reserves `help workflow` for deep exploration/debugging of navigation/selector/ref edge cases.
3. **Bare `agent-device help`** (`buildUsageText`) is trimmed:
   - Cut `Agent Quickstart` lines that duplicated detail already owned by dedicated topics (React Native Metro/Expo recovery, Android IME capture, direct-proxy flags, sparse/AX recovery, the full web command sequence, back/system-back wording) — kept short pointer lines to `help react-native` / `help remote` / `help tv` / `help web` instead.
   - Dropped 3 redundant `Examples:` lines (macOS open, react-devtools, cdp — none pinned by tests, all covered by their own topics).
   - Fixed an alignment bug in `renderAlignedSection`: one long usage string (`tv-remote press|longpress <button> [--duration-ms <ms>]`, 55 chars) forced every other `Commands:` row to pad out to that width — pure whitespace, no content. Capped the alignment column at 26 chars; longer labels fall back to a plain 2-space gap (still satisfies every `\s{2,}` regex in the test suite).
   - The "Default app loop" line — shown in earlier benchmarks (#1101) to flip Haiku from 0/3 to 3/3 — is untouched and still the second line of `Agent Starting Point:`.
4. `physical-device` and the shared per-topic "Related:" footer (`buildHelpTopicUsageText`) now also point at `help manual-qa`, not just `help workflow`.

## Byte sizes (via `buildUsageText()` / `buildCommandUsageText(topic)`, UTF-8)

| Surface | Before | After | Δ |
|---|---|---|---|
| bare `agent-device help` | 16,261 B | 11,734 B | −27.8% |
| `help manual-qa` | 2,351 B | 3,014 B | +663 B (target: stay under ~3.5KB — met) |
| `help react-native` | 7,280 B | 7,652 B | +372 B (routing block got more specific, not a size target) |
| `help workflow` (unchanged content + new footer line) | 31,708 B | 31,793 B | +85 B |

Bare help landed at 11.7KB rather than the ~8KB target. The floor is the auto-generated `Commands:` catalog (5.5KB after the alignment fix, down from 7.2KB — the 1.7KB alignment-padding fix was the only safe cut available there). That catalog is derived from the command-descriptor registry (`src/commands/**`), not owned by `cli-help.ts`; shortening the ~65 per-command summary strings to hit 8KB would be a separate, broader change touching many files well outside a "help text diet," so I left it alone and documented the shortfall here instead of quietly missing the target.

## Test evidence

- `test/skillgym/suites/agent-device-smoke-suite.ts`: grepped for any direct assertions on `cli-help.ts` content (`cli-help`, `buildUsageText`, `HELP_TOPICS`, literal `'help'`) — only one match, a `forbiddenOutputs: [plannedCommand('help')]` check on the *agent's own planned output*, unrelated to help text wording. Not run (LLM bench, per instructions).
- `scripts/help-conformance-bench.mjs`: loads help text via `cliHelp(['--help'])` / `cliHelp(['help', docId])` with no hardcoded string assertions on content — only scores the LLM's planned commands. Not run (LLM bench).
- Unit tests referencing `cli-help.ts`: `src/__tests__/cli-help.test.ts` (21 tests, all about `help workflow`/per-command help, untouched by this change) and `src/cli/parser/__tests__/cli-help-topics.test.ts` (bare-help + all topic assertions) and `src/cli/parser/__tests__/cli-help-command-usage.test.ts`. Updated `cli-help-topics.test.ts`'s "usage includes agent workflows..." test to drop assertions on the ~12 Quickstart lines that were deliberately cut/moved into topics, and added assertions for the new manual-qa pointer and TV/web pointer lines. All 75 tests across the three files pass.
- `pnpm build`, `pnpm lint`, `pnpm typecheck`, `pnpm check:layering` all pass clean.
- `vitest run --project unit-core` (3350 tests): 7 unrelated failures, none in files touched by this PR (daemon-client, runtime-hints, apple/core index, runner-client/xctestrun). Re-ran those 5 files in isolation: 219/220 passed; the 1 remaining failure is a pre-existing stale `packageVersion` fixture (expects "0.19.0", repo is now on 0.19.1) unrelated to help text.

## Deliberately not trimmed

- The `Commands:` catalog itself (5.5KB) — see byte-size note above.
- `help workflow`'s body content — untouched; only the shared "Related:" footer gained a line pointing to `manual-qa`.
- `Agent Workflows:` topic-list descriptions — already compact (1.3KB for 13 topics) and heavily pinned by tests verbatim; not worth the churn for marginal savings.