### PR TITLE
fix: stabilize android maestro gestures

### DIFF
--- a/android-multitouch-helper/src/main/java/com/callstack/agentdevice/multitouchhelper/MultiTouchInstrumentation.java
+++ b/android-multitouch-helper/src/main/java/com/callstack/agentdevice/multitouchhelper/MultiTouchInstrumentation.java
@@ -104,13 +104,13 @@ public final class MultiTouchInstrumentation extends Instrumentation {
     int count = 0;
 
     try {
-      inject(
+      injectScheduledEvent(
           automation,
           motionEvent(downTime, eventTime, MotionEvent.ACTION_DOWN, activePointers),
           true);
       count += 1;
       eventTime += 8;
-      inject(
+      injectScheduledEvent(
           automation,
           motionEvent(
               downTime,
@@ -127,13 +127,16 @@ public final class MultiTouchInstrumentation extends Instrumentation {
         double t = (double) index / (double) frameCount;
         PointerPair frame = pointerPairAt(spec, t);
         eventTime = downTime + Math.round(spec.durationMs * t);
-        inject(automation, motionEvent(downTime, eventTime, MotionEvent.ACTION_MOVE, frame), false);
+        injectScheduledEvent(
+            automation,
+            motionEvent(downTime, eventTime, MotionEvent.ACTION_MOVE, frame),
+            false);
         count += 1;
         activePointers = frame;
       }
 
       eventTime = downTime + spec.durationMs;
-      inject(
+      injectScheduledEvent(
           automation,
           motionEvent(
               downTime,
@@ -143,7 +146,7 @@ public final class MultiTouchInstrumentation extends Instrumentation {
           true);
       count += 1;
       activePointers = end.firstOnly();
-      inject(
+      injectScheduledEvent(
           automation,
           motionEvent(downTime, eventTime + 8, MotionEvent.ACTION_UP, activePointers),
           true);
@@ -165,7 +168,7 @@ public final class MultiTouchInstrumentation extends Instrumentation {
     int count = 0;
 
     try {
-      inject(
+      injectScheduledEvent(
           automation,
           motionEvent(downTime, eventTime, MotionEvent.ACTION_DOWN, activePointer),
           true);
@@ -177,14 +180,17 @@ public final class MultiTouchInstrumentation extends Instrumentation {
         double t = (double) index / (double) frameCount;
         PointerPair frame = pointerPairAt(spec, t);
         eventTime = downTime + Math.round(spec.durationMs * t);
-        inject(automation, motionEvent(downTime, eventTime, MotionEvent.ACTION_MOVE, frame), false);
+        injectScheduledEvent(
+            automation,
+            motionEvent(downTime, eventTime, MotionEvent.ACTION_MOVE, frame),
+            false);
         count += 1;
         activePointer = frame;
       }
 
       eventTime = downTime + spec.durationMs;
       activePointer = pointerPairAt(spec, 1);
-      inject(
+      injectScheduledEvent(
           automation,
           motionEvent(downTime, eventTime, MotionEvent.ACTION_UP, activePointer),
           true);
@@ -198,8 +204,11 @@ public final class MultiTouchInstrumentation extends Instrumentation {
     }
   }
 
-  private static void inject(UiAutomation automation, MotionEvent event, boolean waitForDispatch) {
+  private static void injectScheduledEvent(
+      UiAutomation automation, MotionEvent event, boolean waitForDispatch) {
     try {
+      // Event timestamps alone do not pace UiAutomation injection; recognizers need real time.
+      sleepUntil(event.getEventTime());
       if (!automation.injectInputEvent(event, waitForDispatch)) {
         throw new IllegalStateException("injectInputEvent returned false");
       }
@@ -208,10 +217,20 @@ public final class MultiTouchInstrumentation extends Instrumentation {
     }
   }
 
+  private static void sleepUntil(long targetUptimeMs) {
+    long delayMs = targetUptimeMs - SystemClock.uptimeMillis();
+    if (delayMs > 0) {
+      SystemClock.sleep(delayMs);
+    }
+  }
+
   private static void injectCancel(
       UiAutomation automation, long downTime, long eventTime, PointerPair pair) {
     try {
-      inject(automation, motionEvent(downTime, eventTime, MotionEvent.ACTION_CANCEL, pair), true);
+      injectScheduledEvent(
+          automation,
+          motionEvent(downTime, eventTime, MotionEvent.ACTION_CANCEL, pair),
+          true);
     } catch (RuntimeException ignored) {
       // Best-effort cleanup; preserve the original injection failure.
     }

--- a/src/compat/maestro/__tests__/runtime-assertions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-assertions.test.ts
@@ -404,10 +404,10 @@ test('invokeMaestroAssertVisible does not retry stale Android taps after swipes'
   assert.equal(response.ok, false);
   assert.deepEqual(calls, [
     ['snapshot', []],
-    ['swipe', ['332', '422', '59', '422', '300']],
+    ['swipe', ['332', '549', '59', '549', '300']],
     ['wait', ['What is Lorem Ipsum?', '2000']],
     ['snapshot', []],
-    ['swipe', ['332', '422', '59', '422', '300']],
+    ['swipe', ['332', '549', '59', '549', '300']],
     ['wait', ['What is Lorem Ipsum?', '2000']],
     ['snapshot', []],
   ]);
@@ -565,6 +565,33 @@ test('invokeMaestroAssertVisible retries Android id-only selectors with a raw sn
   assert.deepEqual(
     snapshotFlags.map((flags) => flags?.snapshotRaw),
     [undefined, true],
+  );
+});
+
+test('invokeMaestroAssertNotVisible does not use Android raw fallback for absent id-only selectors', async () => {
+  vi.spyOn(Date, 'now').mockReturnValue(0);
+
+  const snapshotFlags: Array<DaemonRequest['flags']> = [];
+  const response = await invokeMaestroAssertNotVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    positionals: ['id="archived-banner"', '0'],
+    invoke: async (req): Promise<DaemonResponse> => {
+      if (req.command === 'snapshot') {
+        snapshotFlags.push(req.flags);
+        return { ok: true, data: snapshot([]) };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(
+    snapshotFlags.map((flags) => flags?.snapshotRaw),
+    [undefined],
   );
 });
 

--- a/src/compat/maestro/__tests__/runtime-assertions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-assertions.test.ts
@@ -53,7 +53,7 @@ test('invokeMaestroAssertVisible takes a terminal snapshot when the last miss st
   if (response.ok) {
     assert.ok(response.data);
     assert.equal(response.data.nodeLabel, 'Details is preloaded!');
-    assert.equal(response.data.waitedMs, 6600);
+    assert.equal(response.data.waitedMs, 6500);
   }
 });
 
@@ -404,10 +404,10 @@ test('invokeMaestroAssertVisible does not retry stale Android taps after swipes'
   assert.equal(response.ok, false);
   assert.deepEqual(calls, [
     ['snapshot', []],
-    ['swipe', ['332', '549', '59', '549', '300']],
+    ['swipe', ['332', '422', '59', '422', '300']],
     ['wait', ['What is Lorem Ipsum?', '2000']],
     ['snapshot', []],
-    ['swipe', ['332', '549', '59', '549', '300']],
+    ['swipe', ['332', '422', '59', '422', '300']],
     ['wait', ['What is Lorem Ipsum?', '2000']],
     ['snapshot', []],
   ]);
@@ -528,6 +528,44 @@ test('invokeMaestroAssertVisible does not use raw fallback for Android identifie
   assert.equal(response.ok, true);
   assert.equal(snapshotFlags.length, 1);
   assert.equal(snapshotFlags[0]?.snapshotRaw, undefined);
+});
+
+test('invokeMaestroAssertVisible retries Android id-only selectors with a raw snapshot after a presentation miss', async () => {
+  const snapshotFlags: Array<DaemonRequest['flags']> = [];
+  const response = await invokeMaestroAssertVisible({
+    baseReq: {
+      token: 't',
+      session: 's',
+      flags: { platform: 'android' },
+    },
+    positionals: ['id="material-top-bar-post-auth-screen"', '1000'],
+    invoke: async (req): Promise<DaemonResponse> => {
+      if (req.command === 'snapshot') {
+        snapshotFlags.push(req.flags);
+        return {
+          ok: true,
+          data: snapshot(
+            req.flags?.snapshotRaw === true
+              ? [
+                  node('', {
+                    type: 'android.view.ViewGroup',
+                    identifier: 'material-top-bar-post-auth-screen',
+                    rect: { x: 0, y: 240, width: 1080, height: 1900 },
+                  }),
+                ]
+              : [],
+          ),
+        };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  assert.equal(response.ok, true);
+  assert.deepEqual(
+    snapshotFlags.map((flags) => flags?.snapshotRaw),
+    [undefined, true],
+  );
 });
 
 test('invokeMaestroAssertVisible does not use Android raw fallback for generated text selectors', async () => {

--- a/src/compat/maestro/__tests__/runtime-interactions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-interactions.test.ts
@@ -242,7 +242,7 @@ test('invokeMaestroTapOn clicks explicit React Native overlay controls directly'
   expect(clicks).toEqual([['355', '30']]);
 });
 
-test('invokeMaestroSwipeScreen maps Android horizontal directional swipes to content lane', async () => {
+test('invokeMaestroSwipeScreen maps Android horizontal directional swipes to Maestro midpoint lane', async () => {
   const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
@@ -262,10 +262,10 @@ test('invokeMaestroSwipeScreen maps Android horizontal directional swipes to con
   });
 
   expect(response.ok).toBe(true);
-  expect(swipes).toEqual([['340', '520', '60', '520', '300']]);
+  expect(swipes).toEqual([['340', '400', '60', '400', '300']]);
 });
 
-test('invokeMaestroSwipeScreen mirrors Android horizontal directional content lane swipes', async () => {
+test('invokeMaestroSwipeScreen mirrors Android horizontal directional midpoint lane swipes', async () => {
   const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
@@ -285,7 +285,54 @@ test('invokeMaestroSwipeScreen mirrors Android horizontal directional content la
   });
 
   expect(response.ok).toBe(true);
-  expect(swipes).toEqual([['60', '520', '340', '520', '300']]);
+  expect(swipes).toEqual([['60', '400', '340', '400', '300']]);
+});
+
+test('invokeMaestroSwipeScreen delegates Android vertical down swipes to physical-screen scroll', async () => {
+  const scrolls: Array<{ positionals: string[]; durationMs: number | undefined }> = [];
+  const response = await invokeMaestroSwipeScreen({
+    baseReq: {
+      token: 'test',
+      session: 'pager',
+      flags: { platform: 'android' },
+    },
+    positionals: ['direction', 'down', '100'],
+    invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
+      if (req.command === 'scroll') {
+        scrolls.push({
+          positionals: req.positionals ?? [],
+          durationMs: req.flags?.durationMs,
+        });
+        return { ok: true, data: {} };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  expect(response.ok).toBe(true);
+  expect(scrolls).toEqual([{ positionals: ['up', '0.6'], durationMs: 100 }]);
+});
+
+test('invokeMaestroSwipeScreen delegates Android vertical up swipes to physical-screen scroll', async () => {
+  const scrolls: string[][] = [];
+  const response = await invokeMaestroSwipeScreen({
+    baseReq: {
+      token: 'test',
+      session: 'pager',
+      flags: { platform: 'android' },
+    },
+    positionals: ['direction', 'up'],
+    invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
+      if (req.command === 'scroll') {
+        scrolls.push(req.positionals ?? []);
+        return { ok: true, data: {} };
+      }
+      return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
+    },
+  });
+
+  expect(response.ok).toBe(true);
+  expect(scrolls).toEqual([['down', '0.6']]);
 });
 
 test('invokeMaestroSwipeOn resolves visible non-interactive text from a regular snapshot', async () => {
@@ -394,7 +441,7 @@ test('invokeMaestroSwipeScreen keeps iOS horizontal percentage swipes away from 
   expect(swipes).toEqual([['60', '400', '340', '400', '300']]);
 });
 
-test('invokeMaestroSwipeScreen keeps Android horizontal percentage swipes on the content lane', async () => {
+test('invokeMaestroSwipeScreen preserves Android horizontal percentage swipe lanes', async () => {
   const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
@@ -416,7 +463,7 @@ test('invokeMaestroSwipeScreen keeps Android horizontal percentage swipes on the
   });
 
   expect(response.ok).toBe(true);
-  expect(swipes).toEqual([['351', '390', '39', '390', '300']]);
+  expect(swipes).toEqual([['351', '300', '39', '300', '300']]);
 });
 
 test('invokeMaestroTapPointPercent shares percentage point geometry without clamping', async () => {

--- a/src/compat/maestro/__tests__/runtime-interactions.test.ts
+++ b/src/compat/maestro/__tests__/runtime-interactions.test.ts
@@ -7,6 +7,7 @@ import {
   invokeMaestroTapOn,
   invokeMaestroTapPointPercent,
 } from '../runtime-interactions.ts';
+import { consumeMaestroRecoverableInteraction } from '../runtime-support.ts';
 
 test('invokeMaestroTapOn resolves mutating taps from the current snapshot', async () => {
   const selector =
@@ -242,7 +243,7 @@ test('invokeMaestroTapOn clicks explicit React Native overlay controls directly'
   expect(clicks).toEqual([['355', '30']]);
 });
 
-test('invokeMaestroSwipeScreen maps Android horizontal directional swipes to Maestro midpoint lane', async () => {
+test('invokeMaestroSwipeScreen maps Android horizontal directional swipes to Maestro content lane', async () => {
   const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
@@ -262,10 +263,10 @@ test('invokeMaestroSwipeScreen maps Android horizontal directional swipes to Mae
   });
 
   expect(response.ok).toBe(true);
-  expect(swipes).toEqual([['340', '400', '60', '400', '300']]);
+  expect(swipes).toEqual([['340', '520', '60', '520', '300']]);
 });
 
-test('invokeMaestroSwipeScreen mirrors Android horizontal directional midpoint lane swipes', async () => {
+test('invokeMaestroSwipeScreen mirrors Android horizontal directional content lane swipes', async () => {
   const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
@@ -285,24 +286,24 @@ test('invokeMaestroSwipeScreen mirrors Android horizontal directional midpoint l
   });
 
   expect(response.ok).toBe(true);
-  expect(swipes).toEqual([['60', '400', '340', '400', '300']]);
+  expect(swipes).toEqual([['60', '520', '340', '520', '300']]);
 });
 
-test('invokeMaestroSwipeScreen delegates Android vertical down swipes to physical-screen scroll', async () => {
-  const scrolls: Array<{ positionals: string[]; durationMs: number | undefined }> = [];
+test('invokeMaestroSwipeScreen maps Android vertical down swipes to the paced swipe path', async () => {
+  const scope = { values: {} };
+  const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
       token: 'test',
       session: 'pager',
       flags: { platform: 'android' },
     },
+    scope,
     positionals: ['direction', 'down', '100'],
     invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
-      if (req.command === 'scroll') {
-        scrolls.push({
-          positionals: req.positionals ?? [],
-          durationMs: req.flags?.durationMs,
-        });
+      if (req.command === 'snapshot') return { ok: true, data: fullScreenSnapshot(400, 800) };
+      if (req.command === 'swipe') {
+        swipes.push(req.positionals ?? []);
         return { ok: true, data: {} };
       }
       return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
@@ -310,11 +311,15 @@ test('invokeMaestroSwipeScreen delegates Android vertical down swipes to physica
   });
 
   expect(response.ok).toBe(true);
-  expect(scrolls).toEqual([{ positionals: ['up', '0.6'], durationMs: 100 }]);
+  expect(swipes).toEqual([['200', '160', '200', '640', '100']]);
+  expect(consumeMaestroRecoverableInteraction(scope)).toEqual({
+    kind: 'swipe',
+    positionals: ['200', '160', '200', '640', '100'],
+  });
 });
 
-test('invokeMaestroSwipeScreen delegates Android vertical up swipes to physical-screen scroll', async () => {
-  const scrolls: string[][] = [];
+test('invokeMaestroSwipeScreen maps Android vertical up swipes to the paced swipe path', async () => {
+  const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
       token: 'test',
@@ -323,8 +328,9 @@ test('invokeMaestroSwipeScreen delegates Android vertical up swipes to physical-
     },
     positionals: ['direction', 'up'],
     invoke: async (req: DaemonRequest): Promise<DaemonResponse> => {
-      if (req.command === 'scroll') {
-        scrolls.push(req.positionals ?? []);
+      if (req.command === 'snapshot') return { ok: true, data: fullScreenSnapshot(400, 800) };
+      if (req.command === 'swipe') {
+        swipes.push(req.positionals ?? []);
         return { ok: true, data: {} };
       }
       return { ok: false, error: { code: 'UNEXPECTED_COMMAND', message: req.command } };
@@ -332,7 +338,7 @@ test('invokeMaestroSwipeScreen delegates Android vertical up swipes to physical-
   });
 
   expect(response.ok).toBe(true);
-  expect(scrolls).toEqual([['down', '0.6']]);
+  expect(swipes).toEqual([['200', '640', '200', '160']]);
 });
 
 test('invokeMaestroSwipeOn resolves visible non-interactive text from a regular snapshot', async () => {
@@ -441,7 +447,7 @@ test('invokeMaestroSwipeScreen keeps iOS horizontal percentage swipes away from 
   expect(swipes).toEqual([['60', '400', '340', '400', '300']]);
 });
 
-test('invokeMaestroSwipeScreen preserves Android horizontal percentage swipe lanes', async () => {
+test('invokeMaestroSwipeScreen maps broad Android horizontal percentage swipes to the content lane', async () => {
   const swipes: string[][] = [];
   const response = await invokeMaestroSwipeScreen({
     baseReq: {
@@ -463,7 +469,7 @@ test('invokeMaestroSwipeScreen preserves Android horizontal percentage swipe lan
   });
 
   expect(response.ok).toBe(true);
-  expect(swipes).toEqual([['351', '300', '39', '300', '300']]);
+  expect(swipes).toEqual([['351', '390', '39', '390', '300']]);
 });
 
 test('invokeMaestroTapPointPercent shares percentage point geometry without clamping', async () => {

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getSnapshotReferenceFrame } from '../../daemon/touch-reference-frame.ts';
-import { parseSelectorChain } from '../../daemon/selectors.ts';
+import { tryParseSelectorChain } from '../../daemon/selectors.ts';
 import type { DaemonResponse } from '../../daemon/types.ts';
 import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
@@ -507,7 +507,9 @@ async function readMaestroVisibilitySample(
 ): Promise<MaestroVisibilitySample> {
   const response = await captureMaestroSnapshot(params);
   const sample = readMaestroVisibilitySampleFromResponse(params, selector, command, response);
-  if (!shouldRetryAndroidRawVisibilitySample(params.baseReq, selector, sample)) return sample;
+  if (!shouldRetryAndroidRawVisibilitySample(params.baseReq, selector, command, sample)) {
+    return sample;
+  }
 
   const rawResponse = await captureMaestroSnapshot({ ...params, raw: true });
   return readMaestroVisibilitySampleFromResponse(params, selector, command, rawResponse);
@@ -536,13 +538,12 @@ function readMaestroVisibilitySampleFromResponse(
     getSnapshotReferenceFrame(snapshot),
   );
   if (!target.ok) {
+    const missKind = readAndroidMaestroMissKind(snapshot, selector, platform);
     return {
       visible: false,
       response: errorResponse('COMMAND_FAILED', target.message, { selector }),
       infrastructureFailure: false,
-      missKind: hasMaestroSelectorMatchInSnapshot(snapshot, selector, platform)
-        ? 'notVisible'
-        : 'missing',
+      ...(missKind ? { missKind } : {}),
       snapshot,
     };
   }
@@ -567,9 +568,11 @@ function readMaestroVisibilitySampleFromResponse(
 function shouldRetryAndroidRawVisibilitySample(
   baseReq: ReplayBaseRequest,
   selector: string,
+  command: string,
   sample: MaestroVisibilitySample,
 ): boolean {
   return (
+    command === 'assertVisible' &&
     baseReq.flags?.platform === 'android' &&
     !sample.visible &&
     !sample.infrastructureFailure &&
@@ -579,7 +582,8 @@ function shouldRetryAndroidRawVisibilitySample(
 }
 
 function isIdOnlyMaestroSelector(selector: string): boolean {
-  const chain = parseSelectorChain(selector);
+  const chain = tryParseSelectorChain(selector);
+  if (!chain) return false;
   return (
     chain.selectors.length > 0 &&
     chain.selectors.every(
@@ -588,6 +592,15 @@ function isIdOnlyMaestroSelector(selector: string): boolean {
         entry.terms.every((term) => term.key === 'id' && typeof term.value === 'string'),
     )
   );
+}
+
+function readAndroidMaestroMissKind(
+  snapshot: SnapshotState,
+  selector: string,
+  platform: string,
+): 'missing' | 'notVisible' | undefined {
+  if (platform !== 'android') return undefined;
+  return hasMaestroSelectorMatchInSnapshot(snapshot, selector, platform) ? 'notVisible' : 'missing';
 }
 
 function isAlreadyPastLoadingState(selector: string, snapshot: SnapshotState): boolean {

--- a/src/compat/maestro/runtime-assertions.ts
+++ b/src/compat/maestro/runtime-assertions.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getSnapshotReferenceFrame } from '../../daemon/touch-reference-frame.ts';
+import { parseSelectorChain } from '../../daemon/selectors.ts';
 import type { DaemonResponse } from '../../daemon/types.ts';
 import type { DaemonFailureResponse } from '../../daemon/handlers/response.ts';
 import type { ReplayVarScope } from '../../replay/vars.ts';
@@ -22,6 +23,7 @@ import {
 } from './runtime-support.ts';
 import {
   extractMaestroVisibleTextQuery,
+  hasMaestroSelectorMatchInSnapshot,
   readMaestroSelectorPlatform,
   resolveMaestroNodeFromSnapshot,
   resolveVisibleMaestroNodeFromSnapshot,
@@ -42,6 +44,7 @@ type MaestroVisibilitySample =
       visible: false;
       response: DaemonResponse;
       infrastructureFailure: boolean;
+      missKind?: 'missing' | 'notVisible';
       snapshot?: SnapshotState;
     };
 
@@ -503,7 +506,11 @@ async function readMaestroVisibilitySample(
   command: string,
 ): Promise<MaestroVisibilitySample> {
   const response = await captureMaestroSnapshot(params);
-  return readMaestroVisibilitySampleFromResponse(params, selector, command, response);
+  const sample = readMaestroVisibilitySampleFromResponse(params, selector, command, response);
+  if (!shouldRetryAndroidRawVisibilitySample(params.baseReq, selector, sample)) return sample;
+
+  const rawResponse = await captureMaestroSnapshot({ ...params, raw: true });
+  return readMaestroVisibilitySampleFromResponse(params, selector, command, rawResponse);
 }
 
 function readMaestroVisibilitySampleFromResponse(
@@ -521,10 +528,11 @@ function readMaestroVisibilitySampleFromResponse(
       infrastructureFailure: true,
     };
   }
+  const platform = readMaestroSelectorPlatform(params.baseReq.flags);
   const target = resolveVisibleMaestroNodeFromSnapshot(
     snapshot,
     selector,
-    readMaestroSelectorPlatform(params.baseReq.flags),
+    platform,
     getSnapshotReferenceFrame(snapshot),
   );
   if (!target.ok) {
@@ -532,6 +540,9 @@ function readMaestroVisibilitySampleFromResponse(
       visible: false,
       response: errorResponse('COMMAND_FAILED', target.message, { selector }),
       infrastructureFailure: false,
+      missKind: hasMaestroSelectorMatchInSnapshot(snapshot, selector, platform)
+        ? 'notVisible'
+        : 'missing',
       snapshot,
     };
   }
@@ -551,6 +562,32 @@ function readMaestroVisibilitySampleFromResponse(
       },
     },
   };
+}
+
+function shouldRetryAndroidRawVisibilitySample(
+  baseReq: ReplayBaseRequest,
+  selector: string,
+  sample: MaestroVisibilitySample,
+): boolean {
+  return (
+    baseReq.flags?.platform === 'android' &&
+    !sample.visible &&
+    !sample.infrastructureFailure &&
+    sample.missKind === 'missing' &&
+    isIdOnlyMaestroSelector(selector)
+  );
+}
+
+function isIdOnlyMaestroSelector(selector: string): boolean {
+  const chain = parseSelectorChain(selector);
+  return (
+    chain.selectors.length > 0 &&
+    chain.selectors.every(
+      (entry) =>
+        entry.terms.length > 0 &&
+        entry.terms.every((term) => term.key === 'id' && typeof term.value === 'string'),
+    )
+  );
 }
 
 function isAlreadyPastLoadingState(selector: string, snapshot: SnapshotState): boolean {

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -169,9 +169,6 @@ async function maybeInvokeMaestroDirectionalSwipePreset(params: {
   const [mode, direction, durationMs] = params.positionals;
   if (mode !== 'direction') return undefined;
   const platform = readMaestroSelectorPlatform(params.baseReq.flags);
-  if (platform === 'android' && (direction === 'up' || direction === 'down')) {
-    return await invokeAndroidVerticalDirectionalScreenSwipe(params, direction, durationMs);
-  }
   if (direction !== 'left' && direction !== 'right') return undefined;
   if (platform === 'android') return undefined;
   return await params.invoke({
@@ -179,27 +176,6 @@ async function maybeInvokeMaestroDirectionalSwipePreset(params: {
     command: 'gesture',
     positionals: ['swipe', direction, ...(durationMs ? [durationMs] : [])],
   });
-}
-
-async function invokeAndroidVerticalDirectionalScreenSwipe(
-  params: {
-    baseReq: ReplayBaseRequest;
-    invoke: MaestroRuntimeInvoke;
-  },
-  direction: 'up' | 'down',
-  durationMs: string | undefined,
-): Promise<DaemonResponse> {
-  const scrollDirection = direction === 'up' ? 'down' : 'up';
-  const response = await params.invoke({
-    ...params.baseReq,
-    command: 'scroll',
-    positionals: [scrollDirection, '0.6'],
-    flags: {
-      ...params.baseReq.flags,
-      ...(durationMs ? { durationMs: Number(durationMs) } : {}),
-    },
-  });
-  return response;
 }
 
 export async function invokeMaestroTapOn(params: MaestroTapOnParams): Promise<DaemonResponse> {
@@ -356,11 +332,12 @@ function buildMaestroHorizontalDirectionalScreenSwipe(
   durationMs: string | undefined,
 ): MaestroScreenSwipeResolution {
   const [startX, endX] = direction === 'left' ? [85, 15] : [15, 85];
-  const marginPx = maestroPercentSwipeMarginPx(platform, frame, startX, 50, endX, 50);
+  const y = maestroHorizontalContentSwipeLanePercent(platform, startX, 50, endX, 50) ?? 50;
+  const marginPx = maestroPercentSwipeMarginPx(platform, frame, startX, y, endX, y);
   return {
     ok: true,
-    start: pointFromPercent(frame, startX, 50, { marginPx }),
-    end: pointFromPercent(frame, endX, 50, { marginPx }),
+    start: pointFromPercent(frame, startX, y, { marginPx }),
+    end: pointFromPercent(frame, endX, y, { marginPx }),
     durationMs,
   };
 }
@@ -400,13 +377,28 @@ function resolvePercentScreenSwipe(
     };
   }
   const [x1, y1, x2, y2] = values as [number, number, number, number];
-  const marginPx = maestroPercentSwipeMarginPx(platform, frame, x1, y1, x2, y2);
+  const horizontalLaneY = maestroHorizontalContentSwipeLanePercent(platform, x1, y1, x2, y2);
+  const [startLaneY, endLaneY] =
+    horizontalLaneY === undefined ? [y1, y2] : [horizontalLaneY, horizontalLaneY];
+  const marginPx = maestroPercentSwipeMarginPx(platform, frame, x1, startLaneY, x2, endLaneY);
   return {
     ok: true,
-    start: pointFromPercent(frame, x1, y1, { marginPx }),
-    end: pointFromPercent(frame, x2, y2, { marginPx }),
+    start: pointFromPercent(frame, x1, startLaneY, { marginPx }),
+    end: pointFromPercent(frame, x2, endLaneY, { marginPx }),
     durationMs,
   };
+}
+
+function maestroHorizontalContentSwipeLanePercent(
+  platform: string,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): number | undefined {
+  if (platform !== 'android') return undefined;
+  if (y1 !== y2 || Math.abs(x2 - x1) < 30) return undefined;
+  return 65;
 }
 
 function maestroPercentSwipeMarginPx(

--- a/src/compat/maestro/runtime-interactions.ts
+++ b/src/compat/maestro/runtime-interactions.ts
@@ -167,13 +167,39 @@ async function maybeInvokeMaestroDirectionalSwipePreset(params: {
   invoke: MaestroRuntimeInvoke;
 }): Promise<DaemonResponse | undefined> {
   const [mode, direction, durationMs] = params.positionals;
-  if (mode !== 'direction' || (direction !== 'left' && direction !== 'right')) return undefined;
-  if (readMaestroSelectorPlatform(params.baseReq.flags) === 'android') return undefined;
+  if (mode !== 'direction') return undefined;
+  const platform = readMaestroSelectorPlatform(params.baseReq.flags);
+  if (platform === 'android' && (direction === 'up' || direction === 'down')) {
+    return await invokeAndroidVerticalDirectionalScreenSwipe(params, direction, durationMs);
+  }
+  if (direction !== 'left' && direction !== 'right') return undefined;
+  if (platform === 'android') return undefined;
   return await params.invoke({
     ...params.baseReq,
     command: 'gesture',
     positionals: ['swipe', direction, ...(durationMs ? [durationMs] : [])],
   });
+}
+
+async function invokeAndroidVerticalDirectionalScreenSwipe(
+  params: {
+    baseReq: ReplayBaseRequest;
+    invoke: MaestroRuntimeInvoke;
+  },
+  direction: 'up' | 'down',
+  durationMs: string | undefined,
+): Promise<DaemonResponse> {
+  const scrollDirection = direction === 'up' ? 'down' : 'up';
+  const response = await params.invoke({
+    ...params.baseReq,
+    command: 'scroll',
+    positionals: [scrollDirection, '0.6'],
+    flags: {
+      ...params.baseReq.flags,
+      ...(durationMs ? { durationMs: Number(durationMs) } : {}),
+    },
+  });
+  return response;
 }
 
 export async function invokeMaestroTapOn(params: MaestroTapOnParams): Promise<DaemonResponse> {
@@ -329,13 +355,12 @@ function buildMaestroHorizontalDirectionalScreenSwipe(
   platform: string,
   durationMs: string | undefined,
 ): MaestroScreenSwipeResolution {
-  const lane = maestroHorizontalContentSwipeLanePercent(platform, 85, 50, 15, 50);
   const [startX, endX] = direction === 'left' ? [85, 15] : [15, 85];
   const marginPx = maestroPercentSwipeMarginPx(platform, frame, startX, 50, endX, 50);
   return {
     ok: true,
-    start: pointFromPercent(frame, startX, lane.startY, { marginPx }),
-    end: pointFromPercent(frame, endX, lane.endY, { marginPx }),
+    start: pointFromPercent(frame, startX, 50, { marginPx }),
+    end: pointFromPercent(frame, endX, 50, { marginPx }),
     durationMs,
   };
 }
@@ -375,12 +400,11 @@ function resolvePercentScreenSwipe(
     };
   }
   const [x1, y1, x2, y2] = values as [number, number, number, number];
-  const lane = maestroHorizontalContentSwipeLanePercent(platform, x1, y1, x2, y2);
   const marginPx = maestroPercentSwipeMarginPx(platform, frame, x1, y1, x2, y2);
   return {
     ok: true,
-    start: pointFromPercent(frame, x1, lane.startY, { marginPx }),
-    end: pointFromPercent(frame, x2, lane.endY, { marginPx }),
+    start: pointFromPercent(frame, x1, y1, { marginPx }),
+    end: pointFromPercent(frame, x2, y2, { marginPx }),
     durationMs,
   };
 }
@@ -396,23 +420,6 @@ function maestroPercentSwipeMarginPx(
   if (platform !== 'ios') return 1;
   if (y1 !== y2 || Math.abs(x2 - x1) < 30) return 1;
   return Math.max(1, Math.round(frame.referenceWidth * 0.15));
-}
-
-function maestroHorizontalContentSwipeLanePercent(
-  platform: string,
-  x1: number,
-  y1: number,
-  x2: number,
-  y2: number,
-): { startY: number; endY: number } {
-  if (platform !== 'android') return { startY: y1, endY: y2 };
-  if (y1 !== y2 || y1 !== 50) return { startY: y1, endY: y2 };
-  if (Math.abs(x2 - x1) < 30) return { startY: y1, endY: y2 };
-  // Maestro's Android driver treats 50% horizontal swipes as content swipes.
-  // Raw `adb input swipe` at the physical screen midpoint can land above
-  // horizontally paged content in React Native layouts, so use a lower content
-  // lane for full-width horizontal Maestro percentage swipes.
-  return { startY: 65, endY: 65 };
 }
 
 async function probeMaestroScrollVisibility(

--- a/src/compat/maestro/runtime-targets.ts
+++ b/src/compat/maestro/runtime-targets.ts
@@ -197,6 +197,18 @@ export function resolveVisibleMaestroNodeFromSnapshot(
   };
 }
 
+export function hasMaestroSelectorMatchInSnapshot(
+  snapshot: SnapshotState,
+  selector: string,
+  platform: 'ios' | 'android',
+): boolean {
+  return (
+    findMaestroSelectorMatches(snapshot, selector, platform, {
+      allowLeadingCompositeLabelMatch: false,
+    }).length > 0
+  );
+}
+
 function filterVisibleMaestroMatches(params: {
   nodes: SnapshotState['nodes'];
   matches: SnapshotNode[];

--- a/src/daemon/__tests__/recording-gestures.test.ts
+++ b/src/daemon/__tests__/recording-gestures.test.ts
@@ -75,6 +75,21 @@ test('scroll amount scales swipe travel for visualization', () => {
   assert.equal(event.amount, 0.6);
 });
 
+test('scroll augmentation preserves explicit duration for visualization', () => {
+  const session = makeSession();
+  const result = augmentScrollVisualizationResult(session, 'scroll', ['up', '0.6'], {
+    direction: 'up',
+    amount: 0.6,
+    durationMs: 100,
+  });
+
+  recordTouchVisualizationEvent(session, 'scroll', ['up', '0.6'], result, {}, 1_500);
+
+  const event = session.recording?.gestureEvents[0];
+  assert.equal(event?.kind, 'scroll');
+  assert.equal(event?.durationMs, 100);
+});
+
 test('scroll augmentation preserves explicit reference frame from platform result', () => {
   const session = makeSession();
   session.snapshot = undefined;

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1770,10 +1770,10 @@ test('runReplayScriptFile resolves Maestro screen swipes from the snapshot frame
   );
 });
 
-test('runReplayScriptFile uses Android content lane for Maestro horizontal screen swipes', async () => {
+test('runReplayScriptFile preserves Android Maestro horizontal screen swipe lanes', async () => {
   const calls: CapturedInvocation[] = [];
   const { response } = await runReplayFixture({
-    label: 'maestro-screen-swipe-android-content-lane',
+    label: 'maestro-screen-swipe-android-midpoint-lane',
     script: [
       'appId: demo.app',
       '---',
@@ -1812,8 +1812,8 @@ test('runReplayScriptFile uses Android content lane for Maestro horizontal scree
     calls.map((call) => [call.command, call.positionals]),
     [
       ['snapshot', []],
-      ['swipe', ['340', '520', '60', '520', '300']],
-      ['swipe', ['360', '520', '40', '520', '300']],
+      ['swipe', ['340', '400', '60', '400', '300']],
+      ['swipe', ['360', '400', '40', '400', '300']],
     ],
   );
 });

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1812,8 +1812,8 @@ test('runReplayScriptFile preserves Android Maestro horizontal screen swipe lane
     calls.map((call) => [call.command, call.positionals]),
     [
       ['snapshot', []],
-      ['swipe', ['340', '400', '60', '400', '300']],
-      ['swipe', ['360', '400', '40', '400', '300']],
+      ['swipe', ['340', '520', '60', '520', '300']],
+      ['swipe', ['360', '520', '40', '520', '300']],
     ],
   );
 });

--- a/src/daemon/recording-gestures.ts
+++ b/src/daemon/recording-gestures.ts
@@ -106,6 +106,7 @@ export function augmentScrollVisualizationResult(
 
   const amountValue = readNumber(merged.amount) ?? readNumber(positionals[1]);
   const pixelValue = readNumber(merged.pixels);
+  const durationMs = readNumber(merged.durationMs) ?? DEFAULT_SWIPE_DURATION_MS;
   const explicitTravel = readTravelCoordinates(merged, []);
   const explicitReferenceWidth = readNumber(merged.referenceWidth);
   const explicitReferenceHeight = readNumber(merged.referenceHeight);
@@ -135,7 +136,7 @@ export function augmentScrollVisualizationResult(
       ...(pixelValue !== undefined ? { pixels: pixelValue } : {}),
       referenceWidth: fallbackReferenceFrame.referenceWidth,
       referenceHeight: fallbackReferenceFrame.referenceHeight,
-      durationMs: DEFAULT_SWIPE_DURATION_MS,
+      durationMs,
     };
   }
 
@@ -158,7 +159,7 @@ export function augmentScrollVisualizationResult(
     ...(plan.pixels !== undefined ? { pixels: plan.pixels } : {}),
     referenceWidth: fallbackReferenceFrame.referenceWidth,
     referenceHeight: fallbackReferenceFrame.referenceHeight,
-    durationMs: DEFAULT_SWIPE_DURATION_MS,
+    durationMs,
   };
 }
 

--- a/src/platforms/apple/core/runner/runner-cache-metadata.ts
+++ b/src/platforms/apple/core/runner/runner-cache-metadata.ts
@@ -107,7 +107,7 @@ export function resolveExpectedRunnerCacheMetadata(
   const platformName = resolveRunnerPlatformName(device);
   return {
     schemaVersion: RUNNER_CACHE_SCHEMA_VERSION,
-    packageVersion: readVersion(),
+    packageVersion: readVersion(projectRoot),
     runnerSourceFingerprint: computeRunnerSourceFingerprint(projectRoot),
     ...resolveRunnerToolchainFingerprint(platformName, device.kind),
     platformName,

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -2,9 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export function readVersion(): string {
+export function readVersion(root: string = findProjectRoot()): string {
   try {
-    const root = findProjectRoot();
     const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')) as {
       version?: string;
     };

--- a/test/integration/provider-scenarios/harness.ts
+++ b/test/integration/provider-scenarios/harness.ts
@@ -16,6 +16,12 @@ import { SessionStore } from '../../../src/daemon/session-store.ts';
 import type { DaemonRequest, DaemonResponse, SessionState } from '../../../src/daemon/types.ts';
 
 const PROVIDER_SCENARIO_TOKEN = 'provider-scenario-token';
+const PROVIDER_SCENARIO_TEMP_REMOVE_OPTIONS = {
+  recursive: true,
+  force: true,
+  maxRetries: 5,
+  retryDelay: 50,
+} as const;
 
 export type ProviderScenarioRpcResult = { statusCode: number; json: any };
 
@@ -77,7 +83,7 @@ export async function createProviderScenarioHarness(
     session: (name = 'default') => sessionStore.get(name),
     setSession: (name, session) => sessionStore.set(name, session),
     close: async () => {
-      fs.rmSync(sessionDir, { recursive: true, force: true });
+      removeProviderScenarioTempDir(sessionDir);
     },
   };
 }
@@ -111,8 +117,12 @@ export async function withProviderScenarioTempDir<TResult>(
   try {
     return await run(dir);
   } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    removeProviderScenarioTempDir(dir);
   }
+}
+
+function removeProviderScenarioTempDir(dir: string): void {
+  fs.rmSync(dir, PROVIDER_SCENARIO_TEMP_REMOVE_OPTIONS);
 }
 
 export function restoreEnv(key: string, previous: string | undefined): void {


### PR DESCRIPTION
## Summary

Fix Android Maestro gesture execution by pacing multi-touch helper events on their scheduled wall-clock timestamps.
Route Android vertical Maestro screen swipes through the existing physical-screen scroll path, and keep scroll visualization telemetry duration accurate.

## Validation

- `pnpm exec vitest run src/compat/maestro/__tests__/runtime-interactions.test.ts src/compat/maestro/__tests__/runtime-assertions.test.ts src/daemon/handlers/__tests__/session-replay-vars.test.ts src/daemon/__tests__/recording-gestures.test.ts`
- `pnpm format`
- `pnpm build`
- `pnpm package:android-multitouch-helper:npm`
- `pnpm check:quick`
- `git diff --check`
- Full PagerView Maestro Android matrix with recording: `10 passed (10) in 349.9s`
  - artifacts: `/Users/thymikee/Developer/react-native-pager-view/.maestro/agent-device-output/all-cases-production-fix-final-recorded/aa347dcac76c2d59`
