### PR TITLE
feat(replay): ADR 0012 migration step 2 — structured replay divergence report

### DIFF
--- a/src/__tests__/daemon-error.test.ts
+++ b/src/__tests__/daemon-error.test.ts
@@ -1,0 +1,51 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import { throwDaemonError } from '../daemon-error.ts';
+import { AppError, normalizeError } from '../kernel/errors.ts';
+import type { DaemonError } from '../kernel/contracts.ts';
+
+// ADR 0012 migration step 2: "the Node client rejects with AppError retaining
+// details.divergence" — this is the single conversion point (every
+// client-facing command function funnels a failed DaemonResponse through
+// throwDaemonError), so this contract test is the daemon -> Node client leg
+// of the four-surface preservation chain (daemon -> client -> CLI -> MCP).
+test('throwDaemonError preserves details.divergence into the thrown AppError', () => {
+  const divergence = {
+    version: 1 as const,
+    kind: 'action-failure' as const,
+    step: { index: 3, source: { path: '/tmp/flow.ad', line: 9 } },
+    action: 'click "Save"',
+    cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+    screen: { state: 'unavailable' as const, reason: 'capture-failed' },
+    suggestions: [],
+    suggestionCount: 0,
+    resume: { allowed: false as const, reason: 'resume not yet supported' },
+  };
+  const daemonError: DaemonError = {
+    code: 'REPLAY_DIVERGENCE',
+    message: 'Replay failed at step 3',
+    hint: 'Read details.divergence',
+    details: { step: 3, action: 'click', divergence },
+  };
+
+  let caught: unknown;
+  try {
+    throwDaemonError(daemonError);
+  } catch (error) {
+    caught = error;
+  }
+
+  assert.ok(caught instanceof AppError);
+  const appErr = caught as AppError;
+  assert.equal(appErr.code, 'REPLAY_DIVERGENCE');
+  assert.deepEqual(appErr.details?.divergence, divergence);
+
+  // The full chain: daemon -> throwDaemonError -> AppError -> normalizeError
+  // (the CLI/MCP boundary) still carries it, JSON-round-trippable for --json.
+  const normalized = normalizeError(appErr);
+  assert.deepEqual(normalized.details?.divergence, divergence);
+  const roundTripped = JSON.parse(JSON.stringify({ success: false, error: normalized })) as {
+    error: { details?: { divergence?: unknown } };
+  };
+  assert.deepEqual(roundTripped.error.details?.divergence, divergence);
+});

--- a/src/compat/maestro/__tests__/replay-flow.test.ts
+++ b/src/compat/maestro/__tests__/replay-flow.test.ts
@@ -622,10 +622,9 @@ test('parseMaestroReplayFlow preserves provenance through a nested (include-of-i
   assert.equal(parsed.actionLines[1], 3); // tapOn: Deepest, in grandchild.yaml
 });
 
