### PR TITLE
fix: read runner cache package version from project root

### DIFF
--- a/src/platforms/apple/core/runner/runner-cache-metadata.ts
+++ b/src/platforms/apple/core/runner/runner-cache-metadata.ts
@@ -107,7 +107,7 @@ export function resolveExpectedRunnerCacheMetadata(
   const platformName = resolveRunnerPlatformName(device);
   return {
     schemaVersion: RUNNER_CACHE_SCHEMA_VERSION,
-    packageVersion: readVersion(),
+    packageVersion: readVersion(projectRoot),
     runnerSourceFingerprint: computeRunnerSourceFingerprint(projectRoot),
     ...resolveRunnerToolchainFingerprint(platformName, device.kind),
     platformName,

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -2,13 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export function readVersion(): string {
+export function readVersion(root: string = findProjectRoot()): string {
   try {
-    const root = findProjectRoot();
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as {
-      version?: string;
+      version?: unknown;
     };
-    return pkg.version ?? '0.0.0';
+    return typeof pkg.version === 'string' ? pkg.version : '0.0.0';
   } catch {
     return '0.0.0';
   }


### PR DESCRIPTION
## Summary

Fix the Coverage failure on current main by making expected XCTest runner cache metadata read packageVersion from the same projectRoot used for the runner source fingerprint.

The metadata writer script already reads projectRoot/package.json; the TypeScript resolver was reading the repo root version instead, so release bumps made the script-vs-resolver test compare 0.19.0 against 0.19.1.

## Validation

pnpm exec vitest run src/platforms/apple/core/__tests__/runner-xctestrun.test.ts
pnpm test:coverage -- --runInBand
pnpm typecheck
pnpm format