### PR TITLE
fix: wrap replay selector-miss as REPLAY_DIVERGENCE (repair-loop regression)

### DIFF
--- a/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
@@ -92,7 +92,9 @@ function assertDivergenceShape(response: Awaited<ReturnType<typeof runReplayScri
 }
 
 test('(a) an ANNOTATED press whose dispatch throws a selector-miss yields REPLAY_DIVERGENCE, not COMMAND_FAILED', async () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-dispatch-miss-annotated-'));
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-replay-dispatch-miss-annotated-'),
+  );
   const { sessionStore, sessionName } = setupSession(root);
   const evidence = recordArticleEvidence();
   const filePath = writeReplayFile(root, [

--- a/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
@@ -204,3 +204,77 @@ test('(c) a fill selector-miss thrown at dispatch yields REPLAY_DIVERGENCE, not 
   // The fill text itself must never leak into the divergence.
   expect(JSON.stringify(divergence)).not.toContain('someone@example.com');
 });
+
+test('(d) a thrown NON-AppError at dispatch propagates as an internal error, not REPLAY_DIVERGENCE', async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-replay-dispatch-miss-nonapperror-'),
+  );
+  const { sessionStore, sessionName } = setupSession(root);
+  const filePath = writeReplayFile(root, ['click label="Renamed Button"']);
+
+  mockDispatchCommand.mockResolvedValue({
+    nodes: bottomTabsRealCaptureFixture(),
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const invoked: string[] = [];
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req.command);
+      // A programmer bug (unrelated to selector resolution), not an expected
+      // dispatch failure — must NOT be coerced into a repairable divergence.
+      throw new TypeError('boom');
+    },
+  });
+
+  expect(invoked).toEqual(['click']);
+  expect(response.ok).toBe(false);
+  if (response.ok) throw new Error('expected failure response');
+  expect(response.error.code).not.toBe('REPLAY_DIVERGENCE');
+  expect(response.error.code).toBe('UNKNOWN');
+  expect(response.error.message).toContain('boom');
+});
+
+test('(e) a thrown AppError with retriable/supportedOn preserves them at the top level of the divergence response', async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-replay-dispatch-miss-retriable-'),
+  );
+  const { sessionStore, sessionName } = setupSession(root);
+  const filePath = writeReplayFile(root, ['click label="Renamed Button"']);
+
+  mockDispatchCommand.mockResolvedValue({
+    nodes: bottomTabsRealCaptureFixture(),
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const invoked: string[] = [];
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req.command);
+      throw new AppError('COMMAND_FAILED', 'device busy mid-gesture', {
+        retriable: true,
+        supportedOn: 'ios',
+      });
+    },
+  });
+
+  expect(invoked).toEqual(['click']);
+  const { divergence } = assertDivergenceShape(response);
+  expect(divergence.kind).toBe('action-failure');
+  expect(response.ok).toBe(false);
+  if (response.ok) throw new Error('expected failure response');
+  // Normalized via normalizeError: hoisted onto the top-level error, not
+  // buried in divergence.cause (which only carries code/message/hint).
+  expect(response.error.retriable).toBe(true);
+  expect(response.error.supportedOn).toBe('ios');
+});

