### PR TITLE
fix: add curated suggestions for open-url and close-session

### DIFF
--- a/src/cli/parser/__tests__/command-suggestions.test.ts
+++ b/src/cli/parser/__tests__/command-suggestions.test.ts
@@ -109,6 +109,26 @@ test('get-text, gettext, and get_text suggest get text', () => {
   }
 });
 
+test('open-url suggests open <url>', () => {
+  assert.throws(
+    () => parseArgs(['open-url', 'https://example.com']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: open-url. Did you mean open <url>?',
+  );
+});
+
+test('close-session suggests close', () => {
+  assert.throws(
+    () => parseArgs(['close-session']),
+    (error: unknown) =>
+      error instanceof AppError &&
+      error.code === 'INVALID_ARGS' &&
+      error.message === 'Unknown command: close-session. Did you mean close?',
+  );
+});
+
 test('screencap and capture suggest screenshot', () => {
   for (const guess of ['screencap', 'capture']) {
     assert.throws(

--- a/src/cli/parser/command-suggestions.ts
+++ b/src/cli/parser/command-suggestions.ts
@@ -38,6 +38,8 @@ const COMMAND_ALIAS_SUGGESTIONS: Record<string, CommandAliasSuggestion> = {
   'get-text': { command: 'get', example: 'get text' },
   gettext: { command: 'get', example: 'get text' },
   get_text: { command: 'get', example: 'get text' },
+  'open-url': { command: 'open', example: 'open <url>' },
+  'close-session': { command: 'close', example: 'close' },
 };
 
 export function listCommandAliasSuggestionEntries(): Array<[string, CommandAliasSuggestion]> {


### PR DESCRIPTION
## Summary

- The 2026-07-09 help-conformance benchmark run showed agents guessing `open-url` and `close-session` as command names (1x each), and the CLI produced no "Did you mean" hint for either — the Levenshtein nearest-name fallback doesn't cover them because both tokens exceed the edit-distance threshold for their length versus the real command names (`open`, `close`).
- Verified pre-fix behavior directly: `node bin/agent-device.mjs open-url` and `node bin/agent-device.mjs close-session` both returned a bare `Unknown command: ...` with no hint.
- Added curated entries in `src/cli/parser/command-suggestions.ts` following the existing convention: `open-url` → `open <url>`, `close-session` → `close`.
- Added unit tests mirroring the existing per-token test pattern in `src/cli/parser/__tests__/command-suggestions.test.ts`.

## Test plan

- [x] `node bin/agent-device.mjs open-url` now prints `Unknown command: open-url. Did you mean open <url>?`
- [x] `node bin/agent-device.mjs close-session` now prints `Unknown command: close-session. Did you mean close?`
- [x] `npx vitest run src/cli/parser` — 170/170 passing (includes the two new cases plus the registry-drift guards)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm check:layering` all clean
- [x] `npx fallow audit --base origin/main` — no issues in the 2 changed files