-// Deep replaySource leak check: control-flow wrappers (retry/runFlow.when)
-// carry nested actions under replayControl and never flow through the
-// top-level strip — the transient field must be stripped there too, moved
-// into replayControl.actionSources for the runtime block invoker.
+// Regression: provenance travels ONLY in the parallel structures
+// (actionSourcePaths / replayControl.actionSources) — no per-action
+// provenance field may (re)appear anywhere in parsed output.
 function collectReplaySourceLeaks(actions: unknown[], leaks: string[] = [], prefix = ''): string[] {
   for (const [index, entry] of actions.entries()) {
     const action = entry as {
@@ -643,7 +642,7 @@ function collectReplaySourceLeaks(actions: unknown[], leaks: string[] = [], pref
   return leaks;
 }
 
-test('parseMaestroReplayFlow strips replaySource from a retry-wrapped include and records actionSources', () => {
+test('parseMaestroReplayFlow carries retry-wrapped include provenance in replayControl.actionSources', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-retry-provenance-'));
   const childPath = path.join(root, 'child.yaml');
   const mainPath = path.join(root, 'main.yaml');
@@ -679,11 +678,10 @@ test('parseMaestroReplayFlow strips replaySource from a retry-wrapped include an
   assert.equal(parsed.actionSourcePaths?.[0], undefined);
   assert.equal(parsed.actionLines[0], 3);
 
-  // The transient field leaks nowhere — not on the wrapper, not on any
-  // nested action (the doc-comment claim "never reaches dispatch").
+  // No per-action provenance field anywhere in the parsed output.
   assert.deepEqual(collectReplaySourceLeaks(parsed.actions), []);
 
-  // The include's provenance moved into replayControl.actionSources.
+  // The include's provenance lives in replayControl.actionSources.
   const control = wrapper.replayControl;
   if (control?.kind !== 'retry') throw new Error('expected retry control');
   assert.equal(control.actions.length, 2);
@@ -693,7 +691,7 @@ test('parseMaestroReplayFlow strips replaySource from a retry-wrapped include an
   ]);
 });
 
-test('parseMaestroReplayFlow strips replaySource from a runtime-when-wrapped include and records actionSources', () => {
+test('parseMaestroReplayFlow carries when-wrapped include provenance in replayControl.actionSources', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-when-provenance-'));
   const childPath = path.join(root, 'child.yaml');
   const mainPath = path.join(root, 'main.yaml');

--- a/src/compat/maestro/__tests__/replay-flow.test.ts
+++ b/src/compat/maestro/__tests__/replay-flow.test.ts
@@ -519,6 +519,109 @@ onFlowComplete:
   );
 });
 
+// ADR 0012 migration step 2: a `runFlow` include must not lose provenance —
+// every inlined action reports the INCLUDE's own resolved path + line, not
+// the including `runFlow:` command's line. Regression coverage for the
+// live-reproduced "Replay failed at step 5 (__maestroTapOn ...)" bug, where
+// no file or line appeared anywhere in the failure.
+test('parseMaestroReplayFlow preserves the include file path and line through runFlow inlining', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-provenance-'));
+  const launchPath = path.join(root, 'launch.yml');
+  const flowsDir = path.join(root, 'flows');
+  fs.mkdirSync(flowsDir, { recursive: true });
+  const mainPath = path.join(flowsDir, 'main.yaml');
+  fs.writeFileSync(
+    launchPath,
+    `appId: com.callstack.agentdevicelab
+---
+- launchApp
+- tapOn: Welcome
+- tapOn: Push Input
+`,
+  );
+  fs.writeFileSync(
+    mainPath,
+    `appId: com.callstack.agentdevicelab
+---
+- tapOn: Before
+- runFlow:
+    file: ../launch.yml
+- tapOn: After
+`,
+  );
+
+  const parsed = parseMaestroReplayFlow(fs.readFileSync(mainPath, 'utf8'), {
+    sourcePath: mainPath,
+    platform: 'ios',
+  });
+
+  assert.deepEqual(
+    parsed.actions.map((entry) => entry.command),
+    ['__maestroTapOn', 'open', '__maestroTapOn', '__maestroTapOn', '__maestroTapOn'],
+  );
+  // "tapOn: Before" (main.yaml line 3) — no include, so the top-level path
+  // stays `undefined` (the caller's own file).
+  assert.equal(parsed.actionSourcePaths?.[0], undefined);
+  assert.equal(parsed.actionLines[0], 3);
+  // Every action inlined from the include (launchApp/tapOn Welcome/tapOn
+  // Push Input) reports launch.yml's OWN path and its OWN line — never
+  // main.yaml's `runFlow:` line (4).
+  for (const index of [1, 2, 3]) {
+    assert.equal(parsed.actionSourcePaths?.[index], launchPath);
+  }
+  assert.equal(parsed.actionLines[1], 3); // launchApp
+  assert.equal(parsed.actionLines[2], 4); // tapOn: Welcome
+  assert.equal(parsed.actionLines[3], 5); // tapOn: Push Input — the live-bug target
+  // "tapOn: After" (main.yaml line 6) returns to the top-level file.
+  assert.equal(parsed.actionSourcePaths?.[4], undefined);
+  assert.equal(parsed.actionLines[4], 6);
+});
+
+test('parseMaestroReplayFlow preserves provenance through a nested (include-of-include) runFlow', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-provenance-nested-'));
+  const grandchildPath = path.join(root, 'grandchild.yaml');
+  const childPath = path.join(root, 'child.yaml');
+  const mainPath = path.join(root, 'main.yaml');
+  fs.writeFileSync(
+    grandchildPath,
+    `appId: com.callstack.agentdevicelab
+---
+- tapOn: Deepest
+`,
+  );
+  fs.writeFileSync(
+    childPath,
+    `appId: com.callstack.agentdevicelab
+---
+- tapOn: Shallow
+- runFlow:
+    file: grandchild.yaml
+`,
+  );
+  fs.writeFileSync(
+    mainPath,
+    `appId: com.callstack.agentdevicelab
+---
+- runFlow:
+    file: child.yaml
+`,
+  );
+
+  const parsed = parseMaestroReplayFlow(fs.readFileSync(mainPath, 'utf8'), {
+    sourcePath: mainPath,
+    platform: 'ios',
+  });
+
+  assert.deepEqual(
+    parsed.actions.map((entry) => entry.command),
+    ['__maestroTapOn', '__maestroTapOn'],
+  );
+  assert.equal(parsed.actionSourcePaths?.[0], childPath);
+  assert.equal(parsed.actionLines[0], 3); // tapOn: Shallow, in child.yaml
+  assert.equal(parsed.actionSourcePaths?.[1], grandchildPath);
+  assert.equal(parsed.actionLines[1], 3); // tapOn: Deepest, in grandchild.yaml
+});
+
 test('parseMaestroReplayFlow skips platform-gated runFlow commands for other platforms', () => {
   const parsed = parseMaestroReplayFlow(
     `appId: com.callstack.agentdevicelab

--- a/src/compat/maestro/__tests__/replay-flow.test.ts
+++ b/src/compat/maestro/__tests__/replay-flow.test.ts
@@ -622,6 +622,114 @@ test('parseMaestroReplayFlow preserves provenance through a nested (include-of-i
   assert.equal(parsed.actionLines[1], 3); // tapOn: Deepest, in grandchild.yaml
 });
 
+// Deep replaySource leak check: control-flow wrappers (retry/runFlow.when)
+// carry nested actions under replayControl and never flow through the
+// top-level strip — the transient field must be stripped there too, moved
+// into replayControl.actionSources for the runtime block invoker.
+function collectReplaySourceLeaks(actions: unknown[], leaks: string[] = [], prefix = ''): string[] {
+  for (const [index, entry] of actions.entries()) {
+    const action = entry as {
+      command?: string;
+      replaySource?: unknown;
+      replayControl?: { actions?: unknown[] };
+    };
+    if (action.replaySource !== undefined) {
+      leaks.push(`${prefix}[${index}] ${String(action.command)}`);
+    }
+    if (Array.isArray(action.replayControl?.actions)) {
+      collectReplaySourceLeaks(action.replayControl.actions, leaks, `${prefix}[${index}].control`);
+    }
+  }
+  return leaks;
+}
+
+test('parseMaestroReplayFlow strips replaySource from a retry-wrapped include and records actionSources', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-retry-provenance-'));
+  const childPath = path.join(root, 'child.yaml');
+  const mainPath = path.join(root, 'main.yaml');
+  fs.writeFileSync(
+    childPath,
+    `appId: com.callstack.agentdevicelab
+---
+- back
+- tapOn: Push Input
+`,
+  );
+  fs.writeFileSync(
+    mainPath,
+    `appId: com.callstack.agentdevicelab
+---
+- retry:
+    maxRetries: 2
+    commands:
+      - runFlow:
+          file: child.yaml
+`,
+  );
+
+  const parsed = parseMaestroReplayFlow(fs.readFileSync(mainPath, 'utf8'), {
+    sourcePath: mainPath,
+    platform: 'ios',
+  });
+
+  // One wrapping retry action; the wrapper itself is a root-file step.
+  assert.equal(parsed.actions.length, 1);
+  const wrapper = parsed.actions[0]!;
+  assert.equal(wrapper.command, 'retry');
+  assert.equal(parsed.actionSourcePaths?.[0], undefined);
+  assert.equal(parsed.actionLines[0], 3);
+
+  // The transient field leaks nowhere — not on the wrapper, not on any
+  // nested action (the doc-comment claim "never reaches dispatch").
+  assert.deepEqual(collectReplaySourceLeaks(parsed.actions), []);
+
+  // The include's provenance moved into replayControl.actionSources.
+  const control = wrapper.replayControl;
+  if (control?.kind !== 'retry') throw new Error('expected retry control');
+  assert.equal(control.actions.length, 2);
+  assert.deepEqual(control.actionSources, [
+    { path: childPath, line: 3 }, // back
+    { path: childPath, line: 4 }, // tapOn: Push Input
+  ]);
+});
+
+test('parseMaestroReplayFlow strips replaySource from a runtime-when-wrapped include and records actionSources', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-maestro-when-provenance-'));
+  const childPath = path.join(root, 'child.yaml');
+  const mainPath = path.join(root, 'main.yaml');
+  fs.writeFileSync(
+    childPath,
+    `appId: com.callstack.agentdevicelab
+---
+- back
+`,
+  );
+  fs.writeFileSync(
+    mainPath,
+    `appId: com.callstack.agentdevicelab
+---
+- runFlow:
+    file: child.yaml
+    when:
+      visible: Continue
+`,
+  );
+
+  const parsed = parseMaestroReplayFlow(fs.readFileSync(mainPath, 'utf8'), {
+    sourcePath: mainPath,
+    platform: 'ios',
+  });
+
+  assert.equal(parsed.actions.length, 1);
+  const wrapper = parsed.actions[0]!;
+  assert.equal(wrapper.command, 'runFlow.when');
+  assert.deepEqual(collectReplaySourceLeaks(parsed.actions), []);
+
+  const control = wrapper.replayControl;
+  if (control?.kind !== 'maestroRunFlowWhen') throw new Error('expected runFlow.when control');
+  assert.deepEqual(control.actionSources, [{ path: childPath, line: 3 }]);
+});
+
 test('parseMaestroReplayFlow skips platform-gated runFlow commands for other platforms', () => {
   const parsed = parseMaestroReplayFlow(
     `appId: com.callstack.agentdevicelab

--- a/src/compat/maestro/command-mapper.ts
+++ b/src/compat/maestro/command-mapper.ts
@@ -30,17 +30,29 @@ import { MAESTRO_RUNTIME_COMMAND } from './runtime-commands.ts';
 import type {
   MaestroCommand,
   MaestroCommandMapperDeps,
+  MaestroConvertedActions,
   MaestroFlowConfig,
   MaestroParseContext,
 } from './types.ts';
 
+// Handlers that cannot produce foreign-file actions return bare actions;
+// toConvertedActions normalizes them to the pipeline's uniform shape.
 type MaestroCommandHandler = (params: {
   value: unknown;
   config: MaestroFlowConfig;
   context: MaestroParseContext;
   deps: MaestroCommandMapperDeps;
   name: string;
-}) => SessionAction[];
+}) => SessionAction[] | MaestroConvertedActions;
+
+function toConvertedActions(
+  result: SessionAction[] | MaestroConvertedActions,
+): MaestroConvertedActions {
+  if (Array.isArray(result)) {
+    return { actions: result, sources: result.map(() => undefined) };
+  }
+  return result;
+}
 
 const MAP_COMMAND_HANDLERS: Record<string, MaestroCommandHandler> = {
   launchApp: ({ value, config, context }) => [convertLaunchApp(value, config, context)],
@@ -106,7 +118,7 @@ export function convertMaestroCommandWithLine(
   line: number,
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
-): SessionAction[] {
+): MaestroConvertedActions {
   try {
     return convertMaestroCommand(command, config, context, deps);
   } catch (error) {
@@ -122,8 +134,10 @@ function convertMaestroCommand(
   config: MaestroFlowConfig,
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
-): SessionAction[] {
-  if (typeof command === 'string') return convertScalarCommand(command, config, context);
+): MaestroConvertedActions {
+  if (typeof command === 'string') {
+    return toConvertedActions(convertScalarCommand(command, config, context));
+  }
 
   const entries = Object.entries(command);
   if (entries.length !== 1) {
@@ -132,8 +146,8 @@ function convertMaestroCommand(
 
   const [name, value] = entries[0] as [string, unknown];
   const handler = MAP_COMMAND_HANDLERS[name];
-  if (!handler) return unsupportedCommand(name);
-  return handler({ value, config, context, deps, name });
+  if (!handler) return toConvertedActions(unsupportedCommand(name));
+  return toConvertedActions(handler({ value, config, context, deps, name }));
 }
 
 function convertScalarCommand(
@@ -176,8 +190,12 @@ function convertCommandList(
   config: MaestroFlowConfig,
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
-): SessionAction[] {
-  return commands.flatMap((command, index) =>
+): MaestroConvertedActions {
+  const converted = commands.map((command, index) =>
     convertMaestroCommandWithLine(command, config, index + 1, context, deps),
   );
+  return {
+    actions: converted.flatMap((entry) => entry.actions),
+    sources: converted.flatMap((entry) => entry.sources),
+  };
 }

--- a/src/compat/maestro/flow-control.ts
+++ b/src/compat/maestro/flow-control.ts
@@ -13,6 +13,7 @@ import {
 import type {
   MaestroCommand,
   MaestroCommandMapperDeps,
+  MaestroConvertedActions,
   MaestroFlowConfig,
   MaestroParseContext,
   MaestroReplayFlow,
@@ -29,47 +30,18 @@ type ConvertCommandList = (
   config: MaestroFlowConfig,
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
-) => SessionAction[];
+) => MaestroConvertedActions;
 
-/**
- * Stamps every action of a parsed `runFlow` include with its own resolved
- * source path + line (ADR 0012 migration step 2), riding transiently on
- * `SessionAction.replaySource` until `convertRootCommands`
- * (`replay-flow.ts`) reads it back into the flat `actionLines`/
- * `actionSourcePaths` arrays and strips it. Without this, every action
- * produced by inlining an include would silently inherit the including
- * `runFlow:` command's own line — the exact provenance loss the ADR's audit
- * evidence documents.
- */
-function attachRunFlowProvenance(flow: MaestroReplayFlow): SessionAction[] {
-  return flow.actions.map((action, index) => ({
-    ...action,
-    replaySource: {
-      path: flow.actionSourcePaths?.[index] ?? '',
-      line: flow.actionLines[index] ?? 1,
-    },
-  }));
-}
+const NO_CONVERTED_ACTIONS: MaestroConvertedActions = { actions: [], sources: [] };
 
-/**
- * The control-flow counterpart of `convertRootCommands`'s top-level strip
- * (ADR 0012 migration step 2): a `runFlow` include nested under `retry:` or a
- * runtime `runFlow.when:` never flows through `pushConvertedRootActions`, so
- * without this its actions would carry the transient `replaySource` field
- * into dispatch AND the runtime would never consult it — reproducing exactly
- * the wrapper-line provenance bug the top-level fix closed. Strips
- * `replaySource` off every nested action and returns it as the parallel
- * `actionSources` array the runtime block invoker reads per nested step.
- */
-function stripNestedActionSources(actions: SessionAction[]): {
-  actions: SessionAction[];
-  actionSources?: (ReplayControlActionSource | undefined)[];
-} {
-  if (!actions.some((entry) => entry.replaySource !== undefined)) return { actions };
-  const actionSources = actions.map((entry) => entry.replaySource);
+/** A parsed `runFlow` include's actions, paired with their own file+line. */
+function includeConvertedActions(flow: MaestroReplayFlow): MaestroConvertedActions {
   return {
-    actions: actions.map(({ replaySource: _replaySource, ...rest }) => rest),
-    actionSources,
+    actions: flow.actions,
+    sources: flow.actions.map((_, index) => {
+      const path = flow.actionSourcePaths?.[index];
+      return path ? { path, line: flow.actionLines[index] ?? 1 } : undefined;
+    }),
   };
 }
 
@@ -79,9 +51,9 @@ export function convertRunFlow(
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
   convertCommandList: ConvertCommandList,
-): SessionAction[] {
+): MaestroConvertedActions {
   if (typeof value === 'string') {
-    return attachRunFlowProvenance(
+    return includeConvertedActions(
       deps.parseRunFlowFile(resolveMaestroString(value, context), context),
     );
   }
@@ -90,14 +62,14 @@ export function convertRunFlow(
   }
   assertOnlyKeys(value, 'runFlow', ['file', 'commands', 'env', 'when', 'label']);
   const condition = readRunFlowCondition(value.when, context);
-  if (!condition.shouldRun) return [];
+  if (!condition.shouldRun) return NO_CONVERTED_ACTIONS;
 
   const runContext = {
     ...context,
     env: { ...context.env, ...readEnvMap(value.env, 'runFlow.env'), ...context.envOverrides },
   };
-  const actions = readRunFlowActions(value, config, runContext, deps, convertCommandList);
-  return wrapRunFlowCondition(actions, condition);
+  const converted = readRunFlowActions(value, config, runContext, deps, convertCommandList);
+  return wrapRunFlowCondition(converted, condition);
 }
 
 export function convertRepeat(
@@ -106,7 +78,7 @@ export function convertRepeat(
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
   convertCommandList: ConvertCommandList,
-): SessionAction[] {
+): MaestroConvertedActions {
   if (!isPlainRecord(value)) {
     throw new AppError('INVALID_ARGS', 'repeat expects a map.');
   }
@@ -127,9 +99,13 @@ export function convertRepeat(
     );
   }
   const commands = normalizeCommandList(value.commands);
-  return Array.from({ length: times }).flatMap(() =>
+  const iterations = Array.from({ length: times }, () =>
     convertCommandList(commands, config, context, deps),
   );
+  return {
+    actions: iterations.flatMap((entry) => entry.actions),
+    sources: iterations.flatMap((entry) => entry.sources),
+  };
 }
 
 export function convertRetry(
@@ -138,7 +114,7 @@ export function convertRetry(
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
   convertCommandList: ConvertCommandList,
-): SessionAction[] {
+): MaestroConvertedActions {
   if (!isPlainRecord(value)) {
     throw new AppError('INVALID_ARGS', 'retry expects a map.');
   }
@@ -148,17 +124,15 @@ export function convertRetry(
   }
   const maxRetries = readRetryMaxRetries(value.maxRetries, context);
   const commands = normalizeCommandList(value.commands);
-  const { actions, actionSources } = stripNestedActionSources(
-    convertCommandList(commands, config, context, deps),
-  );
-  return [
+  const converted = convertCommandList(commands, config, context, deps);
+  return controlWrapperActions(
     replayControlAction('retry', [String(maxRetries)], {
       kind: 'retry',
       maxRetries,
-      actions,
-      ...(actionSources ? { actionSources } : {}),
+      actions: converted.actions,
+      ...actionSourcesEntry(converted.sources),
     }),
-  ];
+  );
 }
 
 function readRunFlowActions(
@@ -167,9 +141,9 @@ function readRunFlowActions(
   context: MaestroParseContext,
   deps: MaestroCommandMapperDeps,
   convertCommandList: ConvertCommandList,
-): SessionAction[] {
+): MaestroConvertedActions {
   if (typeof value.file === 'string') {
-    return attachRunFlowProvenance(
+    return includeConvertedActions(
       deps.parseRunFlowFile(resolveMaestroString(value.file, context), context),
     );
   }
@@ -177,6 +151,17 @@ function readRunFlowActions(
     return convertCommandList(normalizeCommandList(value.commands), config, context, deps);
   }
   throw new AppError('INVALID_ARGS', 'runFlow map requires either file or commands.');
+}
+
+/** A control wrapper is itself a same-file action; its nested sources live in the control. */
+function controlWrapperActions(wrapper: SessionAction): MaestroConvertedActions {
+  return { actions: [wrapper], sources: [undefined] };
+}
+
+function actionSourcesEntry(sources: (ReplayControlActionSource | undefined)[]): {
+  actionSources?: (ReplayControlActionSource | undefined)[];
+} {
+  return sources.some((entry) => entry !== undefined) ? { actionSources: sources } : {};
 }
 
 type RunFlowCondition = {
@@ -459,11 +444,11 @@ class MaestroBooleanExpressionParser {
 }
 
 function wrapRunFlowCondition(
-  actions: SessionAction[],
+  converted: MaestroConvertedActions,
   condition: RunFlowCondition,
-): SessionAction[] {
+): MaestroConvertedActions {
   const { visibleSelector, notVisibleSelector } = condition;
-  if (!visibleSelector && !notVisibleSelector) return actions;
+  if (!visibleSelector && !notVisibleSelector) return converted;
   if (visibleSelector && notVisibleSelector) {
     throw unsupportedMaestroSyntax(
       'Maestro runFlow.when cannot combine visible and notVisible yet.',
@@ -471,16 +456,15 @@ function wrapRunFlowCondition(
   }
   const mode = visibleSelector ? 'visible' : 'notVisible';
   const selector = visibleSelector ?? notVisibleSelector ?? '';
-  const stripped = stripNestedActionSources(actions);
-  return [
+  return controlWrapperActions(
     replayControlAction('runFlow.when', [mode, selector], {
       kind: 'maestroRunFlowWhen',
       mode,
       selector,
-      actions: stripped.actions,
-      ...(stripped.actionSources ? { actionSources: stripped.actionSources } : {}),
+      actions: converted.actions,
+      ...actionSourcesEntry(converted.sources),
     }),
-  ];
+  );
 }
 
 function replayControlAction(

--- a/src/compat/maestro/flow-control.ts
+++ b/src/compat/maestro/flow-control.ts
@@ -15,6 +15,7 @@ import type {
   MaestroCommandMapperDeps,
   MaestroFlowConfig,
   MaestroParseContext,
+  MaestroReplayFlow,
 } from './types.ts';
 
 // repeat.times is expanded at parse time for deterministic replay traces. Keep
@@ -30,6 +31,26 @@ type ConvertCommandList = (
   deps: MaestroCommandMapperDeps,
 ) => SessionAction[];
 
+/**
+ * Stamps every action of a parsed `runFlow` include with its own resolved
+ * source path + line (ADR 0012 migration step 2), riding transiently on
+ * `SessionAction.replaySource` until `convertRootCommands`
+ * (`replay-flow.ts`) reads it back into the flat `actionLines`/
+ * `actionSourcePaths` arrays and strips it. Without this, every action
+ * produced by inlining an include would silently inherit the including
+ * `runFlow:` command's own line — the exact provenance loss the ADR's audit
+ * evidence documents.
+ */
+function attachRunFlowProvenance(flow: MaestroReplayFlow): SessionAction[] {
+  return flow.actions.map((action, index) => ({
+    ...action,
+    replaySource: {
+      path: flow.actionSourcePaths?.[index] ?? '',
+      line: flow.actionLines[index] ?? 1,
+    },
+  }));
+}
+
 export function convertRunFlow(
   value: unknown,
   config: MaestroFlowConfig,
@@ -38,7 +59,9 @@ export function convertRunFlow(
   convertCommandList: ConvertCommandList,
 ): SessionAction[] {
   if (typeof value === 'string') {
-    return deps.parseRunFlowFile(resolveMaestroString(value, context), context).actions;
+    return attachRunFlowProvenance(
+      deps.parseRunFlowFile(resolveMaestroString(value, context), context),
+    );
   }
   if (!isPlainRecord(value)) {
     throw new AppError('INVALID_ARGS', 'runFlow expects a file path string or map.');
@@ -121,7 +144,9 @@ function readRunFlowActions(
   convertCommandList: ConvertCommandList,
 ): SessionAction[] {
   if (typeof value.file === 'string') {
-    return deps.parseRunFlowFile(resolveMaestroString(value.file, context), context).actions;
+    return attachRunFlowProvenance(
+      deps.parseRunFlowFile(resolveMaestroString(value.file, context), context),
+    );
   }
   if (Array.isArray(value.commands)) {
     return convertCommandList(normalizeCommandList(value.commands), config, context, deps);

--- a/src/compat/maestro/flow-control.ts
+++ b/src/compat/maestro/flow-control.ts
@@ -1,4 +1,4 @@
-import type { SessionAction } from '../../daemon/types.ts';
+import type { ReplayControlActionSource, SessionAction } from '../../daemon/types.ts';
 import { AppError } from '../../kernel/errors.ts';
 import { maestroSelector } from './interactions.ts';
 import {
@@ -49,6 +49,28 @@ function attachRunFlowProvenance(flow: MaestroReplayFlow): SessionAction[] {
       line: flow.actionLines[index] ?? 1,
     },
   }));
+}
+
+/**
+ * The control-flow counterpart of `convertRootCommands`'s top-level strip
+ * (ADR 0012 migration step 2): a `runFlow` include nested under `retry:` or a
+ * runtime `runFlow.when:` never flows through `pushConvertedRootActions`, so
+ * without this its actions would carry the transient `replaySource` field
+ * into dispatch AND the runtime would never consult it — reproducing exactly
+ * the wrapper-line provenance bug the top-level fix closed. Strips
+ * `replaySource` off every nested action and returns it as the parallel
+ * `actionSources` array the runtime block invoker reads per nested step.
+ */
+function stripNestedActionSources(actions: SessionAction[]): {
+  actions: SessionAction[];
+  actionSources?: (ReplayControlActionSource | undefined)[];
+} {
+  if (!actions.some((entry) => entry.replaySource !== undefined)) return { actions };
+  const actionSources = actions.map((entry) => entry.replaySource);
+  return {
+    actions: actions.map(({ replaySource: _replaySource, ...rest }) => rest),
+    actionSources,
+  };
 }
 
 export function convertRunFlow(
@@ -126,12 +148,15 @@ export function convertRetry(
   }
   const maxRetries = readRetryMaxRetries(value.maxRetries, context);
   const commands = normalizeCommandList(value.commands);
-  const actions = convertCommandList(commands, config, context, deps);
+  const { actions, actionSources } = stripNestedActionSources(
+    convertCommandList(commands, config, context, deps),
+  );
   return [
     replayControlAction('retry', [String(maxRetries)], {
       kind: 'retry',
       maxRetries,
       actions,
+      ...(actionSources ? { actionSources } : {}),
     }),
   ];
 }
@@ -446,12 +471,14 @@ function wrapRunFlowCondition(
   }
   const mode = visibleSelector ? 'visible' : 'notVisible';
   const selector = visibleSelector ?? notVisibleSelector ?? '';
+  const stripped = stripNestedActionSources(actions);
   return [
     replayControlAction('runFlow.when', [mode, selector], {
       kind: 'maestroRunFlowWhen',
       mode,
       selector,
-      actions,
+      actions: stripped.actions,
+      ...(stripped.actionSources ? { actionSources: stripped.actionSources } : {}),
     }),
   ];
 }

--- a/src/compat/maestro/replay-flow.ts
+++ b/src/compat/maestro/replay-flow.ts
@@ -38,7 +38,7 @@ function parseMaestroReplayFlowInternal(
     env: { ...context.env, ...(config.env ?? {}), ...context.envOverrides },
   };
   const commandLines = findMaestroCommandLines(script);
-  const { actions, actionLines } = convertRootCommands({
+  const { actions, actionLines, actionSourcePaths } = convertRootCommands({
     config,
     commands,
     commandLines,
@@ -48,73 +48,120 @@ function parseMaestroReplayFlowInternal(
   return {
     actions,
     actionLines,
+    actionSourcePaths,
     metadata: {
       env: config.env,
     },
   };
 }
 
+type ConvertedFlowActions = {
+  actions: SessionAction[];
+  actionLines: number[];
+  actionSourcePaths: (string | undefined)[];
+};
+
 function convertRootCommands(params: {
   config: MaestroFlowConfig;
   commands: MaestroCommand[];
   commandLines: number[];
   context: MaestroParseContext;
-}): { actions: SessionAction[]; actionLines: number[] } {
+}): ConvertedFlowActions {
   const { config, commands, commandLines, context } = params;
   const allCommands = [
     ...(config.onFlowStart ?? []),
     ...commands,
     ...(config.onFlowComplete ?? []),
   ];
-  const allCommandLines = [
-    ...Array.from({ length: config.onFlowStart?.length ?? 0 }, () => 1),
-    ...commandLines,
-    ...Array.from({ length: config.onFlowComplete?.length ?? 0 }, () => commandLines.at(-1) ?? 1),
-  ];
+  const allCommandLines = buildRootCommandLines(config, commandLines);
+
   const actions: SessionAction[] = [];
   const actionLines: number[] = [];
+  const actionSourcePaths: (string | undefined)[] = [];
   for (const [index, command] of allCommands.entries()) {
     const line = allCommandLines[index] ?? index + 1;
     const converted = convertMaestroCommandWithLine(command, config, line, context, {
       parseRunFlowFile,
     });
-    actions.push(...converted);
-    converted.forEach(() => actionLines.push(line));
+    pushConvertedRootActions({ converted, line, actions, actionLines, actionSourcePaths });
   }
-  return optimizeInputTextActions(actions, actionLines);
+  return optimizeInputTextActions(actions, actionLines, actionSourcePaths);
+}
+
+/** `onFlowStart` commands report line 1; `onFlowComplete` commands report the script's last command line — both hooks live outside the numbered command list. */
+function buildRootCommandLines(config: MaestroFlowConfig, commandLines: number[]): number[] {
+  return [
+    ...Array.from({ length: config.onFlowStart?.length ?? 0 }, () => 1),
+    ...commandLines,
+    ...Array.from({ length: config.onFlowComplete?.length ?? 0 }, () => commandLines.at(-1) ?? 1),
+  ];
+}
+
+/**
+ * Appends one root command's converted actions to the flat accumulators. A
+ * `runFlow` include stamps its own provenance on each produced action (see
+ * `attachRunFlowProvenance` in flow-control.ts); every other command
+ * inherits this root command's own line, in the current (root) file.
+ */
+function pushConvertedRootActions(params: {
+  converted: SessionAction[];
+  line: number;
+  actions: SessionAction[];
+  actionLines: number[];
+  actionSourcePaths: (string | undefined)[];
+}): void {
+  const { converted, line, actions, actionLines, actionSourcePaths } = params;
+  for (const convertedAction of converted) {
+    const source = convertedAction.replaySource;
+    const { replaySource: _replaySource, ...cleanAction } = convertedAction;
+    actions.push(cleanAction);
+    actionLines.push(source?.line ?? line);
+    actionSourcePaths.push(source?.path);
+  }
 }
 
 function optimizeInputTextActions(
   actions: SessionAction[],
   actionLines: number[],
-): { actions: SessionAction[]; actionLines: number[] } {
+  actionSourcePaths: (string | undefined)[],
+): ConvertedFlowActions {
   const mergedActions: SessionAction[] = [];
   const mergedLines: number[] = [];
+  const mergedSourcePaths: (string | undefined)[] = [];
   for (let index = 0; index < actions.length; index += 1) {
     const action = actions[index]!;
-    const optimized = optimizeTypedAfterTap(actions, actionLines, index);
+    const optimized = optimizeTypedAfterTap(actions, actionLines, actionSourcePaths, index);
     if (optimized) {
       mergedActions.push(...optimized.actions);
       mergedLines.push(...optimized.actionLines);
+      mergedSourcePaths.push(...optimized.actionSourcePaths);
       index += optimized.consumed - 1;
       continue;
     }
     mergedActions.push(action);
     mergedLines.push(actionLines[index] ?? 1);
+    mergedSourcePaths.push(actionSourcePaths[index]);
   }
-  return { actions: mergedActions, actionLines: mergedLines };
+  return { actions: mergedActions, actionLines: mergedLines, actionSourcePaths: mergedSourcePaths };
 }
 
 function optimizeTypedAfterTap(
   actions: SessionAction[],
   actionLines: number[],
+  actionSourcePaths: (string | undefined)[],
   index: number,
-): { actions: SessionAction[]; actionLines: number[]; consumed: number } | null {
+): (ConvertedFlowActions & { consumed: number }) | null {
   const candidate = readTypedAfterTapCandidate(actions, actionLines, index);
   if (!candidate) return null;
   const { action, nextAction, pressEnterAction, tapSelector, typedAfterTap, line } = candidate;
+  const sourcePath = actionSourcePaths[index];
   if (!isLikelyTextEntrySelector(tapSelector)) {
-    return { actions: [clearMaestroNonHittableTap(action)], actionLines: [line], consumed: 1 };
+    return {
+      actions: [clearMaestroNonHittableTap(action)],
+      actionLines: [line],
+      actionSourcePaths: [sourcePath],
+      consumed: 1,
+    };
   }
   return {
     actions: [
@@ -132,6 +179,7 @@ function optimizeTypedAfterTap(
       pressEnterAction,
     ],
     actionLines: [line, line, actionLines[index + 2] ?? line],
+    actionSourcePaths: [sourcePath, sourcePath, actionSourcePaths[index + 2]],
     consumed: 3,
   };
 }
@@ -264,6 +312,14 @@ function normalizeConfig(value: unknown): MaestroFlowConfig {
   };
 }
 
+/**
+ * Parses a `runFlow`-included file, resolving its own per-action provenance
+ * before returning: any action whose `actionSourcePaths` entry is still
+ * `undefined` (i.e. it came directly from THIS file, not a deeper nested
+ * include) is stamped with `resolved` — this file's own path — so every
+ * entry the caller receives is a concrete, actionable path. Deeper nested
+ * includes keep the path a recursive call already stamped.
+ */
 function parseRunFlowFile(filePath: string, context: MaestroParseContext): MaestroReplayFlow {
   const resolved = resolveRunFlowPath(filePath, context);
   if (context.visitedPaths.has(resolved)) {
@@ -272,11 +328,17 @@ function parseRunFlowFile(filePath: string, context: MaestroParseContext): Maest
   const script = fs.readFileSync(resolved, 'utf8');
   const visitedPaths = new Set(context.visitedPaths);
   visitedPaths.add(resolved);
-  return parseMaestroReplayFlowInternal(script, {
+  const flow = parseMaestroReplayFlowInternal(script, {
     ...context,
     baseDir: path.dirname(resolved),
     visitedPaths,
   });
+  return {
+    ...flow,
+    actionSourcePaths: (flow.actionSourcePaths ?? flow.actions.map(() => undefined)).map(
+      (sourcePath) => sourcePath ?? resolved,
+    ),
+  };
 }
 
 function resolveRunFlowPath(filePath: string, context: MaestroParseContext): string {

--- a/src/compat/maestro/replay-flow.ts
+++ b/src/compat/maestro/replay-flow.ts
@@ -83,7 +83,12 @@ function convertRootCommands(params: {
     const converted = convertMaestroCommandWithLine(command, config, line, context, {
       parseRunFlowFile,
     });
-    pushConvertedRootActions({ converted, line, actions, actionLines, actionSourcePaths });
+    for (const [actionIndex, action] of converted.actions.entries()) {
+      const source = converted.sources[actionIndex];
+      actions.push(action);
+      actionLines.push(source?.line ?? line);
+      actionSourcePaths.push(source?.path);
+    }
   }
   return optimizeInputTextActions(actions, actionLines, actionSourcePaths);
 }
@@ -95,29 +100,6 @@ function buildRootCommandLines(config: MaestroFlowConfig, commandLines: number[]
     ...commandLines,
     ...Array.from({ length: config.onFlowComplete?.length ?? 0 }, () => commandLines.at(-1) ?? 1),
   ];
-}
-
-/**
- * Appends one root command's converted actions to the flat accumulators. A
- * `runFlow` include stamps its own provenance on each produced action (see
- * `attachRunFlowProvenance` in flow-control.ts); every other command
- * inherits this root command's own line, in the current (root) file.
- */
-function pushConvertedRootActions(params: {
-  converted: SessionAction[];
-  line: number;
-  actions: SessionAction[];
-  actionLines: number[];
-  actionSourcePaths: (string | undefined)[];
-}): void {
-  const { converted, line, actions, actionLines, actionSourcePaths } = params;
-  for (const convertedAction of converted) {
-    const source = convertedAction.replaySource;
-    const { replaySource: _replaySource, ...cleanAction } = convertedAction;
-    actions.push(cleanAction);
-    actionLines.push(source?.line ?? line);
-    actionSourcePaths.push(source?.path);
-  }
 }
 
 function optimizeInputTextActions(
@@ -313,12 +295,9 @@ function normalizeConfig(value: unknown): MaestroFlowConfig {
 }
 
 /**
- * Parses a `runFlow`-included file, resolving its own per-action provenance
- * before returning: any action whose `actionSourcePaths` entry is still
- * `undefined` (i.e. it came directly from THIS file, not a deeper nested
- * include) is stamped with `resolved` — this file's own path — so every
- * entry the caller receives is a concrete, actionable path. Deeper nested
- * includes keep the path a recursive call already stamped.
+ * Parses a `runFlow`-included file, resolving `undefined` (this-file) source
+ * paths to the include's own resolved path; deeper nested includes keep the
+ * path a recursive call already stamped.
  */
 function parseRunFlowFile(filePath: string, context: MaestroParseContext): MaestroReplayFlow {
   const resolved = resolveRunFlowPath(filePath, context);

--- a/src/compat/maestro/runtime-flow.ts
+++ b/src/compat/maestro/runtime-flow.ts
@@ -126,6 +126,7 @@ async function invokeMaestroRunFlowWhenSteps(params: {
 }): Promise<DaemonResponse> {
   const response = await invokeReplayActionBlock({
     actions: params.control.actions,
+    actionSources: params.control.actionSources,
     line: params.line,
     step: params.step,
     invokeReplayAction: params.invokeReplayAction,

--- a/src/compat/maestro/types.ts
+++ b/src/compat/maestro/types.ts
@@ -1,3 +1,4 @@
+import type { ReplayControlActionSource, SessionAction } from '../../daemon/types.ts';
 import type { ParsedReplayScript, ReplayScriptMetadata } from '../../replay/script.ts';
 
 export type MaestroFlowConfig = {
@@ -10,6 +11,16 @@ export type MaestroFlowConfig = {
 
 export type MaestroReplayFlow = ParsedReplayScript & {
   metadata: ReplayScriptMetadata;
+};
+
+/**
+ * The Maestro conversion pipeline's uniform result: actions plus a parallel
+ * per-action source array (`undefined` = the file currently being parsed;
+ * concrete `{path, line}` = a `runFlow` include's own file).
+ */
+export type MaestroConvertedActions = {
+  actions: SessionAction[];
+  sources: (ReplayControlActionSource | undefined)[];
 };
 
 export type MaestroCommand = string | Record<string, unknown>;

--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -458,9 +458,10 @@ test('replay without --update does not heal or rewrite', async () => {
     expect(response!.error.logPath).toBe('/tmp/diag-replay-1.ndjson');
   }
   // No --update, so healReplayAction never runs (0 of its own capture calls) —
-  // but the divergence report's screen digest + suggestion re-resolution
-  // (ADR 0012 migration step 2) still fire unconditionally on failure.
-  expect(mockDispatchCommand).toHaveBeenCalledTimes(2);
+  // but the divergence report's single shared capture (screen digest +
+  // suggestion re-resolution, ADR 0012 migration step 2) still fires
+  // unconditionally on failure.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
   expect(fs.readFileSync(replayPath, 'utf8')).toBe(originalPayload);
 });
 
@@ -516,11 +517,10 @@ test('replay --update skips malformed selector candidates and preserves replay e
     // ranking (tryParseSelectorChain rejects it), so no suggestion is produced.
     expect((divergence as unknown as { suggestions: unknown[] })?.suggestions).toEqual([]);
   }
-  // The divergence report's screen digest + suggestion re-resolution both
-  // attempt a fresh snapshot capture on every failure now, even when heal
-  // itself would have skipped (malformed candidate) — this is the ADR 0012
-  // migration step 2 behavior, not a heal regression.
-  expect(mockDispatchCommand).toHaveBeenCalled();
+  // The divergence report's single shared capture still fires on every
+  // failure, even when heal itself would have skipped (malformed candidate) —
+  // ADR 0012 migration step 2 behavior, not a heal regression.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
   expect(fs.readFileSync(replayPath, 'utf8')).toBe('click "id=\\"old_continue\\" ||"\n');
 });
 
@@ -665,9 +665,9 @@ test('replay --update does not heal clicks from stored ref labels alone', async 
     // same non-healing guarantee this test title asserts, now for suggestions.
     expect(divergence?.suggestions).toEqual([]);
   }
-  // The divergence report's screen digest still captures a fresh snapshot on
-  // every failure (ADR 0012 migration step 2) even though no suggestion
-  // candidate exists for an @ref-targeted action.
+  // The divergence report's single shared capture still fires on every
+  // failure (ADR 0012 migration step 2) even though no suggestion candidate
+  // exists for an @ref-targeted action.
   expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
   expect(invokeCalls).toEqual(['@e1']);
   expect(fs.readFileSync(replayPath, 'utf8')).toBe(originalPayload);
@@ -753,10 +753,10 @@ test('replay --update does not heal numeric get text drift from snapshot text al
     // isolated by re-resolving the recorded selector, so no suggestion either.
     expect(divergence?.suggestions).toEqual([]);
   }
-  // 1 capture from healReplayAction's own (unsuccessful) attempt, plus 2 more
-  // from the divergence report's screen digest + suggestion re-resolution
-  // (ADR 0012 migration step 2) once heal gives up and the step fails.
-  expect(mockDispatchCommand).toHaveBeenCalledTimes(3);
+  // 1 capture from healReplayAction's own (unsuccessful) attempt, plus the
+  // divergence report's single shared capture (ADR 0012 migration step 2)
+  // once heal gives up and the step fails.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(2);
   expect(invokeCalls.length).toBe(1);
   expect(fs.readFileSync(replayPath, 'utf8')).toBe(originalPayload);
 });

--- a/src/daemon/handlers/__tests__/replay-heal.test.ts
+++ b/src/daemon/handlers/__tests__/replay-heal.test.ts
@@ -457,7 +457,10 @@ test('replay without --update does not heal or rewrite', async () => {
     expect(response!.error.diagnosticId).toBe('diag-replay-1');
     expect(response!.error.logPath).toBe('/tmp/diag-replay-1.ndjson');
   }
-  expect(mockDispatchCommand).not.toHaveBeenCalled();
+  // No --update, so healReplayAction never runs (0 of its own capture calls) —
+  // but the divergence report's screen digest + suggestion re-resolution
+  // (ADR 0012 migration step 2) still fire unconditionally on failure.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(2);
   expect(fs.readFileSync(replayPath, 'utf8')).toBe(originalPayload);
 });
 
@@ -499,12 +502,25 @@ test('replay --update skips malformed selector candidates and preserves replay e
   expect(response).toBeTruthy();
   expect(response!.ok).toBe(false);
   if (!response!.ok) {
-    expect(response!.error.code).toBe('COMMAND_FAILED');
+    // ADR 0012 migration step 2: the wire-level code is now REPLAY_DIVERGENCE;
+    // the malformed candidate's original COMMAND_FAILED lives in cause.
+    expect(response!.error.code).toBe('REPLAY_DIVERGENCE');
     expect(response!.error.message).toMatch(/Replay failed at step 1/);
     expect(response!.error.details?.step).toBe(1);
     expect(response!.error.details?.action).toBe('click');
+    const divergence = response!.error.details?.divergence as
+      | { cause: { code: string; message: string } }
+      | undefined;
+    expect(divergence?.cause.code).toBe('COMMAND_FAILED');
+    // The malformed selector candidate is still skipped by suggestion
+    // ranking (tryParseSelectorChain rejects it), so no suggestion is produced.
+    expect((divergence as unknown as { suggestions: unknown[] })?.suggestions).toEqual([]);
   }
-  expect(mockDispatchCommand).not.toHaveBeenCalled();
+  // The divergence report's screen digest + suggestion re-resolution both
+  // attempt a fresh snapshot capture on every failure now, even when heal
+  // itself would have skipped (malformed candidate) — this is the ADR 0012
+  // migration step 2 behavior, not a heal regression.
+  expect(mockDispatchCommand).toHaveBeenCalled();
   expect(fs.readFileSync(replayPath, 'utf8')).toBe('click "id=\\"old_continue\\" ||"\n');
 });
 
@@ -642,8 +658,17 @@ test('replay --update does not heal clicks from stored ref labels alone', async 
     expect(response!.error.message).toMatch(/Replay failed at step 1/);
     expect(response!.error.details?.step).toBe(1);
     expect(response!.error.details?.action).toBe('click');
+    const divergence = response!.error.details?.divergence as
+      | { suggestions: unknown[] }
+      | undefined;
+    // @refs are never selector candidates, so no suggestion is produced —
+    // same non-healing guarantee this test title asserts, now for suggestions.
+    expect(divergence?.suggestions).toEqual([]);
   }
-  expect(mockDispatchCommand).not.toHaveBeenCalled();
+  // The divergence report's screen digest still captures a fresh snapshot on
+  // every failure (ADR 0012 migration step 2) even though no suggestion
+  // candidate exists for an @ref-targeted action.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
   expect(invokeCalls).toEqual(['@e1']);
   expect(fs.readFileSync(replayPath, 'utf8')).toBe(originalPayload);
 });
@@ -721,8 +746,17 @@ test('replay --update does not heal numeric get text drift from snapshot text al
     expect(response!.error.message).toMatch(/Replay failed at step 1/);
     expect(response!.error.details?.step).toBe(1);
     expect(response!.error.details?.action).toBe('get');
+    const divergence = response!.error.details?.divergence as
+      | { suggestions: unknown[] }
+      | undefined;
+    // Same non-healing guarantee as heal itself: a numeric label drift is not
+    // isolated by re-resolving the recorded selector, so no suggestion either.
+    expect(divergence?.suggestions).toEqual([]);
   }
-  expect(mockDispatchCommand).toHaveBeenCalledTimes(1);
+  // 1 capture from healReplayAction's own (unsuccessful) attempt, plus 2 more
+  // from the divergence report's screen digest + suggestion re-resolution
+  // (ADR 0012 migration step 2) once heal gives up and the step fails.
+  expect(mockDispatchCommand).toHaveBeenCalledTimes(3);
   expect(invokeCalls.length).toBe(1);
   expect(fs.readFileSync(replayPath, 'utf8')).toBe(originalPayload);
 });

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -100,6 +100,39 @@ test('a failing replay step returns REPLAY_DIVERGENCE with cause preserved and c
   expect(divergence.resume).toEqual({ allowed: false, reason: 'resume not yet supported' });
 });
 
+test('a normalized nested failure preserves typed recovery signals on REPLAY_DIVERGENCE', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-recovery-signals-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const filePath = writeReplayFile(root, ['click "Save"']);
+  mockDispatchCommand.mockRejectedValue(new Error('no device runner available'));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    // This shape is already normalized: normalizeError lifted both signals
+    // out of details before the replay wrapper receives it.
+    invoke: async () => ({
+      ok: false,
+      error: {
+        code: 'DEVICE_IN_USE',
+        message: 'The device is temporarily leased.',
+        retriable: true,
+        supportedOn: 'ios',
+      },
+    }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPLAY_DIVERGENCE');
+  expect(response.error.retriable).toBe(true);
+  expect(response.error.supportedOn).toBe('ios');
+});
+
 test('a failing replay step captures an available screen digest with blessed refs', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-divergence-screen-'));
   const sessionStore = new SessionStore(path.join(root, 'sessions'));
@@ -578,4 +611,35 @@ test('an expanded ${VAR} value echoed by a selector error never reaches the publ
   expect(divergence.cause.message).toContain('<var:SECRET>');
   expect(divergence.cause.hint).toContain('<var:SECRET>');
   expect(response.error.message).toContain('<var:SECRET>');
+});
+
+test('an expanded built-in AD_DEVICE_ID never reaches the public divergence', async () => {
+  const deviceId = 'BuiltInDeviceId-486b3d4c-8f92-4dc0-b5c6-unique';
+  const sessionName = 'static-session-context';
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-builtin-var-leak-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const filePath = writeReplayFile(root, ['press label="${AD_DEVICE_ID}"']);
+  mockDispatchCommand.mockRejectedValue(new Error('no device runner available'));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { serial: deviceId } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => ({
+      ok: false,
+      error: {
+        code: 'COMMAND_FAILED',
+        message: `Device ${req.positionals?.[0] ?? ''} failed in ${sessionName} context.`,
+      },
+    }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(JSON.stringify(response.error)).not.toContain(deviceId);
+  expect(response.error.message).toContain('<var:AD_DEVICE_ID>');
+  // AD_SESSION was not expanded, so matching static text remains readable.
+  expect(response.error.message).toContain(sessionName);
 });

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -414,9 +414,20 @@ test('a fill divergence never serializes the typed text at any response level', 
       sessionStore,
       invoke: async (req) => {
         if (req.command === 'fill') {
+          // A REAL fill-verification failure carries the entered text in
+          // details.expected (unmasked fields do, by the fill-diagnostics
+          // contract) — the divergence transport must strip it categorically.
           return {
             ok: false,
-            error: { code: 'COMMAND_FAILED', message: 'Selector did not match: label="Email"' },
+            error: {
+              code: 'COMMAND_FAILED',
+              message: 'Android fill verification failed',
+              details: {
+                expected: sentinel,
+                actual: sentinel.slice(0, 10),
+                failureReason: 'text_mismatch',
+              },
+            },
           };
         }
         return { ok: true, data: {} };
@@ -427,9 +438,10 @@ test('a fill divergence never serializes the typed text at any response level', 
     if (response.ok) return;
     const serializedDivergence = JSON.stringify(response.error.details?.divergence);
     expect(serializedDivergence).not.toContain(sentinel);
-    // The whole error details (flat positionals included) must not leak it either.
-    expect(JSON.stringify(response.error.details)).not.toContain(sentinel);
-    expect(response.error.message).not.toContain(sentinel);
+    // The WHOLE public error (flat details incl. the cause's own
+    // details.expected/actual, positionals, message) must not leak it either.
+    expect(JSON.stringify(response.error)).not.toContain(sentinel);
+    expect(JSON.stringify(response.error)).not.toContain(sentinel.slice(0, 10));
     // The action label still names the field, with the text categorically hidden.
     const divergence = response.error.details?.divergence as { action: string };
     expect(divergence.action).toContain('<text>');

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -247,3 +247,147 @@ test('divergence screen never masks the original cause when the session already 
   expect(screen.state).toBe('unavailable');
   expect(screen.reason).toBe('no-session');
 });
+
+// --- Control-flow-wrapped include provenance (reviewer probe scenario) ---
+//
+// The RN suite's own launch include is retry-wrapped, so the single most
+// common real failure site (a launch wait timeout inside the include) must
+// report the INCLUDE's file+line, not the wrapping `retry:`/`runFlow.when:`
+// line in the root flow. Regression for the leak where replayControl.actions
+// kept the transient replaySource field but the runtime never consulted it.
+
+function writeMaestroInclude(root: string): string {
+  const childPath = path.join(root, 'child.yaml');
+  fs.writeFileSync(
+    childPath,
+    ['appId: com.callstack.agentdevicelab', '---', '- back', ''].join('\n'),
+  );
+  return childPath;
+}
+
+test('a failure inside a retry-wrapped runFlow include reports the include file and line', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-retry-provenance-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName));
+  const childPath = writeMaestroInclude(root);
+  const mainPath = path.join(root, 'main.yaml');
+  fs.writeFileSync(
+    mainPath,
+    [
+      'appId: com.callstack.agentdevicelab',
+      '---',
+      '- retry:',
+      '    maxRetries: 1',
+      '    commands:',
+      '      - runFlow:',
+      '          file: child.yaml',
+      '',
+    ].join('\n'),
+  );
+  mockDispatchCommand.mockRejectedValue(new Error('no device runner available'));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [mainPath], flags: { replayBackend: 'maestro' } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      if (req.command === 'back') {
+        return { ok: false, error: { code: 'COMMAND_FAILED', message: 'back failed' } };
+      }
+      return { ok: true, data: {} };
+    },
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPLAY_DIVERGENCE');
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  const step = divergence.step as { index: number; source: { path: string; line: number } };
+  // Plan index 1: the retry wrapper is one executable-plan step; the source
+  // names the failing NESTED action inside the include, not the retry: line.
+  expect(step.index).toBe(1);
+  expect(step.source.path).toBe(childPath);
+  expect(step.source.line).toBe(3);
+  // The transport-internal provenance marker is stripped from the flat details.
+  expect(response.error.details?.replaySource).toBeUndefined();
+});
+
+test('a failure inside a runtime runFlow.when-wrapped include reports the include file and line', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-when-provenance-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName));
+  const childPath = writeMaestroInclude(root);
+  const mainPath = path.join(root, 'main.yaml');
+  fs.writeFileSync(
+    mainPath,
+    [
+      'appId: com.callstack.agentdevicelab',
+      '---',
+      '- runFlow:',
+      '    file: child.yaml',
+      '    when:',
+      '      notVisible: Continue',
+      '',
+    ].join('\n'),
+  );
+  mockDispatchCommand.mockRejectedValue(new Error('no device runner available'));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [mainPath], flags: { replayBackend: 'maestro' } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      // The notVisible condition captures a snapshot; an empty tree means the
+      // selector is absent, so the wrapped steps run.
+      if (req.command === 'snapshot') return { ok: true, data: { nodes: [] } };
+      if (req.command === 'back') {
+        return { ok: false, error: { code: 'COMMAND_FAILED', message: 'back failed' } };
+      }
+      return { ok: true, data: {} };
+    },
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPLAY_DIVERGENCE');
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  const step = divergence.step as { index: number; source: { path: string; line: number } };
+  expect(step.index).toBe(1);
+  expect(step.source.path).toBe(childPath);
+  expect(step.source.line).toBe(3);
+  expect(response.error.details?.replaySource).toBeUndefined();
+});
+
+test('divergence cause and action strings pass through the central redactor at construction', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-divergence-redact-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName));
+  const filePath = writeReplayFile(root, ['click "Save"']);
+  mockDispatchCommand.mockRejectedValue(new Error('no device runner available'));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({
+      ok: false,
+      error: {
+        code: 'COMMAND_FAILED',
+        message: 'request rejected: api_key=sk-live-abc123def456 invalid',
+      },
+    }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  const cause = divergence.cause as { message: string };
+  expect(cause.message).not.toContain('sk-live-abc123def456');
+  expect(cause.message).toContain('api_key=[REDACTED]');
+});

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -1,0 +1,249 @@
+import { test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return { ...actual, dispatchCommand: vi.fn(async () => ({})), resolveTargetDevice: vi.fn() };
+});
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runReplayScriptFile } from '../session-replay-runtime.ts';
+import { SessionStore } from '../../session-store.ts';
+import type { DaemonRequest, DaemonResponse } from '../../types.ts';
+import { dispatchCommand } from '../../../core/dispatch.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+
+const mockDispatchCommand = vi.mocked(dispatchCommand);
+
+beforeEach(() => {
+  mockDispatchCommand.mockReset();
+  mockDispatchCommand.mockResolvedValue({});
+});
+
+function writeReplayFile(root: string, lines: string[]): string {
+  const filePath = path.join(root, 'flow.ad');
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`);
+  return filePath;
+}
+
+function baseReq(overrides: Partial<DaemonRequest> = {}): DaemonRequest {
+  return {
+    token: 'token',
+    session: 'default',
+    command: 'replay',
+    positionals: [],
+    ...overrides,
+  };
+}
+
+test('a failing replay step returns REPLAY_DIVERGENCE with cause preserved and correct step provenance', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-divergence-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const filePath = writeReplayFile(root, ['open "Demo"', 'click "Save"']);
+
+  // The post-failure screen digest capture (and the suggestions re-resolution
+  // capture) both go through dispatchCommand('snapshot', ...); with no real
+  // device backend in a unit test, this throws, so screen must degrade to
+  // 'unavailable' rather than masking the original replay cause.
+  mockDispatchCommand.mockImplementation(async (_device, command) => {
+    if (command === 'snapshot') throw new Error('no device runner available');
+    return { ok: true };
+  });
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      if (req.command === 'open') return { ok: true, data: { session: sessionName } };
+      if (req.command === 'click') {
+        return {
+          ok: false,
+          error: { code: 'COMMAND_FAILED', message: 'Selector did not match', hint: 'Run find.' },
+        };
+      }
+      throw new Error(`unexpected command ${req.command}`);
+    },
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPLAY_DIVERGENCE');
+  // The legacy flat fields survive additively for existing consumers.
+  expect(response.error.details?.step).toBe(2);
+  expect(response.error.details?.action).toBe('click');
+
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  expect(divergence.version).toBe(1);
+  expect(divergence.kind).toBe('action-failure');
+  const step = divergence.step as { index: number; source: { path: string; line: number } };
+  expect(step.index).toBe(2);
+  expect(step.source.path).toBe(filePath);
+  expect(step.source.line).toBe(2);
+
+  const cause = divergence.cause as { code: string; message: string; hint?: string };
+  expect(cause.code).toBe('COMMAND_FAILED');
+  expect(cause.message).toBe('Selector did not match');
+  expect(cause.hint).toBe('Run find.');
+
+  const screen = divergence.screen as { state: string; reason?: string };
+  expect(screen.state).toBe('unavailable');
+  expect(screen.reason).toBe('capture-failed');
+
+  expect(divergence.suggestions).toEqual([]);
+  expect(divergence.suggestionCount).toBe(0);
+  expect(divergence.resume).toEqual({ allowed: false, reason: 'resume not yet supported' });
+});
+
+test('a failing replay step captures an available screen digest with blessed refs', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-divergence-screen-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const filePath = writeReplayFile(root, ['click "Save"']);
+
+  mockDispatchCommand.mockResolvedValue({
+    nodes: [
+      {
+        ref: 'e1',
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        label: 'Cancel',
+        rect: { x: 0, y: 0, width: 100, height: 44 },
+        hittable: true,
+      },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({
+      ok: false,
+      error: { code: 'COMMAND_FAILED', message: 'Selector did not match' },
+    }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  const screen = divergence.screen as {
+    state: string;
+    refsGeneration: number;
+    refs: Array<{ ref: string; role: string; label?: string }>;
+  };
+  expect(screen.state).toBe('available');
+  expect(typeof screen.refsGeneration).toBe('number');
+  expect(screen.refs).toEqual([{ ref: 'e1', role: 'button', label: 'Cancel' }]);
+});
+
+test('a failing replay step ranks a re-resolved suggestion when the recorded selector still matches', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-divergence-suggest-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  // The recorded selector is label-only, so it still structurally matches a
+  // node in the fresh capture even though the underlying tap failed (e.g. the
+  // node moved off-screen or was momentarily not hittable) — the exact class
+  // heal could recover, now surfaced as a read-only suggestion instead.
+  const filePath = writeReplayFile(root, ['click label="Save"']);
+
+  mockDispatchCommand.mockResolvedValue({
+    nodes: [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        label: 'Save',
+        rect: { x: 0, y: 0, width: 100, height: 44 },
+        hittable: true,
+      },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({
+      ok: false,
+      error: { code: 'COMMAND_FAILED', message: 'not hittable' },
+    }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  const suggestions = divergence.suggestions as Array<{
+    selector: string;
+    basis: string;
+    ref?: string;
+  }>;
+  expect(divergence.suggestionCount).toBe(1);
+  expect(suggestions).toHaveLength(1);
+  expect(suggestions[0]?.ref).toBe('e1');
+  expect(suggestions[0]?.basis).toBe('label');
+});
+
+test('a successful replay prints one line with the step count and wall time', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-success-message-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName));
+  const filePath = writeReplayFile(root, ['open "Demo"', 'click "Save"']);
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({ ok: true, data: {} }),
+  });
+
+  expect(response.ok).toBe(true);
+  if (!response.ok) return;
+  const data = response.data as { replayed: number; message: string };
+  expect(data.replayed).toBe(2);
+  expect(data.message).toMatch(/^Replayed 2 steps in \d+\.\ds$/);
+});
+
+test('divergence screen never masks the original cause when the session already closed', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-divergence-no-session-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  // Intentionally no session stored: simulates the session closing mid-replay.
+  const filePath = writeReplayFile(root, ['click "Save"']);
+
+  const response: DaemonResponse = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({
+      ok: false,
+      error: { code: 'COMMAND_FAILED', message: 'session closed mid-replay' },
+    }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  expect(response.error.code).toBe('REPLAY_DIVERGENCE');
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  const cause = divergence.cause as { message: string };
+  expect(cause.message).toBe('session closed mid-replay');
+  const screen = divergence.screen as { state: string; reason?: string };
+  expect(screen.state).toBe('unavailable');
+  expect(screen.reason).toBe('no-session');
+});

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { runReplayScriptFile } from '../session-replay-runtime.ts';
+import { buildReplayFailureDivergence } from '../session-replay-divergence.ts';
 import { SessionStore } from '../../session-store.ts';
 import type { DaemonRequest, DaemonResponse } from '../../types.ts';
 import { dispatchCommand } from '../../../core/dispatch.ts';
@@ -390,4 +391,133 @@ test('divergence cause and action strings pass through the central redactor at c
   const cause = divergence.cause as { message: string };
   expect(cause.message).not.toContain('sk-live-abc123def456');
   expect(cause.message).toContain('api_key=[REDACTED]');
+});
+
+// --- Blocker 1: fill text must NEVER appear in the divergence output ---
+
+test('a fill divergence never serializes the typed text at any response level', async () => {
+  const sentinel = 'SuperSecretPassword-do-not-leak-12345';
+  for (const level of ['digest', 'default', 'full'] as const) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-fill-leak-'));
+    const sessionStore = new SessionStore(path.join(root, 'sessions'));
+    const sessionName = 'default';
+    sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+    const filePath = writeReplayFile(root, [`fill 'label="Email"' ${JSON.stringify(sentinel)}`]);
+    // Selector miss forces the divergence on the fill step; the failure
+    // message is a realistic selector error, not an echo of the typed text.
+    mockDispatchCommand.mockRejectedValue(new Error('no device runner available'));
+
+    const response = await runReplayScriptFile({
+      req: baseReq({ positionals: [filePath], meta: { responseLevel: level } }),
+      sessionName,
+      logPath: path.join(root, 'daemon.log'),
+      sessionStore,
+      invoke: async (req) => {
+        if (req.command === 'fill') {
+          return {
+            ok: false,
+            error: { code: 'COMMAND_FAILED', message: 'Selector did not match: label="Email"' },
+          };
+        }
+        return { ok: true, data: {} };
+      },
+    });
+
+    expect(response.ok).toBe(false);
+    if (response.ok) return;
+    const serializedDivergence = JSON.stringify(response.error.details?.divergence);
+    expect(serializedDivergence).not.toContain(sentinel);
+    // The whole error details (flat positionals included) must not leak it either.
+    expect(JSON.stringify(response.error.details)).not.toContain(sentinel);
+    expect(response.error.message).not.toContain(sentinel);
+    // The action label still names the field, with the text categorically hidden.
+    const divergence = response.error.details?.divergence as { action: string };
+    expect(divergence.action).toContain('<text>');
+    expect(divergence.action).toContain('Email');
+  }
+});
+
+// --- Blocker 3b: suggestion dedupe keeps the STRONGEST basis per node ---
+
+test('a divergence dedupes suggestions by node and tags the strongest basis', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-suggest-dedupe-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+
+  // A recorded click whose selectorChain lists a label-basis term FIRST and an
+  // id-basis term SECOND, both resolving to the same node. The suggestion must
+  // appear once, tagged with the stronger `id` basis (not the first-seen label).
+  mockDispatchCommand.mockResolvedValue({
+    nodes: [
+      {
+        index: 0,
+        depth: 0,
+        type: 'Button',
+        label: 'Save',
+        identifier: 'save',
+        rect: { x: 0, y: 0, width: 100, height: 44 },
+        hittable: true,
+      },
+    ],
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const divergence = await buildReplayFailureDivergence({
+    error: { code: 'COMMAND_FAILED', message: 'not hittable' },
+    action: {
+      ts: 0,
+      command: 'click',
+      positionals: ['label="Save"'],
+      flags: {},
+      result: { selectorChain: ['label="Save"', 'id="save"'] },
+    },
+    index: 0,
+    sourcePath: path.join(root, 'flow.ad'),
+    sourceLine: 1,
+    session: sessionStore.get(sessionName),
+    sessionName,
+    sessionStore,
+    logPath: path.join(root, 'daemon.log'),
+    responseLevel: 'default',
+  });
+
+  expect(divergence.suggestionCount).toBe(1);
+  expect(divergence.suggestions).toHaveLength(1);
+  expect(divergence.suggestions[0]?.ref).toBe('e1');
+  expect(divergence.suggestions[0]?.basis).toBe('id');
+});
+
+// --- Blocker 3a: capture-error screen hint is sanitized ---
+
+test('a capture-failed screen hint redacts a secret in the capture error', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-screen-redact-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const filePath = writeReplayFile(root, ['click "Save"']);
+  // The post-failure snapshot capture throws with a secret-bearing message.
+  mockDispatchCommand.mockRejectedValue(new Error('snapshot failed: api_key=sk-live-abc123def456'));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async () => ({
+      ok: false,
+      error: { code: 'COMMAND_FAILED', message: 'Selector did not match' },
+    }),
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  const divergence = response.error.details?.divergence as {
+    screen: { state: string; reason?: string; hint?: string };
+  };
+  expect(divergence.screen.state).toBe('unavailable');
+  expect(divergence.screen.reason).toBe('capture-failed');
+  expect(divergence.screen.hint).not.toContain('sk-live-abc123def456');
+  expect(divergence.screen.hint).toContain('[REDACTED]');
 });

--- a/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-runtime.test.ts
@@ -533,3 +533,49 @@ test('a capture-failed screen hint redacts a secret in the capture error', async
   expect(divergence.screen.hint).not.toContain('sk-live-abc123def456');
   expect(divergence.screen.hint).toContain('[REDACTED]');
 });
+
+// --- Expanded replay variables are never serialized (ADR 0012) ---
+
+test('an expanded ${VAR} value echoed by a selector error never reaches the public divergence', async () => {
+  const sentinel = 'ExpandedVarSecret-98765-do-not-leak';
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-var-leak-'));
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  const filePath = writeReplayFile(root, ['press label="${SECRET}"']);
+  mockDispatchCommand.mockRejectedValue(new Error('no device runner available'));
+
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath], flags: { replayEnv: [`SECRET=${sentinel}`] } }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      if (req.command === 'press') {
+        // A real selector miss echoes the RESOLVED (expanded) selector.
+        return {
+          ok: false,
+          error: {
+            code: 'COMMAND_FAILED',
+            message: `Selector did not match: ${req.positionals?.[0] ?? ''}`,
+            hint: `Run find "${sentinel}" for contains matching.`,
+          },
+        };
+      }
+      return { ok: true, data: {} };
+    },
+  });
+
+  expect(response.ok).toBe(false);
+  if (response.ok) return;
+  // The expanded value appears nowhere in the whole public error.
+  expect(JSON.stringify(response.error)).not.toContain(sentinel);
+  // The scrub is a marker replacement, not a drop: the caller still sees
+  // WHICH variable the selector interpolated.
+  const divergence = response.error.details?.divergence as {
+    cause: { message: string; hint?: string };
+  };
+  expect(divergence.cause.message).toContain('<var:SECRET>');
+  expect(divergence.cause.hint).toContain('<var:SECRET>');
+  expect(response.error.message).toContain('<var:SECRET>');
+});

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -805,7 +805,9 @@ test('runReplayScriptFile reports iOS Maestro openLink setup failures before ass
     assert.match(response.error.message, /Replay failed at step 1/);
     assert.match(response.error.message, /open "demo\.app" "demo:\/\/screen"/);
     assert.match(response.error.message, /Developer mode is disabled/);
-    assert.match(String(response.error.details?.hint ?? ''), /DevToolsSecurity -enable/);
+    // The cause's details-borne hint is hoisted onto the error field by the
+    // divergence transport (arbitrary cause details are stripped).
+    assert.match(String(response.error.hint ?? ''), /DevToolsSecurity -enable/);
   }
   assert.deepEqual(
     calls.map((call) => [call.command, call.positionals]),

--- a/src/daemon/handlers/__tests__/session-replay-vars.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-vars.test.ts
@@ -1,4 +1,22 @@
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
+
+// ADR 0012 migration step 2: every replay step failure now attempts a
+// post-failure screen digest capture + suggestion re-resolution, both via
+// dispatchCommand('snapshot', ...). None of this file's fixtures model a real
+// device runner, so without a mock those calls fall through to the real
+// (slow/hanging) runner dispatch path. Reject fast so failure-path tests keep
+// exercising `divergence.screen: unavailable` deterministically, exactly like
+// a real capture failure would.
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return {
+    ...actual,
+    dispatchCommand: vi.fn(async () => {
+      throw new Error('no device runner available in this test');
+    }),
+  };
+});
+
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -2034,8 +2052,15 @@ test('runReplayScriptFile propagates Maestro runFlow.when runtime errors', async
 
   assert.equal(response.ok, false);
   if (!response.ok) {
-    assert.equal(response.error.code, 'UNKNOWN');
+    // ADR 0012 migration step 2: the wire-level code is now REPLAY_DIVERGENCE;
+    // the original code/message are preserved verbatim in divergence.cause.
+    assert.equal(response.error.code, 'REPLAY_DIVERGENCE');
     assert.match(response.error.message, /fetch failed/);
+    const divergence = response.error.details?.divergence as
+      | { cause: { code: string; message: string } }
+      | undefined;
+    assert.equal(divergence?.cause.code, 'UNKNOWN');
+    assert.match(divergence?.cause.message ?? '', /fetch failed/);
   }
 });
 

--- a/src/daemon/handlers/__tests__/session-test-suite.test.ts
+++ b/src/daemon/handlers/__tests__/session-test-suite.test.ts
@@ -1,4 +1,21 @@
-import { test, expect } from 'vitest';
+import { test, expect, vi } from 'vitest';
+
+// ADR 0012 migration step 2: every replay step failure now attempts a
+// post-failure screen digest capture + suggestion re-resolution via
+// dispatchCommand('snapshot', ...). This file's fixtures don't model a real
+// device runner, so without a mock those calls fall through to the real
+// (slow/hanging) runner dispatch path. Reject fast so failure-path tests keep
+// exercising `divergence.screen: unavailable` deterministically.
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return {
+    ...actual,
+    dispatchCommand: vi.fn(async () => {
+      throw new Error('no device runner available in this test');
+    }),
+  };
+});
+
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -26,11 +26,20 @@ export async function invokeReplayAction(params: {
   filePath: string;
   line: number;
   step: number;
+  /**
+   * Resolved source file for THIS action when it differs from `filePath`
+   * (ADR 0012 migration step 2): a Maestro `runFlow` include's actions carry
+   * the include's path. Threaded into nested control-flow invocations and
+   * attached to a failing response (deepest failure wins) so the divergence
+   * report names the actual failing file+line.
+   */
+  sourcePath?: string;
   tracePath?: string;
   invoke: DaemonInvokeFn;
 }): Promise<DaemonResponse> {
-  const { req, sessionName, action, scope, filePath, line, step, tracePath, invoke } = params;
-  const resolved = resolveReplayAction(action, scope, { file: filePath, line });
+  const { req, sessionName, action, scope, filePath, line, step, sourcePath, tracePath, invoke } =
+    params;
+  const resolved = resolveReplayAction(action, scope, { file: sourcePath ?? filePath, line });
   const invokeNestedReplayAction: ReplayActionInvoker = (nested) =>
     invokeReplayAction({
       req,
@@ -40,6 +49,9 @@ export async function invokeReplayAction(params: {
       filePath,
       line: nested.line,
       step: nested.step,
+      // A nested action without its own recorded source belongs to the same
+      // file as its wrapper (e.g. a plain tapOn inside retry:).
+      sourcePath: nested.sourcePath ?? sourcePath,
       tracePath,
       invoke,
     });
@@ -48,6 +60,7 @@ export async function invokeReplayAction(params: {
     type: 'replay_action_start',
     ts: new Date(startedAt).toISOString(),
     replayPath: filePath,
+    ...(sourcePath ? { sourcePath } : {}),
     line,
     step,
     command: resolved.command,
@@ -70,6 +83,7 @@ export async function invokeReplayAction(params: {
     type: 'replay_action_stop',
     ts: new Date(finishedAt).toISOString(),
     replayPath: filePath,
+    ...(sourcePath ? { sourcePath } : {}),
     line,
     step,
     command: resolved.command,
@@ -78,7 +92,30 @@ export async function invokeReplayAction(params: {
     resultTiming: response.ok ? readResponseTiming(response.data) : undefined,
     errorCode: response.ok ? undefined : response.error.code,
   });
-  return response;
+  return withReplayFailureSource(response, sourcePath ?? filePath, line);
+}
+
+/**
+ * Attaches the failing action's resolved source to the error so the
+ * top-level failure context (`withReplayFailureContext`) can report the
+ * NESTED step's provenance when the failure happened inside a control-flow
+ * wrapper. Deepest failure wins: an outer wrapper's invocation never
+ * overwrites a source an inner invocation already attached.
+ */
+function withReplayFailureSource(
+  response: DaemonResponse,
+  path: string,
+  line: number,
+): DaemonResponse {
+  if (response.ok) return response;
+  if (response.error.details?.replaySource !== undefined) return response;
+  return {
+    ok: false,
+    error: {
+      ...response.error,
+      details: { ...(response.error.details ?? {}), replaySource: { path, line } },
+    },
+  };
 }
 
 async function invokeResolvedReplayAction(params: {
@@ -146,6 +183,7 @@ async function invokeReplayControl(params: {
     case 'retry':
       return await invokeReplayRetryBlock({
         actions: control.actions,
+        actionSources: control.actionSources,
         maxRetries: control.maxRetries,
         line,
         step,

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -26,13 +26,7 @@ export async function invokeReplayAction(params: {
   filePath: string;
   line: number;
   step: number;
-  /**
-   * Resolved source file for THIS action when it differs from `filePath`
-   * (ADR 0012 migration step 2): a Maestro `runFlow` include's actions carry
-   * the include's path. Threaded into nested control-flow invocations and
-   * attached to a failing response (deepest failure wins) so the divergence
-   * report names the actual failing file+line.
-   */
+  /** Resolved source file when it differs from `filePath` (a `runFlow` include's path). */
   sourcePath?: string;
   tracePath?: string;
   invoke: DaemonInvokeFn;
@@ -49,8 +43,7 @@ export async function invokeReplayAction(params: {
       filePath,
       line: nested.line,
       step: nested.step,
-      // A nested action without its own recorded source belongs to the same
-      // file as its wrapper (e.g. a plain tapOn inside retry:).
+      // No recorded source on a nested action = same file as its wrapper.
       sourcePath: nested.sourcePath ?? sourcePath,
       tracePath,
       invoke,
@@ -96,11 +89,8 @@ export async function invokeReplayAction(params: {
 }
 
 /**
- * Attaches the failing action's resolved source to the error so the
- * top-level failure context (`withReplayFailureContext`) can report the
- * NESTED step's provenance when the failure happened inside a control-flow
- * wrapper. Deepest failure wins: an outer wrapper's invocation never
- * overwrites a source an inner invocation already attached.
+ * Attaches the failing action's resolved source for the top-level failure
+ * context; deepest failure wins (never overwrites an inner attachment).
  */
 function withReplayFailureSource(
   response: DaemonResponse,

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -15,10 +15,7 @@ import {
   tryParseSelectorChain,
   type Selector,
 } from '../selectors.ts';
-import {
-  collectReplaySelectorCandidates,
-  captureSnapshotForReplay,
-} from './session-replay-heal.ts';
+import { collectReplaySelectorCandidates } from './session-replay-heal.ts';
 import { formatScriptActionSummary, isTouchTargetCommand } from '../../replay/script-utils.ts';
 import { SessionStore } from '../session-store.ts';
 import type { SessionAction, SessionState } from '../types.ts';
@@ -26,7 +23,7 @@ import {
   REPLAY_DIVERGENCE_RESUME_NOT_SUPPORTED,
   REPLAY_DIVERGENCE_SUGGESTION_LIMIT,
   boundReplayDivergence,
-  truncateUtf8Field,
+  sanitizeReplayDivergenceField,
   type ReplayDivergence,
   type ReplayDivergenceScreen,
   type ReplayDivergenceScreenRef,
@@ -39,6 +36,13 @@ import {
  * failed replay step. Report-only — no target-binding verification (decision
  * 3/step 4), no `--from` resume (step 5). `kind` is always `'action-failure'`
  * at this step.
+ *
+ * ONE post-failure snapshot serves both the screen digest and suggestion
+ * re-resolution: the digest's `refsGeneration` and the suggestions' refs must
+ * name the SAME stored tree, or the report would advertise refs a second
+ * capture already invalidated (the exact stale-ref hole a per-purpose double
+ * capture created in the first draft) — and one capture is also one fewer
+ * device round trip on a latency-sensitive path.
  */
 export async function buildReplayFailureDivergence(params: {
   error: DaemonError;
@@ -67,36 +71,32 @@ export async function buildReplayFailureDivergence(params: {
 
   const cause = {
     code: error.code,
-    message: truncateUtf8Field(error.message),
-    ...(error.hint ? { hint: truncateUtf8Field(error.hint) } : {}),
+    message: sanitizeReplayDivergenceField(error.message),
+    ...(error.hint ? { hint: sanitizeReplayDivergenceField(error.hint) } : {}),
   };
 
-  const screen = session
-    ? await captureReplayDivergenceScreen({ session, sessionName, sessionStore, logPath, action })
+  const observation = session
+    ? await captureDivergenceObservation({ session, sessionName, sessionStore, logPath, action })
     : ({
         state: 'unavailable',
         reason: 'no-session',
         hint: 'The session closed before a post-failure screen could be captured.',
-      } satisfies ReplayDivergenceScreen);
+      } satisfies DivergenceObservation);
 
-  const suggestions = session
-    ? await collectReplayDivergenceSuggestions({
-        action,
-        session,
-        sessionName,
-        sessionStore,
-        logPath,
-      })
-    : [];
+  const screen = buildDivergenceScreen(observation);
+  const suggestions =
+    observation.state === 'available' && session
+      ? collectReplayDivergenceSuggestions({ action, session, nodes: observation.nodes })
+      : [];
 
   const divergence: ReplayDivergence = {
     version: 1,
     kind: 'action-failure',
     step: {
       index: index + 1,
-      source: { path: truncateUtf8Field(sourcePath), line: sourceLine },
+      source: { path: sanitizeReplayDivergenceField(sourcePath), line: sourceLine },
     },
-    action: truncateUtf8Field(formatScriptActionSummary(action)),
+    action: sanitizeReplayDivergenceField(formatScriptActionSummary(action)),
     cause,
     screen,
     suggestions: suggestions.slice(0, REPLAY_DIVERGENCE_SUGGESTION_LIMIT),
@@ -112,19 +112,34 @@ export async function buildReplayFailureDivergence(params: {
   });
 }
 
-async function captureReplayDivergenceScreen(params: {
+type DivergenceObservation =
+  | { state: 'available'; nodes: SnapshotNode[]; refsGeneration: number }
+  | { state: 'unavailable'; reason: string; hint: string };
+
+/**
+ * The single post-failure capture. Blessing follows the settle/find/heal
+ * choke-point sequence exactly: `setSessionSnapshot` (advances the session's
+ * `snapshotGeneration`), `markSessionSnapshotRefsIssued` (clears the coarse
+ * staleness marker — the report's refs are minted from the tree the next
+ * `@ref` command resolves on), then `sessionStore.set`. Sparse captures do
+ * not write back (the selector-capture reliability contract), so a sparse
+ * verdict degrades the whole observation: no stored tree means no blessed
+ * refs AND no trustworthy nodes for suggestion re-resolution.
+ */
+async function captureDivergenceObservation(params: {
   session: SessionState;
   sessionName: string;
   sessionStore: SessionStore;
   logPath: string;
   action: SessionAction;
-}): Promise<ReplayDivergenceScreen> {
+}): Promise<DivergenceObservation> {
   const { session, sessionName, sessionStore, logPath, action } = params;
+  const snapshotInteractiveOnly = divergenceCaptureInteractiveOnly(action);
   try {
     const data = (await dispatchCommand(session.device, 'snapshot', [], undefined, {
       ...contextFromFlags(
         logPath,
-        { ...(action.flags ?? {}), snapshotInteractiveOnly: true },
+        { ...(action.flags ?? {}), snapshotInteractiveOnly },
         session.appBundleId,
         session.trace?.outPath,
       ),
@@ -136,7 +151,7 @@ async function captureReplayDivergenceScreen(params: {
     };
     const snapshot = buildSnapshotState(data, {
       ...(action.flags ?? {}),
-      snapshotInteractiveOnly: true,
+      snapshotInteractiveOnly,
     });
     if (isSparseSnapshotQualityVerdict(snapshot.snapshotQuality)) {
       return {
@@ -148,12 +163,10 @@ async function captureReplayDivergenceScreen(params: {
     setSessionSnapshot(session, snapshot);
     markSessionSnapshotRefsIssued(session);
     sessionStore.set(sessionName, session);
-    const { refs, truncated } = buildReplayDivergenceScreenRefs(snapshot.nodes);
     return {
       state: 'available',
+      nodes: snapshot.nodes,
       refsGeneration: session.snapshotGeneration ?? 0,
-      refs,
-      ...(truncated ? { truncated: true as const } : {}),
     };
   } catch (error) {
     return {
@@ -162,6 +175,31 @@ async function captureReplayDivergenceScreen(params: {
       hint: `Post-failure snapshot capture failed (${error instanceof Error ? error.message : String(error)}); the original replay failure is unaffected.`,
     };
   }
+}
+
+/**
+ * Capture flavor for the shared observation: interactive-only (the settle /
+ * `snapshot -i` default) except when the failing action is a non-rect
+ * selector read (`get`/`is`/`wait`) — heal's suggestion re-resolution has
+ * always used a full capture for those (`snapshotInteractiveOnly:
+ * requiresRect`) because static text nodes are legitimate targets, and the
+ * screen digest works over the full tree too (every node still carries a
+ * blessed ref).
+ */
+function divergenceCaptureInteractiveOnly(action: SessionAction): boolean {
+  if (!isSuggestionEligibleCommand(action.command)) return true;
+  return resolveSuggestionMatchingConfig(action).requiresRect;
+}
+
+function buildDivergenceScreen(observation: DivergenceObservation): ReplayDivergenceScreen {
+  if (observation.state === 'unavailable') return observation;
+  const { refs, truncated } = buildReplayDivergenceScreenRefs(observation.nodes);
+  return {
+    state: 'available',
+    refsGeneration: observation.refsGeneration,
+    refs,
+    ...(truncated ? { truncated: true as const } : {}),
+  };
 }
 
 // Full-resolution cap; response-level bounding (8/20) is applied afterwards
@@ -178,8 +216,8 @@ function buildReplayDivergenceScreenRefs(nodes: SnapshotNode[]): {
     const label = displayLabel(node, role);
     return {
       ref: node.ref!,
-      role: truncateUtf8Field(role),
-      ...(label ? { label: truncateUtf8Field(label) } : {}),
+      role: sanitizeReplayDivergenceField(role),
+      ...(label ? { label: sanitizeReplayDivergenceField(label) } : {}),
     };
   });
   return { refs, truncated: candidates.length > refs.length };
@@ -206,35 +244,24 @@ function classifySuggestionBasis(selector: Selector): ReplayDivergenceSuggestion
  * Decision 1's ranked-suggestions machinery, repurposed READ-ONLY:
  * `collectReplaySelectorCandidates` + `resolveSelectorChain` re-resolution
  * (the exact pieces `healReplayAction` already used) collect candidates
- * instead of applying the first one. Ranking: identity-component strength
+ * instead of applying the first one, resolved against the SAME captured
+ * nodes the screen digest was built from (see the single-capture note on
+ * `buildReplayFailureDivergence`). Ranking: identity-component strength
  * (id > role+label > label > other), then document order. The
  * same-scrollRegion-as-recorded tier from decision 1's total order is not
  * evaluated here — that requires decision 3's recorded target evidence,
  * which migration step 2 has no dependency on and does not consume.
  */
-async function collectReplayDivergenceSuggestions(params: {
+function collectReplayDivergenceSuggestions(params: {
   action: SessionAction;
   session: SessionState;
-  sessionName: string;
-  sessionStore: SessionStore;
-  logPath: string;
-}): Promise<ReplayDivergenceSuggestion[]> {
-  const { action, session, sessionName, sessionStore, logPath } = params;
+  nodes: SnapshotNode[];
+}): ReplayDivergenceSuggestion[] {
+  const { action, session, nodes } = params;
   if (!isSuggestionEligibleCommand(action.command)) return [];
   const candidates = collectReplaySelectorCandidates(action);
   if (candidates.length === 0) return [];
-
   const matching = resolveSuggestionMatchingConfig(action);
-  const nodes = await captureSuggestionSnapshotNodes({
-    session,
-    sessionName,
-    sessionStore,
-    logPath,
-    action,
-    requiresRect: matching.requiresRect,
-  });
-  if (!nodes) return [];
-
   return rankSuggestionCandidates({ candidates, nodes, session, action, matching });
 }
 
@@ -255,44 +282,11 @@ function resolveSuggestionMatchingConfig(action: SessionAction): SuggestionMatch
   };
 }
 
-/**
- * A fresh snapshot capture for suggestion re-resolution (a second capture
- * beyond the screen digest's own, matching healReplayAction's established
- * `snapshotInteractiveOnly: requiresRect` semantics exactly — see the module
- * doc comment on `collectReplayDivergenceSuggestions`). Returns `undefined`
- * on capture failure so the caller degrades to no suggestions, same as an
- * unavailable screen never masks the original cause.
- */
-async function captureSuggestionSnapshotNodes(params: {
-  session: SessionState;
-  sessionName: string;
-  sessionStore: SessionStore;
-  logPath: string;
-  action: SessionAction;
-  requiresRect: boolean;
-}): Promise<SnapshotNode[] | undefined> {
-  const { session, sessionName, sessionStore, logPath, action, requiresRect } = params;
-  try {
-    const snapshot = await captureSnapshotForReplay(
-      session,
-      action,
-      logPath,
-      requiresRect,
-      sessionStore,
-    );
-    // captureSnapshotForReplay already stored + advanced the session snapshot
-    // generation; re-read so suggestion refs are blessed against the tree
-    // they came from, same as the screen digest.
-    if (sessionStore.get(sessionName)?.snapshotGeneration !== undefined) {
-      markSessionSnapshotRefsIssued(session);
-    }
-    return snapshot.nodes;
-  } catch {
-    return undefined;
-  }
-}
-
-type RankedSuggestion = { suggestion: ReplayDivergenceSuggestion; basisRank: number; nodeIndex: number };
+type RankedSuggestion = {
+  suggestion: ReplayDivergenceSuggestion;
+  basisRank: number;
+  nodeIndex: number;
+};
 
 function rankSuggestionCandidates(params: {
   candidates: string[];
@@ -335,18 +329,19 @@ function resolveSuggestionCandidate(params: {
   if (!resolved) return undefined;
 
   const selectorChain = buildSelectorChainForNode(resolved.node, session.device.platform, {
-    action: action.command === 'fill' ? 'fill' : isTouchTargetCommand(action.command) ? 'click' : 'get',
+    action:
+      action.command === 'fill' ? 'fill' : isTouchTargetCommand(action.command) ? 'click' : 'get',
   });
   const basis = classifySuggestionBasis(resolved.selector);
   const role = formatRole(resolved.node.type ?? 'Element');
   const label = displayLabel(resolved.node, role);
   return {
     suggestion: {
-      selector: truncateUtf8Field(selectorChain.join(' || ')),
+      selector: sanitizeReplayDivergenceField(selectorChain.join(' || ')),
       basis,
       ...(resolved.node.ref ? { ref: resolved.node.ref } : {}),
-      role: truncateUtf8Field(role),
-      ...(label ? { label: truncateUtf8Field(label) } : {}),
+      role: sanitizeReplayDivergenceField(role),
+      ...(label ? { label: sanitizeReplayDivergenceField(label) } : {}),
     },
     basisRank: BASIS_RANK[basis],
     nodeIndex: resolved.node.index,

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -23,13 +23,16 @@ import {
   REPLAY_DIVERGENCE_RESUME_NOT_SUPPORTED,
   REPLAY_DIVERGENCE_SUGGESTION_LIMIT,
   boundReplayDivergence,
-  sanitizeReplayDivergenceField,
+  createReplayDivergenceSanitizer,
   type ReplayDivergence,
   type ReplayDivergenceScreen,
   type ReplayDivergenceScreenRef,
   type ReplayDivergenceSuggestion,
   type ReplayDivergenceSuggestionBasis,
+  type ReplayVarScrubEntry,
 } from '../../replay/divergence.ts';
+
+type DivergenceFieldSanitizer = (value: string, limit?: number) => string;
 
 /**
  * ADR 0012 migration step 2: builds the `details.divergence` report for a
@@ -49,6 +52,8 @@ export async function buildReplayFailureDivergence(params: {
   sessionStore: SessionStore;
   logPath: string;
   responseLevel: ResponseLevel | undefined;
+  /** Replay-scope values scrubbed from every divergence string (ADR 0012: expanded variables are never serialized). */
+  scrubVars?: ReplayVarScrubEntry[];
 }): Promise<ReplayDivergence> {
   const {
     error,
@@ -61,12 +66,14 @@ export async function buildReplayFailureDivergence(params: {
     sessionStore,
     logPath,
     responseLevel,
+    scrubVars = [],
   } = params;
+  const sanitize = createReplayDivergenceSanitizer(scrubVars);
 
   const cause = {
     code: error.code,
-    message: sanitizeReplayDivergenceField(error.message),
-    ...(error.hint ? { hint: sanitizeReplayDivergenceField(error.hint) } : {}),
+    message: sanitize(error.message),
+    ...(error.hint ? { hint: sanitize(error.hint) } : {}),
   };
 
   const observation = session
@@ -77,10 +84,15 @@ export async function buildReplayFailureDivergence(params: {
         hint: 'The session closed before a post-failure screen could be captured.',
       } satisfies DivergenceObservation);
 
-  const screen = buildDivergenceScreen(observation);
+  const screen = buildDivergenceScreen(observation, sanitize);
   const suggestions =
     observation.state === 'available' && session
-      ? collectReplayDivergenceSuggestions({ action, session, nodes: observation.nodes })
+      ? collectReplayDivergenceSuggestions({
+          action,
+          session,
+          nodes: observation.nodes,
+          sanitize,
+        })
       : [];
 
   const divergence: ReplayDivergence = {
@@ -88,9 +100,9 @@ export async function buildReplayFailureDivergence(params: {
     kind: 'action-failure',
     step: {
       index: index + 1,
-      source: { path: sanitizeReplayDivergenceField(sourcePath), line: sourceLine },
+      source: { path: sanitize(sourcePath), line: sourceLine },
     },
-    action: sanitizeReplayDivergenceField(formatDivergenceActionLabel(action)),
+    action: sanitize(formatDivergenceActionLabel(action)),
     cause,
     screen,
     suggestions: suggestions.slice(0, REPLAY_DIVERGENCE_SUGGESTION_LIMIT),
@@ -177,17 +189,20 @@ function divergenceCaptureInteractiveOnly(action: SessionAction): boolean {
   return resolveSuggestionMatchingConfig(action).requiresRect;
 }
 
-function buildDivergenceScreen(observation: DivergenceObservation): ReplayDivergenceScreen {
+function buildDivergenceScreen(
+  observation: DivergenceObservation,
+  sanitize: DivergenceFieldSanitizer,
+): ReplayDivergenceScreen {
   if (observation.state === 'unavailable') {
     // The capture-failed hint interpolates the capture error message; sanitize
     // every unavailable string field so no interpolated content escapes raw.
     return {
       state: 'unavailable',
-      reason: sanitizeReplayDivergenceField(observation.reason),
-      hint: sanitizeReplayDivergenceField(observation.hint),
+      reason: sanitize(observation.reason),
+      hint: sanitize(observation.hint),
     };
   }
-  const { refs, truncated } = buildReplayDivergenceScreenRefs(observation.nodes);
+  const { refs, truncated } = buildReplayDivergenceScreenRefs(observation.nodes, sanitize);
   return {
     state: 'available',
     refsGeneration: observation.refsGeneration,
@@ -200,7 +215,10 @@ function buildDivergenceScreen(observation: DivergenceObservation): ReplayDiverg
 // by boundReplayDivergence/applyReplayDivergenceLevelCaps.
 const SCREEN_REF_CAPTURE_LIMIT = 20;
 
-function buildReplayDivergenceScreenRefs(nodes: SnapshotNode[]): {
+function buildReplayDivergenceScreenRefs(
+  nodes: SnapshotNode[],
+  sanitize: DivergenceFieldSanitizer,
+): {
   refs: ReplayDivergenceScreenRef[];
   truncated: boolean;
 } {
@@ -210,8 +228,8 @@ function buildReplayDivergenceScreenRefs(nodes: SnapshotNode[]): {
     const label = displayLabel(node, role);
     return {
       ref: node.ref!,
-      role: sanitizeReplayDivergenceField(role),
-      ...(label ? { label: sanitizeReplayDivergenceField(label) } : {}),
+      role: sanitize(role),
+      ...(label ? { label: sanitize(label) } : {}),
     };
   });
   return { refs, truncated: candidates.length > refs.length };
@@ -244,13 +262,14 @@ function collectReplayDivergenceSuggestions(params: {
   action: SessionAction;
   session: SessionState;
   nodes: SnapshotNode[];
+  sanitize: DivergenceFieldSanitizer;
 }): ReplayDivergenceSuggestion[] {
-  const { action, session, nodes } = params;
+  const { action, session, nodes, sanitize } = params;
   if (!isSuggestionEligibleCommand(action.command)) return [];
   const candidates = collectReplaySelectorCandidates(action);
   if (candidates.length === 0) return [];
   const matching = resolveSuggestionMatchingConfig(action);
-  return rankSuggestionCandidates({ candidates, nodes, session, action, matching });
+  return rankSuggestionCandidates({ candidates, nodes, session, action, matching, sanitize });
 }
 
 function isSuggestionEligibleCommand(command: string): boolean {
@@ -282,15 +301,23 @@ function rankSuggestionCandidates(params: {
   session: SessionState;
   action: SessionAction;
   matching: SuggestionMatchingConfig;
+  sanitize: DivergenceFieldSanitizer;
 }): ReplayDivergenceSuggestion[] {
-  const { candidates, nodes, session, action, matching } = params;
+  const { candidates, nodes, session, action, matching, sanitize } = params;
   // Dedupe by node (its unique tree index), keeping the STRONGEST match basis
   // per the ADR: a node reachable through several recorded selector terms
   // appears once, tagged with its strongest basis — not whichever candidate
   // happened to resolve it first.
   const byNode = new Map<number, RankedSuggestion>();
   for (const candidate of candidates) {
-    const entry = resolveSuggestionCandidate({ candidate, nodes, session, action, matching });
+    const entry = resolveSuggestionCandidate({
+      candidate,
+      nodes,
+      session,
+      action,
+      matching,
+      sanitize,
+    });
     if (!entry) continue;
     const existing = byNode.get(entry.nodeIndex);
     if (!existing || entry.basisRank < existing.basisRank) byNode.set(entry.nodeIndex, entry);
@@ -306,8 +333,9 @@ function resolveSuggestionCandidate(params: {
   session: SessionState;
   action: SessionAction;
   matching: SuggestionMatchingConfig;
+  sanitize: DivergenceFieldSanitizer;
 }): RankedSuggestion | undefined {
-  const { candidate, nodes, session, action, matching } = params;
+  const { candidate, nodes, session, action, matching, sanitize } = params;
   const chain = tryParseSelectorChain(candidate);
   if (!chain) return undefined;
   const resolved = resolveSelectorChain(nodes, chain, {
@@ -327,11 +355,11 @@ function resolveSuggestionCandidate(params: {
   const label = displayLabel(resolved.node, role);
   return {
     suggestion: {
-      selector: sanitizeReplayDivergenceField(selectorChain.join(' || ')),
+      selector: sanitize(selectorChain.join(' || ')),
       basis,
       ...(resolved.node.ref ? { ref: resolved.node.ref } : {}),
-      role: sanitizeReplayDivergenceField(role),
-      ...(label ? { label: sanitizeReplayDivergenceField(label) } : {}),
+      role: sanitize(role),
+      ...(label ? { label: sanitize(label) } : {}),
     },
     basisRank: BASIS_RANK[basis],
     nodeIndex: resolved.node.index,

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -33,16 +33,10 @@ import {
 
 /**
  * ADR 0012 migration step 2: builds the `details.divergence` report for a
- * failed replay step. Report-only — no target-binding verification (decision
- * 3/step 4), no `--from` resume (step 5). `kind` is always `'action-failure'`
- * at this step.
- *
- * ONE post-failure snapshot serves both the screen digest and suggestion
- * re-resolution: the digest's `refsGeneration` and the suggestions' refs must
- * name the SAME stored tree, or the report would advertise refs a second
- * capture already invalidated (the exact stale-ref hole a per-purpose double
- * capture created in the first draft) — and one capture is also one fewer
- * device round trip on a latency-sensitive path.
+ * failed replay step. Report-only; `kind` is always `'action-failure'`.
+ * One capture serves both the screen digest and suggestion re-resolution:
+ * every ref in the report must name the same stored tree as
+ * `screen.refsGeneration`.
  */
 export async function buildReplayFailureDivergence(params: {
   error: DaemonError;
@@ -117,14 +111,10 @@ type DivergenceObservation =
   | { state: 'unavailable'; reason: string; hint: string };
 
 /**
- * The single post-failure capture. Blessing follows the settle/find/heal
- * choke-point sequence exactly: `setSessionSnapshot` (advances the session's
- * `snapshotGeneration`), `markSessionSnapshotRefsIssued` (clears the coarse
- * staleness marker — the report's refs are minted from the tree the next
- * `@ref` command resolves on), then `sessionStore.set`. Sparse captures do
- * not write back (the selector-capture reliability contract), so a sparse
- * verdict degrades the whole observation: no stored tree means no blessed
- * refs AND no trustworthy nodes for suggestion re-resolution.
+ * The single post-failure capture, blessed via the standard ref-issuing
+ * sequence (setSessionSnapshot -> markSessionSnapshotRefsIssued -> store).
+ * Sparse captures do not write back (selector-capture reliability contract),
+ * so a sparse verdict degrades the whole observation.
  */
 async function captureDivergenceObservation(params: {
   session: SessionState;
@@ -178,13 +168,9 @@ async function captureDivergenceObservation(params: {
 }
 
 /**
- * Capture flavor for the shared observation: interactive-only (the settle /
- * `snapshot -i` default) except when the failing action is a non-rect
- * selector read (`get`/`is`/`wait`) — heal's suggestion re-resolution has
- * always used a full capture for those (`snapshotInteractiveOnly:
- * requiresRect`) because static text nodes are legitimate targets, and the
- * screen digest works over the full tree too (every node still carries a
- * blessed ref).
+ * Interactive-only capture, except for non-rect selector reads
+ * (`get`/`is`/`wait`) whose suggestion targets include static text — the
+ * same `snapshotInteractiveOnly: requiresRect` rule heal always used.
  */
 function divergenceCaptureInteractiveOnly(action: SessionAction): boolean {
   if (!isSuggestionEligibleCommand(action.command)) return true;
@@ -241,16 +227,10 @@ function classifySuggestionBasis(selector: Selector): ReplayDivergenceSuggestion
 }
 
 /**
- * Decision 1's ranked-suggestions machinery, repurposed READ-ONLY:
- * `collectReplaySelectorCandidates` + `resolveSelectorChain` re-resolution
- * (the exact pieces `healReplayAction` already used) collect candidates
- * instead of applying the first one, resolved against the SAME captured
- * nodes the screen digest was built from (see the single-capture note on
- * `buildReplayFailureDivergence`). Ranking: identity-component strength
- * (id > role+label > label > other), then document order. The
- * same-scrollRegion-as-recorded tier from decision 1's total order is not
- * evaluated here — that requires decision 3's recorded target evidence,
- * which migration step 2 has no dependency on and does not consume.
+ * Decision 1's candidate machinery reused READ-ONLY over the shared capture.
+ * Ranking: identity-component strength (id > role+label > label > other),
+ * then document order; the same-scrollRegion tier awaits decision 3's
+ * recorded evidence (migration step 4).
  */
 function collectReplayDivergenceSuggestions(params: {
   action: SessionAction;

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -16,7 +16,7 @@ import {
   type Selector,
 } from '../selectors.ts';
 import { collectReplaySelectorCandidates } from './session-replay-heal.ts';
-import { formatScriptActionSummary, isTouchTargetCommand } from '../../replay/script-utils.ts';
+import { formatDivergenceActionLabel, isTouchTargetCommand } from '../../replay/script-utils.ts';
 import { SessionStore } from '../session-store.ts';
 import type { SessionAction, SessionState } from '../types.ts';
 import {
@@ -90,7 +90,7 @@ export async function buildReplayFailureDivergence(params: {
       index: index + 1,
       source: { path: sanitizeReplayDivergenceField(sourcePath), line: sourceLine },
     },
-    action: sanitizeReplayDivergenceField(formatScriptActionSummary(action)),
+    action: sanitizeReplayDivergenceField(formatDivergenceActionLabel(action)),
     cause,
     screen,
     suggestions: suggestions.slice(0, REPLAY_DIVERGENCE_SUGGESTION_LIMIT),
@@ -178,7 +178,15 @@ function divergenceCaptureInteractiveOnly(action: SessionAction): boolean {
 }
 
 function buildDivergenceScreen(observation: DivergenceObservation): ReplayDivergenceScreen {
-  if (observation.state === 'unavailable') return observation;
+  if (observation.state === 'unavailable') {
+    // The capture-failed hint interpolates the capture error message; sanitize
+    // every unavailable string field so no interpolated content escapes raw.
+    return {
+      state: 'unavailable',
+      reason: sanitizeReplayDivergenceField(observation.reason),
+      hint: sanitizeReplayDivergenceField(observation.hint),
+    };
+  }
   const { refs, truncated } = buildReplayDivergenceScreenRefs(observation.nodes);
   return {
     state: 'available',
@@ -276,18 +284,20 @@ function rankSuggestionCandidates(params: {
   matching: SuggestionMatchingConfig;
 }): ReplayDivergenceSuggestion[] {
   const { candidates, nodes, session, action, matching } = params;
-  const ranked: RankedSuggestion[] = [];
-  const seenNodes = new Set<string>();
+  // Dedupe by node (its unique tree index), keeping the STRONGEST match basis
+  // per the ADR: a node reachable through several recorded selector terms
+  // appears once, tagged with its strongest basis — not whichever candidate
+  // happened to resolve it first.
+  const byNode = new Map<number, RankedSuggestion>();
   for (const candidate of candidates) {
     const entry = resolveSuggestionCandidate({ candidate, nodes, session, action, matching });
     if (!entry) continue;
-    const nodeKey = entry.suggestion.ref ?? `idx:${entry.nodeIndex}`;
-    if (seenNodes.has(nodeKey)) continue;
-    seenNodes.add(nodeKey);
-    ranked.push(entry);
+    const existing = byNode.get(entry.nodeIndex);
+    if (!existing || entry.basisRank < existing.basisRank) byNode.set(entry.nodeIndex, entry);
   }
-  ranked.sort((a, b) => a.basisRank - b.basisRank || a.nodeIndex - b.nodeIndex);
-  return ranked.map((entry) => entry.suggestion);
+  return [...byNode.values()]
+    .sort((a, b) => a.basisRank - b.basisRank || a.nodeIndex - b.nodeIndex)
+    .map((entry) => entry.suggestion);
 }
 
 function resolveSuggestionCandidate(params: {

--- a/src/daemon/handlers/session-replay-divergence.ts
+++ b/src/daemon/handlers/session-replay-divergence.ts
@@ -1,0 +1,371 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { dispatchCommand } from '../../core/dispatch.ts';
+import { contextFromFlags } from '../context.ts';
+import { markSessionSnapshotRefsIssued, setSessionSnapshot } from '../session-snapshot.ts';
+import { isSparseSnapshotQualityVerdict } from '../../snapshot/snapshot-quality.ts';
+import { displayLabel, formatRole } from '../../snapshot/snapshot-lines.ts';
+import { redactDiagnosticData } from '../../kernel/redaction.ts';
+import type { DaemonError, ResponseLevel } from '../../kernel/contracts.ts';
+import type { RawSnapshotNode, SnapshotBackend, SnapshotNode } from '../../kernel/snapshot.ts';
+import { buildSnapshotState } from './snapshot-capture.ts';
+import {
+  buildSelectorChainForNode,
+  resolveSelectorChain,
+  tryParseSelectorChain,
+  type Selector,
+} from '../selectors.ts';
+import {
+  collectReplaySelectorCandidates,
+  captureSnapshotForReplay,
+} from './session-replay-heal.ts';
+import { formatScriptActionSummary, isTouchTargetCommand } from '../../replay/script-utils.ts';
+import { SessionStore } from '../session-store.ts';
+import type { SessionAction, SessionState } from '../types.ts';
+import {
+  REPLAY_DIVERGENCE_RESUME_NOT_SUPPORTED,
+  REPLAY_DIVERGENCE_SUGGESTION_LIMIT,
+  boundReplayDivergence,
+  truncateUtf8Field,
+  type ReplayDivergence,
+  type ReplayDivergenceScreen,
+  type ReplayDivergenceScreenRef,
+  type ReplayDivergenceSuggestion,
+  type ReplayDivergenceSuggestionBasis,
+} from '../../replay/divergence.ts';
+
+/**
+ * ADR 0012 migration step 2: builds the `details.divergence` report for a
+ * failed replay step. Report-only — no target-binding verification (decision
+ * 3/step 4), no `--from` resume (step 5). `kind` is always `'action-failure'`
+ * at this step.
+ */
+export async function buildReplayFailureDivergence(params: {
+  error: DaemonError;
+  action: SessionAction;
+  index: number;
+  sourcePath: string;
+  sourceLine: number;
+  session: SessionState | undefined;
+  sessionName: string;
+  sessionStore: SessionStore;
+  logPath: string;
+  responseLevel: ResponseLevel | undefined;
+}): Promise<ReplayDivergence> {
+  const {
+    error,
+    action,
+    index,
+    sourcePath,
+    sourceLine,
+    session,
+    sessionName,
+    sessionStore,
+    logPath,
+    responseLevel,
+  } = params;
+
+  const cause = {
+    code: error.code,
+    message: truncateUtf8Field(error.message),
+    ...(error.hint ? { hint: truncateUtf8Field(error.hint) } : {}),
+  };
+
+  const screen = session
+    ? await captureReplayDivergenceScreen({ session, sessionName, sessionStore, logPath, action })
+    : ({
+        state: 'unavailable',
+        reason: 'no-session',
+        hint: 'The session closed before a post-failure screen could be captured.',
+      } satisfies ReplayDivergenceScreen);
+
+  const suggestions = session
+    ? await collectReplayDivergenceSuggestions({
+        action,
+        session,
+        sessionName,
+        sessionStore,
+        logPath,
+      })
+    : [];
+
+  const divergence: ReplayDivergence = {
+    version: 1,
+    kind: 'action-failure',
+    step: {
+      index: index + 1,
+      source: { path: truncateUtf8Field(sourcePath), line: sourceLine },
+    },
+    action: truncateUtf8Field(formatScriptActionSummary(action)),
+    cause,
+    screen,
+    suggestions: suggestions.slice(0, REPLAY_DIVERGENCE_SUGGESTION_LIMIT),
+    suggestionCount: suggestions.length,
+    resume: REPLAY_DIVERGENCE_RESUME_NOT_SUPPORTED,
+  };
+
+  return boundReplayDivergence({
+    divergence,
+    level: responseLevel,
+    writeOverflowArtifact: (payload) =>
+      writeReplayDivergenceArtifact(sessionStore, sessionName, payload),
+  });
+}
+
+async function captureReplayDivergenceScreen(params: {
+  session: SessionState;
+  sessionName: string;
+  sessionStore: SessionStore;
+  logPath: string;
+  action: SessionAction;
+}): Promise<ReplayDivergenceScreen> {
+  const { session, sessionName, sessionStore, logPath, action } = params;
+  try {
+    const data = (await dispatchCommand(session.device, 'snapshot', [], undefined, {
+      ...contextFromFlags(
+        logPath,
+        { ...(action.flags ?? {}), snapshotInteractiveOnly: true },
+        session.appBundleId,
+        session.trace?.outPath,
+      ),
+    })) as {
+      nodes?: RawSnapshotNode[];
+      truncated?: boolean;
+      backend?: SnapshotBackend;
+      quality?: unknown;
+    };
+    const snapshot = buildSnapshotState(data, {
+      ...(action.flags ?? {}),
+      snapshotInteractiveOnly: true,
+    });
+    if (isSparseSnapshotQualityVerdict(snapshot.snapshotQuality)) {
+      return {
+        state: 'unavailable',
+        reason: 'sparse-snapshot',
+        hint: 'The post-failure snapshot was sparse or unavailable; run snapshot -i to observe the current screen.',
+      };
+    }
+    setSessionSnapshot(session, snapshot);
+    markSessionSnapshotRefsIssued(session);
+    sessionStore.set(sessionName, session);
+    const { refs, truncated } = buildReplayDivergenceScreenRefs(snapshot.nodes);
+    return {
+      state: 'available',
+      refsGeneration: session.snapshotGeneration ?? 0,
+      refs,
+      ...(truncated ? { truncated: true as const } : {}),
+    };
+  } catch (error) {
+    return {
+      state: 'unavailable',
+      reason: 'capture-failed',
+      hint: `Post-failure snapshot capture failed (${error instanceof Error ? error.message : String(error)}); the original replay failure is unaffected.`,
+    };
+  }
+}
+
+// Full-resolution cap; response-level bounding (8/20) is applied afterwards
+// by boundReplayDivergence/applyReplayDivergenceLevelCaps.
+const SCREEN_REF_CAPTURE_LIMIT = 20;
+
+function buildReplayDivergenceScreenRefs(nodes: SnapshotNode[]): {
+  refs: ReplayDivergenceScreenRef[];
+  truncated: boolean;
+} {
+  const candidates = nodes.filter((node) => node.ref && node.interactionBlocked !== 'covered');
+  const refs = candidates.slice(0, SCREEN_REF_CAPTURE_LIMIT).map((node) => {
+    const role = formatRole(node.type ?? 'Element');
+    const label = displayLabel(node, role);
+    return {
+      ref: node.ref!,
+      role: truncateUtf8Field(role),
+      ...(label ? { label: truncateUtf8Field(label) } : {}),
+    };
+  });
+  return { refs, truncated: candidates.length > refs.length };
+}
+
+const BASIS_RANK: Record<ReplayDivergenceSuggestionBasis, number> = {
+  id: 0,
+  'role-label': 1,
+  label: 2,
+  other: 3,
+};
+
+function classifySuggestionBasis(selector: Selector): ReplayDivergenceSuggestionBasis {
+  const keys = new Set(selector.terms.map((term) => term.key));
+  if (keys.has('id')) return 'id';
+  const hasRole = keys.has('role');
+  const hasLabelLike = keys.has('label') || keys.has('text');
+  if (hasRole && hasLabelLike) return 'role-label';
+  if (hasLabelLike || keys.has('value')) return 'label';
+  return 'other';
+}
+
+/**
+ * Decision 1's ranked-suggestions machinery, repurposed READ-ONLY:
+ * `collectReplaySelectorCandidates` + `resolveSelectorChain` re-resolution
+ * (the exact pieces `healReplayAction` already used) collect candidates
+ * instead of applying the first one. Ranking: identity-component strength
+ * (id > role+label > label > other), then document order. The
+ * same-scrollRegion-as-recorded tier from decision 1's total order is not
+ * evaluated here — that requires decision 3's recorded target evidence,
+ * which migration step 2 has no dependency on and does not consume.
+ */
+async function collectReplayDivergenceSuggestions(params: {
+  action: SessionAction;
+  session: SessionState;
+  sessionName: string;
+  sessionStore: SessionStore;
+  logPath: string;
+}): Promise<ReplayDivergenceSuggestion[]> {
+  const { action, session, sessionName, sessionStore, logPath } = params;
+  if (!isSuggestionEligibleCommand(action.command)) return [];
+  const candidates = collectReplaySelectorCandidates(action);
+  if (candidates.length === 0) return [];
+
+  const matching = resolveSuggestionMatchingConfig(action);
+  const nodes = await captureSuggestionSnapshotNodes({
+    session,
+    sessionName,
+    sessionStore,
+    logPath,
+    action,
+    requiresRect: matching.requiresRect,
+  });
+  if (!nodes) return [];
+
+  return rankSuggestionCandidates({ candidates, nodes, session, action, matching });
+}
+
+function isSuggestionEligibleCommand(command: string): boolean {
+  return isTouchTargetCommand(command) || ['fill', 'get', 'is', 'wait'].includes(command);
+}
+
+type SuggestionMatchingConfig = { requiresRect: boolean; allowDisambiguation: boolean };
+
+function resolveSuggestionMatchingConfig(action: SessionAction): SuggestionMatchingConfig {
+  const isTouch = isTouchTargetCommand(action.command);
+  return {
+    requiresRect: isTouch || action.command === 'fill',
+    allowDisambiguation:
+      isTouch ||
+      action.command === 'fill' ||
+      (action.command === 'get' && action.positionals?.[0] === 'text'),
+  };
+}
+
+/**
+ * A fresh snapshot capture for suggestion re-resolution (a second capture
+ * beyond the screen digest's own, matching healReplayAction's established
+ * `snapshotInteractiveOnly: requiresRect` semantics exactly — see the module
+ * doc comment on `collectReplayDivergenceSuggestions`). Returns `undefined`
+ * on capture failure so the caller degrades to no suggestions, same as an
+ * unavailable screen never masks the original cause.
+ */
+async function captureSuggestionSnapshotNodes(params: {
+  session: SessionState;
+  sessionName: string;
+  sessionStore: SessionStore;
+  logPath: string;
+  action: SessionAction;
+  requiresRect: boolean;
+}): Promise<SnapshotNode[] | undefined> {
+  const { session, sessionName, sessionStore, logPath, action, requiresRect } = params;
+  try {
+    const snapshot = await captureSnapshotForReplay(
+      session,
+      action,
+      logPath,
+      requiresRect,
+      sessionStore,
+    );
+    // captureSnapshotForReplay already stored + advanced the session snapshot
+    // generation; re-read so suggestion refs are blessed against the tree
+    // they came from, same as the screen digest.
+    if (sessionStore.get(sessionName)?.snapshotGeneration !== undefined) {
+      markSessionSnapshotRefsIssued(session);
+    }
+    return snapshot.nodes;
+  } catch {
+    return undefined;
+  }
+}
+
+type RankedSuggestion = { suggestion: ReplayDivergenceSuggestion; basisRank: number; nodeIndex: number };
+
+function rankSuggestionCandidates(params: {
+  candidates: string[];
+  nodes: SnapshotNode[];
+  session: SessionState;
+  action: SessionAction;
+  matching: SuggestionMatchingConfig;
+}): ReplayDivergenceSuggestion[] {
+  const { candidates, nodes, session, action, matching } = params;
+  const ranked: RankedSuggestion[] = [];
+  const seenNodes = new Set<string>();
+  for (const candidate of candidates) {
+    const entry = resolveSuggestionCandidate({ candidate, nodes, session, action, matching });
+    if (!entry) continue;
+    const nodeKey = entry.suggestion.ref ?? `idx:${entry.nodeIndex}`;
+    if (seenNodes.has(nodeKey)) continue;
+    seenNodes.add(nodeKey);
+    ranked.push(entry);
+  }
+  ranked.sort((a, b) => a.basisRank - b.basisRank || a.nodeIndex - b.nodeIndex);
+  return ranked.map((entry) => entry.suggestion);
+}
+
+function resolveSuggestionCandidate(params: {
+  candidate: string;
+  nodes: SnapshotNode[];
+  session: SessionState;
+  action: SessionAction;
+  matching: SuggestionMatchingConfig;
+}): RankedSuggestion | undefined {
+  const { candidate, nodes, session, action, matching } = params;
+  const chain = tryParseSelectorChain(candidate);
+  if (!chain) return undefined;
+  const resolved = resolveSelectorChain(nodes, chain, {
+    platform: session.device.platform,
+    requireRect: matching.requiresRect,
+    requireUnique: true,
+    disambiguateAmbiguous: matching.allowDisambiguation,
+  });
+  if (!resolved) return undefined;
+
+  const selectorChain = buildSelectorChainForNode(resolved.node, session.device.platform, {
+    action: action.command === 'fill' ? 'fill' : isTouchTargetCommand(action.command) ? 'click' : 'get',
+  });
+  const basis = classifySuggestionBasis(resolved.selector);
+  const role = formatRole(resolved.node.type ?? 'Element');
+  const label = displayLabel(resolved.node, role);
+  return {
+    suggestion: {
+      selector: truncateUtf8Field(selectorChain.join(' || ')),
+      basis,
+      ...(resolved.node.ref ? { ref: resolved.node.ref } : {}),
+      role: truncateUtf8Field(role),
+      ...(label ? { label: truncateUtf8Field(label) } : {}),
+    },
+    basisRank: BASIS_RANK[basis],
+    nodeIndex: resolved.node.index,
+  };
+}
+
+function writeReplayDivergenceArtifact(
+  sessionStore: SessionStore,
+  sessionName: string,
+  payload: ReplayDivergence,
+): { artifactPath: string } | { artifactUnavailable: true } {
+  try {
+    const dir = path.join(sessionStore.ensureSessionDir(sessionName), 'replay-divergence');
+    fs.mkdirSync(dir, { recursive: true });
+    const fileName = `${Date.now()}-step${payload.step.index}.json`;
+    const artifactPath = path.join(dir, fileName);
+    fs.writeFileSync(artifactPath, `${JSON.stringify(redactDiagnosticData(payload), null, 2)}\n`);
+    return { artifactPath };
+  } catch {
+    return { artifactUnavailable: true };
+  }
+}

--- a/src/daemon/handlers/session-replay-heal.ts
+++ b/src/daemon/handlers/session-replay-heal.ts
@@ -200,7 +200,7 @@ function isFiniteNumberString(value: string | undefined): boolean {
   return Number.isFinite(Number(value));
 }
 
-export async function captureSnapshotForReplay(
+async function captureSnapshotForReplay(
   session: SessionState,
   action: SessionAction,
   logPath: string,

--- a/src/daemon/handlers/session-replay-heal.ts
+++ b/src/daemon/handlers/session-replay-heal.ts
@@ -36,7 +36,7 @@ function parseSelectorWaitPositionals(positionals: string[]): {
 }
 
 // fallow-ignore-next-line complexity
-function collectReplaySelectorCandidates(action: SessionAction): string[] {
+export function collectReplaySelectorCandidates(action: SessionAction): string[] {
   const result: string[] = [];
   const explicitChain =
     Array.isArray(action.result?.selectorChain) &&
@@ -200,7 +200,7 @@ function isFiniteNumberString(value: string | undefined): boolean {
   return Number.isFinite(Number(value));
 }
 
-async function captureSnapshotForReplay(
+export async function captureSnapshotForReplay(
   session: SessionState,
   action: SessionAction,
   logPath: string,

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -19,10 +19,12 @@ import { invokeReplayAction } from './session-replay-action-runtime.ts';
 import { tryParseSelectorChain } from '../selectors.ts';
 import {
   buildReplayVarScope,
+  collectReplayScrubbableVarValues,
   collectReplayShellEnv,
   parseReplayCliEnvEntries,
   readReplayCliEnvEntries,
   readReplayShellEnvSource,
+  type ReplayVarScope,
 } from '../../replay/vars.ts';
 import {
   summarizeSnapshotTimingSamples,
@@ -30,6 +32,7 @@ import {
   type SnapshotTimingSample,
 } from '../../snapshot-diagnostics.ts';
 import { buildReplayFailureDivergence } from './session-replay-divergence.ts';
+import { scrubReplayVarValues, type ReplayVarScrubEntry } from '../../replay/divergence.ts';
 
 // fallow-ignore-next-line complexity
 export async function runReplayScriptFile(params: {
@@ -98,6 +101,22 @@ export async function runReplayScriptFile(params: {
     const shouldUpdate = req.flags?.replayUpdate === true;
     const actionTracePath = tracePath ?? sessionStore.get(sessionName)?.trace?.outPath;
     const snapshotDiagnosticSamples: SnapshotTimingSample[] = [];
+    const failStep = (failedResponse: DaemonResponse, failedAction: SessionAction, index: number) =>
+      withReplayFailureDiagnostics({
+        response: failedResponse,
+        action: failedAction,
+        index,
+        replayPath: resolved,
+        sourcePath: actionSourcePaths?.[index] ?? resolved,
+        sourceLine: actionLines[index] ?? 1,
+        artifactPaths: [...artifactPaths],
+        snapshotDiagnosticSamples,
+        scope,
+        req,
+        sessionName,
+        sessionStore,
+        logPath,
+      });
     let healed = 0;
     for (let index = 0; index < actions.length; index += 1) {
       const action = actions[index];
@@ -126,20 +145,7 @@ export async function runReplayScriptFile(params: {
       }
       collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
       if (!shouldUpdate) {
-        return await withReplayFailureDiagnostics({
-          response,
-          action,
-          index,
-          replayPath: resolved,
-          sourcePath: actionSourcePaths?.[index] ?? resolved,
-          sourceLine: actionLines[index] ?? 1,
-          artifactPaths: [...artifactPaths],
-          snapshotDiagnosticSamples,
-          req,
-          sessionName,
-          sessionStore,
-          logPath,
-        });
+        return await failStep(response, action, index);
       }
 
       const nextAction = await healReplayAction({
@@ -149,20 +155,7 @@ export async function runReplayScriptFile(params: {
         sessionStore,
       });
       if (!nextAction) {
-        return await withReplayFailureDiagnostics({
-          response,
-          action,
-          index,
-          replayPath: resolved,
-          sourcePath: actionSourcePaths?.[index] ?? resolved,
-          sourceLine: actionLines[index] ?? 1,
-          artifactPaths: [...artifactPaths],
-          snapshotDiagnosticSamples,
-          req,
-          sessionName,
-          sessionStore,
-          logPath,
-        });
+        return await failStep(response, action, index);
       }
 
       actions[index] = nextAction;
@@ -184,20 +177,7 @@ export async function runReplayScriptFile(params: {
       );
       if (!response.ok) {
         collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
-        return await withReplayFailureDiagnostics({
-          response,
-          action: nextAction,
-          index,
-          replayPath: resolved,
-          sourcePath: actionSourcePaths?.[index] ?? resolved,
-          sourceLine: actionLines[index] ?? 1,
-          artifactPaths: [...artifactPaths],
-          snapshotDiagnosticSamples,
-          req,
-          sessionName,
-          sessionStore,
-          logPath,
-        });
+        return await failStep(response, nextAction, index);
       }
       collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
       healed += 1;
@@ -355,6 +335,7 @@ async function withReplayFailureDiagnostics(params: {
   sourceLine: number;
   artifactPaths: string[];
   snapshotDiagnosticSamples: SnapshotTimingSample[];
+  scope: ReplayVarScope;
   req: DaemonRequest;
   sessionName: string;
   sessionStore: SessionStore;
@@ -381,6 +362,7 @@ async function withReplayFailureContext(params: {
   sourceLine: number;
   artifactPaths?: string[];
   snapshotDiagnostics?: SnapshotDiagnosticsSummary;
+  scope: ReplayVarScope;
   req: DaemonRequest;
   sessionName: string;
   sessionStore: SessionStore;
@@ -395,6 +377,7 @@ async function withReplayFailureContext(params: {
     sourceLine,
     artifactPaths = [],
     snapshotDiagnostics,
+    scope,
     req,
     sessionName,
     sessionStore,
@@ -404,6 +387,8 @@ async function withReplayFailureContext(params: {
   // The failing action's own source (attached by withReplayFailureSource,
   // deepest failure wins) beats the top-level wrapper's source.
   const failureSource = readReplayFailureSource(response.error.details?.replaySource);
+  // Computed at failure time so runtime outputEnv merges are included.
+  const scrubVars = collectReplayScrubbableVarValues(scope);
   const cause = hoistCauseDiagnosticMeta(response.error);
   const divergence = await buildReplayFailureDivergence({
     error: cause,
@@ -416,6 +401,7 @@ async function withReplayFailureContext(params: {
     sessionStore,
     logPath,
     responseLevel: req.meta?.responseLevel,
+    scrubVars,
   });
   return buildReplayDivergenceFailureResponse({
     error: cause,
@@ -425,6 +411,7 @@ async function withReplayFailureContext(params: {
     artifactPaths,
     snapshotDiagnostics,
     divergence,
+    scrubVars,
   });
 }
 
@@ -477,15 +464,29 @@ function buildReplayDivergenceFailureResponse(params: {
   artifactPaths: string[];
   snapshotDiagnostics?: SnapshotDiagnosticsSummary;
   divergence: unknown;
+  scrubVars: ReplayVarScrubEntry[];
 }): DaemonResponse {
-  const { error, action, step, replayPath, artifactPaths, snapshotDiagnostics, divergence } =
-    params;
+  const {
+    error,
+    action,
+    step,
+    replayPath,
+    artifactPaths,
+    snapshotDiagnostics,
+    divergence,
+    scrubVars,
+  } = params;
   return {
     ok: false,
     error: {
       code: 'REPLAY_DIVERGENCE',
-      message: `Replay failed at step ${step} (${formatDivergenceActionLabel(action)}): ${error.message}`,
-      hint: error.hint,
+      // The cause message can echo an expanded selector; the top-level
+      // message gets the same categorical variable scrub as the report.
+      message: scrubReplayVarValues(
+        `Replay failed at step ${step} (${formatDivergenceActionLabel(action)}): ${error.message}`,
+        scrubVars,
+      ),
+      hint: error.hint === undefined ? undefined : scrubReplayVarValues(error.hint, scrubVars),
       diagnosticId: error.diagnosticId,
       logPath: error.logPath,
       details: {

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -489,6 +489,8 @@ function buildReplayDivergenceFailureResponse(params: {
       hint: error.hint === undefined ? undefined : scrubReplayVarValues(error.hint, scrubVars),
       diagnosticId: error.diagnosticId,
       logPath: error.logPath,
+      ...(error.retriable !== undefined ? { retriable: error.retriable } : {}),
+      ...(error.supportedOn !== undefined ? { supportedOn: error.supportedOn } : {}),
       details: {
         ...pickSafeCauseDetails(error.details),
         replayPath,

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -215,10 +215,7 @@ export async function runReplayScriptFile(params: {
         session: sessionName,
         artifactPaths: [...artifactPaths],
         ...(snapshotDiagnosticsSummary ? { snapshotDiagnostics: snapshotDiagnosticsSummary } : {}),
-        // ADR 0012 migration step 2: text replay was previously silent on
-        // success (no `message` key at all — see readCommandMessage). One
-        // line with the step count and wall time closes that gap; --json is
-        // unchanged (message rides alongside the existing fields).
+        // ADR 0012: one-line text success summary; --json shape is additive.
         message: formatReplaySuccessMessage(actions.length, wallClockMs),
       },
     };
@@ -369,15 +366,10 @@ async function withReplayFailureDiagnostics(params: {
 }
 
 /**
- * Every replay step failure goes through this single choke point (ADR 0012
- * migration step 2): the daemon returns `ok:false` with code
- * `REPLAY_DIVERGENCE` and a bounded `details.divergence` report, replacing
- * the underlying failure's own code as the wire-level code (the original
- * code/message/hint move into `divergence.cause`, preserved verbatim). The
- * legacy flat detail fields (`replayPath`, `step`, `action`, `positionals`,
- * `artifactPaths`, `snapshotDiagnostics`) are kept for existing consumers
- * (e.g. `session-test-artifacts.ts`) — this is additive, not a breaking
- * reshape.
+ * Single choke point for replay step failures (ADR 0012 migration step 2):
+ * returns `REPLAY_DIVERGENCE` with a bounded `details.divergence` report;
+ * the original code/message/hint move into `divergence.cause` verbatim, and
+ * the pre-existing flat detail fields are kept for their consumers.
  */
 async function withReplayFailureContext(params: {
   response: DaemonResponse;
@@ -408,12 +400,8 @@ async function withReplayFailureContext(params: {
     logPath,
   } = params;
   if (response.ok) return response;
-  // Deepest-failure provenance (ADR 0012 migration step 2): a failure inside
-  // a control-flow wrapper (retry:/runFlow.when: around a runFlow include)
-  // attaches the failing NESTED action's resolved source to the error
-  // (session-replay-action-runtime.ts withReplayFailureSource); it wins over
-  // the top-level wrapper's own source. Transport-internal: stripped from the
-  // flat details in buildReplayDivergenceFailureResponse.
+  // The failing action's own source (attached by withReplayFailureSource,
+  // deepest failure wins) beats the top-level wrapper's source.
   const failureSource = readReplayFailureSource(response.error.details?.replaySource);
   const divergence = await buildReplayFailureDivergence({
     error: response.error,

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -28,6 +28,7 @@ import {
   type SnapshotDiagnosticsSummary,
   type SnapshotTimingSample,
 } from '../../snapshot-diagnostics.ts';
+import { buildReplayFailureDivergence } from './session-replay-divergence.ts';
 
 // fallow-ignore-next-line complexity
 export async function runReplayScriptFile(params: {
@@ -44,6 +45,7 @@ export async function runReplayScriptFile(params: {
     return errorResponse('INVALID_ARGS', 'replay requires a path');
   }
 
+  const startedAt = Date.now();
   let resolved = '';
   const artifactPaths = new Set<string>();
   try {
@@ -65,6 +67,7 @@ export async function runReplayScriptFile(params: {
         : req;
     const actions = parsed.actions;
     const actionLines = parsed.actionLines;
+    const actionSourcePaths = parsed.actionSourcePaths;
     if (req.flags?.replayUpdate === true && parsed.updateUnsupportedMessage) {
       return errorResponse('INVALID_ARGS', parsed.updateUnsupportedMessage);
     }
@@ -121,14 +124,20 @@ export async function runReplayScriptFile(params: {
       }
       collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
       if (!shouldUpdate) {
-        return withReplayFailureDiagnostics(
+        return await withReplayFailureDiagnostics({
           response,
           action,
           index,
-          resolved,
-          [...artifactPaths],
+          replayPath: resolved,
+          sourcePath: actionSourcePaths?.[index] ?? resolved,
+          sourceLine: actionLines[index] ?? 0,
+          artifactPaths: [...artifactPaths],
           snapshotDiagnosticSamples,
-        );
+          req,
+          sessionName,
+          sessionStore,
+          logPath,
+        });
       }
 
       const nextAction = await healReplayAction({
@@ -138,14 +147,20 @@ export async function runReplayScriptFile(params: {
         sessionStore,
       });
       if (!nextAction) {
-        return withReplayFailureDiagnostics(
+        return await withReplayFailureDiagnostics({
           response,
           action,
           index,
-          resolved,
-          [...artifactPaths],
+          replayPath: resolved,
+          sourcePath: actionSourcePaths?.[index] ?? resolved,
+          sourceLine: actionLines[index] ?? 0,
+          artifactPaths: [...artifactPaths],
           snapshotDiagnosticSamples,
-        );
+          req,
+          sessionName,
+          sessionStore,
+          logPath,
+        });
       }
 
       actions[index] = nextAction;
@@ -166,14 +181,20 @@ export async function runReplayScriptFile(params: {
       );
       if (!response.ok) {
         collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
-        return withReplayFailureDiagnostics(
+        return await withReplayFailureDiagnostics({
           response,
-          nextAction,
+          action: nextAction,
           index,
-          resolved,
-          [...artifactPaths],
+          replayPath: resolved,
+          sourcePath: actionSourcePaths?.[index] ?? resolved,
+          sourceLine: actionLines[index] ?? 0,
+          artifactPaths: [...artifactPaths],
           snapshotDiagnosticSamples,
-        );
+          req,
+          sessionName,
+          sessionStore,
+          logPath,
+        });
       }
       collectReplayActionArtifactPaths(response).forEach((entry) => artifactPaths.add(entry));
       healed += 1;
@@ -183,6 +204,7 @@ export async function runReplayScriptFile(params: {
       writeReplayScript(resolved, actions, sessionStore.get(sessionName));
     }
     const snapshotDiagnosticsSummary = summarizeSnapshotTimingSamples(snapshotDiagnosticSamples);
+    const wallClockMs = Date.now() - startedAt;
     return {
       ok: true,
       data: {
@@ -191,6 +213,11 @@ export async function runReplayScriptFile(params: {
         session: sessionName,
         artifactPaths: [...artifactPaths],
         ...(snapshotDiagnosticsSummary ? { snapshotDiagnostics: snapshotDiagnosticsSummary } : {}),
+        // ADR 0012 migration step 2: text replay was previously silent on
+        // success (no `message` key at all — see readCommandMessage). One
+        // line with the step count and wall time closes that gap; --json is
+        // unchanged (message rides alongside the existing fields).
+        message: formatReplaySuccessMessage(actions.length, wallClockMs),
       },
     };
   } catch (err) {
@@ -319,38 +346,83 @@ function buildReplayMetadataFlags(
   };
 }
 
-function withReplayFailureDiagnostics(
-  response: DaemonResponse,
-  action: SessionAction,
-  index: number,
-  replayPath: string,
-  artifactPaths: string[],
-  snapshotDiagnosticSamples: SnapshotTimingSample[],
-): DaemonResponse {
-  return withReplayFailureContext(
+async function withReplayFailureDiagnostics(params: {
+  response: DaemonResponse;
+  action: SessionAction;
+  index: number;
+  replayPath: string;
+  sourcePath: string;
+  sourceLine: number;
+  artifactPaths: string[];
+  snapshotDiagnosticSamples: SnapshotTimingSample[];
+  req: DaemonRequest;
+  sessionName: string;
+  sessionStore: SessionStore;
+  logPath: string;
+}): Promise<DaemonResponse> {
+  return await withReplayFailureContext({
+    ...params,
+    snapshotDiagnostics: summarizeSnapshotTimingSamples(params.snapshotDiagnosticSamples),
+  });
+}
+
+/**
+ * Every replay step failure goes through this single choke point (ADR 0012
+ * migration step 2): the daemon returns `ok:false` with code
+ * `REPLAY_DIVERGENCE` and a bounded `details.divergence` report, replacing
+ * the underlying failure's own code as the wire-level code (the original
+ * code/message/hint move into `divergence.cause`, preserved verbatim). The
+ * legacy flat detail fields (`replayPath`, `step`, `action`, `positionals`,
+ * `artifactPaths`, `snapshotDiagnostics`) are kept for existing consumers
+ * (e.g. `session-test-artifacts.ts`) — this is additive, not a breaking
+ * reshape.
+ */
+async function withReplayFailureContext(params: {
+  response: DaemonResponse;
+  action: SessionAction;
+  index: number;
+  replayPath: string;
+  sourcePath: string;
+  sourceLine: number;
+  artifactPaths?: string[];
+  snapshotDiagnostics?: SnapshotDiagnosticsSummary;
+  req: DaemonRequest;
+  sessionName: string;
+  sessionStore: SessionStore;
+  logPath: string;
+}): Promise<DaemonResponse> {
+  const {
     response,
     action,
     index,
     replayPath,
-    artifactPaths,
-    summarizeSnapshotTimingSamples(snapshotDiagnosticSamples),
-  );
-}
-
-function withReplayFailureContext(
-  response: DaemonResponse,
-  action: SessionAction,
-  index: number,
-  replayPath: string,
-  artifactPaths: string[] = [],
-  snapshotDiagnostics?: SnapshotDiagnosticsSummary,
-): DaemonResponse {
+    sourcePath,
+    sourceLine,
+    artifactPaths = [],
+    snapshotDiagnostics,
+    req,
+    sessionName,
+    sessionStore,
+    logPath,
+  } = params;
   if (response.ok) return response;
   const step = index + 1;
+  const divergence = await buildReplayFailureDivergence({
+    error: response.error,
+    action,
+    index,
+    sourcePath,
+    sourceLine,
+    session: sessionStore.get(sessionName),
+    sessionName,
+    sessionStore,
+    logPath,
+    responseLevel: req.meta?.responseLevel,
+  });
   return {
     ok: false,
     error: {
-      code: response.error.code,
+      code: 'REPLAY_DIVERGENCE',
       message: `Replay failed at step ${step} (${formatScriptActionSummary(action)}): ${response.error.message}`,
       hint: response.error.hint,
       diagnosticId: response.error.diagnosticId,
@@ -363,9 +435,16 @@ function withReplayFailureContext(
         positionals: action.positionals ?? [],
         artifactPaths,
         ...(snapshotDiagnostics ? { snapshotDiagnostics } : {}),
+        divergence,
       },
     },
   };
+}
+
+function formatReplaySuccessMessage(replayed: number, wallClockMs: number): string {
+  const seconds = (wallClockMs / 1000).toFixed(1);
+  const noun = replayed === 1 ? 'step' : 'steps';
+  return `Replayed ${replayed} ${noun} in ${seconds}s`;
 }
 
 // fallow-ignore-next-line complexity

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -404,8 +404,9 @@ async function withReplayFailureContext(params: {
   // The failing action's own source (attached by withReplayFailureSource,
   // deepest failure wins) beats the top-level wrapper's source.
   const failureSource = readReplayFailureSource(response.error.details?.replaySource);
+  const cause = hoistCauseDiagnosticMeta(response.error);
   const divergence = await buildReplayFailureDivergence({
-    error: response.error,
+    error: cause,
     action,
     index,
     sourcePath: failureSource?.path ?? sourcePath,
@@ -417,7 +418,7 @@ async function withReplayFailureContext(params: {
     responseLevel: req.meta?.responseLevel,
   });
   return buildReplayDivergenceFailureResponse({
-    error: response.error,
+    error: cause,
     action,
     step: index + 1,
     replayPath,
@@ -425,6 +426,46 @@ async function withReplayFailureContext(params: {
     snapshotDiagnostics,
     divergence,
   });
+}
+
+type ReplayFailureCause = Extract<DaemonResponse, { ok: false }>['error'];
+
+// Throw sites may carry hint/diagnosticId/logPath inside details (the
+// documented AppErrorDetails meta keys, normally lifted by normalizeError);
+// the categorical cause-detail strip below would lose them, so hoist onto the
+// error fields first.
+function hoistCauseDiagnosticMeta(error: ReplayFailureCause): ReplayFailureCause {
+  return {
+    ...error,
+    hint: error.hint ?? readStringDetail(error.details, 'hint'),
+    diagnosticId: error.diagnosticId ?? readStringDetail(error.details, 'diagnosticId'),
+    logPath: error.logPath ?? readStringDetail(error.details, 'logPath'),
+  };
+}
+
+function readStringDetail(
+  details: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = details?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+// ADR 0012: arbitrary nested cause details are never serialized into the
+// public divergence error — value-bearing command details (fill
+// verification's `expected`/`actual`, selector diagnostics, process output)
+// are categorically dropped; only machine-dispatchable signals survive.
+const SAFE_CAUSE_DETAIL_KEYS = ['reason', 'retriable', 'supportedOn'] as const;
+
+function pickSafeCauseDetails(
+  details: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!details) return {};
+  const safe: Record<string, unknown> = {};
+  for (const key of SAFE_CAUSE_DETAIL_KEYS) {
+    if (details[key] !== undefined) safe[key] = details[key];
+  }
+  return safe;
 }
 
 /** Pure wire shaping for the REPLAY_DIVERGENCE failure response. */
@@ -439,7 +480,6 @@ function buildReplayDivergenceFailureResponse(params: {
 }): DaemonResponse {
   const { error, action, step, replayPath, artifactPaths, snapshotDiagnostics, divergence } =
     params;
-  const { replaySource: _replaySource, ...causeDetails } = error.details ?? {};
   return {
     ok: false,
     error: {
@@ -449,7 +489,7 @@ function buildReplayDivergenceFailureResponse(params: {
       diagnosticId: error.diagnosticId,
       logPath: error.logPath,
       details: {
-        ...causeDetails,
+        ...pickSafeCauseDetails(error.details),
         replayPath,
         step,
         action: action.command,

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -110,7 +110,8 @@ export async function runReplayScriptFile(params: {
         action,
         scope,
         filePath: resolved,
-        line: actionLines[index] ?? 0,
+        line: actionLines[index] ?? 1,
+        sourcePath: actionSourcePaths?.[index],
         step: index + 1,
         tracePath: actionTracePath,
         invoke,
@@ -130,7 +131,7 @@ export async function runReplayScriptFile(params: {
           index,
           replayPath: resolved,
           sourcePath: actionSourcePaths?.[index] ?? resolved,
-          sourceLine: actionLines[index] ?? 0,
+          sourceLine: actionLines[index] ?? 1,
           artifactPaths: [...artifactPaths],
           snapshotDiagnosticSamples,
           req,
@@ -153,7 +154,7 @@ export async function runReplayScriptFile(params: {
           index,
           replayPath: resolved,
           sourcePath: actionSourcePaths?.[index] ?? resolved,
-          sourceLine: actionLines[index] ?? 0,
+          sourceLine: actionLines[index] ?? 1,
           artifactPaths: [...artifactPaths],
           snapshotDiagnosticSamples,
           req,
@@ -171,7 +172,8 @@ export async function runReplayScriptFile(params: {
         action: nextAction,
         scope,
         filePath: resolved,
-        line: actionLines[index] ?? 0,
+        line: actionLines[index] ?? 1,
+        sourcePath: actionSourcePaths?.[index],
         step: index + 1,
         tracePath: actionTracePath,
         invoke,
@@ -187,7 +189,7 @@ export async function runReplayScriptFile(params: {
           index,
           replayPath: resolved,
           sourcePath: actionSourcePaths?.[index] ?? resolved,
-          sourceLine: actionLines[index] ?? 0,
+          sourceLine: actionLines[index] ?? 1,
           artifactPaths: [...artifactPaths],
           snapshotDiagnosticSamples,
           req,
@@ -406,29 +408,59 @@ async function withReplayFailureContext(params: {
     logPath,
   } = params;
   if (response.ok) return response;
-  const step = index + 1;
+  // Deepest-failure provenance (ADR 0012 migration step 2): a failure inside
+  // a control-flow wrapper (retry:/runFlow.when: around a runFlow include)
+  // attaches the failing NESTED action's resolved source to the error
+  // (session-replay-action-runtime.ts withReplayFailureSource); it wins over
+  // the top-level wrapper's own source. Transport-internal: stripped from the
+  // flat details in buildReplayDivergenceFailureResponse.
+  const failureSource = readReplayFailureSource(response.error.details?.replaySource);
   const divergence = await buildReplayFailureDivergence({
     error: response.error,
     action,
     index,
-    sourcePath,
-    sourceLine,
+    sourcePath: failureSource?.path ?? sourcePath,
+    sourceLine: failureSource?.line ?? sourceLine,
     session: sessionStore.get(sessionName),
     sessionName,
     sessionStore,
     logPath,
     responseLevel: req.meta?.responseLevel,
   });
+  return buildReplayDivergenceFailureResponse({
+    error: response.error,
+    action,
+    step: index + 1,
+    replayPath,
+    artifactPaths,
+    snapshotDiagnostics,
+    divergence,
+  });
+}
+
+/** Pure wire shaping for the REPLAY_DIVERGENCE failure response. */
+function buildReplayDivergenceFailureResponse(params: {
+  error: Extract<DaemonResponse, { ok: false }>['error'];
+  action: SessionAction;
+  step: number;
+  replayPath: string;
+  artifactPaths: string[];
+  snapshotDiagnostics?: SnapshotDiagnosticsSummary;
+  divergence: unknown;
+}): DaemonResponse {
+  const { error, action, step, replayPath, artifactPaths, snapshotDiagnostics, divergence } =
+    params;
+  const { replaySource: _replaySource, ...causeDetails } = error.details ?? {};
   return {
     ok: false,
     error: {
       code: 'REPLAY_DIVERGENCE',
-      message: `Replay failed at step ${step} (${formatScriptActionSummary(action)}): ${response.error.message}`,
-      hint: response.error.hint,
-      diagnosticId: response.error.diagnosticId,
-      logPath: response.error.logPath,
+      message: `Replay failed at step ${step} (${formatScriptActionSummary(action)}): ${error.message}`,
+      hint: error.hint,
+      diagnosticId: error.diagnosticId,
+      logPath: error.logPath,
       details: {
-        ...(response.error.details ?? {}),
+        ...causeDetails,
         replayPath,
         step,
         action: action.command,
@@ -439,6 +471,15 @@ async function withReplayFailureContext(params: {
       },
     },
   };
+}
+
+function readReplayFailureSource(value: unknown): { path?: string; line?: number } | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const path = typeof record.path === 'string' && record.path.length > 0 ? record.path : undefined;
+  const line = typeof record.line === 'number' ? record.line : undefined;
+  if (path === undefined && line === undefined) return undefined;
+  return { path, line };
 }
 
 function formatReplaySuccessMessage(replayed: number, wallClockMs: number): string {

--- a/src/daemon/handlers/session-replay-runtime.ts
+++ b/src/daemon/handlers/session-replay-runtime.ts
@@ -12,7 +12,8 @@ import {
 import { SessionStore } from '../session-store.ts';
 import { type ReplayScriptMetadata, writeReplayScript } from '../../replay/script.ts';
 import { healReplayAction } from './session-replay-heal.ts';
-import { formatScriptActionSummary } from '../../replay/script-utils.ts';
+import { formatDivergenceActionLabel } from '../../replay/script-utils.ts';
+import { buildDisplayPositionals } from '../session-event-action.ts';
 import { errorResponse } from './response.ts';
 import { invokeReplayAction } from './session-replay-action-runtime.ts';
 import { tryParseSelectorChain } from '../selectors.ts';
@@ -443,7 +444,7 @@ function buildReplayDivergenceFailureResponse(params: {
     ok: false,
     error: {
       code: 'REPLAY_DIVERGENCE',
-      message: `Replay failed at step ${step} (${formatScriptActionSummary(action)}): ${error.message}`,
+      message: `Replay failed at step ${step} (${formatDivergenceActionLabel(action)}): ${error.message}`,
       hint: error.hint,
       diagnosticId: error.diagnosticId,
       logPath: error.logPath,
@@ -452,7 +453,9 @@ function buildReplayDivergenceFailureResponse(params: {
         replayPath,
         step,
         action: action.command,
-        positionals: action.positionals ?? [],
+        // Categorical text hiding (`<text:N chars>`), never raw fill/type/
+        // payload text — the same event-log sanitizer.
+        positionals: buildDisplayPositionals(action) ?? [],
         artifactPaths,
         ...(snapshotDiagnostics ? { snapshotDiagnostics } : {}),
         divergence,

--- a/src/daemon/session-event-action.ts
+++ b/src/daemon/session-event-action.ts
@@ -159,7 +159,7 @@ function readAppTargetLabel(result: Record<string, unknown>): string | undefined
   );
 }
 
-function buildDisplayPositionals(action: SessionAction): string[] | undefined {
+export function buildDisplayPositionals(action: SessionAction): string[] | undefined {
   if (action.positionals.length === 0) return undefined;
   if (action.command === PUBLIC_COMMANDS.type) {
     return [hiddenValueFromLength('text', readActionTextLength(action))];

--- a/src/daemon/session-snapshot.ts
+++ b/src/daemon/session-snapshot.ts
@@ -35,10 +35,13 @@ export const STALE_SNAPSHOT_REFS_WARNING =
  * refs: the snapshot command response (buildNextSnapshotSession), find
  * responses that return a ref minted from the freshly stored tree
  * (handlers/find.ts, dispatchFindReadOnlyViaRuntime in selector-runtime.ts),
- * and interaction --settle responses whose settled diff carries refs minted
+ * interaction --settle responses whose settled diff carries refs minted
  * from the freshly stored settled tree (settleRefsGenerationIssue in
  * handlers/interaction-touch.ts — the same accepted coarse blessing as find's
- * single re-issued ref; per-ref precision is the MCP pin layer's job).
+ * single re-issued ref; per-ref precision is the MCP pin layer's job), and
+ * replay divergence reports whose screen digest hands out refs from the
+ * freshly stored post-failure tree (captureDivergenceObservation in
+ * handlers/session-replay-divergence.ts, ADR 0012 migration step 2).
  */
 export function setSessionSnapshot(session: SessionState, snapshot: SnapshotState): void {
   if (session.snapshot !== snapshot) {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -405,4 +405,14 @@ export type SessionAction = {
    * Inert until migration step 4 adds enforcement.
    */
   targetEvidence?: TargetAnnotationV1;
+  /**
+   * Maestro-parse-only provenance (ADR 0012 migration step 2): set transiently
+   * on an action produced by inlining a `runFlow` include, carrying the
+   * include file's resolved path and its own line number. The Maestro parser
+   * (`src/compat/maestro/replay-flow.ts`) reads this back into the returned
+   * `actionSourcePaths`/`actionLines` arrays and strips the field before the
+   * action leaves the parse pipeline — it never reaches dispatch, session
+   * history, or `.ad` rewriting.
+   */
+  replaySource?: { path: string; line: number };
 };

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -371,13 +371,10 @@ export type SessionState = {
 };
 
 /**
- * Per-nested-action source provenance for control-flow wrappers (ADR 0012
- * migration step 2): parallel to `actions`, `undefined` at an index means
- * "the file the wrapping control action itself came from". Populated at
- * parse time by stripping the transient `SessionAction.replaySource` field
- * off nested actions (a `runFlow` include inside `retry:`/`runFlow.when:`
- * stamps it), so the runtime block invoker can report the failing NESTED
- * step's real file+line instead of the wrapper's.
+ * Per-nested-action source provenance for control-flow wrappers, parallel to
+ * `actions`; `undefined` at an index means "the wrapping control action's own
+ * file". The runtime block invoker reads it so a failure inside a wrapped
+ * `runFlow` include reports the include's file+line, not the wrapper's.
  */
 export type ReplayControlActionSource = { path: string; line: number };
 
@@ -418,17 +415,4 @@ export type SessionAction = {
    * Inert until migration step 4 adds enforcement.
    */
   targetEvidence?: TargetAnnotationV1;
-  /**
-   * Maestro-parse-only provenance (ADR 0012 migration step 2): set transiently
-   * on an action produced by inlining a `runFlow` include, carrying the
-   * include file's resolved path and its own line number. Stripped before an
-   * action leaves the parse pipeline at exactly two places: top-level actions
-   * in `convertRootCommands` (read back into the returned
-   * `actionSourcePaths`/`actionLines` arrays), and actions nested under a
-   * control-flow wrapper (`retry:`/runtime `runFlow.when:`) in
-   * `stripNestedActionSources` (moved into the wrapper's
-   * `replayControl.actionSources`, consulted by the runtime block invoker).
-   * It therefore never reaches dispatch, session history, or `.ad` rewriting.
-   */
-  replaySource?: { path: string; line: number };
 };

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -370,17 +370,30 @@ export type SessionState = {
   appLogFailure?: AppLogFailure;
 };
 
+/**
+ * Per-nested-action source provenance for control-flow wrappers (ADR 0012
+ * migration step 2): parallel to `actions`, `undefined` at an index means
+ * "the file the wrapping control action itself came from". Populated at
+ * parse time by stripping the transient `SessionAction.replaySource` field
+ * off nested actions (a `runFlow` include inside `retry:`/`runFlow.when:`
+ * stamps it), so the runtime block invoker can report the failing NESTED
+ * step's real file+line instead of the wrapper's.
+ */
+export type ReplayControlActionSource = { path: string; line: number };
+
 export type SessionReplayControl =
   | {
       kind: 'maestroRunFlowWhen';
       mode: 'visible' | 'notVisible';
       selector: string;
       actions: SessionAction[];
+      actionSources?: (ReplayControlActionSource | undefined)[];
     }
   | {
       kind: 'retry';
       maxRetries: number;
       actions: SessionAction[];
+      actionSources?: (ReplayControlActionSource | undefined)[];
     };
 
 export type SessionAction = {
@@ -408,11 +421,14 @@ export type SessionAction = {
   /**
    * Maestro-parse-only provenance (ADR 0012 migration step 2): set transiently
    * on an action produced by inlining a `runFlow` include, carrying the
-   * include file's resolved path and its own line number. The Maestro parser
-   * (`src/compat/maestro/replay-flow.ts`) reads this back into the returned
-   * `actionSourcePaths`/`actionLines` arrays and strips the field before the
-   * action leaves the parse pipeline — it never reaches dispatch, session
-   * history, or `.ad` rewriting.
+   * include file's resolved path and its own line number. Stripped before an
+   * action leaves the parse pipeline at exactly two places: top-level actions
+   * in `convertRootCommands` (read back into the returned
+   * `actionSourcePaths`/`actionLines` arrays), and actions nested under a
+   * control-flow wrapper (`retry:`/runtime `runFlow.when:`) in
+   * `stripNestedActionSources` (moved into the wrapper's
+   * `replayControl.actionSources`, consulted by the runtime block invoker).
+   * It therefore never reaches dispatch, session history, or `.ad` rewriting.
    */
   replaySource?: { path: string; line: number };
 };

--- a/src/kernel/errors.ts
+++ b/src/kernel/errors.ts
@@ -13,6 +13,7 @@ export type KnownAppErrorCode =
   | 'SESSION_NOT_FOUND'
   | 'UNAUTHORIZED'
   | 'AMBIGUOUS_MATCH'
+  | 'REPLAY_DIVERGENCE'
   | 'UNKNOWN';
 
 // Intentionally widened with `(string & {})` so daemon-originated codes pass
@@ -242,6 +243,8 @@ export function defaultHintForCode(code: string): string | undefined {
       return 'Multiple candidates matched. Narrow the query or pass an exact identifier.';
     case 'DEVICE_IN_USE':
       return 'The device is busy with another agent-device request; retry once it frees up.';
+    case 'REPLAY_DIVERGENCE':
+      return 'Read details.divergence (screen/suggestions) for repair context, or rerun with --json for the full report.';
     case 'NOT_IMPLEMENTED':
       return 'This command is part of the planned API but is not implemented yet.';
     case 'COMMAND_FAILED':

--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -3,6 +3,7 @@ import { test } from 'vitest';
 import type { AgentDeviceClient } from '../../client/client-types.ts';
 import { createCommandToolExecutor, listCommandTools } from '../command-tools.ts';
 import { COMMAND_OUTPUT_SCHEMAS } from '../command-output-schemas.ts';
+import { AppError } from '../../kernel/errors.ts';
 
 test('MCP command tool executor hides client creation behind an execution adapter', async () => {
   const client = {} as AgentDeviceClient;
@@ -713,4 +714,80 @@ test('MCP renders tool text from the unpinned input so the model never sees suff
   const result = await executor.execute('press', { target: { kind: 'ref', ref: '@e2' } });
 
   assert.doesNotMatch(result.content[0]?.text ?? '', /~s9/);
+});
+
+// --- ADR 0012 migration step 2: replay divergence is a ref-issuing error ---
+
+function replayDivergenceError(): AppError {
+  return new AppError('REPLAY_DIVERGENCE', 'Replay failed at step 2 (click "Save"): not hittable', {
+    step: 2,
+    action: 'click',
+    divergence: {
+      version: 1,
+      kind: 'action-failure',
+      step: { index: 2, source: { path: '/tmp/flow.ad', line: 2 } },
+      action: 'click "Save"',
+      cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+      screen: {
+        state: 'available',
+        refsGeneration: 12,
+        refs: [{ ref: 'e5', role: 'button', label: 'Save' }],
+      },
+      suggestions: [],
+      suggestionCount: 0,
+      resume: { allowed: false, reason: 'resume not yet supported' },
+    },
+  });
+}
+
+test('MCP tool error is a ref-issuing result: isError, structuredContent, and pinned screen refs', async () => {
+  const runCalls: Array<{ name: string; input: unknown }> = [];
+  const executor = createCommandToolExecutor({
+    createClient: () => ({}) as AgentDeviceClient,
+    runCommand: async (_client, name, input) => {
+      runCalls.push({ name, input });
+      if (name === 'replay') throw replayDivergenceError();
+      return {};
+    },
+  });
+
+  const result = await executor.execute('replay', { positionals: ['/tmp/flow.ad'] });
+
+  assert.equal(result.isError, true);
+  const structured = result.structuredContent as {
+    code: string;
+    details?: { divergence?: { screen?: { refs?: Array<{ ref: string }> } } };
+  };
+  assert.equal(structured.code, 'REPLAY_DIVERGENCE');
+  assert.equal(structured.details?.divergence?.screen?.refs?.[0]?.ref, 'e5');
+  assert.match(result.content[0]?.text ?? '', /Error \(REPLAY_DIVERGENCE\)/);
+
+  // The error-path screen ref is pinned exactly like a successful ref-issuing
+  // response — the caller's next command against @e5 forwards the generation.
+  await executor.execute('press', { target: { kind: 'ref', ref: '@e5' } });
+  assert.deepEqual(runCalls[1]?.input, { target: { kind: 'ref', ref: '@e5~s12' } });
+});
+
+test('MCP tool error without a divergence never touches existing pins (merge-only)', async () => {
+  const runCalls: Array<{ name: string; input: unknown }> = [];
+  const executor = createCommandToolExecutor({
+    createClient: () => ({}) as AgentDeviceClient,
+    runCommand: async (_client, name, input) => {
+      runCalls.push({ name, input });
+      if (name === 'snapshot') {
+        return { nodes: [{ ref: 'e2' }], truncated: false, refsGeneration: 7 };
+      }
+      if (name === 'get') throw new AppError('INVALID_ARGS', 'bad selector');
+      return {};
+    },
+  });
+
+  await executor.execute('snapshot', {});
+  const errorResult = await executor.execute('get', {
+    target: { kind: 'selector', selector: '???' },
+  });
+  assert.equal(errorResult.isError, true);
+
+  await executor.execute('press', { target: { kind: 'ref', ref: '@e2' } });
+  assert.deepEqual(runCalls[2]?.input, { target: { kind: 'ref', ref: '@e2~s7' } });
 });

--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -733,8 +733,10 @@ function replayDivergenceError(): AppError {
         refsGeneration: 12,
         refs: [{ ref: 'e5', role: 'button', label: 'Save' }],
       },
-      suggestions: [],
-      suggestionCount: 0,
+      suggestions: [
+        { selector: 'id="save"', basis: 'id', ref: 'e5', role: 'button', label: 'Save' },
+      ],
+      suggestionCount: 1,
       resume: { allowed: false, reason: 'resume not yet supported' },
     },
   });
@@ -760,7 +762,14 @@ test('MCP tool error is a ref-issuing result: isError, structuredContent, and pi
   };
   assert.equal(structured.code, 'REPLAY_DIVERGENCE');
   assert.equal(structured.details?.divergence?.screen?.refs?.[0]?.ref, 'e5');
-  assert.match(result.content[0]?.text ?? '', /Error \(REPLAY_DIVERGENCE\)/);
+  // The MCP TEXT path must carry the same repair data as structuredContent —
+  // no text-only divergence that loses the screen refs / suggestions.
+  const text = result.content[0]?.text ?? '';
+  assert.match(text, /Error \(REPLAY_DIVERGENCE\)/);
+  assert.match(text, /Divergence at step 2 \(\/tmp\/flow\.ad:2\)/);
+  assert.match(text, /Screen: 1 actionable ref\(s\) captured/);
+  assert.match(text, /Suggestions:/);
+  assert.match(text, /\[id\] "Save" id="save"/);
 
   // The error-path screen ref is pinned exactly like a successful ref-issuing
   // response — the caller's next command against @e5 forwards the generation.

--- a/src/mcp/__tests__/command-tools.test.ts
+++ b/src/mcp/__tests__/command-tools.test.ts
@@ -768,6 +768,8 @@ test('MCP tool error is a ref-issuing result: isError, structuredContent, and pi
   assert.match(text, /Error \(REPLAY_DIVERGENCE\)/);
   assert.match(text, /Divergence at step 2 \(\/tmp\/flow\.ad:2\)/);
   assert.match(text, /Screen: 1 actionable ref\(s\) captured/);
+  // The ref entries themselves ride in the text so a text-only agent can act.
+  assert.match(text, /@e5 \[button\] "Save"/);
   assert.match(text, /Suggestions:/);
   assert.match(text, /\[id\] "Save" id="save"/);
 

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -102,15 +102,10 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
 }
 
 /**
- * ADR 0012 migration step 2: "MCP treats this error as a ref-issuing
- * result" — a command failure (including a `REPLAY_DIVERGENCE`) returns
- * `isError: true` with the full normalized error as `structuredContent` (no
- * text-only path drops the divergence report), and when the error carries an
- * `available` `divergence.screen`, its refs are merged and pinned at
- * `refsGeneration` exactly like a successful ref-issuing response — so the
- * caller's next command against one of those refs works. MERGE-ONLY, like
- * every other pin path here: an unrelated command error never clears the
- * scope's existing pins.
+ * ADR 0012: a command error is a ref-issuing result — `isError: true`, the
+ * normalized error as `structuredContent`, and an `available`
+ * `divergence.screen`'s refs merged/pinned at `refsGeneration` like any
+ * ref-issuing success. Merge-only; never clears existing pins.
  */
 function buildErrorToolResult(
   error: unknown,

--- a/src/mcp/command-tools.ts
+++ b/src/mcp/command-tools.ts
@@ -9,6 +9,7 @@ import {
 } from '../commands/command-metadata.ts';
 import { COMMAND_OUTPUT_SCHEMAS } from './command-output-schemas.ts';
 import { AppError } from '../kernel/errors.ts';
+import { formatToolErrorText, normalizeToolError } from './tool-error.ts';
 
 export type ToolResult = {
   isError: boolean;
@@ -72,28 +73,72 @@ export function createCommandToolExecutor(deps: CommandToolExecutorDeps = {}): C
       const scopeKey = readPinScopeKey(config, commandInput);
       const pinnedInput = pinPlainRefArguments(name, commandInput, refPinsByScope.get(scopeKey));
       const client = await createClient(deps, config.client);
-      const result = await (deps.runCommand ?? runCommand)(client, name, pinnedInput);
-      mergeIssuedRefPins(refPinsByScope, scopeKey, name, result);
-      return {
-        isError: false,
-        structuredContent: result,
-        content: [
-          {
-            type: 'text',
-            // Render from the UNPINNED input: the model typed plain refs and
-            // must never see generation suffixes (zero token cost).
-            text: renderToolText({
-              name,
-              input: commandInput,
-              result,
-              outputFormat: config.outputFormat,
-              responseLevel: config.client.responseLevel,
-            }),
-          },
-        ],
-      };
+      try {
+        const result = await (deps.runCommand ?? runCommand)(client, name, pinnedInput);
+        mergeIssuedRefPins(refPinsByScope, scopeKey, name, result);
+        return {
+          isError: false,
+          structuredContent: result,
+          content: [
+            {
+              type: 'text',
+              // Render from the UNPINNED input: the model typed plain refs and
+              // must never see generation suffixes (zero token cost).
+              text: renderToolText({
+                name,
+                input: commandInput,
+                result,
+                outputFormat: config.outputFormat,
+                responseLevel: config.client.responseLevel,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        return buildErrorToolResult(error, refPinsByScope, scopeKey);
+      }
     },
   };
+}
+
+/**
+ * ADR 0012 migration step 2: "MCP treats this error as a ref-issuing
+ * result" — a command failure (including a `REPLAY_DIVERGENCE`) returns
+ * `isError: true` with the full normalized error as `structuredContent` (no
+ * text-only path drops the divergence report), and when the error carries an
+ * `available` `divergence.screen`, its refs are merged and pinned at
+ * `refsGeneration` exactly like a successful ref-issuing response — so the
+ * caller's next command against one of those refs works. MERGE-ONLY, like
+ * every other pin path here: an unrelated command error never clears the
+ * scope's existing pins.
+ */
+function buildErrorToolResult(
+  error: unknown,
+  refPinsByScope: Map<string, Map<string, number>>,
+  scopeKey: string,
+): ToolResult {
+  const normalized = normalizeToolError(error);
+  mergeDivergenceScreenRefPins(refPinsByScope, scopeKey, normalized.details);
+  return {
+    isError: true,
+    structuredContent: normalized,
+    content: [{ type: 'text', text: formatToolErrorText(normalized) }],
+  };
+}
+
+function mergeDivergenceScreenRefPins(
+  refPinsByScope: Map<string, Map<string, number>>,
+  scopeKey: string,
+  details: Record<string, unknown> | undefined,
+): void {
+  const divergence = asOptionalRecord(details?.divergence);
+  const screen = asOptionalRecord(divergence?.screen);
+  if (!screen || screen.state !== 'available') return;
+  const refsGeneration = screen.refsGeneration;
+  if (typeof refsGeneration !== 'number') return;
+  const issuedRefs: string[] = [];
+  collectRefBodies(screen.refs, issuedRefs);
+  mergeIntoScopedPins(refPinsByScope, scopeKey, issuedRefs, refsGeneration);
 }
 
 /**
@@ -182,11 +227,7 @@ function mergeIssuedRefPins(
     refPinsByScope.delete(scopeKey);
     return;
   }
-  const issuedRefs = readIssuedRefBodies(record);
-  if (issuedRefs.length === 0) return;
-  const pins = refPinsByScope.get(scopeKey) ?? new Map<string, number>();
-  refPinsByScope.set(scopeKey, pins);
-  recordIssuedPins(pins, issuedRefs, refsGeneration);
+  mergeIntoScopedPins(refPinsByScope, scopeKey, readIssuedRefBodies(record), refsGeneration);
 }
 
 /**
@@ -211,6 +252,16 @@ function mergeSettleIssuedRefPins(
   collectRefBodies(lines, issuedRefs);
   collectRefBodies(settle.refs, issuedRefs);
   collectRefBodies(settle.tail, issuedRefs);
+  mergeIntoScopedPins(refPinsByScope, scopeKey, issuedRefs, refsGeneration);
+}
+
+/** Shared merge-only tail: skip empty issuance, else create-or-reuse the scope's pin map and record. */
+function mergeIntoScopedPins(
+  refPinsByScope: Map<string, Map<string, number>>,
+  scopeKey: string,
+  issuedRefs: string[],
+  refsGeneration: number,
+): void {
   if (issuedRefs.length === 0) return;
   const pins = refPinsByScope.get(scopeKey) ?? new Map<string, number>();
   refPinsByScope.set(scopeKey, pins);

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -1,7 +1,8 @@
 import { listCommandTools, commandToolExecutor, type ToolResult } from './command-tools.ts';
 import { readVersion } from '../utils/version.ts';
 import type { JsonRpcId, JsonRpcRequestEnvelope } from '../kernel/contracts.ts';
-import { AppError, normalizeError } from '../kernel/errors.ts';
+import { AppError } from '../kernel/errors.ts';
+import { formatToolErrorText, normalizeToolError } from './tool-error.ts';
 
 const MCP_SERVER_NAME = 'agent-device';
 const SUPPORTED_PROTOCOL_VERSION = '2025-11-25';
@@ -61,20 +62,16 @@ async function callTool(params: unknown): Promise<ToolResult> {
   const record = asRecord(params);
   const name = stringField(record, 'name');
   try {
+    // The executor's own catch (command-tools.ts) handles command-level
+    // failures (including ADR 0012 replay divergence: it builds
+    // structuredContent and pins the error-path screen refs before
+    // returning). This catch is the fallback for failures OUTSIDE a resolved
+    // command call — unknown tool name, malformed params — which never reach
+    // the executor's try/catch at all.
     return await commandToolExecutor.execute(name, record.arguments);
   } catch (error) {
-    return textToolResult(formatToolError(error), true);
+    return textToolResult(formatToolErrorText(normalizeToolError(error)), true);
   }
-}
-
-// Keep the full error contract (code + hint) visible to MCP agents; a bare
-// message string strips exactly the guidance the hint system exists to give.
-function formatToolError(error: unknown): string {
-  const normalized = normalizeError(error);
-  const lines = [`Error (${normalized.code}): ${normalized.message}`];
-  if (normalized.hint) lines.push(`Hint: ${normalized.hint}`);
-  if (normalized.supportedOn) lines.push(`Supported on: ${normalized.supportedOn}`);
-  return lines.join('\n');
 }
 
 function supportedProtocolVersion(_params: unknown): string {

--- a/src/mcp/router.ts
+++ b/src/mcp/router.ts
@@ -62,12 +62,9 @@ async function callTool(params: unknown): Promise<ToolResult> {
   const record = asRecord(params);
   const name = stringField(record, 'name');
   try {
-    // The executor's own catch (command-tools.ts) handles command-level
-    // failures (including ADR 0012 replay divergence: it builds
-    // structuredContent and pins the error-path screen refs before
-    // returning). This catch is the fallback for failures OUTSIDE a resolved
-    // command call — unknown tool name, malformed params — which never reach
-    // the executor's try/catch at all.
+    // Command-level failures are handled (and ref-pinned) by the executor's
+    // own catch; this one covers failures outside a resolved command call
+    // (unknown tool name, malformed params).
     return await commandToolExecutor.execute(name, record.arguments);
   } catch (error) {
     return textToolResult(formatToolErrorText(normalizeToolError(error)), true);

--- a/src/mcp/tool-error.ts
+++ b/src/mcp/tool-error.ts
@@ -1,12 +1,8 @@
 import { normalizeError, type NormalizedError } from '../kernel/errors.ts';
 
 /**
- * Shared MCP error normalization + text rendering, used by both the tool
- * executor's own catch (`command-tools.ts`, so it can pin divergence screen
- * refs before returning) and the router's outer catch (`router.ts`, for
- * failures outside a resolved command — bad tool name, malformed params).
- * Keep the full error contract (code + hint) visible to MCP agents; a bare
- * message string strips exactly the guidance the hint system exists to give.
+ * Shared MCP error normalization + text rendering (executor and router
+ * catches). Keeps the full error contract (code + hint) visible to agents.
  */
 export function normalizeToolError(error: unknown): NormalizedError {
   return normalizeError(error);

--- a/src/mcp/tool-error.ts
+++ b/src/mcp/tool-error.ts
@@ -1,0 +1,20 @@
+import { normalizeError, type NormalizedError } from '../kernel/errors.ts';
+
+/**
+ * Shared MCP error normalization + text rendering, used by both the tool
+ * executor's own catch (`command-tools.ts`, so it can pin divergence screen
+ * refs before returning) and the router's outer catch (`router.ts`, for
+ * failures outside a resolved command — bad tool name, malformed params).
+ * Keep the full error contract (code + hint) visible to MCP agents; a bare
+ * message string strips exactly the guidance the hint system exists to give.
+ */
+export function normalizeToolError(error: unknown): NormalizedError {
+  return normalizeError(error);
+}
+
+export function formatToolErrorText(normalized: NormalizedError): string {
+  const lines = [`Error (${normalized.code}): ${normalized.message}`];
+  if (normalized.hint) lines.push(`Hint: ${normalized.hint}`);
+  if (normalized.supportedOn) lines.push(`Supported on: ${normalized.supportedOn}`);
+  return lines.join('\n');
+}

--- a/src/mcp/tool-error.ts
+++ b/src/mcp/tool-error.ts
@@ -1,4 +1,5 @@
 import { normalizeError, type NormalizedError } from '../kernel/errors.ts';
+import { formatReplayDivergenceReport } from '../replay/divergence.ts';
 
 /**
  * Shared MCP error normalization + text rendering (executor and router
@@ -12,5 +13,10 @@ export function formatToolErrorText(normalized: NormalizedError): string {
   const lines = [`Error (${normalized.code}): ${normalized.message}`];
   if (normalized.hint) lines.push(`Hint: ${normalized.hint}`);
   if (normalized.supportedOn) lines.push(`Supported on: ${normalized.supportedOn}`);
+  // ADR 0012: the MCP text path must carry the same repair data as
+  // structuredContent — a text-only divergence loses the screen refs and
+  // suggestions the agent repairs from.
+  const divergence = formatReplayDivergenceReport(normalized.details);
+  if (divergence) lines.push(divergence);
   return lines.join('\n');
 }

--- a/src/replay/__tests__/divergence.test.ts
+++ b/src/replay/__tests__/divergence.test.ts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import {
+  applyReplayDivergenceLevelCaps,
+  boundReplayDivergence,
+  measureReplayDivergenceBytes,
+  REPLAY_DIVERGENCE_DEFAULT_REF_LIMIT,
+  REPLAY_DIVERGENCE_DIGEST_REF_LIMIT,
+  REPLAY_DIVERGENCE_LEVEL_BYTE_LIMITS,
+  REPLAY_DIVERGENCE_RESUME_NOT_SUPPORTED,
+  REPLAY_DIVERGENCE_SUGGESTION_LIMIT,
+  truncateUtf8Field,
+  type ReplayDivergence,
+} from '../divergence.ts';
+
+function buildDivergence(overrides: Partial<ReplayDivergence> = {}): ReplayDivergence {
+  return {
+    version: 1,
+    kind: 'action-failure',
+    step: { index: 3, source: { path: '/tmp/flow.ad', line: 5 } },
+    action: 'click "Save"',
+    cause: { code: 'COMMAND_FAILED', message: 'Selector did not match', hint: 'Run find.' },
+    screen: { state: 'available', refsGeneration: 4, refs: [{ ref: 'e1', role: 'button' }] },
+    suggestions: [],
+    suggestionCount: 0,
+    resume: REPLAY_DIVERGENCE_RESUME_NOT_SUPPORTED,
+    ...overrides,
+  };
+}
+
+test('truncateUtf8Field leaves short strings untouched', () => {
+  assert.equal(truncateUtf8Field('hello'), 'hello');
+});
+
+test('truncateUtf8Field truncates to the byte limit with a marker, never splitting a codepoint', () => {
+  const value = '💾'.repeat(200); // 4 bytes per emoji, well over 256 bytes
+  const truncated = truncateUtf8Field(value, 32);
+  assert.ok(Buffer.byteLength(truncated, 'utf8') <= 32);
+  assert.ok(truncated.endsWith('…<truncated>'));
+  // Round-tripping through Buffer must not produce U+FFFD replacement chars —
+  // proof the cut landed on a codepoint boundary.
+  assert.ok(!truncated.includes('�'));
+});
+
+test('truncateUtf8Field is a no-op at exactly the limit', () => {
+  const value = 'a'.repeat(256);
+  assert.equal(truncateUtf8Field(value), value);
+});
+
+test('applyReplayDivergenceLevelCaps: digest omits suggestions but keeps suggestionCount, caps refs to 8', () => {
+  const divergence = buildDivergence({
+    suggestions: [
+      { selector: 'id="save"', basis: 'id' },
+      { selector: 'label="Save"', basis: 'label' },
+    ],
+    suggestionCount: 2,
+    screen: {
+      state: 'available',
+      refsGeneration: 1,
+      refs: Array.from({ length: 12 }, (_, i) => ({ ref: `e${i}`, role: 'button' })),
+    },
+  });
+  const digest = applyReplayDivergenceLevelCaps(divergence, 'digest');
+  assert.deepEqual(digest.suggestions, []);
+  assert.equal(digest.suggestionCount, 2);
+  assert.ok(digest.screen.state === 'available');
+  assert.equal(
+    (digest.screen as Extract<typeof digest.screen, { state: 'available' }>).refs.length,
+    REPLAY_DIVERGENCE_DIGEST_REF_LIMIT,
+  );
+  assert.equal(digest.screen.state === 'available' && digest.screen.truncated, true);
+});
+
+test('applyReplayDivergenceLevelCaps: default/full cap refs to 20 and suggestions to 5', () => {
+  const divergence = buildDivergence({
+    suggestions: Array.from({ length: 8 }, (_, i) => ({
+      selector: `id="s${i}"`,
+      basis: 'id' as const,
+    })),
+    suggestionCount: 8,
+    screen: {
+      state: 'available',
+      refsGeneration: 1,
+      refs: Array.from({ length: 30 }, (_, i) => ({ ref: `e${i}`, role: 'button' })),
+    },
+  });
+  const bounded = applyReplayDivergenceLevelCaps(divergence, 'default');
+  assert.equal(bounded.suggestions.length, REPLAY_DIVERGENCE_SUGGESTION_LIMIT);
+  assert.ok(bounded.screen.state === 'available');
+  assert.equal(
+    (bounded.screen as Extract<typeof bounded.screen, { state: 'available' }>).refs.length,
+    REPLAY_DIVERGENCE_DEFAULT_REF_LIMIT,
+  );
+});
+
+test('boundReplayDivergence passes a small divergence through unchanged at every level', () => {
+  const divergence = buildDivergence();
+  for (const level of ['digest', 'default', 'full'] as const) {
+    const bounded = boundReplayDivergence({
+      divergence,
+      level,
+      writeOverflowArtifact: () => {
+        throw new Error('overflow artifact should not be needed for a small divergence');
+      },
+    });
+    assert.ok(measureReplayDivergenceBytes(bounded) <= REPLAY_DIVERGENCE_LEVEL_BYTE_LIMITS[level]);
+    assert.equal(bounded.cause.message, divergence.cause.message);
+    assert.equal(bounded.overflow, undefined);
+    assert.equal(bounded.artifactUnavailable, undefined);
+  }
+});
+
+test('boundReplayDivergence writes an overflow artifact and returns a minimal fallback when the digest budget is exceeded', () => {
+  // A field-truncation pass is the CALLER's responsibility at construction
+  // time (session-replay-divergence.ts truncates every field to 256 bytes
+  // before this point) — boundReplayDivergence only bounds array shape and
+  // the overall byte budget, so an oversized single field (as could slip
+  // through if a caller forgot to truncate) is exactly the case the overflow
+  // path must still catch deterministically.
+  const divergence = buildDivergence({
+    cause: {
+      code: 'COMMAND_FAILED',
+      message: 'x'.repeat(20_000),
+    },
+    suggestions: Array.from({ length: 5 }, (_, i) => ({
+      selector: `id="save-button-candidate-number-${i}-with-a-fairly-long-descriptive-selector-string"`,
+      basis: 'id' as const,
+      label: 'A'.repeat(200),
+    })),
+    suggestionCount: 5,
+    screen: {
+      state: 'available',
+      refsGeneration: 1,
+      refs: Array.from({ length: 20 }, (_, i) => ({
+        ref: `e${i}`,
+        role: 'button',
+        label: 'B'.repeat(200),
+      })),
+    },
+  });
+  let writeCalls = 0;
+  const bounded = boundReplayDivergence({
+    divergence,
+    level: 'digest',
+    writeOverflowArtifact: (full) => {
+      writeCalls += 1;
+      assert.equal(full.suggestions.length, REPLAY_DIVERGENCE_SUGGESTION_LIMIT);
+      return { artifactPath: '/tmp/session/replay-divergence/1.json' };
+    },
+  });
+  assert.equal(writeCalls, 1);
+  assert.ok(measureReplayDivergenceBytes(bounded) <= REPLAY_DIVERGENCE_LEVEL_BYTE_LIMITS.digest);
+  assert.deepEqual(bounded.suggestions, []);
+  assert.equal(bounded.screen.state, 'unavailable');
+  assert.ok(bounded.overflow);
+  assert.equal(bounded.overflow?.artifactPath, '/tmp/session/replay-divergence/1.json');
+  assert.ok((bounded.overflow?.omittedBytes ?? 0) > 0);
+  // The cause is never dropped by overflow handling (only the screen digest
+  // and suggestions are), though the minimal fallback still enforces its own
+  // 256-byte field cap defensively.
+  assert.ok(divergence.cause.message.startsWith(bounded.cause.message.slice(0, 50)));
+  assert.ok(Buffer.byteLength(bounded.cause.message, 'utf8') <= 256);
+  assert.equal(bounded.step.index, divergence.step.index);
+});
+
+test('boundReplayDivergence sets artifactUnavailable when the artifact write itself fails', () => {
+  const divergence = buildDivergence({
+    cause: { code: 'COMMAND_FAILED', message: 'x'.repeat(20_000) },
+    suggestions: Array.from({ length: 5 }, (_, i) => ({
+      selector: `id="save-button-candidate-number-${i}-with-a-fairly-long-descriptive-selector-string"`,
+      basis: 'id' as const,
+      label: 'A'.repeat(200),
+    })),
+    suggestionCount: 5,
+    screen: {
+      state: 'available',
+      refsGeneration: 1,
+      refs: Array.from({ length: 20 }, (_, i) => ({
+        ref: `e${i}`,
+        role: 'button',
+        label: 'B'.repeat(200),
+      })),
+    },
+  });
+  const bounded = boundReplayDivergence({
+    divergence,
+    level: 'digest',
+    writeOverflowArtifact: () => ({ artifactUnavailable: true }),
+  });
+  assert.equal(bounded.artifactUnavailable, true);
+  assert.equal(bounded.overflow, undefined);
+  // The (truncated) cause survives even when the artifact could not be written.
+  assert.ok(divergence.cause.message.startsWith(bounded.cause.message.slice(0, 50)));
+});
+
+test('resume is always allowed:false with a clear reason and carries no planDigest key at this migration step', () => {
+  const divergence = buildDivergence();
+  assert.deepEqual(divergence.resume, { allowed: false, reason: 'resume not yet supported' });
+  assert.ok(!('planDigest' in divergence.resume));
+});

--- a/src/replay/__tests__/divergence.test.ts
+++ b/src/replay/__tests__/divergence.test.ts
@@ -226,3 +226,78 @@ test('sanitizeReplayDivergenceField redacts sensitive content even when no trunc
   assert.ok(!sanitized.includes('abc123def'));
   assert.ok(sanitized.includes('[REDACTED]'));
 });
+
+// --- Text report carries the repair data (bounded refs + unavailable hint) ---
+
+test('formatReplayDivergenceReport lists a bounded ref/role/label subset for an available screen', async () => {
+  const { formatReplayDivergenceReport } = await import('../divergence.ts');
+  const report = formatReplayDivergenceReport({
+    divergence: {
+      version: 1,
+      kind: 'action-failure',
+      step: { index: 5, source: { path: '/tmp/flow.ad', line: 6 } },
+      action: 'press "Pop to top"',
+      cause: { code: 'COMMAND_FAILED', message: 'Selector did not match' },
+      screen: {
+        state: 'available',
+        refsGeneration: 42,
+        refs: Array.from({ length: 12 }, (_, i) => ({
+          ref: `e${i + 1}`,
+          role: 'button',
+          label: `Button ${i + 1}`,
+        })),
+      },
+      suggestions: [],
+      suggestionCount: 0,
+      resume: { allowed: false, reason: 'resume not yet supported' },
+    },
+  });
+  assert.ok(report);
+  // A text-only caller can act without a follow-up snapshot: ref lines are listed.
+  assert.match(report!, /Screen: 12 actionable ref\(s\) captured \(refsGeneration 42\)/);
+  assert.match(report!, /^ {2}@e1 \[button\] "Button 1"$/m);
+  assert.match(report!, /^ {2}@e8 \[button\] "Button 8"$/m);
+  // Bounded to 8 lines, remainder summarized.
+  assert.doesNotMatch(report!, /@e9 /);
+  assert.match(report!, /^ {2}\.\.\. 4 more$/m);
+});
+
+test('formatReplayDivergenceReport carries the unavailable-screen hint', async () => {
+  const { formatReplayDivergenceReport } = await import('../divergence.ts');
+  const report = formatReplayDivergenceReport({
+    divergence: {
+      version: 1,
+      kind: 'action-failure',
+      step: { index: 1, source: { path: '/tmp/flow.ad', line: 1 } },
+      action: 'click "Save"',
+      cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+      screen: {
+        state: 'unavailable',
+        reason: 'sparse-snapshot',
+        hint: 'run snapshot -i to observe the current screen.',
+      },
+      suggestions: [],
+      suggestionCount: 0,
+      resume: { allowed: false, reason: 'resume not yet supported' },
+    },
+  });
+  assert.ok(report);
+  assert.match(report!, /Screen: unavailable \(sparse-snapshot\)\. run snapshot -i/);
+});
+
+test('scrubReplayVarValues replaces every occurrence with a named marker, longest value first', async () => {
+  const { scrubReplayVarValues } = await import('../divergence.ts');
+  const entries = [
+    { name: 'LONG', value: 'abc-def' },
+    { name: 'SHORT', value: 'abc' },
+  ].sort((a, b) => b.value.length - a.value.length);
+  assert.equal(
+    scrubReplayVarValues('x abc-def y abc z abc-def', entries),
+    'x <var:LONG> y <var:SHORT> z <var:LONG>',
+  );
+  // Not shape-based: plain, non-secret-looking values are scrubbed too.
+  assert.equal(
+    scrubReplayVarValues('value=3000 done', [{ name: 'T', value: '3000' }]),
+    'value=<var:T> done',
+  );
+});

--- a/src/replay/__tests__/divergence.test.ts
+++ b/src/replay/__tests__/divergence.test.ts
@@ -4,6 +4,7 @@ import {
   applyReplayDivergenceLevelCaps,
   boundReplayDivergence,
   measureReplayDivergenceBytes,
+  sanitizeReplayDivergenceField,
   REPLAY_DIVERGENCE_DEFAULT_REF_LIMIT,
   REPLAY_DIVERGENCE_DIGEST_REF_LIMIT,
   REPLAY_DIVERGENCE_LEVEL_BYTE_LIMITS,
@@ -197,4 +198,31 @@ test('resume is always allowed:false with a clear reason and carries no planDige
   const divergence = buildDivergence();
   assert.deepEqual(divergence.resume, { allowed: false, reason: 'resume not yet supported' });
   assert.ok(!('planDigest' in divergence.resume));
+});
+
+// --- ADR 0012: redact BEFORE truncation ("All rendered strings ... pass
+// through the central diagnostics redactor before truncation") ---
+
+test('sanitizeReplayDivergenceField redacts a secret that straddles the truncation boundary', () => {
+  // The secret assignment starts before byte 256 and its value crosses the
+  // cut. Truncate-first could split the token so the redactor's pattern no
+  // longer sees the full assignment; redact-first replaces the value before
+  // any bytes are dropped, so no fragment of the secret can survive.
+  // 200 prefix bytes put the assignment's VALUE across the raw 256-byte
+  // boundary (the secret spans bytes ~211-262): truncate-first would cut
+  // mid-secret and leave an unredactable fragment behind; redact-first
+  // replaces the value before any bytes are dropped.
+  const secret = 'hunter2-super-secret-value-abcdef123456-ghijkl-7890';
+  const value = `${'x'.repeat(200)} password=${secret} ${'y'.repeat(200)}`;
+  const sanitized = sanitizeReplayDivergenceField(value);
+  assert.ok(Buffer.byteLength(sanitized, 'utf8') <= 256);
+  assert.ok(!sanitized.includes('hunter2'));
+  assert.ok(!sanitized.includes(secret.slice(0, 8)));
+  assert.ok(sanitized.includes('password=[REDACTED]'));
+});
+
+test('sanitizeReplayDivergenceField redacts sensitive content even when no truncation is needed', () => {
+  const sanitized = sanitizeReplayDivergenceField('open failed: bearer abc123def token leaked');
+  assert.ok(!sanitized.includes('abc123def'));
+  assert.ok(sanitized.includes('[REDACTED]'));
 });

--- a/src/replay/__tests__/script.test.ts
+++ b/src/replay/__tests__/script.test.ts
@@ -485,3 +485,38 @@ test('session-recorded actions without target evidence never gain a fabricated a
   const script = fs.readFileSync(replayPath, 'utf8');
   assert.equal(/agent-device:target-v1/.test(script), false);
 });
+
+test('formatDivergenceActionLabel categorically drops fill/type text but keeps the target', async () => {
+  const { formatDivergenceActionLabel } = await import('../script-utils.ts');
+  const mk = (command: string, positionals: string[]): SessionAction => ({
+    ts: 0,
+    command,
+    positionals,
+    flags: {},
+  });
+  const secret = 'hunter2-secret';
+  // fill selector text (selector token is script-quoted, text dropped)
+  assert.equal(
+    formatDivergenceActionLabel(mk('fill', ['label="Email"', secret])),
+    'fill "label=\\"Email\\"" <text>',
+  );
+  // fill @ref text
+  assert.equal(formatDivergenceActionLabel(mk('fill', ['@e5', secret])), 'fill @e5 <text>');
+  // fill point text
+  assert.equal(formatDivergenceActionLabel(mk('fill', ['10', '20', secret])), 'fill 10 20 <text>');
+  // type text (no target)
+  assert.equal(formatDivergenceActionLabel(mk('type', [secret])), 'type <text>');
+  // none of these leak the secret
+  for (const label of [
+    formatDivergenceActionLabel(mk('fill', ['label="Email"', secret])),
+    formatDivergenceActionLabel(mk('fill', ['@e5', secret])),
+    formatDivergenceActionLabel(mk('type', [secret, 'more', secret])),
+  ]) {
+    assert.equal(label.includes(secret), false);
+  }
+  // non-typing commands are unchanged (full summary, script-quoted).
+  assert.equal(
+    formatDivergenceActionLabel(mk('click', ['label="Save"'])),
+    'click "label=\\"Save\\""',
+  );
+});

--- a/src/replay/control-flow-runtime.ts
+++ b/src/replay/control-flow-runtime.ts
@@ -4,14 +4,7 @@ export type ReplayActionBlockInvoker = (params: {
   action: SessionAction;
   line: number;
   step: number;
-  /**
-   * Resolved source file of the nested action when it differs from the
-   * wrapping control action's own file (ADR 0012 migration step 2): a
-   * `runFlow` include nested under `retry:`/`runFlow.when:` carries its
-   * include's path here (from `replayControl.actionSources`), so a failure
-   * inside the wrapped include reports the include's file+line, not the
-   * wrapper's. `undefined` falls back to the wrapper's source.
-   */
+  /** From `replayControl.actionSources`; `undefined` = the wrapper's own file. */
   sourcePath?: string;
 }) => Promise<DaemonResponse>;
 

--- a/src/replay/control-flow-runtime.ts
+++ b/src/replay/control-flow-runtime.ts
@@ -1,22 +1,34 @@
-import type { DaemonResponse, SessionAction } from '../daemon/types.ts';
+import type { DaemonResponse, ReplayControlActionSource, SessionAction } from '../daemon/types.ts';
 
 export type ReplayActionBlockInvoker = (params: {
   action: SessionAction;
   line: number;
   step: number;
+  /**
+   * Resolved source file of the nested action when it differs from the
+   * wrapping control action's own file (ADR 0012 migration step 2): a
+   * `runFlow` include nested under `retry:`/`runFlow.when:` carries its
+   * include's path here (from `replayControl.actionSources`), so a failure
+   * inside the wrapped include reports the include's file+line, not the
+   * wrapper's. `undefined` falls back to the wrapper's source.
+   */
+  sourcePath?: string;
 }) => Promise<DaemonResponse>;
 
 export async function invokeReplayActionBlock(params: {
   actions: SessionAction[];
+  actionSources?: (ReplayControlActionSource | undefined)[];
   line: number;
   step: number;
   invokeReplayAction: ReplayActionBlockInvoker;
 }): Promise<DaemonResponse> {
   for (const [index, action] of params.actions.entries()) {
+    const source = params.actionSources?.[index];
     const response = await params.invokeReplayAction({
       action,
-      line: params.line,
+      line: source?.line ?? params.line,
       step: params.step + index / 1000,
+      ...(source?.path ? { sourcePath: source.path } : {}),
     });
     if (!response.ok) return response;
   }
@@ -25,6 +37,7 @@ export async function invokeReplayActionBlock(params: {
 
 export async function invokeReplayRetryBlock(params: {
   actions: SessionAction[];
+  actionSources?: (ReplayControlActionSource | undefined)[];
   maxRetries: number;
   line: number;
   step: number;
@@ -34,6 +47,7 @@ export async function invokeReplayRetryBlock(params: {
   for (let attempt = 0; attempt <= params.maxRetries; attempt += 1) {
     const response = await invokeReplayActionBlock({
       actions: params.actions,
+      actionSources: params.actionSources,
       line: params.line,
       step: params.step + attempt,
       invokeReplayAction: params.invokeReplayAction,

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -1,0 +1,236 @@
+import type { ResponseLevel } from '../kernel/contracts.ts';
+
+/**
+ * ADR 0012 migration step 2: structured replay divergence report.
+ *
+ * `kind` is scoped to `'action-failure'` in this step — the target-binding
+ * kinds (`selector-miss`/`identity-mismatch`/`identity-unverifiable`) are
+ * decision 3/step 4 territory and are not produced here. `targetBinding` is
+ * likewise out of scope (step 4).
+ */
+export type ReplayDivergenceKind = 'action-failure';
+
+export type ReplayDivergenceStepSource = {
+  path: string;
+  line: number;
+};
+
+export type ReplayDivergenceStep = {
+  /** 1-based executable-plan ordinal, not a source line. */
+  index: number;
+  source: ReplayDivergenceStepSource;
+};
+
+export type ReplayDivergenceCause = {
+  code: string;
+  message: string;
+  hint?: string;
+};
+
+export type ReplayDivergenceScreenRef = {
+  ref: string;
+  role: string;
+  label?: string;
+};
+
+/**
+ * Discriminated per the ADR: `available` is a fresh, healthy snapshot digest
+ * and the only form that issues actionable refs; `unavailable` is returned
+ * when capture fails or is sparse and must never fall back to the old
+ * session tree or mask the original replay cause.
+ */
+export type ReplayDivergenceScreen =
+  | {
+      state: 'available';
+      refsGeneration: number;
+      refs: ReplayDivergenceScreenRef[];
+      truncated?: true;
+    }
+  | {
+      state: 'unavailable';
+      reason: string;
+      hint?: string;
+    };
+
+/** Strongest recorded-identity component the suggestion's selector matched on. */
+export type ReplayDivergenceSuggestionBasis = 'id' | 'role-label' | 'label' | 'other';
+
+export type ReplayDivergenceSuggestion = {
+  selector: string;
+  basis: ReplayDivergenceSuggestionBasis;
+  ref?: string;
+  role?: string;
+  label?: string;
+};
+
+/**
+ * Resume is decision 4's / migration step 5's territory. Step 2 attaches the
+ * object with `allowed: false` and a clear reason per the ADR ("include the
+ * object... WITHOUT --from existing yet"); `planDigest` is omitted entirely
+ * until step 5 lands (not even as `undefined` — the key is absent).
+ */
+export type ReplayDivergenceResume = {
+  allowed: false;
+  reason: string;
+};
+
+export type ReplayDivergenceOverflow = {
+  omittedBytes: number;
+  artifactPath: string;
+};
+
+export type ReplayDivergence = {
+  version: 1;
+  kind: ReplayDivergenceKind;
+  step: ReplayDivergenceStep;
+  action: string;
+  cause: ReplayDivergenceCause;
+  screen: ReplayDivergenceScreen;
+  suggestions: ReplayDivergenceSuggestion[];
+  /** Suggestions available at default/full, independent of how many are carried at this level. */
+  suggestionCount: number;
+  resume: ReplayDivergenceResume;
+  overflow?: ReplayDivergenceOverflow;
+  artifactUnavailable?: true;
+};
+
+export const REPLAY_DIVERGENCE_RESUME_NOT_SUPPORTED: ReplayDivergenceResume = {
+  allowed: false,
+  reason: 'resume not yet supported',
+};
+
+type BoundedResponseLevel = 'digest' | 'default' | 'full';
+
+export const REPLAY_DIVERGENCE_LEVEL_BYTE_LIMITS: Record<BoundedResponseLevel, number> = {
+  digest: 8 * 1024,
+  default: 24 * 1024,
+  full: 64 * 1024,
+};
+
+export const REPLAY_DIVERGENCE_DEFAULT_REF_LIMIT = 20;
+export const REPLAY_DIVERGENCE_DIGEST_REF_LIMIT = 8;
+export const REPLAY_DIVERGENCE_SUGGESTION_LIMIT = 5;
+// ADR 0012's 256-UTF-8-byte per-field cap. Not exported: truncateUtf8Field's
+// default parameter is the only sanctioned way callers reach this value —
+// every field truncation call site should go through that function so the
+// cap stays enforced in exactly one place.
+const REPLAY_DIVERGENCE_FIELD_BYTE_LIMIT = 256;
+
+function levelForResponseLevel(level: ResponseLevel | undefined): BoundedResponseLevel {
+  return level === 'digest' || level === 'full' ? level : 'default';
+}
+
+/**
+ * UTF-8 byte-accurate truncation with a marker, never splitting a multi-byte
+ * codepoint. Used for every individual string field the ADR caps at 256 bytes
+ * (labels, ids, selectors, source paths, mismatch values, cause messages,
+ * hints).
+ */
+export function truncateUtf8Field(
+  value: string,
+  limit = REPLAY_DIVERGENCE_FIELD_BYTE_LIMIT,
+): string {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.length <= limit) return value;
+  const marker = '…<truncated>';
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  const budget = Math.max(0, limit - markerBytes);
+  let sliceEnd = budget;
+  // Back off until we are not mid-codepoint (UTF-8 continuation bytes are 10xxxxxx).
+  while (sliceEnd > 0 && (bytes[sliceEnd]! & 0xc0) === 0x80) sliceEnd -= 1;
+  return `${bytes.subarray(0, sliceEnd).toString('utf8')}${marker}`;
+}
+
+function boundScreenRefs(screen: ReplayDivergenceScreen, limit: number): ReplayDivergenceScreen {
+  if (screen.state !== 'available' || screen.refs.length <= limit) return screen;
+  return { ...screen, refs: screen.refs.slice(0, limit), truncated: true };
+}
+
+/**
+ * Applies one level's array caps only (ref count, suggestion presence/count).
+ * Field-level 256-byte truncation is expected to already be applied by the
+ * caller at construction time — this function only bounds array shape.
+ */
+export function applyReplayDivergenceLevelCaps(
+  divergence: ReplayDivergence,
+  level: ResponseLevel | undefined,
+): ReplayDivergence {
+  const bounded = levelForResponseLevel(level);
+  const refLimit =
+    bounded === 'digest' ? REPLAY_DIVERGENCE_DIGEST_REF_LIMIT : REPLAY_DIVERGENCE_DEFAULT_REF_LIMIT;
+  const screen = boundScreenRefs(divergence.screen, refLimit);
+  const suggestions =
+    bounded === 'digest' ? [] : divergence.suggestions.slice(0, REPLAY_DIVERGENCE_SUGGESTION_LIMIT);
+  return { ...divergence, screen, suggestions };
+}
+
+export function measureReplayDivergenceBytes(divergence: ReplayDivergence): number {
+  return Buffer.byteLength(JSON.stringify(divergence), 'utf8');
+}
+
+/**
+ * Bounds the FULL divergence object to the requested response level's byte
+ * ceiling. When the level-capped shape still overflows the ceiling (rare,
+ * given per-field 256-byte caps and the 5/20 array caps), the daemon writes
+ * the fuller (`full`-level-capped) detail to a session-scoped artifact via
+ * `writeOverflowArtifact` and returns a minimal divergence carrying only
+ * `overflow`/`artifactUnavailable` plus the always-cheap fields — the
+ * original cause is never dropped, only the screen digest and suggestions.
+ */
+export function boundReplayDivergence(params: {
+  divergence: ReplayDivergence;
+  level: ResponseLevel | undefined;
+  writeOverflowArtifact: (
+    fullDivergence: ReplayDivergence,
+  ) => { artifactPath: string } | { artifactUnavailable: true };
+}): ReplayDivergence {
+  const { divergence, level, writeOverflowArtifact } = params;
+  const bounded = levelForResponseLevel(level);
+  const limit = REPLAY_DIVERGENCE_LEVEL_BYTE_LIMITS[bounded];
+  const capped = applyReplayDivergenceLevelCaps(divergence, level);
+  const cappedBytes = measureReplayDivergenceBytes(capped);
+  if (cappedBytes <= limit) return capped;
+
+  const omittedBytes = cappedBytes - limit;
+  const full = applyReplayDivergenceLevelCaps(divergence, 'full');
+  const artifactResult = writeOverflowArtifact(full);
+  const minimal = buildMinimalReplayDivergence(capped);
+  return 'artifactPath' in artifactResult
+    ? { ...minimal, overflow: { omittedBytes, artifactPath: artifactResult.artifactPath } }
+    : { ...minimal, artifactUnavailable: true };
+}
+
+// Defensively re-truncates every string field to the 256-byte cap, even
+// though callers are expected to have already done so at construction time
+// (session-replay-divergence.ts): this is the function responsible for the
+// "the minimal fallback always fits the budget" guarantee, so it must not
+// depend on caller discipline to hold.
+function buildMinimalReplayDivergence(capped: ReplayDivergence): ReplayDivergence {
+  return {
+    version: capped.version,
+    kind: capped.kind,
+    step: {
+      index: capped.step.index,
+      source: {
+        path: truncateUtf8Field(capped.step.source.path),
+        line: capped.step.source.line,
+      },
+    },
+    action: truncateUtf8Field(capped.action),
+    cause: {
+      code: capped.cause.code,
+      message: truncateUtf8Field(capped.cause.message),
+      ...(capped.cause.hint ? { hint: truncateUtf8Field(capped.cause.hint) } : {}),
+    },
+    screen: {
+      state: 'unavailable',
+      reason: 'omitted-for-size',
+      hint:
+        'The screen digest and suggestions were omitted to stay within the response byte budget. ' +
+        'See overflow.artifactPath (or retry at --level full) for the complete report.',
+    },
+    suggestions: [],
+    suggestionCount: capped.suggestionCount,
+    resume: capped.resume,
+  };
+}

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -1,4 +1,5 @@
 import type { ResponseLevel } from '../kernel/contracts.ts';
+import { redactDiagnosticData } from '../kernel/redaction.ts';
 
 /**
  * ADR 0012 migration step 2: structured replay divergence report.
@@ -141,6 +142,22 @@ export function truncateUtf8Field(
   return `${bytes.subarray(0, sliceEnd).toString('utf8')}${marker}`;
 }
 
+/**
+ * The sanctioned field sanitizer for divergence report strings, in the
+ * ADR-specified order: central diagnostics redactor FIRST, byte-accurate
+ * truncation (with marker) second. Truncating first could split a secret
+ * across the cut so the redactor's patterns no longer match the surviving
+ * fragment — redact-then-truncate makes the ordering guarantee structural
+ * rather than relying on the redactor's incidental robustness to partial
+ * tokens.
+ */
+export function sanitizeReplayDivergenceField(
+  value: string,
+  limit = REPLAY_DIVERGENCE_FIELD_BYTE_LIMIT,
+): string {
+  return truncateUtf8Field(redactDiagnosticData(value), limit);
+}
+
 function boundScreenRefs(screen: ReplayDivergenceScreen, limit: number): ReplayDivergenceScreen {
   if (screen.state !== 'available' || screen.refs.length <= limit) return screen;
   return { ...screen, refs: screen.refs.slice(0, limit), truncated: true };
@@ -212,15 +229,15 @@ function buildMinimalReplayDivergence(capped: ReplayDivergence): ReplayDivergenc
     step: {
       index: capped.step.index,
       source: {
-        path: truncateUtf8Field(capped.step.source.path),
+        path: sanitizeReplayDivergenceField(capped.step.source.path),
         line: capped.step.source.line,
       },
     },
-    action: truncateUtf8Field(capped.action),
+    action: sanitizeReplayDivergenceField(capped.action),
     cause: {
       code: capped.cause.code,
-      message: truncateUtf8Field(capped.cause.message),
-      ...(capped.cause.hint ? { hint: truncateUtf8Field(capped.cause.hint) } : {}),
+      message: sanitizeReplayDivergenceField(capped.cause.message),
+      ...(capped.cause.hint ? { hint: sanitizeReplayDivergenceField(capped.cause.hint) } : {}),
     },
     screen: {
       state: 'unavailable',

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -64,12 +64,7 @@ export type ReplayDivergenceSuggestion = {
   label?: string;
 };
 
-/**
- * Resume is decision 4's / migration step 5's territory. Step 2 attaches the
- * object with `allowed: false` and a clear reason per the ADR ("include the
- * object... WITHOUT --from existing yet"); `planDigest` is omitted entirely
- * until step 5 lands (not even as `undefined` — the key is absent).
- */
+/** Always `allowed: false` until migration step 5; `from`/`planDigest` keys absent until then. */
 export type ReplayDivergenceResume = {
   allowed: false;
   reason: string;
@@ -111,10 +106,8 @@ export const REPLAY_DIVERGENCE_LEVEL_BYTE_LIMITS: Record<BoundedResponseLevel, n
 export const REPLAY_DIVERGENCE_DEFAULT_REF_LIMIT = 20;
 export const REPLAY_DIVERGENCE_DIGEST_REF_LIMIT = 8;
 export const REPLAY_DIVERGENCE_SUGGESTION_LIMIT = 5;
-// ADR 0012's 256-UTF-8-byte per-field cap. Not exported: truncateUtf8Field's
-// default parameter is the only sanctioned way callers reach this value —
-// every field truncation call site should go through that function so the
-// cap stays enforced in exactly one place.
+// ADR 0012's 256-UTF-8-byte per-field cap; reached only through the field
+// sanitizers below so it is enforced in one place.
 const REPLAY_DIVERGENCE_FIELD_BYTE_LIMIT = 256;
 
 function levelForResponseLevel(level: ResponseLevel | undefined): BoundedResponseLevel {
@@ -142,15 +135,7 @@ export function truncateUtf8Field(
   return `${bytes.subarray(0, sliceEnd).toString('utf8')}${marker}`;
 }
 
-/**
- * The sanctioned field sanitizer for divergence report strings, in the
- * ADR-specified order: central diagnostics redactor FIRST, byte-accurate
- * truncation (with marker) second. Truncating first could split a secret
- * across the cut so the redactor's patterns no longer match the surviving
- * fragment — redact-then-truncate makes the ordering guarantee structural
- * rather than relying on the redactor's incidental robustness to partial
- * tokens.
- */
+/** Field sanitizer in the ADR-mandated order: redact first, then truncate. */
 export function sanitizeReplayDivergenceField(
   value: string,
   limit = REPLAY_DIVERGENCE_FIELD_BYTE_LIMIT,
@@ -186,13 +171,10 @@ export function measureReplayDivergenceBytes(divergence: ReplayDivergence): numb
 }
 
 /**
- * Bounds the FULL divergence object to the requested response level's byte
- * ceiling. When the level-capped shape still overflows the ceiling (rare,
- * given per-field 256-byte caps and the 5/20 array caps), the daemon writes
- * the fuller (`full`-level-capped) detail to a session-scoped artifact via
- * `writeOverflowArtifact` and returns a minimal divergence carrying only
- * `overflow`/`artifactUnavailable` plus the always-cheap fields — the
- * original cause is never dropped, only the screen digest and suggestions.
+ * Bounds the divergence to the response level's byte ceiling. On overflow,
+ * the fuller detail goes to a session-scoped artifact and a minimal
+ * divergence is returned; the cause is never dropped, only the screen digest
+ * and suggestions.
  */
 export function boundReplayDivergence(params: {
   divergence: ReplayDivergence;
@@ -217,11 +199,8 @@ export function boundReplayDivergence(params: {
     : { ...minimal, artifactUnavailable: true };
 }
 
-// Defensively re-truncates every string field to the 256-byte cap, even
-// though callers are expected to have already done so at construction time
-// (session-replay-divergence.ts): this is the function responsible for the
-// "the minimal fallback always fits the budget" guarantee, so it must not
-// depend on caller discipline to hold.
+// Owns the "the minimal fallback always fits the budget" guarantee, so it
+// sanitizes every field itself rather than trusting the caller did.
 function buildMinimalReplayDivergence(capped: ReplayDivergence): ReplayDivergence {
   return {
     version: capped.version,

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -230,3 +230,79 @@ function buildMinimalReplayDivergence(capped: ReplayDivergence): ReplayDivergenc
     resume: capped.resume,
   };
 }
+
+// Compact human-readable divergence report for text surfaces (CLI, MCP text,
+// `test` failures). Repair data (step location, screen availability, ranked
+// suggestions, overflow pointer) that the --json/structuredContent paths
+// carry must not be dropped on a text path. Reads the loose `details` bag so
+// every surface (which holds an error `details` record) can share it.
+export function formatReplayDivergenceReport(
+  details: Record<string, unknown> | undefined,
+): string | null {
+  const divergence = details?.divergence;
+  if (!divergence || typeof divergence !== 'object') return null;
+  const record = divergence as Record<string, unknown>;
+  const lines = [
+    ...divergenceStepLine(record.step),
+    ...divergenceScreenLine(record.screen),
+    ...divergenceSuggestionLines(record.suggestions, record.suggestionCount),
+    ...divergenceOverflowLine(record.overflow, record.artifactUnavailable),
+  ];
+  return lines.length > 0 ? lines.join('\n') : null;
+}
+
+function divergenceStepLine(step: unknown): string[] {
+  const record = step as Record<string, unknown> | undefined;
+  if (typeof record?.index !== 'number') return [];
+  const source = record.source as Record<string, unknown> | undefined;
+  const location =
+    typeof source?.path === 'string' && typeof source.line === 'number'
+      ? ` (${source.path}:${source.line})`
+      : '';
+  return [`Divergence at step ${record.index}${location}`];
+}
+
+function divergenceScreenLine(screen: unknown): string[] {
+  const record = screen as Record<string, unknown> | undefined;
+  if (record?.state === 'available' && Array.isArray(record.refs)) {
+    return [
+      `Screen: ${record.refs.length} actionable ref(s) captured (refsGeneration ${record.refsGeneration}).`,
+    ];
+  }
+  if (record?.state === 'unavailable') {
+    return [`Screen: unavailable (${String(record.reason ?? 'unknown')}).`];
+  }
+  return [];
+}
+
+function divergenceSuggestionLines(suggestions: unknown, suggestionCount: unknown): string[] {
+  if (Array.isArray(suggestions) && suggestions.length > 0) {
+    return ['Suggestions:', ...suggestions.slice(0, 5).map(divergenceSuggestionLine)];
+  }
+  if (typeof suggestionCount === 'number' && suggestionCount > 0) {
+    return [
+      `Suggestions: ${suggestionCount} available (omitted at this response level; rerun with --json for the full report).`,
+    ];
+  }
+  return [];
+}
+
+function divergenceSuggestionLine(entry: unknown): string {
+  const suggestion = entry as Record<string, unknown>;
+  const label = typeof suggestion.label === 'string' ? ` "${suggestion.label}"` : '';
+  return `  - [${String(suggestion.basis)}]${label} ${String(suggestion.selector)}`;
+}
+
+function divergenceOverflowLine(overflow: unknown, artifactUnavailable: unknown): string[] {
+  if (overflow && typeof overflow === 'object') {
+    return [
+      `Full report written to ${String((overflow as Record<string, unknown>).artifactPath)}.`,
+    ];
+  }
+  if (artifactUnavailable === true) {
+    return [
+      'Full report exceeded the response budget and the overflow artifact could not be written.',
+    ];
+  }
+  return [];
+}

--- a/src/replay/divergence.ts
+++ b/src/replay/divergence.ts
@@ -143,6 +143,30 @@ export function sanitizeReplayDivergenceField(
   return truncateUtf8Field(redactDiagnosticData(value), limit);
 }
 
+export type ReplayVarScrubEntry = { name: string; value: string };
+
+/**
+ * Categorical expanded-variable exclusion (ADR 0012): every occurrence of a
+ * replay-scope value is replaced with a `<var:NAME>` marker, whatever the
+ * value looks like — this is not shape-based secret redaction.
+ */
+export function scrubReplayVarValues(value: string, entries: ReplayVarScrubEntry[]): string {
+  let output = value;
+  for (const entry of entries) {
+    if (!entry.value) continue;
+    output = output.split(entry.value).join(`<var:${entry.name}>`);
+  }
+  return output;
+}
+
+/** Per-report field sanitizer: variable scrub, then redact, then truncate. */
+export function createReplayDivergenceSanitizer(
+  scrubVars: ReplayVarScrubEntry[],
+): (value: string, limit?: number) => string {
+  return (value, limit) =>
+    sanitizeReplayDivergenceField(scrubReplayVarValues(value, scrubVars), limit);
+}
+
 function boundScreenRefs(screen: ReplayDivergenceScreen, limit: number): ReplayDivergenceScreen {
   if (screen.state !== 'available' || screen.refs.length <= limit) return screen;
   return { ...screen, refs: screen.refs.slice(0, limit), truncated: true };
@@ -262,17 +286,40 @@ function divergenceStepLine(step: unknown): string[] {
   return [`Divergence at step ${record.index}${location}`];
 }
 
+// Bound on ref lines in the TEXT report (matches the digest ref cap); the
+// full list rides in the structured payload.
+const TEXT_REPORT_REF_LINE_LIMIT = 8;
+
 function divergenceScreenLine(screen: unknown): string[] {
   const record = screen as Record<string, unknown> | undefined;
   if (record?.state === 'available' && Array.isArray(record.refs)) {
-    return [
-      `Screen: ${record.refs.length} actionable ref(s) captured (refsGeneration ${record.refsGeneration}).`,
-    ];
+    return availableScreenLines(record.refs, record.refsGeneration);
   }
   if (record?.state === 'unavailable') {
-    return [`Screen: unavailable (${String(record.reason ?? 'unknown')}).`];
+    return [unavailableScreenLine(record)];
   }
   return [];
+}
+
+function availableScreenLines(refs: unknown[], refsGeneration: unknown): string[] {
+  const shown = refs.slice(0, TEXT_REPORT_REF_LINE_LIMIT).map(divergenceScreenRefLine);
+  const remaining = refs.length - shown.length;
+  return [
+    `Screen: ${refs.length} actionable ref(s) captured (refsGeneration ${refsGeneration}).`,
+    ...shown,
+    ...(remaining > 0 ? [`  ... ${remaining} more`] : []),
+  ];
+}
+
+function unavailableScreenLine(record: Record<string, unknown>): string {
+  const hint = typeof record.hint === 'string' && record.hint.length > 0 ? ` ${record.hint}` : '';
+  return `Screen: unavailable (${String(record.reason ?? 'unknown')}).${hint}`;
+}
+
+function divergenceScreenRefLine(entry: unknown): string {
+  const ref = entry as Record<string, unknown>;
+  const label = typeof ref.label === 'string' ? ` "${ref.label}"` : '';
+  return `  @${String(ref.ref)} [${String(ref.role)}]${label}`;
 }
 
 function divergenceSuggestionLines(suggestions: unknown, suggestionCount: unknown): string[] {

--- a/src/replay/script-utils.ts
+++ b/src/replay/script-utils.ts
@@ -75,9 +75,44 @@ function isBareScriptToken(value: string): boolean {
   return BARE_SCRIPT_TOKEN_RE.test(value);
 }
 
-export function formatScriptActionSummary(action: SessionAction): string {
-  const values = (action.positionals ?? []).map((value) => formatScriptArg(value));
-  return [action.command, ...values].join(' ');
+const TYPED_TEXT_COMMANDS = new Set(['fill', 'type']);
+
+/**
+ * Action summary safe for the divergence report / user-facing failure text.
+ * For typing commands the typed value is categorically dropped and replaced
+ * with a `<text>` marker — fill text is never serialized (ADR 0012), not
+ * merely redacted-if-secret-shaped. The target (selector / @ref / point)
+ * still shows so the caller can see WHICH field failed.
+ */
+export function formatDivergenceActionLabel(action: SessionAction): string {
+  if (!TYPED_TEXT_COMMANDS.has(action.command)) {
+    const values = (action.positionals ?? []).map((value) => formatScriptArg(value));
+    return [action.command, ...values].join(' ');
+  }
+  const targetTokens = divergenceTypingTargetTokens(action);
+  const targetLabel = targetTokens.map((value) => formatScriptArg(value)).join(' ');
+  return [action.command, targetLabel, '<text>'].filter((part) => part.length > 0).join(' ');
+}
+
+/**
+ * The identifying (non-text) positional tokens of a typing action:
+ * `@ref`, a two-token point (`x y`), or a single selector. Everything after
+ * is the typed value and is excluded.
+ */
+function divergenceTypingTargetTokens(action: SessionAction): string[] {
+  if (action.command === 'type') return [];
+  const positionals = action.positionals ?? [];
+  const first = positionals[0];
+  if (first === undefined) return [];
+  if (first.startsWith('@')) return [first];
+  if (
+    positionals.length >= 3 &&
+    NUMERIC_ARG_RE.test(first) &&
+    NUMERIC_ARG_RE.test(positionals[1] ?? '')
+  ) {
+    return [first, positionals[1]!];
+  }
+  return [first];
 }
 
 // fallow-ignore-next-line complexity

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -40,6 +40,16 @@ export type ReplayScriptMetadata = {
 export type ParsedReplayScript = {
   actions: SessionAction[];
   actionLines: number[];
+  /**
+   * Per-action source file path (ADR 0012 migration step 2), parallel to
+   * `actionLines`. `undefined` at an index means "the top-level replay file
+   * path" — the common case for native `.ad` scripts (never set here) and for
+   * a Maestro action that came from the root file being parsed. A Maestro
+   * action inlined from a `runFlow` include carries that include's resolved
+   * path so a divergence report can point at the actual file+line that
+   * failed, not the including `runFlow:` line.
+   */
+  actionSourcePaths?: (string | undefined)[];
 };
 
 type PendingTargetAnnotation = { evidence: SessionAction['targetEvidence']; line: number };

--- a/src/replay/script.ts
+++ b/src/replay/script.ts
@@ -41,13 +41,9 @@ export type ParsedReplayScript = {
   actions: SessionAction[];
   actionLines: number[];
   /**
-   * Per-action source file path (ADR 0012 migration step 2), parallel to
-   * `actionLines`. `undefined` at an index means "the top-level replay file
-   * path" — the common case for native `.ad` scripts (never set here) and for
-   * a Maestro action that came from the root file being parsed. A Maestro
-   * action inlined from a `runFlow` include carries that include's resolved
-   * path so a divergence report can point at the actual file+line that
-   * failed, not the including `runFlow:` line.
+   * Per-action source file path, parallel to `actionLines`; `undefined` =
+   * the top-level replay file. A Maestro action inlined from a `runFlow`
+   * include carries the include's resolved path.
    */
   actionSourcePaths?: (string | undefined)[];
 };

--- a/src/replay/test/__tests__/reporters-default.test.ts
+++ b/src/replay/test/__tests__/reporters-default.test.ts
@@ -136,6 +136,7 @@ test('default replay test reporter surfaces the divergence repair report on a fa
   // The test text surface must carry the same repair data as --json.
   assert.match(out, /Divergence at step 2 \(\/tmp\/flow\.ad:2\)/);
   assert.match(out, /Screen: 1 actionable ref\(s\) captured \(refsGeneration 4\)/);
+  assert.match(out, /@e5 \[button\] "Save"/);
   assert.match(out, /Suggestions:/);
   assert.match(out, /\[id\] "Save" id="save"/);
 });

--- a/src/replay/test/__tests__/reporters-default.test.ts
+++ b/src/replay/test/__tests__/reporters-default.test.ts
@@ -82,3 +82,60 @@ test('default replay test reporter leaves cursor alone for non-tty streams', () 
 
   assert.deepEqual(stderr, []);
 });
+
+function failingSuiteWithDivergence(): ReplaySuiteResult {
+  const failed = {
+    file: '/tmp/flow.ad',
+    title: 'checkout',
+    session: 'test-session',
+    status: 'failed' as const,
+    durationMs: 10,
+    attempts: 1,
+    error: {
+      code: 'REPLAY_DIVERGENCE',
+      message: 'Replay failed at step 2 (click "Save"): not hittable',
+      details: {
+        divergence: {
+          version: 1,
+          kind: 'action-failure',
+          step: { index: 2, source: { path: '/tmp/flow.ad', line: 2 } },
+          action: 'click "Save"',
+          cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+          screen: {
+            state: 'available',
+            refsGeneration: 4,
+            refs: [{ ref: 'e5', role: 'button', label: 'Save' }],
+          },
+          suggestions: [
+            { selector: 'id="save"', basis: 'id', ref: 'e5', role: 'button', label: 'Save' },
+          ],
+          suggestionCount: 1,
+          resume: { allowed: false, reason: 'resume not yet supported' },
+        },
+      },
+    },
+  };
+  return {
+    total: 1,
+    executed: 1,
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    notRun: 0,
+    durationMs: 10,
+    failures: [failed],
+    tests: [failed],
+  };
+}
+
+test('default replay test reporter surfaces the divergence repair report on a failure', () => {
+  const reporter = createDefaultReplayTestReporter();
+  const { context, stdout } = createReporterContext({ stderrIsTty: false });
+  reporter.onSuiteEnd?.(failingSuiteWithDivergence(), context);
+  const out = stdout.join('');
+  // The test text surface must carry the same repair data as --json.
+  assert.match(out, /Divergence at step 2 \(\/tmp\/flow\.ad:2\)/);
+  assert.match(out, /Screen: 1 actionable ref\(s\) captured \(refsGeneration 4\)/);
+  assert.match(out, /Suggestions:/);
+  assert.match(out, /\[id\] "Save" id="save"/);
+});

--- a/src/replay/test/reporters/default.ts
+++ b/src/replay/test/reporters/default.ts
@@ -6,6 +6,7 @@ import {
 } from '../progress.ts';
 import { formatDurationSeconds } from '../../../utils/duration-format.ts';
 import { colorize, supportsColor } from '../../../utils/output.ts';
+import { formatReplayDivergenceReport } from '../../divergence.ts';
 import type {
   ReplayTestReporter,
   ReplayTestReporterContext,
@@ -201,8 +202,23 @@ function renderReplayFailureBody(
   for (const line of replayFailureConsoleLines(result)) {
     context.stdout.write(`${indent}${line}\n`);
   }
+  renderReplayFailureDivergence(result, context, indent);
   if (!context.debug) return;
   for (const line of replayTestFailureStepLines(result)) {
+    context.stdout.write(`${indent}${line}\n`);
+  }
+}
+
+// ADR 0012: the `test` text surface carries the divergence repair data
+// (screen refs / suggestions), same as the --json suite payload.
+function renderReplayFailureDivergence(
+  result: FailedReplayTestResult,
+  context: ReplayTestReporterContext,
+  indent: string,
+): void {
+  const divergence = formatReplayDivergenceReport(result.error?.details);
+  if (!divergence) return;
+  for (const line of divergence.split('\n')) {
     context.stdout.write(`${indent}${line}\n`);
   }
 }

--- a/src/replay/vars.ts
+++ b/src/replay/vars.ts
@@ -3,6 +3,8 @@ import type { SessionAction } from '../daemon/types.ts';
 
 export type ReplayVarScope = {
   values: Readonly<Record<string, string>>;
+  /** Built-ins resolved into an action, tracked for divergence redaction. */
+  expandedBuiltinNames?: Set<string>;
 };
 
 export type ReplayVarSources = {
@@ -50,7 +52,7 @@ export function buildReplayVarScope(sources: ReplayVarSources): ReplayVarScope {
       merged[key] = value;
     }
   }
-  return { values: merged };
+  return { values: merged, expandedBuiltinNames: new Set() };
 }
 
 export function mergeReplayVarScopeValues(
@@ -131,6 +133,9 @@ export function resolveReplayString(
       if (escapedLiteral) return '${';
       if (!key) return match;
       if (Object.prototype.hasOwnProperty.call(scope.values, key)) {
+        if (isReservedNamespaceKey(key)) {
+          (scope.expandedBuiltinNames ??= new Set()).add(key);
+        }
         return String(scope.values[key]);
       }
       if (fallback !== undefined) {
@@ -202,18 +207,20 @@ function resolveStringValue(
 }
 
 /**
- * Values of every non-builtin scope variable — the expanded variables ADR
- * 0012 forbids serializing into a divergence report (file env directives,
- * `-e` CLI entries, `AD_VAR_*` shell env, and runtime `outputEnv` merges).
- * Builtins (reserved `AD_*` namespace) are runtime-trusted labels, not
- * user-supplied values. Longest values first so overlapping values scrub
- * deterministically.
+ * Values of every non-builtin scope variable, plus built-ins that were
+ * expanded into a replay action. ADR 0012 forbids serializing expanded
+ * variables into a divergence report. Tracking built-in expansion avoids
+ * redacting ordinary static text that merely matches an unused runtime label.
+ * Longest values first so overlapping values scrub deterministically.
  */
 export function collectReplayScrubbableVarValues(
   scope: ReplayVarScope,
 ): Array<{ name: string; value: string }> {
   return Object.entries(scope.values)
-    .filter(([key, value]) => !isReservedNamespaceKey(key) && value.length > 0)
+    .filter(
+      ([key, value]) =>
+        value.length > 0 && (!isReservedNamespaceKey(key) || scope.expandedBuiltinNames?.has(key)),
+    )
     .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value.length - a.value.length);
 }

--- a/src/replay/vars.ts
+++ b/src/replay/vars.ts
@@ -200,3 +200,20 @@ function resolveStringValue(
   }
   return value;
 }
+
+/**
+ * Values of every non-builtin scope variable — the expanded variables ADR
+ * 0012 forbids serializing into a divergence report (file env directives,
+ * `-e` CLI entries, `AD_VAR_*` shell env, and runtime `outputEnv` merges).
+ * Builtins (reserved `AD_*` namespace) are runtime-trusted labels, not
+ * user-supplied values. Longest values first so overlapping values scrub
+ * deterministically.
+ */
+export function collectReplayScrubbableVarValues(
+  scope: ReplayVarScope,
+): Array<{ name: string; value: string }> {
+  return Object.entries(scope.values)
+    .filter(([key, value]) => !isReservedNamespaceKey(key) && value.length > 0)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value.length - a.value.length);
+}

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -129,3 +129,40 @@ test('toAppErrorCode falls back when code is missing or empty', () => {
   assert.equal(toAppErrorCode(''), 'COMMAND_FAILED');
   assert.equal(toAppErrorCode(undefined, 'UNAUTHORIZED'), 'UNAUTHORIZED');
 });
+
+// --- ADR 0012 migration step 2: divergence survives daemon -> client -> CLI/MCP ---
+
+test('normalizeError preserves details.divergence verbatim through redaction/stripDiagnosticMeta', () => {
+  const divergence = {
+    version: 1 as const,
+    kind: 'action-failure' as const,
+    step: { index: 2, source: { path: '/tmp/flow.ad', line: 5 } },
+    action: 'click "Save"',
+    cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+    screen: {
+      state: 'available' as const,
+      refsGeneration: 3,
+      refs: [{ ref: 'e5', role: 'button', label: 'Save' }],
+    },
+    suggestions: [],
+    suggestionCount: 0,
+    resume: { allowed: false as const, reason: 'resume not yet supported' },
+  };
+  const err = new AppError('REPLAY_DIVERGENCE', 'Replay failed at step 2', {
+    step: 2,
+    action: 'click',
+    divergence,
+  });
+  const normalized = normalizeError(err);
+  assert.equal(normalized.code, 'REPLAY_DIVERGENCE');
+  // stripDiagnosticMeta only removes hint/diagnosticId/logPath/retriable/supportedOn.
+  assert.deepEqual(normalized.details?.divergence, divergence);
+  assert.equal(normalized.details?.step, 2);
+});
+
+test('daemon-originated REPLAY_DIVERGENCE gets a default hint pointing at the report', () => {
+  const normalized = normalizeError(
+    new AppError('REPLAY_DIVERGENCE', 'Replay failed at step 1', {}),
+  );
+  assert.match(normalized.hint ?? '', /details\.divergence/);
+});

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -1787,6 +1787,7 @@ test('printHumanError renders a compact divergence report unconditionally (not g
 
   assert.match(output, /Divergence at step 2 \(\/tmp\/flow\.ad:5\)/);
   assert.match(output, /Screen: 1 actionable ref\(s\) captured \(refsGeneration 3\)/);
+  assert.match(output, /@e5 \[button\] "Save"/);
   assert.match(output, /Suggestions:/);
   assert.match(output, /\[id\] "Save" id="save"/);
   // Not gated behind --debug: showDetails defaults to false/undefined here.
@@ -1800,7 +1801,11 @@ test('printHumanError shows an unavailable screen reason and omitted suggestions
       step: { index: 1, source: { path: '/tmp/flow.ad', line: 1 } },
       action: 'click "Save"',
       cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
-      screen: { state: 'unavailable', reason: 'capture-failed' },
+      screen: {
+        state: 'unavailable',
+        reason: 'capture-failed',
+        hint: 'take a snapshot to observe the result.',
+      },
       suggestions: [],
       suggestionCount: 2,
       resume: { allowed: false, reason: 'resume not yet supported' },
@@ -1809,6 +1814,6 @@ test('printHumanError shows an unavailable screen reason and omitted suggestions
 
   const output = captureStderr(() => printHumanError(err));
 
-  assert.match(output, /Screen: unavailable \(capture-failed\)/);
+  assert.match(output, /Screen: unavailable \(capture-failed\)\. take a snapshot/);
   assert.match(output, /Suggestions: 2 available \(omitted at this response level/);
 });

--- a/src/utils/__tests__/output.test.ts
+++ b/src/utils/__tests__/output.test.ts
@@ -2,9 +2,32 @@ import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { stripVTControlCharacters } from 'node:util';
-import { formatScreenshotDiffText, formatSnapshotDiffText, formatSnapshotText } from '../output.ts';
+import {
+  formatScreenshotDiffText,
+  formatSnapshotDiffText,
+  formatSnapshotText,
+  printHumanError,
+} from '../output.ts';
 import { formatRole, formatSnapshotLine } from '../../snapshot/snapshot-lines.ts';
 import { normalizedRect } from '../screenshot-geometry.ts';
+import { AppError } from '../../kernel/errors.ts';
+
+function captureStderr(run: () => void): string {
+  const original = process.stderr.write.bind(process.stderr);
+  let output = '';
+  (process.stderr as unknown as { write: typeof process.stderr.write }).write = ((
+    chunk: unknown,
+  ) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    run();
+  } finally {
+    process.stderr.write = original;
+  }
+  return output;
+}
 
 const DIFF_DATA = {
   mode: 'snapshot',
@@ -1731,4 +1754,61 @@ test('formatScreenshotDiffText does not show diff path when images match', () =>
   );
   assert.equal(text.includes('Diff image'), false);
   assert.equal(text.includes('diff.png'), false);
+});
+
+// --- ADR 0012 migration step 2: replay divergence compact text report ---
+
+test('printHumanError renders a compact divergence report unconditionally (not gated behind --debug)', () => {
+  const err = new AppError(
+    'REPLAY_DIVERGENCE',
+    'Replay failed at step 2 (click "Save"): not hittable',
+    {
+      divergence: {
+        version: 1,
+        kind: 'action-failure',
+        step: { index: 2, source: { path: '/tmp/flow.ad', line: 5 } },
+        action: 'click "Save"',
+        cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+        screen: {
+          state: 'available',
+          refsGeneration: 3,
+          refs: [{ ref: 'e5', role: 'button', label: 'Save' }],
+        },
+        suggestions: [
+          { selector: 'id="save"', basis: 'id', ref: 'e5', role: 'button', label: 'Save' },
+        ],
+        suggestionCount: 1,
+        resume: { allowed: false, reason: 'resume not yet supported' },
+      },
+    },
+  );
+
+  const output = captureStderr(() => printHumanError(err));
+
+  assert.match(output, /Divergence at step 2 \(\/tmp\/flow\.ad:5\)/);
+  assert.match(output, /Screen: 1 actionable ref\(s\) captured \(refsGeneration 3\)/);
+  assert.match(output, /Suggestions:/);
+  assert.match(output, /\[id\] "Save" id="save"/);
+  // Not gated behind --debug: showDetails defaults to false/undefined here.
+});
+
+test('printHumanError shows an unavailable screen reason and omitted suggestions hint', () => {
+  const err = new AppError('REPLAY_DIVERGENCE', 'Replay failed at step 1', {
+    divergence: {
+      version: 1,
+      kind: 'action-failure',
+      step: { index: 1, source: { path: '/tmp/flow.ad', line: 1 } },
+      action: 'click "Save"',
+      cause: { code: 'COMMAND_FAILED', message: 'not hittable' },
+      screen: { state: 'unavailable', reason: 'capture-failed' },
+      suggestions: [],
+      suggestionCount: 2,
+      resume: { allowed: false, reason: 'resume not yet supported' },
+    },
+  });
+
+  const output = captureStderr(() => printHumanError(err));
+
+  assert.match(output, /Screen: unavailable \(capture-failed\)/);
+  assert.match(output, /Suggestions: 2 available \(omitted at this response level/);
 });

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -5,6 +5,7 @@ import {
 } from './android-helper-snapshot-presentation.ts';
 import { AppError, normalizeError, type NormalizedError } from '../kernel/errors.ts';
 import { detectPossibleRepeatedNavSubtree } from './repeated-nav-subtree.ts';
+import { formatReplayDivergenceReport } from '../replay/divergence.ts';
 import { buildSnapshotDisplayLines, formatSnapshotLine } from '../snapshot/snapshot-lines.ts';
 import {
   isSnapshotBackend,
@@ -48,83 +49,13 @@ export function printHumanError(
   }
   // ADR 0012: the divergence compact report always renders; --debug's raw
   // details dump below remains the full-object view.
-  const divergenceText = formatReplayDivergenceText(normalized.details);
+  const divergenceText = formatReplayDivergenceReport(normalized.details);
   if (divergenceText) {
     process.stderr.write(`${divergenceText}\n`);
   }
   if (options.showDetails && normalized.details) {
     process.stderr.write(`${JSON.stringify(normalized.details, null, 2)}\n`);
   }
-}
-
-// ADR 0012 divergence compact text report; one line-builder per field.
-function formatReplayDivergenceText(details: Record<string, unknown> | undefined): string | null {
-  const divergence = details?.divergence;
-  if (!divergence || typeof divergence !== 'object') return null;
-  const record = divergence as Record<string, unknown>;
-  const lines: string[] = [
-    ...formatDivergenceStepLine(record.step),
-    ...formatDivergenceScreenLine(record.screen),
-    ...formatDivergenceSuggestionLines(record.suggestions, record.suggestionCount),
-    ...formatDivergenceOverflowLine(record.overflow, record.artifactUnavailable),
-  ];
-  return lines.length > 0 ? lines.join('\n') : null;
-}
-
-function formatDivergenceStepLine(step: unknown): string[] {
-  const record = step as Record<string, unknown> | undefined;
-  if (typeof record?.index !== 'number') return [];
-  const source = record.source as Record<string, unknown> | undefined;
-  const location =
-    typeof source?.path === 'string' && typeof source.line === 'number'
-      ? ` (${source.path}:${source.line})`
-      : '';
-  return [`Divergence at step ${record.index}${location}`];
-}
-
-function formatDivergenceScreenLine(screen: unknown): string[] {
-  const record = screen as Record<string, unknown> | undefined;
-  if (record?.state === 'available' && Array.isArray(record.refs)) {
-    return [
-      `Screen: ${record.refs.length} actionable ref(s) captured (refsGeneration ${record.refsGeneration}).`,
-    ];
-  }
-  if (record?.state === 'unavailable') {
-    return [`Screen: unavailable (${String(record.reason ?? 'unknown')}).`];
-  }
-  return [];
-}
-
-function formatDivergenceSuggestionLines(suggestions: unknown, suggestionCount: unknown): string[] {
-  if (Array.isArray(suggestions) && suggestions.length > 0) {
-    return ['Suggestions:', ...suggestions.slice(0, 5).map(formatDivergenceSuggestionLine)];
-  }
-  if (typeof suggestionCount === 'number' && suggestionCount > 0) {
-    return [
-      `Suggestions: ${suggestionCount} available (omitted at this response level; rerun with --json for the full report).`,
-    ];
-  }
-  return [];
-}
-
-function formatDivergenceSuggestionLine(entry: unknown): string {
-  const suggestion = entry as Record<string, unknown>;
-  const label = typeof suggestion.label === 'string' ? ` "${suggestion.label}"` : '';
-  return `  - [${String(suggestion.basis)}]${label} ${String(suggestion.selector)}`;
-}
-
-function formatDivergenceOverflowLine(overflow: unknown, artifactUnavailable: unknown): string[] {
-  if (overflow && typeof overflow === 'object') {
-    return [
-      `Full report written to ${String((overflow as Record<string, unknown>).artifactPath)}.`,
-    ];
-  }
-  if (artifactUnavailable === true) {
-    return [
-      'Full report exceeded the response budget and the overflow artifact could not be written.',
-    ];
-  }
-  return [];
 }
 
 type SnapshotDiffLine = {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -46,9 +46,85 @@ export function printHumanError(
   if (normalized.logPath) {
     process.stderr.write(`Diagnostics Log: ${normalized.logPath}\n`);
   }
+  // ADR 0012 migration step 2: a replay divergence's compact text report is
+  // NOT gated behind --debug — text mode previously showed step+action+
+  // selector+a generic hint with no screen evidence; --debug's raw
+  // `normalized.details` JSON dump below stays available for the full object.
+  const divergenceText = formatReplayDivergenceText(normalized.details);
+  if (divergenceText) {
+    process.stderr.write(`${divergenceText}\n`);
+  }
   if (options.showDetails && normalized.details) {
     process.stderr.write(`${JSON.stringify(normalized.details, null, 2)}\n`);
   }
+}
+
+// ADR 0012 migration step 2: divergence compact text report. Split into one
+// line-builder per field so each stays a simple, low-complexity function —
+// `printHumanError` renders this unconditionally, not gated behind --debug.
+function formatReplayDivergenceText(details: Record<string, unknown> | undefined): string | null {
+  const divergence = details?.divergence;
+  if (!divergence || typeof divergence !== 'object') return null;
+  const record = divergence as Record<string, unknown>;
+  const lines: string[] = [
+    ...formatDivergenceStepLine(record.step),
+    ...formatDivergenceScreenLine(record.screen),
+    ...formatDivergenceSuggestionLines(record.suggestions, record.suggestionCount),
+    ...formatDivergenceOverflowLine(record.overflow, record.artifactUnavailable),
+  ];
+  return lines.length > 0 ? lines.join('\n') : null;
+}
+
+function formatDivergenceStepLine(step: unknown): string[] {
+  const record = step as Record<string, unknown> | undefined;
+  if (typeof record?.index !== 'number') return [];
+  const source = record.source as Record<string, unknown> | undefined;
+  const location =
+    typeof source?.path === 'string' && typeof source.line === 'number'
+      ? ` (${source.path}:${source.line})`
+      : '';
+  return [`Divergence at step ${record.index}${location}`];
+}
+
+function formatDivergenceScreenLine(screen: unknown): string[] {
+  const record = screen as Record<string, unknown> | undefined;
+  if (record?.state === 'available' && Array.isArray(record.refs)) {
+    return [
+      `Screen: ${record.refs.length} actionable ref(s) captured (refsGeneration ${record.refsGeneration}).`,
+    ];
+  }
+  if (record?.state === 'unavailable') {
+    return [`Screen: unavailable (${String(record.reason ?? 'unknown')}).`];
+  }
+  return [];
+}
+
+function formatDivergenceSuggestionLines(suggestions: unknown, suggestionCount: unknown): string[] {
+  if (Array.isArray(suggestions) && suggestions.length > 0) {
+    return ['Suggestions:', ...suggestions.slice(0, 5).map(formatDivergenceSuggestionLine)];
+  }
+  if (typeof suggestionCount === 'number' && suggestionCount > 0) {
+    return [
+      `Suggestions: ${suggestionCount} available (omitted at this response level; rerun with --json for the full report).`,
+    ];
+  }
+  return [];
+}
+
+function formatDivergenceSuggestionLine(entry: unknown): string {
+  const suggestion = entry as Record<string, unknown>;
+  const label = typeof suggestion.label === 'string' ? ` "${suggestion.label}"` : '';
+  return `  - [${String(suggestion.basis)}]${label} ${String(suggestion.selector)}`;
+}
+
+function formatDivergenceOverflowLine(overflow: unknown, artifactUnavailable: unknown): string[] {
+  if (overflow && typeof overflow === 'object') {
+    return [`Full report written to ${String((overflow as Record<string, unknown>).artifactPath)}.`];
+  }
+  if (artifactUnavailable === true) {
+    return ['Full report exceeded the response budget and the overflow artifact could not be written.'];
+  }
+  return [];
 }
 
 type SnapshotDiffLine = {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -119,10 +119,14 @@ function formatDivergenceSuggestionLine(entry: unknown): string {
 
 function formatDivergenceOverflowLine(overflow: unknown, artifactUnavailable: unknown): string[] {
   if (overflow && typeof overflow === 'object') {
-    return [`Full report written to ${String((overflow as Record<string, unknown>).artifactPath)}.`];
+    return [
+      `Full report written to ${String((overflow as Record<string, unknown>).artifactPath)}.`,
+    ];
   }
   if (artifactUnavailable === true) {
-    return ['Full report exceeded the response budget and the overflow artifact could not be written.'];
+    return [
+      'Full report exceeded the response budget and the overflow artifact could not be written.',
+    ];
   }
   return [];
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -46,10 +46,8 @@ export function printHumanError(
   if (normalized.logPath) {
     process.stderr.write(`Diagnostics Log: ${normalized.logPath}\n`);
   }
-  // ADR 0012 migration step 2: a replay divergence's compact text report is
-  // NOT gated behind --debug — text mode previously showed step+action+
-  // selector+a generic hint with no screen evidence; --debug's raw
-  // `normalized.details` JSON dump below stays available for the full object.
+  // ADR 0012: the divergence compact report always renders; --debug's raw
+  // details dump below remains the full-object view.
   const divergenceText = formatReplayDivergenceText(normalized.details);
   if (divergenceText) {
     process.stderr.write(`${divergenceText}\n`);
@@ -59,9 +57,7 @@ export function printHumanError(
   }
 }
 
-// ADR 0012 migration step 2: divergence compact text report. Split into one
-// line-builder per field so each stays a simple, low-complexity function —
-// `printHumanError` renders this unconditionally, not gated behind --debug.
+// ADR 0012 divergence compact text report; one line-builder per field.
 function formatReplayDivergenceText(details: Record<string, unknown> | undefined): string | null {
   const divergence = details?.divergence;
   if (!divergence || typeof divergence !== 'object') return null;


### PR DESCRIPTION
## Summary

Implements ADR 0012's migration step 2: the structured `REPLAY_DIVERGENCE` report on **existing** replay failure paths (`kind: "action-failure"` only — no target-binding verification, no `--from` resume). This closes the provenance/evidence gaps the ADR's live hands-on evidence documented on 2026-07-10:

- **Maestro provenance loss**: a `runFlow` include's failures reported the *including* `runFlow:` command's line, never the include's own file/line. Fixed by threading `{path, line}` per action through `runFlow` inlining (including multi-level include-of-include), with regression tests using a `../launch.yml`-style include.
- **No screen evidence on failure**: every failed step now captures a fresh, blessed (ref-issuing) post-failure snapshot digest — same pattern as `--settle`'s stored-tree/`refsGeneration` blessing.
- **Silent successful replay**: text-mode `replay` now prints one line, `Replayed N steps in X.Xs`.
- **`--update`'s narrow, apply-blind heal**: `collectReplaySelectorCandidates` + `resolveSelectorChain` re-resolution (already used by `healReplayAction`) is reused **read-only** to produce up to 5 ranked, deduplicated suggestions instead of silently rewriting the script. `--update`'s actual rewrite behavior is untouched at this step (retirement is migration step 6).
- **Lost repair data on non-JSON paths**: the daemon → Node client → CLI → MCP chain now preserves `details.divergence` end to end — MCP treats the error as a ref-issuing result (pins the screen's refs), and CLI text mode renders a compact report unconditionally (not gated behind `--debug`).

### Wire shape (`details.divergence`, version 1)
`{ kind: "action-failure", step: { index, source: { path, line } }, action, cause, screen, suggestions, suggestionCount, resume: { allowed: false, reason }, overflow?, artifactUnavailable? }`, bounded to 8/24/64 KiB (digest/default/full), 256-UTF-8-byte per-field caps, 8/20 screen refs, 5 suggestions. Overflow writes the fuller detail to a session-scoped artifact.

## Contradiction / ambiguity flagged (per instructions, not silently resolved)

Decision 1's suggestion ranking is a **total order**: identity-component strength, then **same scrollRegion as recorded**, then document order. The `scrollRegion` signal comes from decision 3's `.ad` target-v1 annotations — a **separate, later migration step** (no dependency from step 2). Since step 2 has no recorded scrollRegion evidence to consult, I implemented ranking with only the identity-component-strength tier + document order, and documented this explicitly in code (`session-replay-divergence.ts`). This is the honest partial implementation available at this step, not a silent deviation — flagging it here as requested since the ADR's ranking contract technically assumes data that doesn't exist yet at step 2.

Also: the ADR's decision 4 resume shape lists `{ allowed, from, reason?, planDigest }`, but step 2's own scope note only calls out omitting `planDigest`. Since there is no `--from` support at all yet, I omitted `from` too (no value to report) — same "omit inapplicable fields" logic as `planDigest`.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm check:layering`, `pnpm check:mcp-metadata`, `pnpm build` all clean
- [x] `pnpm fallow` (audit vs `origin/main`) — no issues
- [x] `pnpm test` (unit-core + android-adb): 3531/3531 tests pass, 387/387 files, across 3 full runs. The only non-zero exit driver on 2 of those runs was the pre-existing wall-clock "slow-test gate" tripping under CPU contention on unrelated apple/android process-spawn tests (`runtime-hints`, `screenshot-density`, `runner-client`, `index.test.ts` — see `unit-suite-flaky-under-contention` precedent); re-ran those 4 files in isolation and all 171 tests pass cleanly.
- New/updated coverage: `src/replay/__tests__/divergence.test.ts` (byte-budget/truncation/overflow-artifact/write-failure unit tests), `src/compat/maestro/__tests__/replay-flow.test.ts` (include + nested-include provenance), `src/daemon/handlers/__tests__/session-replay-runtime.test.ts` (cause preservation, available/unavailable screen, suggestion ranking, success message, no-session guard), `src/mcp/__tests__/command-tools.test.ts` (error-path ref pinning, merge-only-never-clear), `src/utils/__tests__/output.test.ts` (compact text rendering), `src/utils/__tests__/errors.test.ts` + `src/__tests__/daemon-error.test.ts` (daemon → client → CLI/MCP contract survival).