### PR TITLE
fix: unbreak main — repoint relocated request-progress/cancel imports

### DIFF
--- a/test/integration/provider-scenarios/daemon-http-disconnect.test.ts
+++ b/test/integration/provider-scenarios/daemon-http-disconnect.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import http from 'node:http';
 import { afterEach, expect, test, vi } from 'vitest';
-import { emitRequestProgress } from '../../../src/daemon/request-progress.ts';
-import { getRequestSignal } from '../../../src/daemon/request-cancel.ts';
+import { emitRequestProgress } from '../../../src/request/progress.ts';
+import { getRequestSignal } from '../../../src/request/cancel.ts';
 import { createDaemonHttpServer } from '../../../src/daemon/server/http-server.ts';
 import type { DaemonResponse } from '../../../src/daemon/types.ts';
 import {


### PR DESCRIPTION
## Summary
- Main is red: `test/integration/provider-scenarios/daemon-http-disconnect.test.ts` still imports `src/daemon/request-progress.ts` and `src/daemon/request-cancel.ts`, which no longer exist on main.
- These modules were relocated (not to `src/daemon/request-progress-protocol.ts` as initially suspected — that's a distinct protocol-envelope module) to `src/request/progress.ts` (`emitRequestProgress`) and `src/request/cancel.ts` (`getRequestSignal`). The relocating PR's gate didn't run this cross-seam integration test, so the merge-order collision only surfaced once both landed on main.
- Minimal import-only fix: repointed the two broken import paths in the one affected file. Confirmed via grep that no other file has stale `daemon/request-progress` or `daemon/request-cancel` imports. No other changes.

## Test plan
- [x] `pnpm typecheck` — clean (previously the failing check on main)
- [x] `pnpm vitest run test/integration/provider-scenarios/daemon-http-disconnect.test.ts` — 1 passed
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm check:layering` — clean
- [x] `pnpm check:fallow` — clean
- [x] `pnpm check:production-exports` — clean