### PR TITLE
fix(macos): allow XCTest teardown before runner kill

### DIFF
--- a/src/daemon/server/http-server.ts
+++ b/src/daemon/server/http-server.ts
@@ -770,7 +770,7 @@ async function abortInFlightIosRunnerSessionsWhileDisconnected(
 
 function shouldAbortIosRunnerSessionsOnDisconnect(req: DaemonRequest): boolean {
   if (req.flags?.platform === 'android') return false;
-  if (req.flags?.platform === 'ios') return true;
+  if (req.flags?.platform === 'ios' || req.flags?.platform === 'macos') return true;
   return IOS_RUNNER_ABORT_REPLAY_COMMANDS.has(req.command);
 }
 

--- a/src/platforms/apple/core/__tests__/runner-disposal.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-disposal.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { IOS_SIMULATOR, MACOS_DEVICE } from '../../../../__tests__/test-utils/index.ts';
+import {
+  IOS_SIMULATOR,
+  MACOS_DEVICE,
+  TVOS_SIMULATOR,
+} from '../../../../__tests__/test-utils/index.ts';
 import type { ExecResult } from '../../../../utils/exec.ts';
 import type { RunnerSession } from '../runner/runner-session-types.ts';
 
@@ -111,13 +115,16 @@ test('macOS runner abort force-kills only after both grace periods expire', asyn
   expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM', 'SIGKILL']);
 });
 