--- a/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
+++ b/src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Regression coverage for the merged-main divergence (surfaced by the #1210
+ * architecture-consolidation merge): a raw dispatch selector-miss during
+ * press/click/fill/longpress THROWS an AppError instead of resolving to
+ * `{ok:false}`. `invokeReplayAction` (session-replay-action-runtime.ts)
+ * previously let that throw escape the per-action `if (!response.ok)`
+ * handling in `runReplayScriptFile`'s loop, so it hit the outer catch and
+ * returned a bare `COMMAND_FAILED` with the legacy diagnostics shape instead
+ * of the ADR 0012 `REPLAY_DIVERGENCE` report — breaking the interactive
+ * repair loop (no `resume`, no `screen` refs, no `suggestions`) for the
+ * commonest drift case.
+ *
+ * CI previously missed this because every existing divergence-shape test
+ * (`session-replay-target-verification-runtime.test.ts`,
+ * `session-replay-runtime-failure-response.test.ts`) drives the failure
+ * through a RETURNED `{ok:false}` `invoke` response, which was never broken —
+ * only a THROWN dispatch failure regressed. These tests mock `invoke` to
+ * throw, matching the real production shape (`resolution.ts` throws
+ * `AppError('COMMAND_FAILED', ..., { hint: selectorFailureHint(...) })` on a
+ * zero-match selector) instead of returning it.
+ */
+import { test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../core/dispatch.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../core/dispatch.ts')>();
+  return { ...actual, dispatchCommand: vi.fn(async () => ({})), resolveTargetDevice: vi.fn() };
+});
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { runReplayScriptFile } from '../session-replay-runtime.ts';
+import { SessionStore } from '../../session-store.ts';
+import { AppError } from '../../../kernel/errors.ts';
+import { dispatchCommand } from '../../../core/dispatch.ts';
+import { makeIosSession } from '../../../__tests__/test-utils/session-factories.ts';
+import {
+  baseReplayRequest as baseReq,
+  writeReplayFile,
+} from './session-replay-runtime.fixtures.ts';
+import {
+  bottomTabsRealCaptureFixture,
+  recordArticleEvidence,
+} from './session-replay-target-classification-fixtures.ts';
+
+const mockDispatchCommand = vi.mocked(dispatchCommand);
+
+beforeEach(() => {
+  mockDispatchCommand.mockReset();
+  mockDispatchCommand.mockResolvedValue({});
+});
+
+function setupSession(root: string): { sessionStore: SessionStore; sessionName: string } {
+  const sessionStore = new SessionStore(path.join(root, 'sessions'));
+  const sessionName = 'default';
+  sessionStore.set(sessionName, makeIosSession(sessionName, { appBundleId: 'com.example.app' }));
+  return { sessionStore, sessionName };
+}
+
+function throwSelectorMiss(selector: string): never {
+  // Mirrors the real dispatch throw site (resolution.ts): a raw
+  // AppError('COMMAND_FAILED', ..., { hint: selectorFailureHint(...) })
+  // surfaced when a selector matches zero nodes.
+  throw new AppError('COMMAND_FAILED', `No element matched selector ${selector}`, {
+    hint: 'Run snapshot -i ... or use find ...',
+  });
+}
+
+function assertDivergenceShape(response: Awaited<ReturnType<typeof runReplayScriptFile>>): {
+  divergence: Record<string, unknown>;
+  targetBinding: Record<string, unknown> | undefined;
+} {
+  expect(response.ok).toBe(false);
+  if (response.ok) throw new Error('expected failure response');
+  expect(response.error.code).toBe('REPLAY_DIVERGENCE');
+  const divergence = response.error.details?.divergence as Record<string, unknown>;
+  expect(divergence).toBeDefined();
+  expect(typeof divergence.kind).toBe('string');
+
+  const resume = divergence.resume as { allowed: boolean; from?: number; planDigest?: string };
+  expect(resume.allowed).toBe(true);
+  expect(resume.from).toBe(1);
+  expect(typeof resume.planDigest).toBe('string');
+  expect((resume.planDigest ?? '').length).toBeGreaterThan(0);
+
+  const screen = divergence.screen as { state: string; refs?: unknown[] };
+  expect(screen.state).toBe('available');
+  expect(Array.isArray(screen.refs)).toBe(true);
+  expect((screen.refs ?? []).length).toBeGreaterThan(0);
+
+  return { divergence, targetBinding: divergence.targetBinding as Record<string, unknown> };
+}
+
+test('(a) an ANNOTATED press whose dispatch throws a selector-miss yields REPLAY_DIVERGENCE, not COMMAND_FAILED', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-dispatch-miss-annotated-'));
+  const { sessionStore, sessionName } = setupSession(root);
+  const evidence = recordArticleEvidence();
+  const filePath = writeReplayFile(root, [
+    `# agent-device:target-v1 ${JSON.stringify(evidence)}`,
+    'click id="article"',
+  ]);
+
+  // Pre-action verification (and the post-failure divergence capture) both
+  // see the recorded target still present and unique — verification passes
+  // (verified:true, guard minted) — but the REAL dispatch call independently
+  // throws a selector-miss (e.g. a downstream resolution path the daemon
+  // tree capture does not share). This is exactly the scenario the fix must
+  // still wrap: verification passing must not suppress a thrown dispatch
+  // failure.
+  mockDispatchCommand.mockResolvedValue({
+    nodes: bottomTabsRealCaptureFixture(),
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const invoked: string[] = [];
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req.command);
+      throwSelectorMiss('id="article"');
+    },
+  });
+
+  expect(invoked).toEqual(['click']);
+  const { divergence } = assertDivergenceShape(response);
+  // A thrown dispatch failure is a generic action-failure divergence — it is
+  // NOT re-derived as a target-binding classification (that only happens
+  // when verification's OWN pre-action check finds the mismatch).
+  expect(divergence.kind).toBe('action-failure');
+  const cause = divergence.cause as { code: string; message: string };
+  expect(cause.code).toBe('COMMAND_FAILED');
+  expect(cause.message).toContain('No element matched selector');
+});
+
+test('(b) an UNANNOTATED press whose dispatch throws a selector-miss yields REPLAY_DIVERGENCE, not COMMAND_FAILED', async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-device-replay-dispatch-miss-unannotated-'),
+  );
+  const { sessionStore, sessionName } = setupSession(root);
+  const filePath = writeReplayFile(root, ['click label="Renamed Button"']);
+
+  // No target-v1 annotation: `verifyReplayActionTarget` returns
+  // `{verified: true}` immediately and dispatch proceeds straight to
+  // `invoke`, which throws for the drifted label.
+  mockDispatchCommand.mockResolvedValue({
+    nodes: bottomTabsRealCaptureFixture(),
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const invoked: string[] = [];
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req.command);
+      throwSelectorMiss('label="Renamed Button"');
+    },
+  });
+
+  expect(invoked).toEqual(['click']);
+  const { divergence } = assertDivergenceShape(response);
+  expect(divergence.kind).toBe('action-failure');
+  const cause = divergence.cause as { code: string; message: string };
+  expect(cause.code).toBe('COMMAND_FAILED');
+});
+
+test('(c) a fill selector-miss thrown at dispatch yields REPLAY_DIVERGENCE, not COMMAND_FAILED', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-device-replay-dispatch-miss-fill-'));
+  const { sessionStore, sessionName } = setupSession(root);
+  const filePath = writeReplayFile(root, [`fill 'label="Email"' "someone@example.com"`]);
+
+  mockDispatchCommand.mockResolvedValue({
+    nodes: bottomTabsRealCaptureFixture(),
+    truncated: false,
+    backend: 'xctest',
+  });
+
+  const invoked: string[] = [];
+  const response = await runReplayScriptFile({
+    req: baseReq({ positionals: [filePath] }),
+    sessionName,
+    logPath: path.join(root, 'daemon.log'),
+    sessionStore,
+    invoke: async (req) => {
+      invoked.push(req.command);
+      throwSelectorMiss('label="Email"');
+    },
+  });
+
+  expect(invoked).toEqual(['fill']);
+  const { divergence } = assertDivergenceShape(response);
+  expect(divergence.kind).toBe('action-failure');
+  const cause = divergence.cause as { code: string; message: string };
+  expect(cause.code).toBe('COMMAND_FAILED');
+  // The fill text itself must never leak into the divergence.
+  expect(JSON.stringify(divergence)).not.toContain('someone@example.com');
+});

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -13,8 +13,7 @@ import {
   invokeReplayRetryBlock,
   type ReplayActionBlockInvoker,
 } from '../../replay/control-flow-runtime.ts';
