### PR TITLE
fix: make settle tail list real actionable targets

### DIFF
--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -313,10 +313,12 @@ test('the settled diff line list is bounded with a truncation marker', async () 
   assert.equal(diff.truncated, true);
 });
 
-test('keyboard Key nodes never spend the settled diff budget', async () => {
+test('keyboard Key nodes and chrome buttons never spend the settled diff budget', async () => {
   const before = buttonSnapshot();
-  // A fill-style settled tree: a summoned keyboard (container + keys) plus the
-  // content change the agent actually cares about.
+  // A fill-style settled tree: a summoned keyboard (container + keys + real
+  // XCUIElementTypeButton chrome like shift/Emoji/return/Dictate/Next
+  // keyboard — NOT Key nodes) plus the content change the agent actually
+  // cares about.
   const keyboardTree = makeSnapshotState([
     {
       index: 0,
@@ -343,8 +345,17 @@ test('keyboard Key nodes never spend the settled diff budget', async () => {
       rect: { x: key * 10, y: 520, width: 10, height: 40 },
       hittable: true,
     })),
-    ...['Next', 'Back', 'Home'].map((label, extra) => ({
+    ...['shift', 'Emoji', 'return', 'Dictate', 'Next keyboard'].map((label, extra) => ({
       index: extra + 28,
+      depth: 1,
+      parentIndex: 1,
+      type: 'Button',
+      label,
+      rect: { x: extra * 40, y: 780, width: 40, height: 40 },
+      hittable: true,
+    })),
+    ...['Next', 'Back', 'Home'].map((label, extra) => ({
+      index: extra + 33,
       depth: 0,
       type: 'Button',
       label,
@@ -371,9 +382,100 @@ test('keyboard Key nodes never spend the settled diff budget', async () => {
   const texts = diff.lines.map((line) => line.text).join('\n');
   assert.match(texts, /Results for alpenglow/);
   assert.match(texts, /keyboard/);
-  // The container line survives as the keyboard signal; individual keys do not.
+  // The container line survives as the keyboard signal; individual keys and
+  // chrome buttons (real XCUIElementTypeButton nodes, not Key nodes) do not.
   assert.ok(!diff.lines.some((line) => /\[key\]/.test(line.text)));
+  assert.ok(!diff.lines.some((line) => /shift|Emoji|return|Dictate|Next keyboard/.test(line.text)));
   assert.equal(diff.summary.additions, 5);
+});
+
+test('keyboard-only changes (container + chrome) do not suppress the settle tail trigger', async () => {
+  // The field and its screen buttons are unchanged by the fill itself; the
+  // keyboard summoning is the only tree change. Before #1167's fix, the
+  // chrome buttons' fresh added-line refs (or, after the diff-only fix, the
+  // container's own added ref) would read as "the diff already handed back a
+  // target" and suppress the tail — leaving the still-relevant screen
+  // buttons invisible.
+  const controls = [
+    {
+      index: 0,
+      depth: 0,
+      type: 'TextField',
+      label: 'Search',
+      rect: { x: 0, y: 0, width: 200, height: 40 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 0,
+      type: 'Button',
+      label: 'Cancel',
+      rect: { x: 0, y: 50, width: 100, height: 40 },
+      hittable: true,
+    },
+    {
+      index: 2,
+      depth: 0,
+      type: 'Button',
+      label: 'Search now',
+      rect: { x: 110, y: 50, width: 100, height: 40 },
+      hittable: true,
+    },
+  ];
+  const before = makeSnapshotState(controls);
+  const settledTree = makeSnapshotState([
+    ...controls,
+    {
+      index: 3,
+      depth: 0,
+      type: 'Keyboard',
+      label: 'keyboard',
+      rect: { x: 0, y: 500, width: 400, height: 300 },
+      hittable: true,
+    },
+    {
+      index: 4,
+      depth: 1,
+      parentIndex: 3,
+      type: 'Button',
+      label: 'shift',
+      rect: { x: 0, y: 520, width: 30, height: 40 },
+      hittable: true,
+    },
+    {
+      index: 5,
+      depth: 1,
+      parentIndex: 3,
+      type: 'Button',
+      label: 'return',
+      rect: { x: 350, y: 520, width: 50, height: 40 },
+      hittable: true,
+    },
+  ]);
+  let captures = 0;
+  const device = createSettleDevice({
+    stored: before,
+    captureSnapshot: () => {
+      captures += 1;
+      return { snapshot: captures === 1 ? before : settledTree };
+    },
+  });
+
+  const result = await device.interactions.fill(selector('label=Search'), 'hello', {
+    session: 'default',
+    settle: {},
+  });
+
+  const settle = result.settle;
+  assert.ok(settle);
+  // Only the keyboard container line is added; its chrome buttons collapse.
+  assert.equal(settle.diff?.summary.additions, 1);
+  assert.ok(!settle.diff?.lines.some((line) => /shift|return/i.test(line.text)));
+  assert.ok(settle.tail, 'keyboard-only additions must not suppress the tail');
+  assert.deepEqual(
+    settle.tail?.map((entry) => entry.label),
+    ['Search', 'Cancel', 'Search now'],
+  );
 });
 
 test('added lines win diff-budget slots over removals under truncation', async () => {
@@ -514,13 +616,19 @@ test('a removals-only settled diff (modal dismiss) attaches an unchanged interac
   assert.ok(settle);
   assert.deepEqual(settle.diff?.summary, { additions: 0, removals: 3, unchanged: 2 });
   assert.ok(!settle.diff?.lines.some((line) => line.kind === 'added'));
-  // The StaticText survives but is not interactive; only the hittable button
-  // makes the tail.
-  assert.deepEqual(settle.tail, [{ ref: 'e1', role: 'button', label: 'Add to cart' }]);
+  // The tail matches `snapshot -i`'s own bar for the settled tree: both
+  // surviving elements are candidates, `hittable` is not required (#1167 post-
+  // merge benchmark: real buttons commonly report `hittable: false`/undefined
+  // right after a dismiss animation, so requiring it silently dropped exactly
+  // the elements the tail exists to surface).
+  assert.deepEqual(settle.tail, [
+    { ref: 'e1', role: 'button', label: 'Add to cart' },
+    { ref: 'e2', role: 'text', label: 'Price: $12' },
+  ]);
   assert.equal(settle.tailTruncated, undefined);
 });
 
-test('the unchanged interactive tail excludes non-hittable and covered candidates', async () => {
+test('the unchanged interactive tail includes non-hittable candidates but excludes covered ones', async () => {
   // Every surviving node's attributes (hittable/blocked-relevant fields) must
   // match a `before` line exactly, or it would read as an added line and
   // suppress the tail entirely (see the trigger-condition test above).
@@ -594,9 +702,73 @@ test('the unchanged interactive tail excludes non-hittable and covered candidate
   const settle = result.settle;
   assert.ok(settle);
   assert.equal(settle.diff?.summary.additions, 0);
-  // Not hittable, then covered, are both excluded; only the plain hittable
-  // button remains.
-  assert.deepEqual(settle.tail, [{ ref: 'e3', role: 'button', label: 'Share' }]);
+  // `hittable: false` no longer excludes a candidate (matches `snapshot -i`'s
+  // own bar); `interactionBlocked: 'covered'` still does.
+  assert.deepEqual(settle.tail, [
+    { ref: 'e1', role: 'button', label: 'Add to cart' },
+    { ref: 'e3', role: 'button', label: 'Share' },
+  ]);
+});
+
+test('the unchanged interactive tail excludes structural application/window chrome', async () => {
+  // The flagship #1167 post-merge benchmark case: after a dialog dismiss, the
+  // old `hittable === true` bar let a lone application/window pair through
+  // (both routinely report `hittable: true` on their full-screen root frame)
+  // while excluding the real button because its `hittable` state was
+  // undefined right after the dismiss animation.
+  const before = makeSnapshotState([
+    { index: 0, depth: 0, type: 'Application', label: 'React Navigation Example' },
+    { index: 1, depth: 0, type: 'Window' },
+    {
+      index: 2,
+      depth: 0,
+      type: 'Button',
+      label: 'Discard and go back',
+      rect: { x: 10, y: 20, width: 200, height: 40 },
+    },
+    {
+      index: 3,
+      depth: 0,
+      type: 'Button',
+      label: 'Cancel',
+      rect: { x: 10, y: 80, width: 200, height: 40 },
+    },
+  ]);
+  // The dialog's own Cancel button is dismissed with it; the application,
+  // window, and the real actionable button survive unchanged. None of the
+  // three carry `hittable: true` here, mirroring the real post-dismiss
+  // capture shape.
+  const after = makeSnapshotState([
+    { index: 0, depth: 0, type: 'Application', label: 'React Navigation Example' },
+    { index: 1, depth: 0, type: 'Window' },
+    {
+      index: 2,
+      depth: 0,
+      type: 'Button',
+      label: 'Discard and go back',
+      rect: { x: 10, y: 20, width: 200, height: 40 },
+    },
+  ]);
+  let captures = 0;
+  const device = createSettleDevice({
+    stored: before,
+    captureSnapshot: () => {
+      captures += 1;
+      return { snapshot: captures === 1 ? before : after };
+    },
+  });
+
+  const result = await device.interactions.press(selector('label=Cancel'), {
+    session: 'default',
+    settle: {},
+  });
+
+  const settle = result.settle;
+  assert.ok(settle);
+  assert.equal(settle.diff?.summary.additions, 0);
+  // Application/window chrome is dropped; the real button is the only entry,
+  // despite carrying no `hittable: true` flag.
+  assert.deepEqual(settle.tail, [{ ref: 'e3', role: 'button', label: 'Discard and go back' }]);
 });
 
 test('the unchanged interactive tail is capped with a truncation marker', async () => {
@@ -656,4 +828,44 @@ test('buildSettleTailEntries dedups candidates already carrying an excluded ref'
   const result = buildSettleTailEntries(settledNodes, new Set(['e1']));
 
   assert.deepEqual(result.tail, [{ ref: 'e2', role: 'button', label: 'Share' }]);
+});
+
+test('buildSettleTailEntries drops application/window chrome and does not require hittable', () => {
+  const settledNodes = makeSnapshotState([
+    { index: 0, depth: 0, type: 'Application', label: 'Example' },
+    { index: 1, depth: 0, type: 'Window' },
+    {
+      index: 2,
+      depth: 0,
+      type: 'Button',
+      label: 'Discard and go back',
+      rect: { x: 10, y: 20, width: 100, height: 40 },
+      // Deliberately no `hittable` field, mirroring a real post-dismiss
+      // capture: the tail bar no longer requires `hittable === true`.
+    },
+  ]).nodes;
+
+  const result = buildSettleTailEntries(settledNodes, new Set());
+
+  assert.deepEqual(result.tail, [{ ref: 'e3', role: 'button', label: 'Discard and go back' }]);
+});
+
+test('buildSettleTailEntries drops the keyboard container and its chrome descendants', () => {
+  const settledNodes = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Button',
+      label: 'Send',
+      rect: { x: 10, y: 20, width: 100, height: 40 },
+      hittable: true,
+    },
+    { index: 1, depth: 0, type: 'Keyboard', label: 'keyboard' },
+    { index: 2, depth: 1, parentIndex: 1, type: 'Key', label: 'q' },
+    { index: 3, depth: 1, parentIndex: 1, type: 'Button', label: 'shift' },
+  ]).nodes;
+
+  const result = buildSettleTailEntries(settledNodes, new Set());
+
+  assert.deepEqual(result.tail, [{ ref: 'e1', role: 'button', label: 'Send' }]);
 });

--- a/src/commands/interaction/runtime/settle.test.ts
+++ b/src/commands/interaction/runtime/settle.test.ts
@@ -313,53 +313,118 @@ test('the settled diff line list is bounded with a truncation marker', async () 
   assert.equal(diff.truncated, true);
 });
 
-test('keyboard Key nodes and chrome buttons never spend the settled diff budget', async () => {
+// Keyboard chrome fixtures mirror the LIVE capture shape (iPhone 17 Pro sim,
+// iOS 26, July 2026, React Navigation playground): the keyboard renders in
+// its own dedicated window; the [Keyboard] container (keys + shift/Emoji/
+// return buttons) and the "Next keyboard"/"Dictate" candidate-bar buttons are
+// SIBLING subtrees under that window — the candidate-bar buttons are NOT
+// descendants of the container, which is exactly what an earlier hand-built
+// fixture got wrong (a container-descendant walk alone misses them).
+function keyboardWindowNodes(startIndex: number, parentIndex?: number) {
+  const kb = startIndex;
+  return [
+    {
+      index: kb,
+      depth: 1,
+      ...(parentIndex !== undefined ? { parentIndex } : {}),
+      type: 'Window',
+      label: 'Next keyboard',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+      hittable: true,
+    },
+    {
+      index: kb + 1,
+      depth: 3,
+      parentIndex: kb,
+      type: 'Other',
+      label: 'Next keyboard',
+      rect: { x: 0, y: 566, width: 402, height: 308 },
+      hittable: true,
+    },
+    {
+      index: kb + 2,
+      depth: 4,
+      parentIndex: kb + 1,
+      type: 'Other',
+      label: 'Padding-Left',
+      rect: { x: 0, y: 583, width: 402, height: 233 },
+    },
+    {
+      index: kb + 3,
+      depth: 5,
+      parentIndex: kb + 2,
+      type: 'Keyboard',
+      label: 'Padding-Left',
+      rect: { x: 0, y: 583, width: 402, height: 233 },
+    },
+    ...Array.from({ length: 26 }, (_, key) => ({
+      index: kb + 4 + key,
+      depth: 7,
+      parentIndex: kb + 3,
+      type: 'Key',
+      label: String.fromCharCode(97 + key),
+      rect: { x: (key % 10) * 40, y: 590 + Math.floor(key / 10) * 54, width: 39, height: 54 },
+    })),
+    ...['shift', 'Emoji', 'return'].map((label, extra) => ({
+      index: kb + 30 + extra,
+      depth: 7,
+      parentIndex: kb + 3,
+      type: 'Button',
+      label,
+      rect: { x: 5 + extra * 50, y: 752, width: 49, height: 54 },
+    })),
+    // Candidate-bar chrome: siblings of the [Keyboard] container's wrapper,
+    // not descendants of the container itself.
+    {
+      index: kb + 33,
+      depth: 5,
+      parentIndex: kb + 1,
+      type: 'Button',
+      label: 'Next keyboard',
+      rect: { x: 8, y: 806, width: 68, height: 69 },
+      hittable: true,
+    },
+    {
+      index: kb + 34,
+      depth: 5,
+      parentIndex: kb + 1,
+      type: 'Button',
+      label: 'Dictate',
+      rect: { x: 325, y: 805, width: 68, height: 69 },
+    },
+  ];
+}
+
+test('keyboard keys, chrome buttons, and candidate-bar siblings never spend the settled diff budget', async () => {
   const before = buttonSnapshot();
-  // A fill-style settled tree: a summoned keyboard (container + keys + real
-  // XCUIElementTypeButton chrome like shift/Emoji/return/Dictate/Next
-  // keyboard — NOT Key nodes) plus the content change the agent actually
-  // cares about.
+  // A fill-style settled tree: the summoned keyboard window plus the content
+  // change the agent actually cares about.
   const keyboardTree = makeSnapshotState([
     {
       index: 0,
       depth: 0,
+      type: 'Application',
+      label: 'Example',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+      hittable: true,
+    },
+    ...keyboardWindowNodes(1, 0),
+    {
+      index: 36,
+      depth: 1,
+      parentIndex: 0,
       type: 'StaticText',
       label: 'Results for alpenglow',
       rect: { x: 0, y: 0, width: 200, height: 20 },
       hittable: true,
     },
-    {
-      index: 1,
-      depth: 0,
-      type: 'Keyboard',
-      label: 'keyboard',
-      rect: { x: 0, y: 500, width: 400, height: 300 },
-      hittable: true,
-    },
-    ...Array.from({ length: 26 }, (_, key) => ({
-      index: key + 2,
-      depth: 1,
-      parentIndex: 1,
-      type: 'Key',
-      label: String.fromCharCode(97 + key),
-      rect: { x: key * 10, y: 520, width: 10, height: 40 },
-      hittable: true,
-    })),
-    ...['shift', 'Emoji', 'return', 'Dictate', 'Next keyboard'].map((label, extra) => ({
-      index: extra + 28,
-      depth: 1,
-      parentIndex: 1,
-      type: 'Button',
-      label,
-      rect: { x: extra * 40, y: 780, width: 40, height: 40 },
-      hittable: true,
-    })),
     ...['Next', 'Back', 'Home'].map((label, extra) => ({
-      index: extra + 33,
-      depth: 0,
+      index: extra + 37,
+      depth: 1,
+      parentIndex: 0,
       type: 'Button',
       label,
-      rect: { x: 0, y: 40 + extra * 40, width: 100, height: 40 },
+      rect: { x: 0, y: 240 + extra * 40, width: 100, height: 40 },
       hittable: true,
     })),
   ]);
@@ -381,15 +446,17 @@ test('keyboard Key nodes and chrome buttons never spend the settled diff budget'
   assert.ok(diff);
   const texts = diff.lines.map((line) => line.text).join('\n');
   assert.match(texts, /Results for alpenglow/);
-  assert.match(texts, /keyboard/);
-  // The container line survives as the keyboard signal; individual keys and
-  // chrome buttons (real XCUIElementTypeButton nodes, not Key nodes) do not.
+  assert.match(texts, /\[keyboard\]/);
+  // The container line survives as the keyboard signal; keys, chrome buttons
+  // under the container, the candidate-bar siblings (Next keyboard/Dictate),
+  // and the keyboard window's own wrappers all collapse.
   assert.ok(!diff.lines.some((line) => /\[key\]/.test(line.text)));
   assert.ok(!diff.lines.some((line) => /shift|Emoji|return|Dictate|Next keyboard/.test(line.text)));
-  assert.equal(diff.summary.additions, 5);
+  // application + keyboard container + StaticText + 3 screen buttons.
+  assert.equal(diff.summary.additions, 6);
 });
 
-test('keyboard-only changes (container + chrome) do not suppress the settle tail trigger', async () => {
+test('keyboard-only changes (window + container + chrome) do not suppress the settle tail trigger', async () => {
   // The field and its screen buttons are unchanged by the fill itself; the
   // keyboard summoning is the only tree change. Before #1167's fix, the
   // chrome buttons' fresh added-line refs (or, after the diff-only fix, the
@@ -423,35 +490,7 @@ test('keyboard-only changes (container + chrome) do not suppress the settle tail
     },
   ];
   const before = makeSnapshotState(controls);
-  const settledTree = makeSnapshotState([
-    ...controls,
-    {
-      index: 3,
-      depth: 0,
-      type: 'Keyboard',
-      label: 'keyboard',
-      rect: { x: 0, y: 500, width: 400, height: 300 },
-      hittable: true,
-    },
-    {
-      index: 4,
-      depth: 1,
-      parentIndex: 3,
-      type: 'Button',
-      label: 'shift',
-      rect: { x: 0, y: 520, width: 30, height: 40 },
-      hittable: true,
-    },
-    {
-      index: 5,
-      depth: 1,
-      parentIndex: 3,
-      type: 'Button',
-      label: 'return',
-      rect: { x: 350, y: 520, width: 50, height: 40 },
-      hittable: true,
-    },
-  ]);
+  const settledTree = makeSnapshotState([...controls, ...keyboardWindowNodes(3)]);
   let captures = 0;
   const device = createSettleDevice({
     stored: before,
@@ -468,14 +507,177 @@ test('keyboard-only changes (container + chrome) do not suppress the settle tail
 
   const settle = result.settle;
   assert.ok(settle);
-  // Only the keyboard container line is added; its chrome buttons collapse.
+  // Only the keyboard container line is added; the window, its wrappers, the
+  // chrome buttons, and the candidate-bar siblings all collapse.
   assert.equal(settle.diff?.summary.additions, 1);
-  assert.ok(!settle.diff?.lines.some((line) => /shift|return/i.test(line.text)));
+  assert.ok(
+    !settle.diff?.lines.some((line) => /shift|return|Dictate|Next keyboard/i.test(line.text)),
+  );
   assert.ok(settle.tail, 'keyboard-only additions must not suppress the tail');
   assert.deepEqual(
     settle.tail?.map((entry) => entry.label),
     ['Search', 'Cancel', 'Search now'],
   );
+});
+
+test('a filled field relabeling itself (self-echo added refs) does not suppress the settle tail', async () => {
+  // Live-verified shape: filling a field re-labels the field line with its
+  // new value (and ancestor wrappers inherit it), so the diff carries added
+  // refs even though nothing NEW appeared on screen. Those self-echo refs
+  // (settled node rect contains the action point) must not suppress the
+  // tail — the next targets after a fill are the screen's unchanged controls.
+  const before = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'TextField',
+      rect: { x: 12, y: 129, width: 377, height: 41 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 0,
+      type: 'Button',
+      label: 'Submit',
+      rect: { x: 12, y: 182, width: 378, height: 40 },
+      hittable: true,
+    },
+  ]);
+  const settledTree = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'TextField',
+      label: 'hello',
+      value: 'hello',
+      rect: { x: 12, y: 129, width: 377, height: 41 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 0,
+      type: 'Button',
+      label: 'Submit',
+      rect: { x: 12, y: 182, width: 378, height: 40 },
+      hittable: true,
+    },
+  ]);
+  let captures = 0;
+  const device = createSettleDevice({
+    stored: before,
+    captureSnapshot: () => {
+      captures += 1;
+      return { snapshot: captures === 1 ? before : settledTree };
+    },
+  });
+
+  const result = await device.interactions.fill(ref('@e1'), 'hello', {
+    session: 'default',
+    settle: {},
+  });
+
+  const settle = result.settle;
+  assert.ok(settle);
+  // The relabeled field IS an added line (with a ref) in the diff...
+  const added = settle.diff?.lines.filter((line) => line.kind === 'added') ?? [];
+  assert.equal(added.length, 1);
+  assert.match(added[0]?.text ?? '', /hello/);
+  assert.ok(added[0]?.ref);
+  // ...but it re-describes the acted-on element, so the tail still fires
+  // with the actual next target.
+  assert.deepEqual(settle.tail, [{ ref: 'e2', role: 'button', label: 'Submit' }]);
+});
+
+test('a keyboard window hosting an app composer field is never window-classified as chrome', async () => {
+  // iOS hosts inputAccessoryView content (e.g. a messaging composer) in the
+  // keyboard window. The conservative guard keeps such windows out of the
+  // whole-window chrome rule: the composer field/send button must stay
+  // visible even though candidate-bar chrome then leaks through.
+  const before = buttonSnapshot();
+  const settledTree = makeSnapshotState([
+    {
+      index: 0,
+      depth: 0,
+      type: 'Application',
+      label: 'Chat',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+      hittable: true,
+    },
+    {
+      index: 1,
+      depth: 1,
+      parentIndex: 0,
+      type: 'Window',
+      rect: { x: 0, y: 0, width: 402, height: 874 },
+      hittable: true,
+    },
+    // inputAccessoryView composer: an editable field OUTSIDE the [Keyboard]
+    // container but INSIDE the keyboard window.
+    {
+      index: 2,
+      depth: 2,
+      parentIndex: 1,
+      type: 'TextField',
+      label: 'Message',
+      rect: { x: 0, y: 500, width: 320, height: 44 },
+      hittable: true,
+    },
+    {
+      index: 3,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Button',
+      label: 'Send',
+      rect: { x: 330, y: 500, width: 60, height: 44 },
+      hittable: true,
+    },
+    {
+      index: 4,
+      depth: 2,
+      parentIndex: 1,
+      type: 'Keyboard',
+      label: 'keyboard',
+      rect: { x: 0, y: 566, width: 402, height: 308 },
+    },
+    {
+      index: 5,
+      depth: 3,
+      parentIndex: 4,
+      type: 'Key',
+      label: 'q',
+      rect: { x: 5, y: 590, width: 39, height: 54 },
+    },
+    {
+      index: 6,
+      depth: 3,
+      parentIndex: 4,
+      type: 'Button',
+      label: 'shift',
+      rect: { x: 5, y: 698, width: 51, height: 54 },
+    },
+  ]);
+  let captures = 0;
+  const device = createSettleDevice({
+    stored: before,
+    captureSnapshot: () => {
+      captures += 1;
+      return { snapshot: captures === 1 ? before : settledTree };
+    },
+  });
+
+  const result = await device.interactions.press(selector('label=Continue'), {
+    session: 'default',
+    settle: {},
+  });
+
+  const diff = result.settle?.diff;
+  assert.ok(diff);
+  const texts = diff.lines.map((line) => line.text).join('\n');
+  // Composer content survives; container-descendant chrome still collapses.
+  assert.match(texts, /Message/);
+  assert.match(texts, /Send/);
+  assert.match(texts, /\[keyboard\]/);
+  assert.ok(!diff.lines.some((line) => /\[key\]|shift/.test(line.text)));
 });
 
 test('added lines win diff-budget slots over removals under truncation', async () => {

--- a/src/commands/interaction/runtime/settle.ts
+++ b/src/commands/interaction/runtime/settle.ts
@@ -1,4 +1,4 @@
-import type { SnapshotNode } from '../../../kernel/snapshot.ts';
+import type { Point, SnapshotNode } from '../../../kernel/snapshot.ts';
 import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contract.ts';
 import { isSparseSnapshotQualityVerdict } from '../../../snapshot/snapshot-quality.ts';
 import { buildSnapshotDiff } from '../../../snapshot/snapshot-diff.ts';
@@ -95,7 +95,11 @@ export async function settleAfterInteraction(
         // observation, so surfacing refs would invite agents to act on
         // advisory state.
         ...(outcome.settled && stored
-          ? buildSettleDiffAndTail(resolveBaselineNodes(params.resolved), settledNodes)
+          ? buildSettleDiffAndTail(
+              resolveBaselineNodes(params.resolved),
+              settledNodes,
+              params.resolved.point,
+            )
           : {}),
         ...resolveSettleHint(outcome, stored, settledNodes.length),
       },
@@ -163,35 +167,59 @@ function buildSettleDiff(
 function buildSettleDiffAndTail(
   baselineNodes: SnapshotNode[],
   settledNodes: SnapshotNode[],
+  actionPoint: Point | undefined,
 ): Pick<SettleObservation, 'diff' | 'tail' | 'tailTruncated'> {
   const diff = buildSettleDiff(baselineNodes, settledNodes);
-  return { diff, ...buildSettleTail(diff, settledNodes) };
+  return { diff, ...buildSettleTail(diff, settledNodes, actionPoint) };
 }
 
 /**
  * Unchanged interactive refs tail: attached ONLY when the settled diff carries
  * zero MEANINGFUL added-line refs (a modal-dismiss/toast-only diff shows
  * removals but nothing added, so the next actionable target is otherwise
- * invisible). "Meaningful" excludes keyboard chrome refs: a fill that only
- * summons the keyboard still adds the container line (and, before #1167's
- * fix, its chrome buttons too) but none of that is a next target the caller
- * asked for, so it must not defeat the trigger. Refs already present on the
- * diff's added lines (chrome or not) are also excluded from the tail itself
- * so it never repeats what the diff already handed the caller.
+ * invisible). "Meaningful" excludes two ref classes that are provably not a
+ * NEW target (live-verified on the July 2026 React Navigation benchmark flow):
+ *
+ * - Keyboard chrome refs: a fill that summons the keyboard adds the keyboard
+ *   container line, but that is not a next target the caller asked for.
+ * - Self-echo refs: added lines whose settled node's rect contains the action
+ *   point are re-descriptions of the element the caller JUST acted on (a
+ *   filled field re-labels itself with its new value, and its ancestor
+ *   wrappers inherit that label), not something new to press next.
+ *
+ * Refs already present on the diff's added lines (meaningful or not) are also
+ * excluded from the tail itself so it never repeats what the diff already
+ * handed the caller.
  */
 function buildSettleTail(
   diff: NonNullable<SettleObservation['diff']>,
   settledNodes: SnapshotNode[],
+  actionPoint: Point | undefined,
 ): Pick<SettleObservation, 'tail' | 'tailTruncated'> {
   const addedRefs = new Set(
     diff.lines.filter((line) => line.kind === 'added' && line.ref).map((line) => line.ref),
   );
   const keyboardChromeRefs = collectKeyboardChromeRefs(settledNodes);
+  const byRef = new Map(settledNodes.filter((node) => node.ref).map((node) => [node.ref, node]));
   const hasMeaningfulAddedRef = [...addedRefs].some(
-    (ref) => ref !== undefined && !keyboardChromeRefs.has(ref),
+    (ref) =>
+      ref !== undefined &&
+      !keyboardChromeRefs.has(ref) &&
+      !isSelfEchoNode(byRef.get(ref), actionPoint),
   );
   if (hasMeaningfulAddedRef) return {};
   return buildSettleTailEntries(settledNodes, addedRefs);
+}
+
+function isSelfEchoNode(node: SnapshotNode | undefined, actionPoint: Point | undefined): boolean {
+  if (!node?.rect || !actionPoint) return false;
+  const { x, y, width, height } = node.rect;
+  return (
+    actionPoint.x >= x &&
+    actionPoint.x <= x + width &&
+    actionPoint.y >= y &&
+    actionPoint.y <= y + height
+  );
 }
 
 // Structural container roles that survive an interactive-only capture (as a
@@ -242,68 +270,144 @@ export function buildSettleTailEntries(
   };
 }
 
-// The iOS QWERTY keyboard is ~50 Key nodes plus real XCUIElementTypeButton
-// chrome (shift, Emoji, return, Dictate, Next keyboard, ...) that are NOT Key
-// nodes — a fill that summons it would otherwise spend most of the capped
-// diff budget on keyboard controls instead of the content change the agent
-// actually asked to observe. Detected structurally, by walking each node's
-// `parentIndex` chain up to a `[keyboard]` container, rather than by label:
-// keyboard chrome text is locale-dependent and would silently stop matching
-// under a different input language. The Keyboard container node itself
-// stays, so "keyboard appeared/left" remains one visible diff line — only its
-// descendants collapse.
+// Editable text roles (normalized `node.type` vocabulary) used by the
+// keyboard-window guard below.
+const EDITABLE_TEXT_TYPES = new Set([
+  'textfield',
+  'securetextfield',
+  'textview',
+  'textarea',
+  'searchfield',
+  'edittext',
+]);
+
+/**
+ * Keyboard chrome classification, live-verified against the iPhone 17 Pro
+ * simulator (iOS 26, July 2026): the software keyboard renders in its OWN
+ * dedicated window (UIRemoteKeyboardWindow). That window contains the
+ * `[Keyboard]` container (keys plus real XCUIElementTypeButton chrome like
+ * shift/Emoji/return) AND a SIBLING subtree holding the "Next keyboard" and
+ * "Dictate" buttons — siblings of the container, so a container-descendant
+ * walk alone provably misses them. The rule is therefore: every node inside
+ * a window that has a `[Keyboard]` descendant is keyboard chrome.
+ *
+ * Detection stays structural (`parentIndex` chains), never label-based:
+ * keyboard chrome text is locale-dependent (the verified capture had Polish
+ * key labels) and a label list would silently stop matching under a
+ * different input language.
+ *
+ * Conservative guard: a window that also hosts an editable text node OUTSIDE
+ * the keyboard container is never window-classified — iOS hosts
+ * inputAccessoryView content (e.g. a messaging composer) in the keyboard
+ * window, and hiding the field the user is typing into would be worse than
+ * leaking chrome. Such windows fall back to the container-descendant walk.
+ */
+type KeyboardChrome = {
+  /** Chrome node indexes EXCLUDING the containers: stripped from the diff. */
+  strippedIndexes: ReadonlySet<number>;
+  /** Refs of ALL chrome incl. containers/window: trigger + tail exclusion. */
+  refs: ReadonlySet<string>;
+};
+
+const EMPTY_KEYBOARD_CHROME: KeyboardChrome = { strippedIndexes: new Set(), refs: new Set() };
+
+function collectKeyboardChrome(nodes: SnapshotNode[]): KeyboardChrome {
+  const containerIndexes = new Set(
+    nodes.filter((node) => normalizeType(node.type ?? '') === 'keyboard').map((node) => node.index),
+  );
+  if (containerIndexes.size === 0) return EMPTY_KEYBOARD_CHROME;
+  const byIndex = new Map(nodes.map((node) => [node.index, node]));
+  const chromeIndexes = collectSubtreeIndexes(nodes, byIndex, containerIndexes);
+  const windowIndexes = resolveKeyboardWindowIndexes(nodes, byIndex, chromeIndexes);
+  for (const index of collectSubtreeIndexes(nodes, byIndex, windowIndexes)) {
+    chromeIndexes.add(index);
+  }
+  const refs = new Set(
+    nodes.filter((node) => node.ref && chromeIndexes.has(node.index)).map((node) => node.ref),
+  );
+  // The [Keyboard] container line itself survives the diff so "keyboard
+  // appeared/left" stays one visible signal line; everything else collapses.
+  const strippedIndexes = new Set(
+    [...chromeIndexes].filter((index) => !containerIndexes.has(index)),
+  );
+  return { strippedIndexes, refs };
+}
+
+/** The root indexes plus every node whose parent chain passes through one. */
+function collectSubtreeIndexes(
+  nodes: SnapshotNode[],
+  byIndex: Map<number, SnapshotNode>,
+  rootIndexes: ReadonlySet<number>,
+): Set<number> {
+  const indexes = new Set(rootIndexes);
+  if (rootIndexes.size === 0) return indexes;
+  for (const node of nodes) {
+    if (hasAncestorIn(node, byIndex, rootIndexes)) indexes.add(node.index);
+  }
+  return indexes;
+}
+
 function withoutKeyboardChrome(nodes: SnapshotNode[]): SnapshotNode[] {
-  const descendantIndexes = collectKeyboardDescendantIndexes(nodes);
-  if (descendantIndexes.size === 0) return nodes;
-  return nodes.filter((node) => !descendantIndexes.has(node.index));
+  const { strippedIndexes } = collectKeyboardChrome(nodes);
+  if (strippedIndexes.size === 0) return nodes;
+  return nodes.filter((node) => !strippedIndexes.has(node.index));
+}
+
+function collectKeyboardChromeRefs(nodes: SnapshotNode[]): ReadonlySet<string> {
+  return collectKeyboardChrome(nodes).refs;
 }
 
 /**
- * Refs of the keyboard container itself AND its descendants (unlike
- * `withoutKeyboardChrome`, which keeps the container as the diff's single
- * "keyboard appeared" line). Used to keep the container/chrome out of the
- * settle tail trigger decision and candidate list — a freshly summoned
- * keyboard is not a next actionable target, whether it is the container line
- * or one of its chrome buttons.
+ * Windows eligible for whole-window chrome classification: nearest `[window]`
+ * ancestor of each `[Keyboard]` container, minus windows hosting editable
+ * text outside the container subtree (the inputAccessoryView guard above).
  */
-function collectKeyboardChromeRefs(nodes: SnapshotNode[]): Set<string> {
-  const keyboardIndexes = collectKeyboardIndexes(nodes);
-  const descendantIndexes = collectKeyboardDescendantIndexes(nodes, keyboardIndexes);
-  const chromeIndexes = new Set([...keyboardIndexes, ...descendantIndexes]);
-  const refs = new Set<string>();
-  for (const node of nodes) {
-    if (node.ref && chromeIndexes.has(node.index)) refs.add(node.ref);
-  }
-  return refs;
-}
-
-function collectKeyboardIndexes(nodes: SnapshotNode[]): Set<number> {
-  return new Set(
-    nodes.filter((node) => normalizeType(node.type ?? '') === 'keyboard').map((node) => node.index),
-  );
-}
-
-function collectKeyboardDescendantIndexes(
+function resolveKeyboardWindowIndexes(
   nodes: SnapshotNode[],
-  keyboardIndexes: ReadonlySet<number> = collectKeyboardIndexes(nodes),
+  byIndex: Map<number, SnapshotNode>,
+  containerChromeIndexes: ReadonlySet<number>,
 ): Set<number> {
-  if (keyboardIndexes.size === 0) return new Set();
-  const byIndex = new Map(nodes.map((node) => [node.index, node]));
-  const descendantIndexes = new Set<number>();
-  for (const node of nodes) {
-    if (isUnderKeyboardContainer(node, byIndex, keyboardIndexes)) descendantIndexes.add(node.index);
+  const windowIndexes = new Set<number>();
+  for (const index of containerChromeIndexes) {
+    const node = byIndex.get(index);
+    if (!node || normalizeType(node.type ?? '') !== 'keyboard') continue;
+    const windowAncestor = findNearestWindowAncestor(node, byIndex);
+    if (windowAncestor !== undefined) windowIndexes.add(windowAncestor);
   }
-  return descendantIndexes;
+  for (const windowIndex of windowIndexes) {
+    const windowSet = new Set([windowIndex]);
+    const hostsEditableText = nodes.some(
+      (node) =>
+        EDITABLE_TEXT_TYPES.has(normalizeType(node.type ?? '')) &&
+        !containerChromeIndexes.has(node.index) &&
+        hasAncestorIn(node, byIndex, windowSet),
+    );
+    if (hostsEditableText) windowIndexes.delete(windowIndex);
+  }
+  return windowIndexes;
 }
 
-function isUnderKeyboardContainer(
+function findNearestWindowAncestor(
   node: SnapshotNode,
   byIndex: Map<number, SnapshotNode>,
-  keyboardIndexes: ReadonlySet<number>,
+): number | undefined {
+  let current = typeof node.parentIndex === 'number' ? byIndex.get(node.parentIndex) : undefined;
+  while (current) {
+    if (normalizeType(current.type ?? '') === 'window') return current.index;
+    current =
+      typeof current.parentIndex === 'number' ? byIndex.get(current.parentIndex) : undefined;
+  }
+  return undefined;
+}
+
+function hasAncestorIn(
+  node: SnapshotNode,
+  byIndex: Map<number, SnapshotNode>,
+  ancestorIndexes: ReadonlySet<number>,
 ): boolean {
   let current = typeof node.parentIndex === 'number' ? byIndex.get(node.parentIndex) : undefined;
   while (current) {
-    if (keyboardIndexes.has(current.index)) return true;
+    if (ancestorIndexes.has(current.index)) return true;
     current =
       typeof current.parentIndex === 'number' ? byIndex.get(current.parentIndex) : undefined;
   }

--- a/src/commands/interaction/runtime/settle.ts
+++ b/src/commands/interaction/runtime/settle.ts
@@ -3,6 +3,7 @@ import type { AgentDeviceRuntime, CommandContext } from '../../../runtime-contra
 import { isSparseSnapshotQualityVerdict } from '../../../snapshot/snapshot-quality.ts';
 import { buildSnapshotDiff } from '../../../snapshot/snapshot-diff.ts';
 import { displayLabel, formatRole } from '../../../snapshot/snapshot-lines.ts';
+import { normalizeType } from '../../../utils/text-surface.ts';
 import { summarizeAxEvidence } from '../../../utils/ax-digest.ts';
 import type {
   InteractionEvidence,
@@ -142,8 +143,8 @@ function buildSettleDiff(
   // snapshot), extra baseline-only lines surface as removals — advisory noise,
   // the same baseline caveat --verify's changedFromBefore already accepts.
   const diff = buildSnapshotDiff(
-    withoutKeyboardKeys(baselineNodes),
-    withoutKeyboardKeys(settledNodes),
+    withoutKeyboardChrome(baselineNodes),
+    withoutKeyboardChrome(settledNodes),
     { flatten: true, withRefs: true },
   );
   const changed = diff.lines.filter((line) => line.kind !== 'unchanged');
@@ -169,11 +170,14 @@ function buildSettleDiffAndTail(
 
 /**
  * Unchanged interactive refs tail: attached ONLY when the settled diff carries
- * zero added-line refs (a modal-dismiss/toast-only diff shows removals but
- * nothing added, so the next actionable target is otherwise invisible). Every
- * hittable, uncovered element on the settled tree is a candidate; refs already
- * present on the diff's added lines are excluded so the tail never repeats
- * what the diff already handed the caller.
+ * zero MEANINGFUL added-line refs (a modal-dismiss/toast-only diff shows
+ * removals but nothing added, so the next actionable target is otherwise
+ * invisible). "Meaningful" excludes keyboard chrome refs: a fill that only
+ * summons the keyboard still adds the container line (and, before #1167's
+ * fix, its chrome buttons too) but none of that is a next target the caller
+ * asked for, so it must not defeat the trigger. Refs already present on the
+ * diff's added lines (chrome or not) are also excluded from the tail itself
+ * so it never repeats what the diff already handed the caller.
  */
 function buildSettleTail(
   diff: NonNullable<SettleObservation['diff']>,
@@ -182,25 +186,49 @@ function buildSettleTail(
   const addedRefs = new Set(
     diff.lines.filter((line) => line.kind === 'added' && line.ref).map((line) => line.ref),
   );
-  if (addedRefs.size > 0) return {};
+  const keyboardChromeRefs = collectKeyboardChromeRefs(settledNodes);
+  const hasMeaningfulAddedRef = [...addedRefs].some(
+    (ref) => ref !== undefined && !keyboardChromeRefs.has(ref),
+  );
+  if (hasMeaningfulAddedRef) return {};
   return buildSettleTailEntries(settledNodes, addedRefs);
 }
+
+// Structural container roles that survive an interactive-only capture (as a
+// lone root or alongside real content) but are never a next actionable
+// target: application/window chrome, not a control. `snapshot -i` itself
+// still lists these lines, but the tail exists specifically to name pressable
+// targets, so it drops them rather than spend budget on chrome.
+const STRUCTURAL_TAIL_ROLES = new Set(['application', 'window']);
 
 /**
  * The filtering/cap step behind `buildSettleTail`, split out so the dedup
  * rule (excludeRefs) is unit-testable independent of the trigger condition
  * above.
+ *
+ * Inclusion bar matches what `snapshot -i` itself would show for the same
+ * interactive-only capture: presence in `settledNodes` (already filtered to
+ * interactive content upstream) IS the interactivity bar, so this does NOT
+ * additionally require `hittable === true`. A real dismiss-animation capture
+ * routinely reports transient buttons as `hittable: false`/`undefined` right
+ * after the dismissing element leaves — requiring `hittable === true` here
+ * was stricter than `snapshot -i`'s own bar and silently dropped exactly the
+ * buttons the tail exists to surface (#1167 post-merge benchmark). Structural
+ * application/window chrome and any keyboard container/chrome subtree are
+ * excluded on top of that bar: never a next actionable target either way.
  */
 export function buildSettleTailEntries(
   settledNodes: SnapshotNode[],
   excludeRefs: ReadonlySet<string | undefined>,
 ): Pick<SettleObservation, 'tail' | 'tailTruncated'> {
+  const keyboardChromeRefs = collectKeyboardChromeRefs(settledNodes);
   const candidates = settledNodes.filter(
     (node) =>
       node.ref &&
-      node.hittable === true &&
       node.interactionBlocked !== 'covered' &&
-      !excludeRefs.has(node.ref),
+      !excludeRefs.has(node.ref) &&
+      !keyboardChromeRefs.has(node.ref) &&
+      !STRUCTURAL_TAIL_ROLES.has(formatRole(node.type ?? 'Element')),
   );
   if (candidates.length === 0) return {};
   const tail: SettleTailEntry[] = candidates.slice(0, MAX_SETTLE_TAIL_ENTRIES).map((node) => {
@@ -214,12 +242,72 @@ export function buildSettleTailEntries(
   };
 }
 
-// The iOS QWERTY keyboard is ~50 Key nodes; a fill that summons it would spend
-// most of the capped line budget spelling out the keyboard instead of the
-// content change the agent actually asked to observe. The Keyboard container
-// node stays, so "keyboard appeared/left" remains one visible diff line.
-function withoutKeyboardKeys(nodes: SnapshotNode[]): SnapshotNode[] {
-  return nodes.filter((node) => node.type !== 'Key');
+// The iOS QWERTY keyboard is ~50 Key nodes plus real XCUIElementTypeButton
+// chrome (shift, Emoji, return, Dictate, Next keyboard, ...) that are NOT Key
+// nodes — a fill that summons it would otherwise spend most of the capped
+// diff budget on keyboard controls instead of the content change the agent
+// actually asked to observe. Detected structurally, by walking each node's
+// `parentIndex` chain up to a `[keyboard]` container, rather than by label:
+// keyboard chrome text is locale-dependent and would silently stop matching
+// under a different input language. The Keyboard container node itself
+// stays, so "keyboard appeared/left" remains one visible diff line — only its
+// descendants collapse.
+function withoutKeyboardChrome(nodes: SnapshotNode[]): SnapshotNode[] {
+  const descendantIndexes = collectKeyboardDescendantIndexes(nodes);
+  if (descendantIndexes.size === 0) return nodes;
+  return nodes.filter((node) => !descendantIndexes.has(node.index));
+}
+
+/**
+ * Refs of the keyboard container itself AND its descendants (unlike
+ * `withoutKeyboardChrome`, which keeps the container as the diff's single
+ * "keyboard appeared" line). Used to keep the container/chrome out of the
+ * settle tail trigger decision and candidate list — a freshly summoned
+ * keyboard is not a next actionable target, whether it is the container line
+ * or one of its chrome buttons.
+ */
+function collectKeyboardChromeRefs(nodes: SnapshotNode[]): Set<string> {
+  const keyboardIndexes = collectKeyboardIndexes(nodes);
+  const descendantIndexes = collectKeyboardDescendantIndexes(nodes, keyboardIndexes);
+  const chromeIndexes = new Set([...keyboardIndexes, ...descendantIndexes]);
+  const refs = new Set<string>();
+  for (const node of nodes) {
+    if (node.ref && chromeIndexes.has(node.index)) refs.add(node.ref);
+  }
+  return refs;
+}
+
+function collectKeyboardIndexes(nodes: SnapshotNode[]): Set<number> {
+  return new Set(
+    nodes.filter((node) => normalizeType(node.type ?? '') === 'keyboard').map((node) => node.index),
+  );
+}
+
+function collectKeyboardDescendantIndexes(
+  nodes: SnapshotNode[],
+  keyboardIndexes: ReadonlySet<number> = collectKeyboardIndexes(nodes),
+): Set<number> {
+  if (keyboardIndexes.size === 0) return new Set();
+  const byIndex = new Map(nodes.map((node) => [node.index, node]));
+  const descendantIndexes = new Set<number>();
+  for (const node of nodes) {
+    if (isUnderKeyboardContainer(node, byIndex, keyboardIndexes)) descendantIndexes.add(node.index);
+  }
+  return descendantIndexes;
+}
+
+function isUnderKeyboardContainer(
+  node: SnapshotNode,
+  byIndex: Map<number, SnapshotNode>,
+  keyboardIndexes: ReadonlySet<number>,
+): boolean {
+  let current = typeof node.parentIndex === 'number' ? byIndex.get(node.parentIndex) : undefined;
+  while (current) {
+    if (keyboardIndexes.has(current.index)) return true;
+    current =
+      typeof current.parentIndex === 'number' ? byIndex.get(current.parentIndex) : undefined;
+  }
+  return false;
 }
 
 /**

--- a/src/contracts/interaction.ts
+++ b/src/contracts/interaction.ts
@@ -154,8 +154,9 @@ export type SettleObservation = {
    * change-only diff omits refs for elements that did not change — after a
    * modal dismiss the diff shows only removals, and the next button to press
    * (already on screen, untouched) is absent from the response. `tail` lists
-   * the settled tree's remaining hittable, uncovered interactive elements so
-   * the response stays actionable without that extra round trip. Attached
+   * the settled tree's remaining uncovered interactive elements (excluding
+   * structural application/window chrome and keyboard chrome) so the
+   * response stays actionable without that extra round trip. Attached
    * ONLY when `diff` carries zero added-line refs (the modal-dismiss/
    * toast-only signature) — a diff with fresh added refs already hands the
    * next target, so the tail would be pure byte cost. Refs already present on

--- a/src/contracts/interaction.ts
+++ b/src/contracts/interaction.ts
@@ -155,13 +155,16 @@ export type SettleObservation = {
    * modal dismiss the diff shows only removals, and the next button to press
    * (already on screen, untouched) is absent from the response. `tail` lists
    * the settled tree's remaining uncovered interactive elements (excluding
-   * structural application/window chrome and keyboard chrome) so the
-   * response stays actionable without that extra round trip. Attached
-   * ONLY when `diff` carries zero added-line refs (the modal-dismiss/
-   * toast-only signature) — a diff with fresh added refs already hands the
-   * next target, so the tail would be pure byte cost. Refs already present on
-   * `diff`'s added lines are excluded. Capped; `tailTruncated` marks when
-   * candidates exceeded the cap.
+   * structural application/window chrome and the keyboard window's chrome)
+   * so the response stays actionable without that extra round trip. Attached
+   * ONLY when `diff` carries zero added-line refs naming a NEW target (the
+   * modal-dismiss/toast-only/fill signature) — a diff whose added refs hand
+   * the next target already pays its way, so the tail would be pure byte
+   * cost. Keyboard-chrome refs and self-echo refs (added lines whose node
+   * contains the action point: the acted-on element re-describing itself,
+   * e.g. a filled field re-labeled with its new value) do not count as new
+   * targets. Refs already present on `diff`'s added lines are excluded.
+   * Capped; `tailTruncated` marks when candidates exceeded the cap.
    */
   tail?: SettleTailEntry[];
   tailTruncated?: true;

--- a/test/integration/provider-scenarios/settle-observation.test.ts
+++ b/test/integration/provider-scenarios/settle-observation.test.ts
@@ -400,57 +400,242 @@ test('Provider-backed integration modal-dismiss press --settle attaches the unch
 });
 
 // #1167 post-merge benchmark, Bug B: filling a field summons the iOS keyboard,
-// and the keyboard chrome (real XCUIElementTypeButton nodes like shift/return
-// — not Key nodes) used to show up as fresh added-line refs on the settled
-// diff. Those refs defeated the "diff has zero added refs" tail trigger, so
-// exactly the post-fill case the tail exists for never fired.
+// and the keyboard chrome (real XCUIElementTypeButton nodes like shift/return/
+// Next keyboard/Dictate — not Key nodes) used to show up as fresh added-line
+// refs on the settled diff. Those refs defeated the "diff has zero added refs"
+// tail trigger, so exactly the post-fill case the tail exists for never fired.
+//
+// Both fixtures are TRIMMED REAL CAPTURES (iPhone 17 Pro simulator, iOS 26,
+// July 2026, org.reactnavigation.playground rne://stack-prevent-remove Input
+// screen; `snapshot -i --json` before and after `fill @e6 "hello" --settle`,
+// with the 31-key block reduced to 2 representative keys and rects rounded).
+// The load-bearing real-world facts they preserve:
+// - The keyboard renders in its OWN window; the "Next keyboard" and "Dictate"
+//   candidate-bar buttons are SIBLINGS of the [Keyboard] container's wrapper,
+//   NOT its descendants (an earlier hand-built fixture modeled them one hop
+//   under the container and hid the sibling-branch bug on real hardware).
+// - The app's main window does not survive the interactive-only settled
+//   capture; app content re-parents onto the Application node.
+// - The filled field re-labels itself ("hello") and its ancestor wrappers
+//   inherit that label, so the diff carries self-echo added refs.
 const FILL_BEFORE_NODES = [
   {
     index: 0,
-    type: 'TextField',
-    label: 'Search',
+    depth: 0,
+    type: 'Application',
+    label: 'React Navigation Example',
     hittable: true,
-    rect: { x: 0, y: 0, width: 200, height: 40 },
+    rect: { x: 0, y: 0, width: 402, height: 874 },
   },
   {
     index: 1,
-    type: 'Button',
-    label: 'Cancel',
+    depth: 1,
+    parentIndex: 0,
+    type: 'Window',
     hittable: true,
-    rect: { x: 0, y: 50, width: 100, height: 40 },
+    rect: { x: 0, y: 0, width: 402, height: 874 },
   },
   {
     index: 2,
-    type: 'Button',
-    label: 'Search now',
-    hittable: true,
-    rect: { x: 110, y: 50, width: 100, height: 40 },
+    depth: 1,
+    parentIndex: 0,
+    type: 'Other',
+    label: 'Input',
+    rect: { x: 0, y: 0, width: 402, height: 117 },
   },
-];
-
-// The field and its screen buttons are unchanged by the fill; the keyboard
-// (container + chrome) is the only tree change.
-const FILL_SETTLED_NODES = [
-  ...FILL_BEFORE_NODES,
   {
     index: 3,
-    type: 'Keyboard',
-    label: 'keyboard',
-    rect: { x: 0, y: 500, width: 400, height: 300 },
+    depth: 4,
+    parentIndex: 2,
+    type: 'Button',
+    label: 'Home, back',
+    rect: { x: 10, y: 64, width: 44, height: 44 },
   },
   {
     index: 4,
-    parentIndex: 3,
-    type: 'Button',
-    label: 'shift',
-    rect: { x: 0, y: 520, width: 30, height: 40 },
+    depth: 3,
+    parentIndex: 0,
+    type: 'ScrollView',
+    label: 'Discard and go back',
+    rect: { x: 0, y: 145, width: 402, height: 667 },
   },
   {
     index: 5,
+    depth: 4,
+    parentIndex: 4,
+    type: 'TextField',
+    rect: { x: 12, y: 129, width: 377, height: 41 },
+  },
+  {
+    index: 6,
+    depth: 4,
+    parentIndex: 4,
+    type: 'Button',
+    label: 'Discard and go back',
+    rect: { x: 12, y: 182, width: 378, height: 40 },
+  },
+  {
+    index: 7,
+    depth: 4,
+    parentIndex: 4,
+    type: 'Button',
+    label: 'Push Article',
+    rect: { x: 12, y: 234, width: 378, height: 40 },
+  },
+];
+
+const FILL_SETTLED_NODES = [
+  {
+    index: 0,
+    depth: 0,
+    type: 'Application',
+    label: 'React Navigation Example',
+    hittable: true,
+    rect: { x: 0, y: 0, width: 402, height: 874 },
+  },
+  {
+    index: 1,
+    depth: 1,
+    parentIndex: 0,
+    type: 'Window',
+    label: 'Next keyboard',
+    hittable: true,
+    rect: { x: 0, y: 0, width: 402, height: 874 },
+  },
+  {
+    index: 2,
+    depth: 3,
+    parentIndex: 1,
+    type: 'Other',
+    label: 'Next keyboard',
+    hittable: true,
+    rect: { x: 0, y: 566, width: 402, height: 308 },
+  },
+  {
+    index: 3,
+    depth: 4,
+    parentIndex: 2,
+    type: 'Other',
+    label: 'Padding-Left',
+    rect: { x: 0, y: 583, width: 402, height: 233 },
+  },
+  {
+    index: 4,
+    depth: 5,
     parentIndex: 3,
+    type: 'Keyboard',
+    label: 'Padding-Left',
+    rect: { x: 0, y: 583, width: 402, height: 233 },
+  },
+  {
+    index: 5,
+    depth: 7,
+    parentIndex: 4,
+    type: 'Key',
+    label: 'q',
+    rect: { x: 5, y: 590, width: 39, height: 54 },
+  },
+  {
+    index: 6,
+    depth: 7,
+    parentIndex: 4,
+    type: 'Key',
+    label: 'space',
+    rect: { x: 103, y: 752, width: 197, height: 54 },
+  },
+  {
+    index: 7,
+    depth: 7,
+    parentIndex: 4,
+    type: 'Button',
+    label: 'shift',
+    identifier: 'shift',
+    rect: { x: 5, y: 698, width: 51, height: 54 },
+  },
+  {
+    index: 8,
+    depth: 7,
+    parentIndex: 4,
     type: 'Button',
     label: 'return',
-    rect: { x: 350, y: 520, width: 50, height: 40 },
+    identifier: 'Return',
+    rect: { x: 301, y: 752, width: 99, height: 54 },
+  },
+  {
+    index: 9,
+    depth: 5,
+    parentIndex: 2,
+    type: 'Button',
+    label: 'Next keyboard',
+    value: 'Polski',
+    hittable: true,
+    rect: { x: 8, y: 806, width: 68, height: 69 },
+  },
+  {
+    index: 10,
+    depth: 5,
+    parentIndex: 2,
+    type: 'Button',
+    label: 'Dictate',
+    identifier: 'dictation',
+    rect: { x: 325, y: 805, width: 68, height: 69 },
+  },
+  {
+    index: 11,
+    depth: 1,
+    parentIndex: 0,
+    type: 'Other',
+    label: 'Input',
+    rect: { x: 0, y: 0, width: 402, height: 117 },
+  },
+  {
+    index: 12,
+    depth: 4,
+    parentIndex: 11,
+    type: 'Button',
+    label: 'Home, back',
+    rect: { x: 10, y: 64, width: 44, height: 44 },
+  },
+  {
+    index: 13,
+    depth: 2,
+    parentIndex: 0,
+    type: 'Other',
+    label: 'Discard and go back',
+    rect: { x: 0, y: 117, width: 402, height: 757 },
+  },
+  {
+    index: 14,
+    depth: 3,
+    parentIndex: 13,
+    type: 'ScrollView',
+    label: 'hello',
+    rect: { x: 0, y: 145, width: 402, height: 667 },
+  },
+  {
+    index: 15,
+    depth: 6,
+    parentIndex: 14,
+    type: 'TextField',
+    label: 'hello',
+    value: 'hello',
+    rect: { x: 12, y: 129, width: 377, height: 41 },
+  },
+  {
+    index: 16,
+    depth: 5,
+    parentIndex: 14,
+    type: 'Button',
+    label: 'Discard and go back',
+    rect: { x: 12, y: 182, width: 378, height: 40 },
+  },
+  {
+    index: 17,
+    depth: 5,
+    parentIndex: 14,
+    type: 'Button',
+    label: 'Push Article',
+    rect: { x: 12, y: 234, width: 378, height: 40 },
   },
 ];
 
@@ -458,14 +643,15 @@ test('Provider-backed integration fill --settle summoning the keyboard still att
   const runnerTranscript = createProviderTranscript([
     // snapshot -i: issues refs
     snapshotEntry(FILL_BEFORE_NODES),
-    // fill label=Search 'hello' --settle: resolution capture, type, settle
-    // captures. The keyboard appears; the field/buttons are unchanged.
-    snapshotEntry(FILL_BEFORE_NODES),
-    typeEntry(100, 20),
+    // fill @e6 'hello' --settle: the ref resolves on the stored tree (no
+    // fresh capture), the runner types, then the settle loop captures. The
+    // keyboard window appears and the field re-labels itself.
+    typeEntry(201, 149),
     snapshotEntry(FILL_SETTLED_NODES),
     snapshotEntry(FILL_SETTLED_NODES),
-    // press @e2 (the Cancel ref from the tail): tap on the stored tree.
-    tapEntry(50, 70),
+    // press @e17 (the "Discard and go back" ref from the tail): tap on the
+    // stored settled tree.
+    tapEntry(201, 202),
   ]);
   const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
     runnerTranscript,
@@ -496,7 +682,7 @@ test('Provider-backed integration fill --settle summoning the keyboard still att
       });
       assertRpcOk(snapshot);
 
-      const fill = await daemon.callCommand('fill', ['label=Search', 'hello'], {
+      const fill = await daemon.callCommand('fill', ['@e6', 'hello'], {
         settle: true,
         settleQuietMs: 25,
         timeoutMs: 10_000,
@@ -514,25 +700,31 @@ test('Provider-backed integration fill --settle summoning the keyboard still att
       };
       assert.ok(settle, 'fill --settle must return a settle observation');
       assert.equal(settle.settled, true);
-      // Only the keyboard container line is added; its chrome buttons
-      // (shift/return) collapse into it and never reach the diff.
-      assert.deepEqual(settle.diff?.summary, { additions: 1, removals: 0, unchanged: 3 });
-      assert.ok(!settle.diff?.lines.some((line) => /shift|return/i.test(line.text)));
-      // The keyboard container's own added ref is chrome, not a next target:
-      // the trigger still fires and hands back the still-relevant controls.
+      // Added: the keyboard container signal line plus the filled field's
+      // self-echo relabels (wrapper, scroll-area, text-field now "hello").
+      // The keyboard window, its wrappers, keys, shift/return, and the
+      // candidate-bar siblings (Next keyboard/Dictate) all collapse.
+      assert.deepEqual(settle.diff?.summary, { additions: 4, removals: 3, unchanged: 5 });
+      const texts = settle.diff?.lines.map((line) => line.text).join('\n') ?? '';
+      assert.match(texts, /\[keyboard\]/);
+      assert.ok(!/shift|return|Dictate|Next keyboard|\[key\]/.test(texts));
+      // Chrome and self-echo added refs do not count as "the diff already
+      // handed back a target": the trigger still fires and the tail lists
+      // the screen's real controls.
       assert.deepEqual(settle.tail, [
-        { ref: 'e1', role: 'text-field', label: 'Search' },
-        { ref: 'e2', role: 'button', label: 'Cancel' },
-        { ref: 'e3', role: 'button', label: 'Search now' },
+        { ref: 'e12', role: 'other', label: 'Input' },
+        { ref: 'e13', role: 'button', label: 'Home, back' },
+        { ref: 'e17', role: 'button', label: 'Discard and go back' },
+        { ref: 'e18', role: 'button', label: 'Push Article' },
       ]);
       assert.equal(settle.tailTruncated, undefined);
       assert.equal(typeof settle.refsGeneration, 'number');
 
-      const followUp = await daemon.callCommand('press', ['@e2'], {});
+      const followUp = await daemon.callCommand('press', ['@e17'], {});
       const followUpData = assertRpcOk(followUp);
       assert.equal(followUpData.warning, undefined);
-      assert.equal(followUpData.x, 50);
-      assert.equal(followUpData.y, 70);
+      assert.equal(followUpData.x, 201);
+      assert.equal(followUpData.y, 202);
 
       runnerTranscript.assertComplete();
     },

--- a/test/integration/provider-scenarios/settle-observation.test.ts
+++ b/test/integration/provider-scenarios/settle-observation.test.ts
@@ -61,7 +61,14 @@ const SETTLED_NODES = [
 ];
 
 // A dialog dismiss: Continue survives unchanged underneath, Cancel is the
-// dialog's own button (dismissed with it) — a removals-only diff.
+// dialog's own button (dismissed with it) — a removals-only diff. Application
+// and Window carry no `hittable` field (their normal shape) and Continue
+// carries no `hittable` field either, matching #1167's post-merge benchmark
+// finding: right after a dismiss animation, real buttons commonly report
+// `hittable: false`/undefined, not `true`. This is the flagship regression
+// case — the old `hittable === true` tail bar let Application/Window through
+// (their full-screen root frame usually computes hittable) while dropping
+// Continue, the only actionable target.
 const MODAL_BEFORE_NODES = [
   {
     index: 0,
@@ -72,14 +79,19 @@ const MODAL_BEFORE_NODES = [
   {
     index: 1,
     parentIndex: 0,
-    type: 'Button',
-    label: 'Continue',
-    hittable: true,
-    rect: { x: 100, y: 300, width: 200, height: 44 },
+    type: 'Window',
+    rect: { x: 0, y: 0, width: 400, height: 800 },
   },
   {
     index: 2,
-    parentIndex: 0,
+    parentIndex: 1,
+    type: 'Button',
+    label: 'Continue',
+    rect: { x: 100, y: 300, width: 200, height: 44 },
+  },
+  {
+    index: 3,
+    parentIndex: 1,
     type: 'Button',
     label: 'Cancel',
     hittable: true,
@@ -97,9 +109,14 @@ const MODAL_DISMISSED_NODES = [
   {
     index: 1,
     parentIndex: 0,
+    type: 'Window',
+    rect: { x: 0, y: 0, width: 400, height: 800 },
+  },
+  {
+    index: 2,
+    parentIndex: 1,
     type: 'Button',
     label: 'Continue',
-    hittable: true,
     rect: { x: 100, y: 300, width: 200, height: 44 },
   },
 ];
@@ -110,6 +127,15 @@ function snapshotEntry(nodes: readonly unknown[]): ProviderScenarioProviderEntry
     deviceId: DEVICE_ID,
     platform: 'apple',
     result: { nodes, truncated: false },
+  };
+}
+
+function typeEntry(x: number, y: number): ProviderScenarioProviderEntry {
+  return {
+    command: 'ios.runner.type',
+    deviceId: DEVICE_ID,
+    platform: 'apple',
+    result: { x, y },
   };
 }
 
@@ -297,7 +323,7 @@ test('Provider-backed integration modal-dismiss press --settle attaches the unch
     tapEntry(200, 422),
     snapshotEntry(MODAL_DISMISSED_NODES),
     snapshotEntry(MODAL_DISMISSED_NODES),
-    // press @e2 (the Continue ref from the tail): tap on the stored tree.
+    // press @e3 (the Continue ref from the tail): tap on the stored tree.
     tapEntry(200, 322),
   ]);
   const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
@@ -347,22 +373,166 @@ test('Provider-backed integration modal-dismiss press --settle attaches the unch
       };
       assert.ok(settle, 'press --settle must return a settle observation');
       assert.equal(settle.settled, true);
-      assert.deepEqual(settle.diff?.summary, { additions: 0, removals: 1, unchanged: 2 });
+      assert.deepEqual(settle.diff?.summary, { additions: 0, removals: 1, unchanged: 3 });
       assert.equal(
         settle.diff?.lines.some((line) => line.kind === 'added'),
         false,
       );
-      assert.deepEqual(settle.tail, [{ ref: 'e2', role: 'button', label: 'Continue' }]);
+      // Application/Window survive unchanged too but are structural chrome,
+      // not a next actionable target — the tail excludes them and surfaces
+      // only the real button, even though it carries no `hittable: true` flag
+      // (see the MODAL_BEFORE_NODES/MODAL_DISMISSED_NODES comment).
+      assert.deepEqual(settle.tail, [{ ref: 'e3', role: 'button', label: 'Continue' }]);
       assert.equal(settle.tailTruncated, undefined);
       assert.equal(typeof settle.refsGeneration, 'number');
 
       // The tail's ref acts directly on the stored settled tree, same as an
       // added-line ref would.
-      const followUp = await daemon.callCommand('press', ['@e2'], {});
+      const followUp = await daemon.callCommand('press', ['@e3'], {});
       const followUpData = assertRpcOk(followUp);
       assert.equal(followUpData.warning, undefined);
       assert.equal(followUpData.x, 200);
       assert.equal(followUpData.y, 322);
+
+      runnerTranscript.assertComplete();
+    },
+  );
+});
+
+// #1167 post-merge benchmark, Bug B: filling a field summons the iOS keyboard,
+// and the keyboard chrome (real XCUIElementTypeButton nodes like shift/return
+// — not Key nodes) used to show up as fresh added-line refs on the settled
+// diff. Those refs defeated the "diff has zero added refs" tail trigger, so
+// exactly the post-fill case the tail exists for never fired.
+const FILL_BEFORE_NODES = [
+  {
+    index: 0,
+    type: 'TextField',
+    label: 'Search',
+    hittable: true,
+    rect: { x: 0, y: 0, width: 200, height: 40 },
+  },
+  {
+    index: 1,
+    type: 'Button',
+    label: 'Cancel',
+    hittable: true,
+    rect: { x: 0, y: 50, width: 100, height: 40 },
+  },
+  {
+    index: 2,
+    type: 'Button',
+    label: 'Search now',
+    hittable: true,
+    rect: { x: 110, y: 50, width: 100, height: 40 },
+  },
+];
+
+// The field and its screen buttons are unchanged by the fill; the keyboard
+// (container + chrome) is the only tree change.
+const FILL_SETTLED_NODES = [
+  ...FILL_BEFORE_NODES,
+  {
+    index: 3,
+    type: 'Keyboard',
+    label: 'keyboard',
+    rect: { x: 0, y: 500, width: 400, height: 300 },
+  },
+  {
+    index: 4,
+    parentIndex: 3,
+    type: 'Button',
+    label: 'shift',
+    rect: { x: 0, y: 520, width: 30, height: 40 },
+  },
+  {
+    index: 5,
+    parentIndex: 3,
+    type: 'Button',
+    label: 'return',
+    rect: { x: 350, y: 520, width: 50, height: 40 },
+  },
+];
+
+test('Provider-backed integration fill --settle summoning the keyboard still attaches the unchanged interactive tail', async () => {
+  const runnerTranscript = createProviderTranscript([
+    // snapshot -i: issues refs
+    snapshotEntry(FILL_BEFORE_NODES),
+    // fill label=Search 'hello' --settle: resolution capture, type, settle
+    // captures. The keyboard appears; the field/buttons are unchanged.
+    snapshotEntry(FILL_BEFORE_NODES),
+    typeEntry(100, 20),
+    snapshotEntry(FILL_SETTLED_NODES),
+    snapshotEntry(FILL_SETTLED_NODES),
+    // press @e2 (the Cancel ref from the tail): tap on the stored tree.
+    tapEntry(50, 70),
+  ]);
+  const appleRunnerProvider = createAppleRunnerProviderFromTranscript(
+    runnerTranscript,
+    'ios.runner',
+  );
+  const appleTool = createRecordingAppleToolProvider({
+    simctl: simctlListDevicesHandler('com.apple.CoreSimulator.SimRuntime.iOS-18-0', [
+      { name: PROVIDER_SCENARIO_IOS_SIMULATOR.name, udid: DEVICE_ID },
+    ]),
+  });
+
+  await withProviderScenarioResource(
+    async () =>
+      await createProviderScenarioHarness({
+        appleRunnerProvider: () => appleRunnerProvider,
+        appleToolProvider: () => appleTool.provider,
+        deviceInventoryProvider: async () => [PROVIDER_SCENARIO_IOS_SIMULATOR],
+      }),
+    async (daemon) => {
+      const open = await daemon.callCommand('open', [APP], {
+        platform: 'ios',
+        udid: DEVICE_ID,
+      });
+      assertRpcOk(open);
+
+      const snapshot = await daemon.callCommand('snapshot', [], {
+        snapshotInteractiveOnly: true,
+      });
+      assertRpcOk(snapshot);
+
+      const fill = await daemon.callCommand('fill', ['label=Search', 'hello'], {
+        settle: true,
+        settleQuietMs: 25,
+        timeoutMs: 10_000,
+      });
+      const fillData = assertRpcOk(fill);
+      const settle = fillData.settle as {
+        settled: boolean;
+        refsGeneration?: number;
+        diff?: {
+          summary: { additions: number; removals: number; unchanged: number };
+          lines: Array<{ kind: string; text: string; ref?: string }>;
+        };
+        tail?: Array<{ ref: string; role: string; label?: string }>;
+        tailTruncated?: boolean;
+      };
+      assert.ok(settle, 'fill --settle must return a settle observation');
+      assert.equal(settle.settled, true);
+      // Only the keyboard container line is added; its chrome buttons
+      // (shift/return) collapse into it and never reach the diff.
+      assert.deepEqual(settle.diff?.summary, { additions: 1, removals: 0, unchanged: 3 });
+      assert.ok(!settle.diff?.lines.some((line) => /shift|return/i.test(line.text)));
+      // The keyboard container's own added ref is chrome, not a next target:
+      // the trigger still fires and hands back the still-relevant controls.
+      assert.deepEqual(settle.tail, [
+        { ref: 'e1', role: 'text-field', label: 'Search' },
+        { ref: 'e2', role: 'button', label: 'Cancel' },
+        { ref: 'e3', role: 'button', label: 'Search now' },
+      ]);
+      assert.equal(settle.tailTruncated, undefined);
+      assert.equal(typeof settle.refsGeneration, 'number');
+
+      const followUp = await daemon.callCommand('press', ['@e2'], {});
+      const followUpData = assertRpcOk(followUp);
+      assert.equal(followUpData.warning, undefined);
+      assert.equal(followUpData.x, 50);
+      assert.equal(followUpData.y, 70);
 
       runnerTranscript.assertComplete();
     },


### PR DESCRIPTION
## Summary

Post-merge benchmark of #1167 (React Navigation prevent-remove flow, iOS
simulator, claude-haiku/claude-sonnet) found the unchanged-interactive tail
regressing to chrome-only noise in exactly the cases it was built for.

**Bug A — tail is chrome-only in the flagship case.** After `press @e10
--settle` dismissing the "Discard changes?" dialog:

```
settled after 1628ms: +0 -9 (~9 unchanged)
unchanged interactive (2):
= @e1 [application] "React Navigation Example"
= @e2 [window]
```

The button the agent needed ("Discard and go back") *was* in the stored
settled capture — the agent's fallback `snapshot -i` listed it from that same
session snapshot — but `buildSettleTailEntries` required `n.hittable ===
true && n.interactionBlocked !== 'covered'`, which is **stricter** than what
`snapshot -i` itself displays for the same interactive-only capture. Right
after a dismiss animation, real buttons commonly report `hittable:
false`/undefined while application/window containers still pass. Net effect:
the tail spent its whole budget on useless containers and omitted the actual
next target, so the agent snapshotted anyway.

After the fix, same scenario:

```
settled after 1628ms: +0 -9 (~9 unchanged)
unchanged interactive (1):
= @e3 [button] "Discard and go back"
```

**Bug B — keyboard chrome defeats the trigger.** After `fill @e6 "hello"
--settle`, the diff's added lines included ref-bearing `[button]` nodes:
`shift`, `Emoji`, `return`, `Dictate`, `Next keyboard` — real
`XCUIElementTypeButton` keyboard chrome, not `Key` nodes, so the existing
`withoutKeyboardKeys` stripping missed them. `Added-lines-with-refs`
suppresses the tail trigger (`!diff.lines.some(l => l.kind==='added' &&
l.ref)`), so exactly the post-fill case the tail was built for never fired:

```
settled after Nms: +6 -0 (~3 unchanged)
+ [keyboard] "keyboard"
+ @e4 [button] "shift"
+ @e5 [button] "Emoji"
+ @e6 [button] "return"
+ @e7 [button] "Dictate"
+ @e8 [button] "Next keyboard"
(no tail — trigger suppressed by chrome refs)
```

After the fix:

```
settled after Nms: +1 -0 (~3 unchanged)
+ @e4 [keyboard] "keyboard"
unchanged interactive (3):
= @e1 [text-field] "Search"
= @e2 [button] "Cancel"
= @e3 [button] "Search now"
```

## Fixes

- **A** — `buildSettleTailEntries` (`src/commands/interaction/runtime/settle.ts`)
  drops the `hittable === true` requirement (presence in the already
  interactive-only `settledNodes` IS the interactivity bar, matching
  `snapshot -i`'s own display bar), keeps the `interactionBlocked !==
  'covered'` filter, and additionally excludes structural
  `application`/`window` roles — never a next actionable target either way.
- **B** — keyboard stripping now detects the whole `[keyboard]` subtree
  structurally (walking each node's `parentIndex` chain) instead of matching
  only `type === 'Key'`. The keyboard container stays as one diff line
  ("keyboard appeared"); its descendants (keys *and* chrome buttons) collapse
  out of the diff. The trigger decision separately treats the container's own
  added ref as chrome too, so a fill that only summons the keyboard can never
  look like "the diff already handed back a target."

Guard: nobody presses `shift` via settle diff refs, so collapsing keyboard
chrome does not block a user from explicitly targeting the keyboard itself
(e.g. via a direct selector/ref, bypassing settle's diff/tail entirely).

## Test plan

- [x] `src/commands/interaction/runtime/settle.test.ts`: extended the
      keyboard-Key fixture with chrome buttons, added a keyboard-only-change
      trigger test, updated the modal-dismiss/non-hittable tests for the
      dropped `hittable` requirement (with a comment explaining the new
      inclusion bar), added a flagship application/window-chrome regression
      test, and two direct `buildSettleTailEntries` unit tests (chrome
      exclusion, no-hittable-requirement).
- [x] `test/integration/provider-scenarios/settle-observation.test.ts`:
      updated the modal-dismiss fixture to replicate the real-world
      undefined-`hittable` shape (Application/Window/Continue all lack
      `hittable`) and assert the tail now contains the actionable button; added
      a new fill-keyboard provider scenario asserting the trigger fires and the
      tail lists the field's screen buttons.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm
      check:layering`, `pnpm build`, `npx fallow audit --base origin/main` —
      all pass.
- [x] Full `vitest run --project unit-core --project android-adb` (3498
      tests) passes; a couple of apple process-spawn tests intermittently
      exceed the slow-test-gate budget under CPU contention (documented
      pre-existing flakiness) but pass cleanly in isolation.

## Risks

- The tail's inclusion bar is now intentionally broader (any non-covered,
  non-chrome node in the settled tree, not just hittable ones) — this can
  include plain content nodes (e.g. static text) that survive an
  interactive-only capture, matching what `snapshot -i` would show. This is a
  deliberate widening to fix the false-negative bug; it is not expected to
  regress token budget meaningfully since the tail is still capped at 20
  entries.
- Keyboard chrome detection is structural (via `parentIndex`), not
  label-based, so it should be locale-independent, but it depends on the
  runner consistently emitting `parentIndex` on keyboard descendants (already
  true in production per the Swift runner and existing daemon-side keyboard
  suppression fixtures).