-test('non-macOS runner abort preserves immediate cancellation', async () => {
-  const session = makeRunnerSession(IOS_SIMULATOR, new Promise<ExecResult>(() => {}));
+test.each([IOS_SIMULATOR, TVOS_SIMULATOR])(
+  '$appleOs runner abort preserves immediate cancellation',
+  async (device) => {
+    const session = makeRunnerSession(device, new Promise<ExecResult>(() => {}));
 
-  await abortRunnerSessionsAndPrepProcesses([session]);
+    await abortRunnerSessionsAndPrepProcesses([session]);
 
-  expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM', 'SIGKILL']);
-});
+    expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM', 'SIGKILL']);
+  },
+);
 
 function makeRunnerSession(
   device: RunnerSession['device'],

--- a/src/platforms/apple/core/__tests__/runner-disposal.test.ts
+++ b/src/platforms/apple/core/__tests__/runner-disposal.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { IOS_SIMULATOR, MACOS_DEVICE } from '../../../../__tests__/test-utils/index.ts';
+import type { ExecResult } from '../../../../utils/exec.ts';
+import type { RunnerSession } from '../runner/runner-session-types.ts';
+
+const {
+  mockCleanupTempFile,
+  mockIsProcessAlive,
+  mockIsProcessGroupAlive,
+  mockRunAppleToolCommand,
+  mockRunXcrun,
+  mockSignalPidsBestEffort,
+} = vi.hoisted(() => ({
+  mockCleanupTempFile: vi.fn(),
+  mockIsProcessAlive: vi.fn(),
+  mockIsProcessGroupAlive: vi.fn(),
+  mockRunAppleToolCommand: vi.fn(),
+  mockRunXcrun: vi.fn(),
+  mockSignalPidsBestEffort: vi.fn(),
+}));
+
+vi.mock('../../../../utils/host-process.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../utils/host-process.ts')>();
+  return {
+    ...actual,
+    isProcessAlive: mockIsProcessAlive,
+    isProcessGroupAlive: mockIsProcessGroupAlive,
+    signalPidsBestEffort: mockSignalPidsBestEffort,
+  };
+});
+
+vi.mock('../runner/runner-transport.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../runner/runner-transport.ts')>();
+  return { ...actual, cleanupTempFile: mockCleanupTempFile };
+});
+
+vi.mock('../tool-provider.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../tool-provider.ts')>();
+  return {
+    ...actual,
+    runAppleToolCommand: mockRunAppleToolCommand,
+    runXcrun: mockRunXcrun,
+  };
+});
+
+import { abortRunnerSessionsAndPrepProcesses } from '../runner/runner-disposal.ts';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(process, 'kill').mockImplementation(() => true);
+  mockIsProcessAlive.mockReturnValue(true);
+  mockIsProcessGroupAlive.mockReturnValue(false);
+  mockRunAppleToolCommand.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+  mockRunXcrun.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+});
+
+test('macOS runner abort waits for XCTest teardown after SIGINT', async () => {
+  const testRun = deferred<ExecResult>();
+  const session = makeRunnerSession(MACOS_DEVICE, testRun.promise);
+
+  const abort = abortRunnerSessionsAndPrepProcesses([session]);
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(runnerSignals(session)).toEqual(['SIGINT']);
+
+  mockIsProcessAlive.mockReturnValue(false);
+  testRun.resolve(execResult());
+  await abort;
+
+  expect(runnerSignals(session)).toEqual(['SIGINT']);
+  expect(mockCleanupTempFile).toHaveBeenCalledWith(session.xctestrunPath);
+  expect(mockCleanupTempFile).toHaveBeenCalledWith(session.jsonPath);
+});
+
+test('macOS runner abort stages TERM after the interrupt grace period', async () => {
+  const testRun = deferred<ExecResult>();
+  const session = makeRunnerSession(MACOS_DEVICE, testRun.promise);
+
+  const abort = abortRunnerSessionsAndPrepProcesses([session]);
+  await vi.advanceTimersByTimeAsync(4_999);
+  expect(runnerSignals(session)).toEqual(['SIGINT']);
+
+  await vi.advanceTimersByTimeAsync(1);
+  expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM']);
+
+  mockIsProcessAlive.mockReturnValue(false);
+  testRun.resolve(execResult());
+  await abort;
+
+  expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM']);
+});
+
+test('macOS runner abort force-kills only after both grace periods expire', async () => {
+  const session = makeRunnerSession(MACOS_DEVICE, new Promise<ExecResult>(() => {}));
+
+  const abort = abortRunnerSessionsAndPrepProcesses([session]);
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM']);
+
+  await vi.advanceTimersByTimeAsync(1_999);
+  expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM']);
+
+  await vi.advanceTimersByTimeAsync(1);
+  await abort;
+  expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM', 'SIGKILL']);
+});
+
+test('non-macOS runner abort preserves immediate cancellation', async () => {
+  const session = makeRunnerSession(IOS_SIMULATOR, new Promise<ExecResult>(() => {}));
+
+  await abortRunnerSessionsAndPrepProcesses([session]);
+
+  expect(runnerSignals(session)).toEqual(['SIGINT', 'SIGTERM', 'SIGKILL']);
+});
+
+function makeRunnerSession(
+  device: RunnerSession['device'],
+  testPromise: Promise<ExecResult>,
+): RunnerSession {
+  return {
+    sessionId: `${device.id}:8123:test`,
+    device,
+    deviceId: device.id,
+    port: 8123,
+    xctestrunPath: `/tmp/${device.id}.xctestrun`,
+    jsonPath: `/tmp/${device.id}.json`,
+    testPromise,
+    child: { pid: 42, exitCode: null },
+    ready: true,
+  };
+}
+
+function runnerSignals(session: RunnerSession): NodeJS.Signals[] {
+  return vi
+    .mocked(process.kill)
+    .mock.calls.filter(([pid]) => pid === -(session.child.pid ?? 0))
+    .map(([, signal]) => signal as NodeJS.Signals);
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function execResult(): ExecResult {
+  return { exitCode: 0, stdout: '', stderr: '' };
+}

--- a/src/platforms/apple/core/runner/runner-disposal.ts
+++ b/src/platforms/apple/core/runner/runner-disposal.ts
@@ -1,5 +1,5 @@
 import { emitDiagnostic } from '../../../../utils/diagnostics.ts';
-import type { DeviceInfo } from '../../../../kernel/device.ts';
+import { isMacOs, type DeviceInfo } from '../../../../kernel/device.ts';
 import {
   isProcessAlive,
   isProcessGroupAlive,
@@ -22,6 +22,8 @@ export const RUNNER_INVALIDATE_WAIT_TIMEOUT_MS = 1_000;
 
 const RUNNER_STOP_WAIT_TIMEOUT_MS = 10_000;
 const RUNNER_SHUTDOWN_TIMEOUT_MS = 15_000;
+const MACOS_RUNNER_INTERRUPT_WAIT_TIMEOUT_MS = 5_000;
+const MACOS_RUNNER_TERM_WAIT_TIMEOUT_MS = 2_000;
 const RUNNER_STALE_XCODEBUILD_KILL_TIMEOUT_MS = 2_000;
 const RUNNER_SIMULATOR_TERMINATE_TIMEOUT_MS = 2_000;
 
@@ -35,15 +37,22 @@ export async function disposeRunnerSession(
   session: RunnerSession,
   options: { graceful?: boolean; waitTimeoutMs?: number } = {},
 ): Promise<void> {
+  let processExitHandled = false;
   if (options.graceful !== false) {
-    await shutdownRunnerSessionGracefully(session);
+    processExitHandled = await shutdownRunnerSessionGracefully(session);
+  } else if (isMacOs(session.device)) {
+    await interruptMacOsRunnerSessions([session]);
+    await cleanupRunnerSessionResources(session);
+    return;
   } else {
     await killRunnerProcessTree(session.child.pid, 'SIGTERM');
   }
 
-  await waitForRunnerProcessExit(session, options.waitTimeoutMs ?? RUNNER_STOP_WAIT_TIMEOUT_MS);
-  if (isRunnerProcessTreeAlive(session.child.pid)) {
-    await killRunnerProcessTree(session.child.pid, 'SIGKILL');
+  if (!processExitHandled) {
+    await waitForRunnerProcessExit(session, options.waitTimeoutMs ?? RUNNER_STOP_WAIT_TIMEOUT_MS);
+    if (isRunnerProcessTreeAlive(session.child.pid)) {
+      await killRunnerProcessTree(session.child.pid, 'SIGKILL');
+    }
   }
   await cleanupRunnerSessionResources(session);
 }
@@ -56,12 +65,15 @@ export async function abortRunnerSessionsAndPrepProcesses(
   activeSessions: readonly RunnerSession[],
 ): Promise<void> {
   const prepProcesses = Array.from(runnerPrepProcesses);
-  await signalRunnerSessions(activeSessions, 'SIGINT');
+  const macOsSessions = activeSessions.filter((session) => isMacOs(session.device));
+  const otherSessions = activeSessions.filter((session) => !isMacOs(session.device));
+  await signalRunnerSessions(otherSessions, 'SIGINT');
   await signalRunnerPrepProcesses(prepProcesses, 'SIGINT');
-  await signalRunnerSessions(activeSessions, 'SIGTERM');
+  await signalRunnerSessions(otherSessions, 'SIGTERM');
   await signalRunnerPrepProcesses(prepProcesses, 'SIGTERM');
-  await signalRunnerSessions(activeSessions, 'SIGKILL');
+  await signalRunnerSessions(otherSessions, 'SIGKILL');
   await signalRunnerPrepProcesses(prepProcesses, 'SIGKILL');
+  await interruptMacOsRunnerSessions(macOsSessions);
   await Promise.allSettled(
     activeSessions.map(async (session) => {
       await cleanupRunnerSessionResources(session);
@@ -83,7 +95,7 @@ export async function stopRunnerPrepProcesses(): Promise<void> {
   );
 }
 
-async function shutdownRunnerSessionGracefully(session: RunnerSession): Promise<void> {
+async function shutdownRunnerSessionGracefully(session: RunnerSession): Promise<boolean> {
   try {
     await waitForRunner(
       session.device,
@@ -94,21 +106,66 @@ async function shutdownRunnerSessionGracefully(session: RunnerSession): Promise<
       undefined,
       RUNNER_SHUTDOWN_TIMEOUT_MS,
     );
+    return false;
   } catch {
-    await killRunnerProcessTree(session.child.pid, 'SIGTERM');
+    if (isMacOs(session.device)) {
+      await interruptMacOsRunnerSessions([session]);
+      return true;
+    } else {
+      await killRunnerProcessTree(session.child.pid, 'SIGTERM');
+      return false;
+    }
   }
 }
 
 async function waitForRunnerProcessExit(
   session: RunnerSession,
   waitTimeoutMs: number,
-): Promise<void> {
+): Promise<boolean> {
+  let timeout: NodeJS.Timeout | undefined;
   try {
-    await Promise.race([
-      session.testPromise,
-      new Promise<void>((resolve) => setTimeout(resolve, waitTimeoutMs)),
+    const exited = await Promise.race([
+      session.testPromise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), waitTimeoutMs);
+      }),
     ]);
-  } catch {}
+    return exited || !isRunnerProcessTreeAlive(session.child.pid);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function interruptMacOsRunnerSessions(sessions: readonly RunnerSession[]): Promise<void> {
+  if (sessions.length === 0) return;
+
+  // CONSERVATIVE: XCTest disables the host screen saver while macOS UI automation runs and
+  // restores it during xcodebuild teardown. Give SIGINT time to complete that teardown before
+  // escalating; revisit only if XCTest exposes a separate public cleanup acknowledgement.
+  await signalRunnerSessions(sessions, 'SIGINT');
+  const afterInterrupt = await runnerSessionsStillAlive(
+    sessions,
+    MACOS_RUNNER_INTERRUPT_WAIT_TIMEOUT_MS,
+  );
+  await signalRunnerSessions(afterInterrupt, 'SIGTERM');
+  const afterTerm = await runnerSessionsStillAlive(
+    afterInterrupt,
+    MACOS_RUNNER_TERM_WAIT_TIMEOUT_MS,
+  );
+  await signalRunnerSessions(afterTerm, 'SIGKILL');
+}
+
+async function runnerSessionsStillAlive(
+  sessions: readonly RunnerSession[],
+  waitTimeoutMs: number,
+): Promise<RunnerSession[]> {
+  const exited = await Promise.all(
+    sessions.map(async (session) => await waitForRunnerProcessExit(session, waitTimeoutMs)),
+  );
+  return sessions.filter((_, index) => !exited[index]);
 }
 
 async function cleanupRunnerSessionResources(session: RunnerSession): Promise<void> {

--- a/test/integration/provider-scenarios/daemon-http-disconnect.test.ts
+++ b/test/integration/provider-scenarios/daemon-http-disconnect.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { afterEach, expect, test, vi } from 'vitest';
+import { emitRequestProgress } from '../../../src/daemon/request-progress.ts';
+import { getRequestSignal } from '../../../src/daemon/request-cancel.ts';
+import { createDaemonHttpServer } from '../../../src/daemon/server/http-server.ts';
+import type { DaemonResponse } from '../../../src/daemon/types.ts';
+import {
+  closeLoopbackServer,
+  listenOnLoopback,
+  skipWhenLoopbackUnavailable,
+} from '../../../src/__tests__/test-utils/loopback.ts';
+
+const { abortAllIosRunnerSessions } = vi.hoisted(() => ({
+  abortAllIosRunnerSessions: vi.fn(async () => {}),
+}));
+
+vi.mock('../../../src/platforms/apple/core/runner/runner-client.ts', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../src/platforms/apple/core/runner/runner-client.ts')
+    >();
+  return { ...actual, abortAllIosRunnerSessions };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test('macOS HTTP snapshot disconnect aborts in-flight Apple runner sessions', async (t) => {
+  if (await skipWhenLoopbackUnavailable(t, 'daemon HTTP disconnect coverage')) return;
+
+  const requestId = 'req-http-macos-snapshot-disconnect';
+  let resolveHandlerDone: () => void = () => {};
+  const handlerDone = new Promise<void>((resolve) => {
+    resolveHandlerDone = resolve;
+  });
+  const server = await createDaemonHttpServer({
+    token: 'provider-scenario-token',
+    handleRequest: async (): Promise<DaemonResponse> => {
+      emitRequestProgress({
+        type: 'command',
+        status: 'progress',
+        message: 'Starting macOS XCTest runner',
+      });
+      const signal = getRequestSignal(requestId);
+      assert.ok(signal, 'request abort signal should be registered during snapshot');
+      await waitForAbort(signal);
+      resolveHandlerDone();
+      return { ok: true, data: { canceled: true } };
+    },
+  });
+
+  try {
+    const port = await listenOnLoopback(server);
+    await Promise.all([
+      abortStreamingRpcAfterFirstChunk(port, {
+        jsonrpc: '2.0',
+        id: 'rpc-macos-snapshot-disconnect',
+        method: 'agent_device.command',
+        params: {
+          command: 'snapshot',
+          flags: { platform: 'macos' },
+          meta: { requestId, requestProgress: 'command' },
+        },
+      }),
+      handlerDone,
+    ]);
+    await vi.waitFor(() => {
+      expect(abortAllIosRunnerSessions).toHaveBeenCalled();
+    });
+  } finally {
+    await closeLoopbackServer(server);
+  }
+});
+
+function abortStreamingRpcAfterFirstChunk(
+  port: number,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let sawChunk = false;
+    const body = JSON.stringify(payload);
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/rpc',
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer provider-scenario-token',
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.once('data', () => {
+          sawChunk = true;
+          res.destroy();
+          req.destroy();
+        });
+        res.on('close', () => (sawChunk ? resolve() : reject(new Error('response closed early'))));
+        res.on('error', (error) => (sawChunk ? resolve() : reject(error)));
+      },
+    );
+    req.on('error', (error) => (sawChunk ? resolve() : reject(error)));
+    req.end(body);
+  });
+}
+
+async function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}


### PR DESCRIPTION
Fixes #1205

## Summary

- stage macOS runner shutdown as `SIGINT`, wait, `SIGTERM`, wait, then `SIGKILL` only if still necessary
- preserve the existing immediate cancellation behavior for iOS, tvOS, and runner preparation processes
- cover normal macOS teardown, TERM escalation, KILL escalation, and non-macOS behavior with focused unit tests

## Problem

XCTest disables the host screen saver while macOS UI automation is running. The runner abort path previously sent `SIGINT`, `SIGTERM`, and `SIGKILL` back-to-back, which could terminate `xcodebuild` before XCTest restored the screen-saver permission.

When a client disconnected during an in-flight request, macOS could therefore remain at `setScreenSaverCanRun: 0`. Dock still recognized the configured hot-corner action, but `loginwindow` refused to start the screen saver.

## Implementation

macOS runner disposal now:

1. sends `SIGINT` and waits up to five seconds for XCTest teardown;
2. sends `SIGTERM` only to runners that remain alive and waits another two seconds; and
3. sends `SIGKILL` only to runners still alive after both grace periods.

The wait helper now reports whether the runner exited and clears its timeout when the test process settles. Graceful-shutdown fallback also reuses the staged macOS path without waiting for the same process twice.

The conservative delay is isolated to macOS because it protects host-wide screen-saver state. Other Apple targets retain their previous immediate abort behavior.

## Validation

Automated checks:

```bash
pnpm exec vitest run --project unit-core src/platforms/apple/core/__tests__/runner-disposal.test.ts
pnpm check:affected --base origin/main --run
```

All four focused regression tests and all nine affected checks passed.

Manual fault-path validation on macOS:

1. Installed the package built from this branch as the active global agent-device CLI.
2. Started a TextEdit snapshot so the macOS XCTest runner was active.
3. Terminated the client while the request was in flight.
4. Confirmed the runner process was cleaned up and no automation marker remained.
5. Confirmed the same `xcodebuild` process restored the loginwindow state:

   ```text
   setScreenSaverCanRun to 0
   setScreenSaverCanRun to 1
   ```

The interrupted runner cleaned up in approximately 1.6 seconds, without requiring TERM or KILL escalation.