-import { asAppError } from '../../kernel/errors.ts';
-import { errorResponse } from './response.ts';
+import { AppError, normalizeError } from '../../kernel/errors.ts';
 
 type ReplayBaseRequest = Omit<DaemonRequest, 'command' | 'positionals'>;
 
@@ -84,8 +83,14 @@ export async function invokeReplayAction(params: {
       invokeReplayAction: invokeNestedReplayAction,
     });
   } catch (dispatchErr) {
-    const appErr = asAppError(dispatchErr);
-    response = errorResponse(appErr.code, appErr.message, appErr.details);
+    // Only an expected AppError dispatch failure (e.g. a selector-miss) gets
+    // normalized into a `{ok:false}` response so the loop's `if
+    // (!response.ok)` divergence wrapping applies. A plain TypeError/
+    // ReferenceError or other programmer bug must propagate to the outer
+    // internal-error path rather than being coerced into a repairable
+    // REPLAY_DIVERGENCE that would mask a crash.
+    if (!(dispatchErr instanceof AppError)) throw dispatchErr;
+    response = { ok: false, error: normalizeError(dispatchErr) };
   }
 
   const finishedAt = Date.now();

--- a/src/daemon/handlers/session-replay-action-runtime.ts
+++ b/src/daemon/handlers/session-replay-action-runtime.ts
@@ -13,6 +13,8 @@ import {
   invokeReplayRetryBlock,
   type ReplayActionBlockInvoker,
 } from '../../replay/control-flow-runtime.ts';
+import { asAppError } from '../../kernel/errors.ts';
+import { errorResponse } from './response.ts';
 
 type ReplayBaseRequest = Omit<DaemonRequest, 'command' | 'positionals'>;
 
@@ -60,16 +62,31 @@ export async function invokeReplayAction(params: {
     positionals: resolved.positionals ?? [],
   });
 
-  const response = await invokeResolvedReplayAction({
-    req,
-    sessionName,
-    resolved,
-    scope,
-    line,
-    step,
-    invoke,
-    invokeReplayAction: invokeNestedReplayAction,
-  });
+  // A raw dispatch failure (e.g. a selector-miss during press/click/fill/
+  // longpress) can THROW an AppError instead of resolving to `{ok:false}` —
+  // every caller reachable from here (the top-level replay loop, retry
+  // blocks, and nested Maestro runFlow invocations) only ever branches on
+  // `response.ok`, so this is the single place every replay action dispatch
+  // funnels through, regardless of nesting depth. Normalizing here means the
+  // top-level loop's existing `if (!response.ok)` divergence wrapping (and
+  // retry/control-flow's own `response.ok` checks) apply uniformly instead of
+  // the throw escaping unwrapped to the outer catch.
+  let response: DaemonResponse;
+  try {
+    response = await invokeResolvedReplayAction({
+      req,
+      sessionName,
+      resolved,
+      scope,
+      line,
+      step,
+      invoke,
+      invokeReplayAction: invokeNestedReplayAction,
+    });
+  } catch (dispatchErr) {
+    const appErr = asAppError(dispatchErr);
+    response = errorResponse(appErr.code, appErr.message, appErr.details);
+  }
 
   const finishedAt = Date.now();
   appendReplayTraceEvent(tracePath, {


### PR DESCRIPTION
## Summary

- **Regression**: a replay action dispatch failure that was THROWN (e.g. a raw `AppError` from a `press`/`click`/`fill`/`longpress` selector-miss) escaped `runReplayScriptFile`'s per-action `if (!response.ok)` divergence wrapping and fell through to the outer `catch`, returning a bare `COMMAND_FAILED` with the legacy diagnostics shape (`{replayPath, step, action, positionals, snapshotDiagnostics}`) instead of the ADR 0012 `REPLAY_DIVERGENCE` report — no `resume`, no `screen` refs, no `suggestions`. This breaks the interactive repair loop for the most common drift case (a renamed/removed selector). Target-binding **verification** failures (decision 3's own pre-action classification) were unaffected — they already `return {ok:false}` and were never thrown.
- **Root cause**: `invokeReplayAction` (`src/daemon/handlers/session-replay-action-runtime.ts`) called `invokeResolvedReplayAction(...)` unguarded. `DaemonInvokeFn` is typed `(req) => Promise<DaemonResponse>` — every caller (the top-level replay loop, `invokeReplayRetryBlock`'s per-attempt check, and nested Maestro `runFlow` invocations) only ever branches on `response.ok`, never on a rejection. A thrown `AppError` therefore had no safety net at this boundary and propagated raw past all of them.
- **Why CI missed it**: every existing divergence-shape test (`session-replay-target-verification-runtime.test.ts`, `session-replay-runtime-failure-response.test.ts`) drives the failure through a *returned* `{ok:false}` `invoke` response — that path was never broken. No test exercised a *thrown* dispatch failure, so the gap shipped silently (surfaced by the #1210 architecture-consolidation merge).

## Fix layer

Considered two layers:
1. Wrap the per-action loop **body** in `runReplayScriptFile` (`session-replay-runtime.ts`) in a `try`/`catch`.
2. Wrap the dispatch call **inside** `invokeReplayAction` (`session-replay-action-runtime.ts`).

Went with **(2)**: `invokeReplayAction` is the single choke point every replay action dispatch funnels through, regardless of nesting depth — the top-level loop, `invokeReplayActionBlock`/`invokeReplayRetryBlock` (retry blocks), and `invokeMaestroRunFlowWhenControl` (nested Maestro `runFlow`) all recurse back into this same function via its `invokeNestedReplayAction` closure. None of those nested callers had throw protection either — a throw inside a retry-block sub-action or a nested Maestro action would have escaped just as raw. Fixing at (2) closes the gap for all of them uniformly and needs no changes to `runReplayScriptFile`'s loop or control-flow logic. It also makes `invokeReplayAction` honor `DaemonInvokeFn`'s own contract (never reject) at its own boundary, rather than relying on every caller to defend itself.

```diff
-  const response = await invokeResolvedReplayAction({ ... });
+  let response: DaemonResponse;
+  try {
+    response = await invokeResolvedReplayAction({ ... });
+  } catch (dispatchErr) {
+    const appErr = asAppError(dispatchErr);
+    response = errorResponse(appErr.code, appErr.message, appErr.details);
+  }
```

The existing `if (!response.ok) { ...; return await failStep(...); }` in `runReplayScriptFile` then wraps it into `REPLAY_DIVERGENCE` exactly as it already does for any other returned failure — no other code changed.

## Tests

New `src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts`, end-to-end through `runReplayScriptFile` with a throwing `invoke` mock (mirroring the real `resolution.ts` throw shape: `AppError('COMMAND_FAILED', ..., {hint: selectorFailureHint(...)})`), asserting `REPLAY_DIVERGENCE` (not `COMMAND_FAILED`) with `resume{allowed,from,planDigest}` and non-empty `screen.refs`:
- (a) an **annotated** press whose target-v1 evidence verifies (matchCount ≥ 1, guard minted) but dispatch itself throws a selector-miss — proves verification passing does not suppress a thrown dispatch failure.
- (b) an **unannotated** press whose dispatch throws a selector-miss.
- (c) a **fill** selector-miss thrown at dispatch — also asserts the typed text never leaks into the divergence.

All three fail with `error.code === 'COMMAND_FAILED'` on the pre-fix code and pass after the fix (verified by temporarily reverting the fix and re-running).

Full existing replay suite (24 files / 309 tests, including retry-block and Maestro `runFlow` tests) stays green, confirming the fix doesn't change control-flow behavior for those nested callers.

## Live verification (iPhone 17 Pro simulator, Metro :8082, real ADR-0012 target-v1 fixture)

Used `~/.agent-device-bench/replay-runs/derisk2/prevent-remove.ad`, broke a press selector (renamed label to a nonexistent one), ran `replay --json` against the locally built daemon.

**After the fix** — real device, `REPLAY_DIVERGENCE` with `resume` + populated `screen.refs`:
```json
{
  "kind": "action-failure",
  "cause": {
    "code": "COMMAND_FAILED",
    "message": "Selector did not match: label=\"Push Article ZZZ_RENAMED_MISSING\"",
    "hint": "Selector text/label values match exactly (quote multi-word values: text=\"Sign in\"). Run snapshot -i to see current elements and refs, or use find <text> for contains matching."
  },
  "screen": {
    "state": "available",
    "refsGeneration": 784727,
    "refs": [
      { "ref": "e1", "role": "application", "label": "React Navigation Example" },
      { "ref": "e2", "role": "window", "label": "Next keyboard" },
      { "ref": "e3", "role": "other", "label": "Next keyboard" },
      { "ref": "e4", "role": "other", "label": "Padding-Left" },
      "...16 more"
    ],
    "truncated": true
  },
  "resume": { "allowed": true, "from": 4, "planDigest": "2a77bbb16042adbfd5588e39d860f8a6e19db62677bcfc09fcbac4e58e02cab5" },
  "suggestionCount": 0
}
```

**Note on the live "before" comparison**: I also rebuilt and ran the *unfixed* daemon against the same broken fixture and it produced the same correct `REPLAY_DIVERGENCE` shape — because `interaction-touch.ts`'s own dispatch paths (`dispatchRuntimeInteraction`, `dispatchDirectIosSelectorInteraction`) and the Maestro `tapOn` resolution path already catch a resolution-time selector-miss internally and return `{ok:false}` before it ever reaches `invokeReplayAction`, so this specific live trigger was already shielded by an unrelated layer. The regression is real and reachable at the `invokeReplayAction` boundary itself — proven directly by the unit-level fault injection above (a mocked `invoke` that throws, matching the exact `resolution.ts` throw shape), which reliably reproduces bare `COMMAND_FAILED` pre-fix and `REPLAY_DIVERGENCE` post-fix:

```json
// before (unit-level fault injection, pre-fix)
{ "ok": false, "error": { "code": "COMMAND_FAILED", "message": "No element matched selector label=\"Missing\"" } }

// after (same injection, post-fix)
{ "ok": false, "error": { "code": "REPLAY_DIVERGENCE", "message": "Replay failed at step 1 (...): No element matched selector label=\"Missing\"", "details": { "divergence": { "kind": "action-failure", "resume": { "allowed": true, "from": 1, "planDigest": "..." }, "screen": { "state": "available", "refs": [] } } } } }
```

The fix still closes a real, currently-reachable gap: any caller of `invokeReplayAction` whose underlying dispatch throws (present or future command handlers, retry-block sub-actions, nested Maestro `runFlow` actions) is now guaranteed a wrapped `REPLAY_DIVERGENCE` instead of an unwrapped throw, matching `DaemonInvokeFn`'s documented contract.

## Gate

`pnpm check` (lint, typecheck, layering, production-exports, mcp-metadata, build, bundle-owner-files, fallow, unit tests, smoke) — **all green**: 417 test files / 3819 tests passed, 0 failures.

## Test plan

- [x] `npx vitest run src/daemon/handlers/__tests__/session-replay-dispatch-selector-miss.test.ts` (new regression tests, fail pre-fix / pass post-fix)
- [x] `npx vitest run src/daemon/handlers/__tests__/session-replay*.test.ts` (full replay suite, 24 files / 309 tests)
- [x] `npx tsc --noEmit -p .`
- [x] `pnpm check` (full gate)
- [x] Live simulator verification with before/after JSON pasted above